### PR TITLE
chore(autoversionize.yml): remove unnecessary flag '--exit-insignific…

### DIFF
--- a/.github/workflows/autoversionize.yml
+++ b/.github/workflows/autoversionize.yml
@@ -32,7 +32,7 @@ jobs:
           git config --local user.name "squid"
       - name: Versionize Release
         id: versionize
-        run: versionize --exit-insignificant-commits
+        run: versionize
         continue-on-error: true
       - name: No release required
         if: steps.versionize.outcome != 'success'


### PR DESCRIPTION
…ant-commits' from versionize command to simplify the workflow and avoid potential issues