### PR TITLE
Fix IndexOfTerminator negative index

### DIFF
--- a/src/Moongate.Core/Extensions/Strings/StringHelper.cs
+++ b/src/Moongate.Core/Extensions/Strings/StringHelper.cs
@@ -243,23 +243,30 @@ public static class StringHelpers
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfTerminator(this Span<byte> buffer, int sizeT) =>
-        sizeT switch
+    public static int IndexOfTerminator(this Span<byte> buffer, int sizeT)
+    {
+        int index = sizeT switch
         {
-            2 => MemoryMarshal.Cast<byte, char>(buffer).IndexOf((char)0) * 2,
-            4 => MemoryMarshal.Cast<byte, uint>(buffer).IndexOf((uint)0) * 4,
+            2 => MemoryMarshal.Cast<byte, char>(buffer).IndexOf((char)0),
+            4 => MemoryMarshal.Cast<byte, uint>(buffer).IndexOf((uint)0),
             _ => buffer.IndexOf((byte)0)
         };
 
-    // TODO: If returns -1, do not multiply by the byte length
+        return index == -1 ? -1 : index * sizeT;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfTerminator(this ReadOnlySpan<byte> buffer, int sizeT) =>
-        sizeT switch
+    public static int IndexOfTerminator(this ReadOnlySpan<byte> buffer, int sizeT)
+    {
+        int index = sizeT switch
         {
-            2 => MemoryMarshal.Cast<byte, char>(buffer).IndexOf((char)0) * 2,
-            4 => MemoryMarshal.Cast<byte, uint>(buffer).IndexOf((uint)0) * 4,
+            2 => MemoryMarshal.Cast<byte, char>(buffer).IndexOf((char)0),
+            4 => MemoryMarshal.Cast<byte, uint>(buffer).IndexOf((uint)0),
             _ => buffer.IndexOf((byte)0)
         };
+
+        return index == -1 ? -1 : index * sizeT;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ReplaceAny(


### PR DESCRIPTION
## Summary
- fix IndexOfTerminator methods so they return -1 when no terminator is found

## Testing
- `dotnet build tests/Moongate.Tests/Moongate.Tests.csproj` *(fails: .NET 9 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68500df898e08329a44a1742b98447a1