### PR TITLE
feat(scripting): add Lua gump callbacks and item script fallback conv…

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,17 +698,23 @@ Related runtime events:
 ### Item `ScriptId` Dispatch
 
 Items can define `scriptId` in templates and runtime entities (`UOItemEntity.ScriptId`).
-`IItemScriptDispatcher` builds the Lua callback name from `scriptId + hook` and dispatches `ItemScriptContext`.
+`IItemScriptDispatcher` resolves `scriptId` as a Lua table and invokes hook functions on that table.
 
-Function naming convention:
+Dispatch convention:
 
-- `on_item_<script_id_normalized>_<hook_normalized>`
+- If `scriptId` is set and not `none`: table name is normalized `scriptId` (non-alphanumeric -> `_`, lowercase)
+- If `scriptId == "none"`: fallback table resolution from item name
+- First candidate: `<normalized_item_name>`
+- Second candidate: `items_<normalized_item_name>`
+- Hook candidates:
+- `single_click` -> `on_click`, `OnClick`, `on_single_click`, `OnSingleClick`
+- `double_click` -> `on_double_click`, `OnDoubleClick`
 
 Example:
 
 - `scriptId = "items.healing-potion"`
-- `hook = "on_use"`
-- Lua function called: `on_item_items_healing_potion_on_use`
+- Lua table resolved: `items_healing_potion`
+- On single click dispatcher tries: `items_healing_potion.on_click` (and aliases)
 
 Example template:
 
@@ -725,9 +731,69 @@ Example template:
 Example Lua:
 
 ```lua
-function on_item_items_healing_potion_on_use(ctx)
-  log.info("Potion used by item " .. tostring(ctx.Item.Id))
-end
+items_healing_potion = {
+  on_click = function(ctx)
+    log.info("Potion clicked, serial=" .. tostring(ctx.item.serial))
+  end,
+  on_double_click = function(ctx)
+    log.info("Potion double clicked by mobile=" .. tostring(ctx.mobile_id))
+  end
+}
+```
+
+Fallback example (`scriptId = "none"` and item name `Brick`):
+
+```lua
+brick = {
+  on_double_click = function(ctx)
+    log.info("Brick double-click from session " .. tostring(ctx.session_id))
+  end
+}
+```
+
+`ctx` payload keys:
+
+- `hook`
+- `session_id`
+- `mobile_id`
+- `metadata`
+- `item`:
+- `serial`, `script_id`, `name`, `map_id`, `item_id`, `amount`, `hue`, `location.{x,y,z}`
+
+### Lua Gump Example
+
+Lua gump flow supports:
+
+- `gump.create()` to build layout/text
+- `gump.send(sessionId, builder, senderSerial, gumpId, x, y)` to open a gump
+- `gump.on(gumpId, buttonId, callback)` to handle `0xB1` button responses
+
+Example (first gump button opens second gump):
+
+```lua
+local FIRST_GUMP = 0xB10C
+local SECOND_GUMP = 0xB10D
+local OPEN_NEXT = 1
+
+gump.on(FIRST_GUMP, OPEN_NEXT, function(ctx)
+  local g2 = gump.create()
+  g2:ResizePic(0, 0, 9200, 260, 120)
+  g2:Text(20, 20, 1152, "Second gump")
+  g2:Text(20, 50, 0, "Opened from button callback")
+  gump.send(ctx.session_id, g2, ctx.character_id or 0, SECOND_GUMP, 140, 90)
+end)
+
+items_brick = {
+  on_double_click = function(ctx)
+    local g1 = gump.create()
+    g1:ResizePic(0, 0, 9200, 280, 150)
+    g1:Text(20, 20, 1152, "First gump")
+    g1:Text(20, 50, 0, "Press button to open next")
+    g1:Button(20, 95, 4005, 4007, OPEN_NEXT)
+    g1:Text(55, 96, 0, "Open next gump")
+    gump.send(ctx.session_id, g1, ctx.mobile_id or 0, FIRST_GUMP, 120, 80)
+  end
+}
 ```
 
 ## Scripts

--- a/docs/articles/getting-started/configuration.md
+++ b/docs/articles/getting-started/configuration.md
@@ -95,6 +95,9 @@ Top-level shape:
     "logToConsole": false,
     "logLevel": "Trace"
   },
+  "scripting": {
+    "enableFileWatcher": true
+  },
   "email": {
     "isEnabled": false,
     "fromAddress": "noreply@localhost",
@@ -124,6 +127,14 @@ Top-level shape:
 - `logs`
 - `cache`
 - `email/templates`
+
+## Scripting
+
+Current scripting runtime option:
+
+- `Scripting.EnableFileWatcher` (`bool`, default `true`)
+  - `true`: enables `FileSystemWatcher` on `scripts/**/*.lua` for live reload notifications
+  - `false`: disables watcher creation entirely
 
 ## Email Templates
 

--- a/docs/articles/scripting/api.md
+++ b/docs/articles/scripting/api.md
@@ -318,30 +318,87 @@ function on_weather_changed(weather)    -- Weather changed
 
 Item templates/entities can define a `scriptId`. The server can dispatch item hooks through `IItemScriptDispatcher`.
 
-### Function Naming Convention
+### Dispatch Convention
 
 ```lua
-on_item_<script_id_normalized>_<hook_normalized>
+<script_id_normalized>.<hook_name>(ctx)
 ```
 
 Example:
 
 ```lua
--- scriptId: "items.healing-potion", hook: "on_use"
-function on_item_items_healing_potion_on_use(ctx)
-    log.info("Item hook called for " .. tostring(ctx.Item.Id))
-end
+-- scriptId: "items.healing-potion" => table "items_healing_potion"
+items_healing_potion = {
+    on_click = function(ctx)
+        log.info("Item hook called for " .. tostring(ctx.item.serial))
+    end,
+    on_double_click = function(ctx)
+        log.info("Double click from session " .. tostring(ctx.session_id))
+    end
+}
 ```
 
-### ItemScriptContext
+Fallback naming when `scriptId == "none"`:
+
+```lua
+-- item name "Brick" -> "brick" (first) then "items_brick" (second)
+brick = {
+    on_double_click = function(ctx)
+        log.info("Brick used by session " .. tostring(ctx.session_id))
+    end
+}
+```
+
+Hook aliases:
+
+- `single_click` -> `on_click`, `OnClick`, `on_single_click`, `OnSingleClick`
+- `double_click` -> `on_double_click`, `OnDoubleClick`
+
+### Gump API
+
+```lua
+local builder = gump.create()
+builder:ResizePic(0, 0, 9200, 280, 150)
+builder:Text(20, 20, 1152, "First gump")
+builder:Button(20, 95, 4005, 4007, 1)
+gump.send(session_id, builder, character_id, 0xB10C, 120, 80)
+
+gump.on(0xB10C, 1, function(ctx)
+    local second = gump.create()
+    second:ResizePic(0, 0, 9200, 260, 120)
+    second:Text(20, 20, 1152, "Second gump")
+    gump.send(ctx.session_id, second, ctx.character_id or 0, 0xB10D, 140, 90)
+end)
+```
+
+`gump.on(...)` callback `ctx` fields:
+
+- `session_id`
+- `character_id`
+- `gump_id`
+- `button_id`
+- `serial`
+- `switches`
+- `text_entries`
+
+### ItemScriptContext (`ctx` payload)
 
 ```lua
 ItemScriptContext = {
-    Session: GameSession|nil,          -- Source session when available
-    Mobile: Mobile|nil,                -- Shortcut for Session.Character
-    Item: Item,                        -- Item target
-    Hook: string,                      -- Hook name (for example "on_use")
-    Metadata: table<string, any>       -- Optional hook payload
+    hook: string,
+    session_id: number|nil,
+    mobile_id: number|nil,
+    metadata: table<string, any>|nil,
+    item: {
+        serial: number,
+        script_id: string|nil,
+        name: string|nil,
+        map_id: number,
+        item_id: number,
+        amount: number,
+        hue: number,
+        location: { x: number, y: number, z: number }
+    }
 }
 ```
 

--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -214,19 +214,58 @@ Moongate supports item-scoped script dispatch through `IItemScriptDispatcher`.
 
 - Source field: `UOItemEntity.ScriptId` (usually filled by item templates via `scriptId`)
 - Runtime input: `ItemScriptContext` (`Session`, `Mobile`, `Item`, `Hook`, `Metadata`)
-- Naming convention:
-  - `on_item_<script_id_normalized>_<hook_normalized>`
+- Dispatch model:
+  - if `scriptId` is set and not `none`, normalized `scriptId` resolves a Lua table
+  - if `scriptId == "none"`, fallback table candidates are:
+    - `<normalized_item_name>`
+    - `items_<normalized_item_name>`
+  - hook resolves a function on that table
 
 Example:
 
 - `scriptId`: `items.healing-potion`
-- hook: `on_use`
-- dispatched Lua function: `on_item_items_healing_potion_on_use`
+- resolved table: `items_healing_potion`
+- `single_click` tries: `on_click`, `OnClick`, `on_single_click`, `OnSingleClick`
+- `double_click` tries: `on_double_click`, `OnDoubleClick`
 
 ```lua
-function on_item_items_healing_potion_on_use(ctx)
-    log.info("Item hook fired for serial: " .. tostring(ctx.Item.Id))
-end
+items_healing_potion = {
+    on_click = function(ctx)
+        log.info("Item hook fired for serial: " .. tostring(ctx.item.serial))
+    end
+}
+```
+
+Fallback example:
+
+```lua
+brick = {
+    on_double_click = function(ctx)
+        log.info("Brick double click: " .. tostring(ctx.session_id))
+    end
+}
+```
+
+## Gump Callbacks
+
+Lua gumps support response callbacks via packet `0xB1`:
+
+- `gump.send(sessionId, builder, senderSerial, gumpId, x, y)`
+- `gump.on(gumpId, buttonId, callback)`
+
+Example:
+
+```lua
+local FIRST_GUMP = 0xB10C
+local SECOND_GUMP = 0xB10D
+local OPEN_NEXT = 1
+
+gump.on(FIRST_GUMP, OPEN_NEXT, function(ctx)
+    local g2 = gump.create()
+    g2:ResizePic(0, 0, 9200, 260, 120)
+    g2:Text(20, 20, 1152, "Second gump")
+    gump.send(ctx.session_id, g2, ctx.character_id or 0, SECOND_GUMP, 140, 90)
+end)
 ```
 
 ### Callback Parameters

--- a/moongate_data/moongate.json
+++ b/moongate_data/moongate.json
@@ -39,6 +39,9 @@
     "SectorEnterSyncRadius": 3,
     "LazySectorEntityLoadRadius": 3
   },
+  "Scripting": {
+    "EnableFileWatcher": true
+  },
   "Email": {
     "IsEnabled": false,
     "FromAddress": "no-reply@moongate.local",

--- a/moongate_data/scripts/init.lua
+++ b/moongate_data/scripts/init.lua
@@ -1,4 +1,6 @@
 require("ai.orion")
+require("items.apple")
+require("items.brick")
 
 function on_player_connected(p)
     log.info("Anvedi che s'e connesson un client")

--- a/moongate_data/scripts/items/apple.lua
+++ b/moongate_data/scripts/items/apple.lua
@@ -1,0 +1,33 @@
+apple = {
+    on_double_click = function(ctx)
+        if ctx == nil or ctx.item == nil then
+            return
+        end
+
+        local serial = tonumber(ctx.item.serial or 0)
+
+        if serial == nil or serial == 0 then
+            return
+        end
+
+        local apple = item.get(serial)
+        if apple == nil then
+            return
+        end
+
+        local deleted = apple:Delete()
+
+        if ctx.session_id ~= nil then
+            if deleted then
+                speech.send(ctx.session_id, "You eat the apple.")
+            else
+                speech.send(ctx.session_id, "You can't eat this apple right now.")
+            end
+            return
+        end
+
+        if deleted then
+            speech.broadcast("An apple has been eaten.")
+        end
+    end,
+}

--- a/moongate_data/scripts/items/brick.lua
+++ b/moongate_data/scripts/items/brick.lua
@@ -1,0 +1,47 @@
+local BRICK_FIRST_GUMP_ID = 0xB10C
+local BRICK_SECOND_GUMP_ID = 0xB10D
+local BRICK_OPEN_SECOND_BUTTON = 1
+
+gump.on(BRICK_FIRST_GUMP_ID, BRICK_OPEN_SECOND_BUTTON, function(ctx)
+    if ctx == nil or ctx.session_id == nil then
+        return
+    end
+
+    local sender = 0
+    if ctx.character_id ~= nil then
+        sender = ctx.character_id
+    end
+
+    local g = gump.create()
+    g:ResizePic(0, 0, 9200, 280, 130)
+    g:NoMove()
+    g:Text(24, 22, 1152, "Brick - second gump")
+    g:Text(24, 52, 0, "You pressed the button.")
+    g:Text(24, 72, 0, "This is the follow-up gump.")
+
+    gump.send(ctx.session_id, g, sender, BRICK_SECOND_GUMP_ID, 140, 90)
+end)
+
+brick = {
+    on_double_click = function(ctx)
+        if ctx == nil or ctx.session_id == nil then
+            return
+        end
+
+        local sender = 0
+        if ctx.mobile_id ~= nil then
+            sender = ctx.mobile_id
+        end
+
+        local g = gump.create()
+        g:ResizePic(0, 0, 9200, 300, 160)
+        g:NoMove()
+        g:Text(24, 18, 1152, "Brick")
+        g:Text(24, 48, 0, "First test gump from item double click.")
+        g:Text(24, 68, 0, "Press the button to open the second gump.")
+        g:Button(24, 108, 4005, 4007, BRICK_OPEN_SECOND_BUTTON)
+        g:Text(58, 109, 0, "Open next gump")
+
+        gump.send(ctx.session_id, g, sender, BRICK_FIRST_GUMP_ID, 120, 80)
+    end,
+}

--- a/moongate_data/templates/items/modernuo/food.json
+++ b/moongate_data/templates/items/modernuo/food.json
@@ -9,12 +9,9 @@
     "hue": "0",
     "goldValue": "0",
     "weight": 1,
-    "scriptId": "items.apple",
+    "scriptId": "apple",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -28,10 +25,7 @@
     "weight": 1,
     "scriptId": "items.apple_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -45,10 +39,7 @@
     "weight": 4,
     "scriptId": "items.awase_miso_soup",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -62,10 +53,7 @@
     "weight": 1,
     "scriptId": "items.bacon",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -79,11 +67,7 @@
     "weight": 1,
     "scriptId": "items.banana",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -97,11 +81,7 @@
     "weight": 1,
     "scriptId": "items.bananas",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -115,10 +95,7 @@
     "weight": 5,
     "scriptId": "items.bento_box",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -132,10 +109,7 @@
     "weight": 1,
     "scriptId": "items.bowl_flour",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -149,10 +123,7 @@
     "weight": 1,
     "scriptId": "items.bread_loaf",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -166,10 +137,7 @@
     "weight": 0.5,
     "scriptId": "items.brightly_colored_eggs",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -183,11 +151,7 @@
     "weight": 1,
     "scriptId": "items.cabbage",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -201,10 +165,7 @@
     "weight": 1,
     "scriptId": "items.cake",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -218,10 +179,7 @@
     "weight": 1,
     "scriptId": "items.cake_mix",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -235,11 +193,7 @@
     "weight": 1,
     "scriptId": "items.cantaloupe",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -253,11 +207,7 @@
     "weight": 1,
     "scriptId": "items.carrot",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -271,10 +221,7 @@
     "weight": 1,
     "scriptId": "items.cheese_pizza",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -288,10 +235,7 @@
     "weight": 0.1,
     "scriptId": "items.cheese_slice",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -305,10 +249,7 @@
     "weight": 0.1,
     "scriptId": "items.cheese_wedge",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -322,10 +263,7 @@
     "weight": 0.1,
     "scriptId": "items.cheese_wheel",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -339,10 +277,7 @@
     "weight": 1,
     "scriptId": "items.chicken_leg",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -356,10 +291,7 @@
     "weight": 1,
     "scriptId": "items.cocoa_butter",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -373,10 +305,7 @@
     "weight": 1,
     "scriptId": "items.cocoa_liquor",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -390,10 +319,7 @@
     "weight": 1,
     "scriptId": "items.cocoa_pulp",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -407,10 +333,7 @@
     "weight": 1,
     "scriptId": "items.coconut",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -424,10 +347,7 @@
     "weight": 1,
     "scriptId": "items.cooked_bird",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -441,10 +361,7 @@
     "weight": 1,
     "scriptId": "items.cookie_mix",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -458,10 +375,7 @@
     "weight": 1,
     "scriptId": "items.cookies",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -475,10 +389,7 @@
     "weight": 1,
     "scriptId": "items.dark_chocolate",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -492,10 +403,7 @@
     "weight": 1,
     "scriptId": "items.dates",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -509,10 +417,7 @@
     "weight": 1,
     "scriptId": "items.dough",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -526,11 +431,7 @@
     "weight": 1,
     "scriptId": "items.ear_of_corn",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -544,10 +445,7 @@
     "weight": 0.5,
     "scriptId": "items.easter_eggs",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -561,10 +459,7 @@
     "weight": 1,
     "scriptId": "items.eggs",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -578,10 +473,7 @@
     "weight": 0.5,
     "scriptId": "items.eggshells",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -595,10 +487,7 @@
     "weight": 5,
     "scriptId": "items.empty_bento_box",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -612,10 +501,7 @@
     "weight": 1,
     "scriptId": "items.empty_pewter_bowl",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -629,10 +515,7 @@
     "weight": 2,
     "scriptId": "items.empty_pewter_tub",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -646,10 +529,7 @@
     "weight": 1,
     "scriptId": "items.empty_wooden_bowl",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -663,10 +543,7 @@
     "weight": 2,
     "scriptId": "items.empty_wooden_tub",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -680,10 +557,7 @@
     "weight": 0.1,
     "scriptId": "items.fish_steak",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -697,10 +571,7 @@
     "weight": 2,
     "scriptId": "items.french_bread",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -714,10 +585,7 @@
     "weight": 1,
     "scriptId": "items.fried_eggs",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -731,10 +599,7 @@
     "weight": 2,
     "scriptId": "items.fruit_basket",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -748,10 +613,7 @@
     "weight": 1,
     "scriptId": "items.fruit_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -765,11 +627,7 @@
     "weight": 0.1,
     "scriptId": "items.glass",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -783,11 +641,7 @@
     "weight": 0.3,
     "scriptId": "items.glass_bottle",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -801,10 +655,7 @@
     "weight": 1,
     "scriptId": "items.grapes",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -818,11 +669,7 @@
     "weight": 1,
     "scriptId": "items.green_gourd",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -836,10 +683,7 @@
     "weight": 4,
     "scriptId": "items.green_tea",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -853,10 +697,7 @@
     "weight": 10,
     "scriptId": "items.green_tea_basket",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -870,10 +711,7 @@
     "weight": 1,
     "scriptId": "items.ham",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -887,11 +725,7 @@
     "weight": 1,
     "scriptId": "items.honeydew_melon",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -905,10 +739,7 @@
     "weight": 1,
     "scriptId": "items.jar_honey",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -922,10 +753,7 @@
     "weight": 2,
     "scriptId": "items.lamb_leg",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -939,10 +767,7 @@
     "weight": 1,
     "scriptId": "items.lemon",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -956,10 +781,7 @@
     "weight": 1,
     "scriptId": "items.lemons",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -973,11 +795,7 @@
     "weight": 1,
     "scriptId": "items.lettuce",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -991,10 +809,7 @@
     "weight": 1,
     "scriptId": "items.lime",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1008,10 +823,7 @@
     "weight": 1,
     "scriptId": "items.limes",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1025,10 +837,7 @@
     "weight": 1,
     "scriptId": "items.meat_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1042,10 +851,7 @@
     "weight": 1,
     "scriptId": "items.milk_chocolate",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1059,10 +865,7 @@
     "weight": 4,
     "scriptId": "items.miso_soup",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1076,10 +879,7 @@
     "weight": 1,
     "scriptId": "items.muffins",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1093,11 +893,7 @@
     "weight": 1,
     "scriptId": "items.onion",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -1111,10 +907,7 @@
     "weight": 1,
     "scriptId": "items.open_coconut",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1128,10 +921,7 @@
     "weight": 1,
     "scriptId": "items.peach",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1145,10 +935,7 @@
     "weight": 1,
     "scriptId": "items.peach_cobbler",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1162,10 +949,7 @@
     "weight": 1,
     "scriptId": "items.pear",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1179,10 +963,7 @@
     "weight": 1,
     "scriptId": "items.pewter_bowl_of_carrots",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1196,10 +977,7 @@
     "weight": 1,
     "scriptId": "items.pewter_bowl_of_corn",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1213,10 +991,7 @@
     "weight": 1,
     "scriptId": "items.pewter_bowl_of_lettuce",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1230,10 +1005,7 @@
     "weight": 1,
     "scriptId": "items.pewter_bowl_of_peas",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1247,10 +1019,7 @@
     "weight": 1,
     "scriptId": "items.pewter_bowl_of_potatos",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1264,11 +1033,7 @@
     "weight": 1,
     "scriptId": "items.pumpkin",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -1282,10 +1047,7 @@
     "weight": 1,
     "scriptId": "items.pumpkin_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1299,10 +1061,7 @@
     "weight": 1,
     "scriptId": "items.quiche",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1316,10 +1075,7 @@
     "weight": 1,
     "scriptId": "items.raw_bird",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1333,10 +1089,7 @@
     "weight": 1,
     "scriptId": "items.raw_chicken_leg",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1350,10 +1103,7 @@
     "weight": 0.1,
     "scriptId": "items.raw_fish_steak",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1367,10 +1117,7 @@
     "weight": 0,
     "scriptId": "items.raw_lamb_leg",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1384,10 +1131,7 @@
     "weight": 1,
     "scriptId": "items.raw_ribs",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1401,10 +1145,7 @@
     "weight": 4,
     "scriptId": "items.red_miso_soup",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1418,10 +1159,7 @@
     "weight": 1,
     "scriptId": "items.ribs",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1435,10 +1173,7 @@
     "weight": 45,
     "scriptId": "items.roast_pig",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1452,10 +1187,7 @@
     "weight": 5,
     "scriptId": "items.sack_flour",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1469,10 +1201,7 @@
     "weight": 1,
     "scriptId": "items.sack_of_sugar",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1486,10 +1215,7 @@
     "weight": 1,
     "scriptId": "items.sausage",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1503,10 +1229,7 @@
     "weight": 1,
     "scriptId": "items.sausage_pizza",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1520,10 +1243,7 @@
     "weight": 10,
     "scriptId": "items.sheaf_of_hay",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1537,10 +1257,7 @@
     "weight": 1,
     "scriptId": "items.slab_of_bacon",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1554,11 +1271,7 @@
     "weight": 1,
     "scriptId": "items.small_pumpkin",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -1572,10 +1285,7 @@
     "weight": 5,
     "scriptId": "items.small_watermelon",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1589,11 +1299,7 @@
     "weight": 1,
     "scriptId": "items.split_coconut",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -1607,11 +1313,7 @@
     "weight": 1,
     "scriptId": "items.squash",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -1625,10 +1327,7 @@
     "weight": 3,
     "scriptId": "items.sushi_platter",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1642,10 +1341,7 @@
     "weight": 3,
     "scriptId": "items.sushi_rolls",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1659,10 +1355,7 @@
     "weight": 1,
     "scriptId": "items.sweet_dough",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1676,11 +1369,7 @@
     "weight": 1,
     "scriptId": "items.turnip",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   },
   {
     "type": "item",
@@ -1694,10 +1383,7 @@
     "weight": 1,
     "scriptId": "items.unbaked_apple_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1711,10 +1397,7 @@
     "weight": 1,
     "scriptId": "items.unbaked_fruit_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1728,10 +1411,7 @@
     "weight": 1,
     "scriptId": "items.unbaked_meat_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1745,10 +1425,7 @@
     "weight": 1,
     "scriptId": "items.unbaked_peach_cobbler",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1762,10 +1439,7 @@
     "weight": 1,
     "scriptId": "items.unbaked_pumpkin_pie",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1779,10 +1453,7 @@
     "weight": 1,
     "scriptId": "items.unbaked_quiche",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1796,10 +1467,7 @@
     "weight": 1,
     "scriptId": "items.uncooked_cheese_pizza",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1813,10 +1481,7 @@
     "weight": 1,
     "scriptId": "items.uncooked_sausage_pizza",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1830,10 +1495,7 @@
     "weight": 1,
     "scriptId": "items.vanilla",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1847,10 +1509,7 @@
     "weight": 1,
     "scriptId": "items.wasabi",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1864,10 +1523,7 @@
     "weight": 1,
     "scriptId": "items.wasabi_clumps",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1881,10 +1537,7 @@
     "weight": 5,
     "scriptId": "items.watermelon",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1898,10 +1551,7 @@
     "weight": 1,
     "scriptId": "items.wheat_sheaf",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1915,10 +1565,7 @@
     "weight": 1,
     "scriptId": "items.white_chocolate",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1932,10 +1579,7 @@
     "weight": 4,
     "scriptId": "items.white_miso_soup",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1949,10 +1593,7 @@
     "weight": 1,
     "scriptId": "items.wooden_bowl",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1966,10 +1607,7 @@
     "weight": 1,
     "scriptId": "items.wooden_bowl_of_carrots",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -1983,10 +1621,7 @@
     "weight": 1,
     "scriptId": "items.wooden_bowl_of_corn",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -2000,10 +1635,7 @@
     "weight": 1,
     "scriptId": "items.wooden_bowl_of_lettuce",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -2017,10 +1649,7 @@
     "weight": 1,
     "scriptId": "items.wooden_bowl_of_peas",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -2034,10 +1663,7 @@
     "weight": 2,
     "scriptId": "items.wooden_bowl_of_stew",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -2051,10 +1677,7 @@
     "weight": 2,
     "scriptId": "items.wooden_bowl_of_tomato_soup",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food"
-    ]
+    "tags": ["modernuo", "food"]
   },
   {
     "type": "item",
@@ -2068,10 +1691,6 @@
     "weight": 1,
     "scriptId": "items.yellow_gourd",
     "isMovable": true,
-    "tags": [
-      "modernuo",
-      "food",
-      "flippable"
-    ]
+    "tags": ["modernuo", "food", "flippable"]
   }
 ]

--- a/moongate_data/templates/items/test.json
+++ b/moongate_data/templates/items/test.json
@@ -10,7 +10,7 @@
     "hue": "hue(2000:2200)",
     "goldValue": "dice(1d4+1)",
     "weight": 1,
-    "scriptId": "items.brick",
+    "scriptId": "brick",
     "isMovable": true
   }
 ]

--- a/src/Moongate.Network.Packets/Outgoing/System/ObjectPropertyList.cs
+++ b/src/Moongate.Network.Packets/Outgoing/System/ObjectPropertyList.cs
@@ -112,6 +112,30 @@ public sealed class ObjectPropertyList : BaseGameNetworkPacket, IPropertyList, I
         return true;
     }
 
+    public ObjectPropertyList Clone()
+    {
+        if (_buffer == null)
+        {
+            throw new ObjectDisposedException(nameof(ObjectPropertyList));
+        }
+
+        var clone = new ObjectPropertyList(Serial);
+
+        foreach (var entry in _entries)
+        {
+            if (entry.Argument is null)
+            {
+                clone.Add(entry.ClilocId);
+            }
+            else
+            {
+                clone.Add(entry.ClilocId, entry.Argument);
+            }
+        }
+
+        return clone;
+    }
+
     public void Dispose()
     {
         if (_buffer != null)

--- a/src/Moongate.Persistence/Services/Persistence/PersistenceUnitOfWork.cs
+++ b/src/Moongate.Persistence/Services/Persistence/PersistenceUnitOfWork.cs
@@ -121,7 +121,7 @@ public sealed class PersistenceUnitOfWork : IPersistenceUnitOfWork, IDisposable
             RecalculateLastEntityIds();
         }
 
-        _logger.Verbose(
+        _logger.Information(
             "Persistence initialize completed Accounts={AccountCount} Mobiles={MobileCount} Items={ItemCount} LastSequenceId={LastSequenceId}",
             _stateStore.AccountsById.Count,
             _stateStore.MobilesById.Count,

--- a/src/Moongate.Scripting/Data/Config/LuaEngineConfig.cs
+++ b/src/Moongate.Scripting/Data/Config/LuaEngineConfig.cs
@@ -3,4 +3,9 @@ namespace Moongate.Scripting.Data.Config;
 /// <summary>
 /// Represents LuaEngineConfig.
 /// </summary>
-public record LuaEngineConfig(string LuarcDirectory, string ScriptsDirectory, string EngineVersion);
+public record LuaEngineConfig(
+    string LuarcDirectory,
+    string ScriptsDirectory,
+    string EngineVersion,
+    bool EnableFileWatcher = true
+);

--- a/src/Moongate.Scripting/Services/LuaScriptEngineService.cs
+++ b/src/Moongate.Scripting/Services/LuaScriptEngineService.cs
@@ -674,7 +674,7 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
             _isInitialized = true;
             _logger.Information("Lua engine initialized successfully");
 
-            if (_watcher == null)
+            if (_engineConfig.EnableFileWatcher && _watcher == null)
             {
                 _watcher = new(_engineConfig.ScriptsDirectory, "*.lua")
                 {
@@ -684,6 +684,11 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
                 };
 
                 _watcher.Changed += OnLuaFilesChanged;
+            }
+
+            if (!_engineConfig.EnableFileWatcher)
+            {
+                _logger.Information("Lua file watcher disabled by configuration.");
             }
         }
         catch (Exception ex)

--- a/src/Moongate.Server/Bootstrap/Phases/InfrastructurePhase.cs
+++ b/src/Moongate.Server/Bootstrap/Phases/InfrastructurePhase.cs
@@ -86,6 +86,11 @@ internal sealed class InfrastructurePhase : IBootstrapPhase
             {
                 context.Config.Email = fileConfig.Email;
             }
+
+            if (fileConfig.Scripting is not null)
+            {
+                context.Config.Scripting = fileConfig.Scripting;
+            }
         }
     }
 

--- a/src/Moongate.Server/Bootstrap/Phases/ServiceRegistrationPhase.cs
+++ b/src/Moongate.Server/Bootstrap/Phases/ServiceRegistrationPhase.cs
@@ -75,7 +75,8 @@ internal sealed class ServiceRegistrationPhase : IBootstrapPhase
             new LuaEngineConfig(
                 context.DirectoriesConfig[DirectoryType.Scripts],
                 context.DirectoriesConfig[DirectoryType.Scripts],
-                VersionUtils.Version
+                VersionUtils.Version,
+                context.Config.Scripting.EnableFileWatcher
             )
         );
         ScriptModuleRegistry.Register(context.Container);

--- a/src/Moongate.Server/Data/Config/MoongateConfig.cs
+++ b/src/Moongate.Server/Data/Config/MoongateConfig.cs
@@ -29,5 +29,7 @@ public class MoongateConfig
 
     public MoongateSpatialConfig Spatial { get; set; } = new();
 
+    public MoongateScriptingConfig Scripting { get; set; } = new();
+
     public MoongateEmailConfig Email { get; set; } = new();
 }

--- a/src/Moongate.Server/Data/Config/MoongateScriptingConfig.cs
+++ b/src/Moongate.Server/Data/Config/MoongateScriptingConfig.cs
@@ -1,0 +1,13 @@
+namespace Moongate.Server.Data.Config;
+
+/// <summary>
+/// Scripting runtime configuration.
+/// </summary>
+public sealed class MoongateScriptingConfig
+{
+    /// <summary>
+    /// Enables file-system watcher for Lua script live reload.
+    /// </summary>
+    public bool EnableFileWatcher { get; set; } = true;
+}
+

--- a/src/Moongate.Server/Data/Events/Items/ItemDeletedEvent.cs
+++ b/src/Moongate.Server/Data/Events/Items/ItemDeletedEvent.cs
@@ -1,0 +1,38 @@
+using Moongate.Server.Data.Events.Base;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Data.Events.Items;
+
+/// <summary>
+/// Event emitted when an item is deleted from persistence.
+/// </summary>
+public readonly record struct ItemDeletedEvent(
+    GameEventBase BaseEvent,
+    long SessionId,
+    Serial ItemId,
+    Serial OldContainerId,
+    Point3D OldLocation,
+    int MapId
+) : IGameEvent
+{
+    /// <summary>
+    /// Creates an item deleted event with current timestamp.
+    /// </summary>
+    public ItemDeletedEvent(
+        long sessionId,
+        Serial itemId,
+        Serial oldContainerId,
+        Point3D oldLocation,
+        int mapId
+    )
+        : this(
+            GameEventBase.CreateNow(),
+            sessionId,
+            itemId,
+            oldContainerId,
+            oldLocation,
+            mapId
+        ) { }
+}
+

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -83,6 +83,7 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<IItemService, ItemService>(Reuse.Singleton);
         container.Register<IPlayerDragService, PlayerDragService>(Reuse.Singleton);
         container.Register<IItemScriptDispatcher, ItemScriptDispatcher>(Reuse.Singleton);
+        container.Register<IGumpScriptDispatcherService, GumpScriptDispatcherService>(Reuse.Singleton);
         container.Register<ILuaBrainRegistry, LuaBrainRegistry>(Reuse.Singleton);
         container.Register<INameService, NameService>(Reuse.Singleton);
         container.RegisterDelegate<IArtService>(_ => new ArtService(), Reuse.Singleton);

--- a/src/Moongate.Server/Handlers/GumpHandler.cs
+++ b/src/Moongate.Server/Handlers/GumpHandler.cs
@@ -1,0 +1,40 @@
+using Moongate.Network.Packets.Data.Packets;
+using Moongate.Network.Packets.Incoming.UI;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Scripting;
+using Moongate.Server.Listeners.Base;
+
+namespace Moongate.Server.Handlers;
+
+[RegisterPacketHandler(PacketDefinition.GumpMenuSelectionPacket)]
+
+/// <summary>
+/// Handles incoming gump button response packets (0xB1).
+/// </summary>
+public sealed class GumpHandler : BasePacketListener
+{
+    private readonly IGumpScriptDispatcherService _gumpScriptDispatcherService;
+
+    public GumpHandler(
+        IOutgoingPacketQueue outgoingPacketQueue,
+        IGumpScriptDispatcherService gumpScriptDispatcherService
+    )
+        : base(outgoingPacketQueue)
+    {
+        _gumpScriptDispatcherService = gumpScriptDispatcherService;
+    }
+
+    protected override Task<bool> HandleCoreAsync(GameSession session, IGameNetworkPacket packet)
+    {
+        if (packet is GumpMenuSelectionPacket gumpPacket)
+        {
+            _gumpScriptDispatcherService.TryDispatch(session, gumpPacket);
+        }
+
+        return Task.FromResult(true);
+    }
+}
+

--- a/src/Moongate.Server/Handlers/ItemHandler.cs
+++ b/src/Moongate.Server/Handlers/ItemHandler.cs
@@ -31,6 +31,7 @@ namespace Moongate.Server.Handlers;
     RegisterPacketHandler(PacketDefinition.DoubleClickPacket)
 ]
 public class ItemHandler : BasePacketListener, IGameEventListener<ItemMovedEvent>, IGameEventListener<ItemAddedInSectorEvent>
+    , IGameEventListener<ItemDeletedEvent>
 {
     private readonly ILogger _logger = Log.ForContext<ItemHandler>();
 
@@ -487,6 +488,57 @@ public class ItemHandler : BasePacketListener, IGameEventListener<ItemMovedEvent
 
                 Enqueue(session, new ObjectInformationPacket(item));
             }
+        }
+    }
+
+    public async Task HandleAsync(ItemDeletedEvent gameEvent, CancellationToken cancellationToken = default)
+    {
+        _ = cancellationToken;
+
+        if (gameEvent.OldContainerId == Serial.Zero)
+        {
+            return;
+        }
+
+        var targetSessionIds = new HashSet<long>();
+
+        if (gameEvent.SessionId > 0 && _gameNetworkSessionService.TryGet(gameEvent.SessionId, out var sourceSession))
+        {
+            targetSessionIds.Add(sourceSession.SessionId);
+        }
+
+        foreach (var session in _gameNetworkSessionService.GetAll())
+        {
+            var character = session.Character;
+
+            if (character is null)
+            {
+                continue;
+            }
+
+            if (character.BackpackId == gameEvent.OldContainerId ||
+                (character.EquippedItemIds.TryGetValue(ItemLayerType.Backpack, out var equippedBackpackId) &&
+                 equippedBackpackId == gameEvent.OldContainerId))
+            {
+                targetSessionIds.Add(session.SessionId);
+            }
+        }
+
+        if (targetSessionIds.Count == 0)
+        {
+            return;
+        }
+
+        var container = await _itemService.GetItemAsync(gameEvent.OldContainerId);
+
+        if (container is null)
+        {
+            return;
+        }
+
+        foreach (var sessionId in targetSessionIds)
+        {
+            Enqueue(sessionId, new DrawContainerAndAddItemCombinedPacket(container));
         }
     }
 }

--- a/src/Moongate.Server/Handlers/ToolTipHandler.cs
+++ b/src/Moongate.Server/Handlers/ToolTipHandler.cs
@@ -27,7 +27,7 @@ public class ToolTipHandler : BasePacketListener
     private readonly ConcurrentDictionary<Serial, CachedItemTooltip> _itemTooltipCache = [];
     private readonly ILogger _logger = Log.ForContext<ToolTipHandler>();
     private readonly IPersistenceService _persistenceService;
-    private readonly record struct CachedItemTooltip(int ItemHashCode, ObjectPropertyList Packet);
+    private readonly record struct CachedItemTooltip(int ItemHashCode, ObjectPropertyList PacketTemplate);
 
     public ToolTipHandler(
         IOutgoingPacketQueue outgoingPacketQueue,
@@ -86,7 +86,7 @@ public class ToolTipHandler : BasePacketListener
             if (item is null)
             {
                 _logger.Debug("MegaCliloc request ignored. Unknown item serial {Serial}.", serial);
-                _itemTooltipCache.TryRemove(serial, out _);
+                RemoveAndDisposeCachedTooltip(serial);
 
                 return null;
             }
@@ -96,7 +96,7 @@ public class ToolTipHandler : BasePacketListener
             if (_itemTooltipCache.TryGetValue(serial, out var cachedTooltip) &&
                 cachedTooltip.ItemHashCode == itemHashCode)
             {
-                return cachedTooltip.Packet;
+                return cachedTooltip.PacketTemplate.Clone();
             }
 
             var propertyList = MegaClilocBuilder.CreateItemTooltip(
@@ -118,14 +118,32 @@ public class ToolTipHandler : BasePacketListener
                 propertyList.Replace(CommonClilocIds.ObjectName, clilocId);
             }
 
-            _itemTooltipCache[serial] = new(itemHashCode, propertyList);
+            ReplaceCachedTooltip(serial, new(itemHashCode, propertyList));
 
-            return propertyList;
+            return propertyList.Clone();
         }
 
         _logger.Debug("MegaCliloc request ignored. Invalid serial {Serial}.", serial);
 
         return null;
+    }
+
+    private void ReplaceCachedTooltip(Serial serial, CachedItemTooltip updated)
+    {
+        if (_itemTooltipCache.TryGetValue(serial, out var previous))
+        {
+            previous.PacketTemplate.Dispose();
+        }
+
+        _itemTooltipCache[serial] = updated;
+    }
+
+    private void RemoveAndDisposeCachedTooltip(Serial serial)
+    {
+        if (_itemTooltipCache.TryRemove(serial, out var removed))
+        {
+            removed.PacketTemplate.Dispose();
+        }
     }
 
     private async Task<bool> HandleMegaClilocPacketAsync(GameSession session, MegaClilocPacket clilocPacket)

--- a/src/Moongate.Server/Interfaces/Services/Scripting/IGumpScriptDispatcherService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Scripting/IGumpScriptDispatcherService.cs
@@ -1,0 +1,22 @@
+using Moongate.Network.Packets.Incoming.UI;
+using Moongate.Server.Data.Session;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Server.Interfaces.Services.Scripting;
+
+/// <summary>
+/// Dispatches incoming gump button responses to Lua callbacks.
+/// </summary>
+public interface IGumpScriptDispatcherService
+{
+    /// <summary>
+    /// Registers a Lua callback for a specific gump and button identifier.
+    /// </summary>
+    void RegisterHandler(uint gumpId, uint buttonId, Closure handler);
+
+    /// <summary>
+    /// Tries to dispatch an incoming gump response to a registered handler.
+    /// </summary>
+    bool TryDispatch(GameSession session, GumpMenuSelectionPacket packet);
+}
+

--- a/src/Moongate.Server/Modules/GumpModule.cs
+++ b/src/Moongate.Server/Modules/GumpModule.cs
@@ -1,5 +1,9 @@
 using Moongate.Scripting.Attributes.Scripts;
+using Moongate.Network.Packets.Outgoing.UI;
 using Moongate.Server.Modules.Builders;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Scripting;
 using MoonSharp.Interpreter;
 
 namespace Moongate.Server.Modules;
@@ -12,6 +16,20 @@ namespace Moongate.Server.Modules;
 public sealed class GumpModule
 {
     private static bool _isBuilderTypeRegistered;
+    private readonly IOutgoingPacketQueue? _outgoingPacketQueue;
+    private readonly IGameNetworkSessionService? _gameNetworkSessionService;
+    private readonly IGumpScriptDispatcherService? _gumpScriptDispatcherService;
+
+    public GumpModule(
+        IOutgoingPacketQueue? outgoingPacketQueue = null,
+        IGameNetworkSessionService? gameNetworkSessionService = null,
+        IGumpScriptDispatcherService? gumpScriptDispatcherService = null
+    )
+    {
+        _outgoingPacketQueue = outgoingPacketQueue;
+        _gameNetworkSessionService = gameNetworkSessionService;
+        _gumpScriptDispatcherService = gumpScriptDispatcherService;
+    }
 
     [ScriptFunction("create", "Creates a new gump builder instance.")]
     public LuaGumpBuilder Create()
@@ -23,5 +41,53 @@ public sealed class GumpModule
         }
 
         return new();
+    }
+
+    [ScriptFunction("send", "Sends a compressed gump to a target session.")]
+    public bool Send(
+        long sessionId,
+        LuaGumpBuilder builder,
+        uint senderSerial = 0,
+        uint gumpId = 1,
+        uint x = 50,
+        uint y = 50
+    )
+    {
+        if (sessionId <= 0 || builder is null || _outgoingPacketQueue is null || _gameNetworkSessionService is null)
+        {
+            return false;
+        }
+
+        if (!_gameNetworkSessionService.TryGet(sessionId, out _))
+        {
+            return false;
+        }
+
+        var packet = new CompressedGumpPacket
+        {
+            SenderSerial = senderSerial,
+            GumpId = gumpId,
+            X = x,
+            Y = y,
+            Layout = builder.BuildLayout()
+        };
+
+        packet.TextLines.AddRange(builder.BuildTexts());
+        _outgoingPacketQueue.Enqueue(sessionId, packet);
+
+        return true;
+    }
+
+    [ScriptFunction("on", "Registers a Lua callback for a gump button response.")]
+    public bool On(uint gumpId, uint buttonId, Closure handler)
+    {
+        if (gumpId == 0 || buttonId == 0 || handler is null || _gumpScriptDispatcherService is null)
+        {
+            return false;
+        }
+
+        _gumpScriptDispatcherService.RegisterHandler(gumpId, buttonId, handler);
+
+        return true;
     }
 }

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -29,7 +29,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3"/>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.12.54" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.13.0" />
         <PackageReference Include="Serilog" Version="4.3.1"/>
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>
         <PackageReference Include="Serilog.Enrichers.Demystifier" Version="1.0.3"/>

--- a/src/Moongate.Server/Services/Entities/ItemFactoryService.cs
+++ b/src/Moongate.Server/Services/Entities/ItemFactoryService.cs
@@ -74,7 +74,7 @@ public sealed class ItemFactoryService : IItemFactoryService
             Name = template.Name,
             Weight = (int)template.Weight,
             Amount = 1,
-            Rarity = ItemRarity.Common,
+            Rarity = template.Rarity,
             ItemId = ParseItemId(template.ItemId),
             Hue = template.Hue.Resolve(),
             GumpId = ParseOptionalInt(template.GumpId),

--- a/src/Moongate.Server/Services/Items/ItemScriptDispatcher.cs
+++ b/src/Moongate.Server/Services/Items/ItemScriptDispatcher.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Moongate.Scripting.Interfaces;
+using Moongate.Scripting.Services;
 using Moongate.Server.Attributes;
 using Moongate.Server.Data.Events.Items;
 using Moongate.Server.Data.Items;
@@ -7,6 +8,7 @@ using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Events;
 using Moongate.Server.Interfaces.Services.Sessions;
 using Moongate.UO.Data.Ids;
+using MoonSharp.Interpreter;
 using Serilog;
 
 namespace Moongate.Server.Services.Items;
@@ -19,9 +21,10 @@ public sealed partial class ItemScriptDispatcher
     : IItemScriptDispatcher, IGameEventListener<ItemSingleClickEvent>, IGameEventListener<ItemDoubleClickEvent>
 {
     private readonly ILogger _logger = Log.ForContext<ItemScriptDispatcher>();
-    private readonly IScriptEngineService _scriptEngineService;
     private readonly IItemService _itemService;
     private readonly IGameNetworkSessionService _gameNetworkSessionService;
+    private readonly Script? _luaScript;
+    private readonly bool _supportsMoonSharpRuntime;
 
     public ItemScriptDispatcher(
         IScriptEngineService scriptEngineService,
@@ -29,9 +32,10 @@ public sealed partial class ItemScriptDispatcher
         IGameNetworkSessionService gameNetworkSessionService
     )
     {
-        _scriptEngineService = scriptEngineService;
         _itemService = itemService;
         _gameNetworkSessionService = gameNetworkSessionService;
+        _luaScript = (scriptEngineService as LuaScriptEngineService)?.LuaScript;
+        _supportsMoonSharpRuntime = _luaScript is not null;
     }
 
     public Task<bool> DispatchAsync(ItemScriptContext context, CancellationToken cancellationToken = default)
@@ -39,24 +43,41 @@ public sealed partial class ItemScriptDispatcher
         _ = cancellationToken;
         ArgumentNullException.ThrowIfNull(context);
 
-        if (string.IsNullOrWhiteSpace(context.Item.ScriptId) || string.IsNullOrWhiteSpace(context.Hook))
+        if (string.IsNullOrWhiteSpace(context.Hook))
         {
             return Task.FromResult(false);
         }
 
-        var tableName = NormalizeToken(context.Item.ScriptId);
-        var contextGlobalName = "__item_script_dispatch_context";
-        _scriptEngineService.RegisterGlobal(contextGlobalName, BuildLuaContextPayload(context));
+        if (!_supportsMoonSharpRuntime || _luaScript is null)
+        {
+            _logger.Warning("Item script dispatch requires MoonSharp runtime. ScriptId={ScriptId}", context.Item.ScriptId);
+
+            return Task.FromResult(false);
+        }
 
         try
         {
-            foreach (var hook in ResolveHookCandidates(context.Hook))
-            {
-                var command = BuildTableDispatchCommand(tableName, hook, contextGlobalName);
-                var result = _scriptEngineService.ExecuteFunction(command);
+            var payload = BuildLuaContextPayload(context);
 
-                if (result.Success && result.Data is bool dispatched && dispatched)
+            foreach (var tableName in ResolveTableCandidates(context))
+            {
+                var scriptTable = ResolveScriptTable(tableName);
+                if (scriptTable is null)
                 {
+                    continue;
+                }
+
+                foreach (var hook in ResolveHookCandidates(context.Hook))
+                {
+                    var hookFunction = ResolveTableFunction(scriptTable, hook);
+
+                    if (hookFunction is null)
+                    {
+                        continue;
+                    }
+
+                    _luaScript.Call(hookFunction, payload);
+
                     return Task.FromResult(true);
                 }
             }
@@ -67,17 +88,12 @@ public sealed partial class ItemScriptDispatcher
         {
             _logger.Error(
                 ex,
-                "Failed to dispatch item script hook '{Hook}' for script '{ScriptId}' table '{TableName}'",
+                "Failed to dispatch item script hook '{Hook}' for script '{ScriptId}'",
                 context.Hook,
-                context.Item.ScriptId,
-                tableName
+                context.Item.ScriptId
             );
 
             return Task.FromResult(false);
-        }
-        finally
-        {
-            _scriptEngineService.UnregisterGlobal(contextGlobalName);
         }
     }
 
@@ -104,22 +120,46 @@ public sealed partial class ItemScriptDispatcher
         return [$"on_{normalizedHook}", $"On{pascal}", normalizedHook];
     }
 
-    private static string BuildTableDispatchCommand(string tableName, string hook, string contextGlobalName)
+    private static IEnumerable<string> ResolveTableCandidates(ItemScriptContext context)
     {
-        return $"""
-                (function()
-                    local t = {tableName}
-                    if type(t) ~= "table" then
-                        return false
-                    end
-                    local f = t["{hook}"]
-                    if type(f) ~= "function" then
-                        return false
-                    end
-                    f({contextGlobalName})
-                    return true
-                end)()
-                """;
+        var scriptId = context.Item.ScriptId?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(scriptId) &&
+            !string.Equals(scriptId, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return NormalizeToken(scriptId);
+            yield break;
+        }
+
+        var normalizedName = NormalizeToken(context.Item.Name ?? string.Empty);
+
+        if (!string.Equals(normalizedName, "unknown", StringComparison.Ordinal))
+        {
+            yield return normalizedName;
+            yield return $"items_{normalizedName}";
+        }
+    }
+
+    private DynValue? ResolveScriptTable(string tableName)
+    {
+        if (_luaScript is null)
+        {
+            return null;
+        }
+
+        return _luaScript.Globals.Get(tableName) is { Type: DataType.Table } table ? table : null;
+    }
+
+    private static DynValue? ResolveTableFunction(DynValue table, string functionName)
+    {
+        if (table.Type != DataType.Table || table.Table is null)
+        {
+            return null;
+        }
+
+        var function = table.Table.Get(functionName);
+
+        return function.Type == DataType.Function ? function : null;
     }
 
     private static Dictionary<string, object?> BuildLuaContextPayload(ItemScriptContext context)

--- a/src/Moongate.Server/Services/Items/ItemService.cs
+++ b/src/Moongate.Server/Services/Items/ItemService.cs
@@ -122,8 +122,25 @@ public sealed class ItemService : IItemService
             return false;
         }
 
+        var oldContainerId = item.ParentContainerId;
+        var oldLocation = item.Location;
+        var mapId = item.MapId;
+
         await DetachFromCurrentOwnerAsync(item);
         var removed = await _persistenceService.UnitOfWork.Items.RemoveAsync(itemId);
+
+        if (removed)
+        {
+            await _gameEventBusService.PublishAsync(
+                new ItemDeletedEvent(
+                    sessionId: 0,
+                    itemId,
+                    oldContainerId,
+                    oldLocation,
+                    mapId
+                )
+            );
+        }
 
         _logger.Debug("Deleted item {ItemId} Removed={Removed}", itemId, removed);
 

--- a/src/Moongate.Server/Services/Scripting/GumpScriptDispatcherService.cs
+++ b/src/Moongate.Server/Services/Scripting/GumpScriptDispatcherService.cs
@@ -1,0 +1,81 @@
+using Moongate.Network.Packets.Incoming.UI;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Scripting;
+using MoonSharp.Interpreter;
+using Serilog;
+
+namespace Moongate.Server.Services.Scripting;
+
+/// <summary>
+/// Default Lua gump response dispatcher.
+/// </summary>
+public sealed class GumpScriptDispatcherService : IGumpScriptDispatcherService
+{
+    private readonly Dictionary<(uint GumpId, uint ButtonId), Closure> _handlers = [];
+    private readonly Lock _syncRoot = new();
+    private readonly ILogger _logger = Log.ForContext<GumpScriptDispatcherService>();
+
+    public void RegisterHandler(uint gumpId, uint buttonId, Closure handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        lock (_syncRoot)
+        {
+            _handlers[(gumpId, buttonId)] = handler;
+        }
+    }
+
+    public bool TryDispatch(GameSession session, GumpMenuSelectionPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(packet);
+
+        Closure? callback;
+
+        lock (_syncRoot)
+        {
+            _handlers.TryGetValue((packet.GumpId, packet.ButtonId), out callback);
+        }
+
+        if (callback is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            callback.OwnerScript.Call(
+                callback,
+                new Dictionary<string, object?>
+                {
+                    ["session_id"] = session.SessionId,
+                    ["character_id"] = session.CharacterId == Moongate.UO.Data.Ids.Serial.Zero
+                                           ? null
+                                           : (uint)session.CharacterId,
+                    ["gump_id"] = packet.GumpId,
+                    ["button_id"] = packet.ButtonId,
+                    ["serial"] = packet.Serial,
+                    ["switches"] = packet.Switches.ToArray(),
+                    ["text_entries"] = packet.TextEntries.ToDictionary(
+                        static pair => pair.Key,
+                        static pair => pair.Value
+                    )
+                }
+            );
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(
+                ex,
+                "Failed to dispatch gump callback GumpId={GumpId} ButtonId={ButtonId}",
+                packet.GumpId,
+                packet.ButtonId
+            );
+
+            return false;
+        }
+    }
+}
+

--- a/src/Moongate.UO.Data/Templates/Items/ItemTemplateDefinition.cs
+++ b/src/Moongate.UO.Data/Templates/Items/ItemTemplateDefinition.cs
@@ -76,4 +76,6 @@ public class ItemTemplateDefinition : ItemTemplateDefinitionBase
     public List<string> Tags { get; set; } = [];
 
     public decimal Weight { get; set; }
+
+    public ItemRarity Rarity { get; set; } = ItemRarity.None;
 }

--- a/tests/Moongate.Tests/Scripting/LuaScriptEngineServiceTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaScriptEngineServiceTests.cs
@@ -4,6 +4,8 @@ using Moongate.Core.Data.Directories;
 using Moongate.Core.Types;
 using Moongate.Network.Client;
 using Moongate.Network.Packets.Incoming.Speech;
+using Moongate.Network.Packets.Incoming.UI;
+using Moongate.Network.Packets.Outgoing.UI;
 using Moongate.Network.Packets.Outgoing.Speech;
 using Moongate.Scripting.Data.Scripts;
 using Moongate.Scripting.Modules;
@@ -13,12 +15,16 @@ using Moongate.Server.Data.Items;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Interfaces.Characters;
 using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Packets;
 using Moongate.Server.Interfaces.Services.Console;
 using Moongate.Server.Interfaces.Services.Sessions;
 using Moongate.Server.Interfaces.Services.Speech;
+using Moongate.Server.Interfaces.Services.Scripting;
 using Moongate.Server.Modules;
+using Moongate.Server.Services.Scripting;
 using Moongate.Server.Types.Commands;
 using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
 using Moongate.Tests.TestSupport;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
@@ -663,6 +669,132 @@ public class LuaScriptEngineServiceTests
     }
 
     [Test]
+    public async Task StartAsync_WithGumpModule_ShouldSendCompressedGumpToSession()
+    {
+        using var temp = new TempDirectory();
+        var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDir = dirs[DirectoryType.Scripts];
+        var luarcDir = temp.Path;
+        Directory.CreateDirectory(scriptsDir);
+        Directory.CreateDirectory(luarcDir);
+
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000022u
+        };
+        sessionService.Add(session);
+
+        var container = new Container();
+        container.RegisterInstance<IOutgoingPacketQueue>(queue);
+        container.RegisterInstance<IGameNetworkSessionService>(sessionService);
+
+        var service = new LuaScriptEngineService(
+            dirs,
+            [new(typeof(GumpModule))],
+            container,
+            new(luarcDir, scriptsDir, "0.1.0"),
+            []
+        );
+
+        await service.StartAsync();
+
+        var result = service.ExecuteFunction(
+            $"""
+             (function()
+                 local g = gump.create()
+                 g:ResizePic(0, 0, 9200, 220, 120)
+                 g:Text(20, 20, 0, "Brick test gump")
+                 return gump.send({session.SessionId}, g, {(uint)session.CharacterId}, 0xB001, 120, 80)
+             end)()
+             """
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Data, Is.EqualTo(true));
+                Assert.That(queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.SessionId, Is.EqualTo(session.SessionId));
+                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGumpModule_ShouldDispatchButtonCallbackAndSendFollowupGump()
+    {
+        using var temp = new TempDirectory();
+        var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDir = dirs[DirectoryType.Scripts];
+        var luarcDir = temp.Path;
+        Directory.CreateDirectory(scriptsDir);
+        Directory.CreateDirectory(luarcDir);
+
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+        var gumpDispatcher = new GumpScriptDispatcherService();
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000022u
+        };
+        sessionService.Add(session);
+
+        var container = new Container();
+        container.RegisterInstance<IOutgoingPacketQueue>(queue);
+        container.RegisterInstance<IGameNetworkSessionService>(sessionService);
+        container.RegisterInstance<IGumpScriptDispatcherService>(gumpDispatcher);
+
+        var service = new LuaScriptEngineService(
+            dirs,
+            [new(typeof(GumpModule))],
+            container,
+            new(luarcDir, scriptsDir, "0.1.0"),
+            []
+        );
+
+        await service.StartAsync();
+
+        var registerResult = service.ExecuteFunction(
+            """
+            (function()
+                return gump.on(0xB10C, 1, function(ctx)
+                    local g = gump.create()
+                    g:Text(20, 20, 0, "Second gump")
+                    return gump.send(ctx.session_id, g, ctx.character_id or 0, 0xB10D, 130, 90)
+                end)
+            end)()
+            """
+        );
+
+        Assert.That(registerResult.Success, Is.True);
+        Assert.That(registerResult.Data, Is.EqualTo(true));
+
+        var packet = new GumpMenuSelectionPacket();
+        var parsed = packet.TryParse(BuildGumpResponsePacket((uint)session.CharacterId, 0xB10C, 1));
+        Assert.That(parsed, Is.True);
+
+        var dispatched = gumpDispatcher.TryDispatch(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(dispatched, Is.True);
+                Assert.That(queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.SessionId, Is.EqualTo(session.SessionId));
+                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+                var gump = (CompressedGumpPacket)outbound.Packet;
+                Assert.That(gump.GumpId, Is.EqualTo(0xB10D));
+            }
+        );
+    }
+
+    [Test]
     public async Task StartAsync_WithLogModule_ShouldKeepLogAsTable()
     {
         using var temp = new TempDirectory();
@@ -830,6 +962,35 @@ public class LuaScriptEngineServiceTests
         Assert.That(name, Is.EqualTo("hello_world_method"));
     }
 
+    [Test]
+    public async Task StartAsync_WhenFileWatcherIsDisabled_ShouldNotCreateWatcher()
+    {
+        using var temp = new TempDirectory();
+        var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDir = dirs[DirectoryType.Scripts];
+        var luarcDir = temp.Path;
+        Directory.CreateDirectory(scriptsDir);
+        Directory.CreateDirectory(luarcDir);
+
+        var service = new LuaScriptEngineService(
+            dirs,
+            [],
+            new Container(),
+            new(luarcDir, scriptsDir, "0.1.0", EnableFileWatcher: false),
+            []
+        );
+
+        await service.StartAsync();
+
+        var watcherField = typeof(LuaScriptEngineService).GetField(
+            "_watcher",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
+        );
+        var watcher = watcherField?.GetValue(service);
+
+        Assert.That(watcher, Is.Null);
+    }
+
     private static LuaScriptEngineService CreateService(string rootPath)
     {
         var dirs = new DirectoriesConfig(rootPath, Enum.GetNames<DirectoryType>());
@@ -846,4 +1007,36 @@ public class LuaScriptEngineServiceTests
             []
         );
     }
+
+    private static byte[] BuildGumpResponsePacket(uint serial, uint gumpId, uint buttonId)
+    {
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+        bw.Write((byte)0xB1);
+        bw.Write((ushort)0);
+        WriteUInt32BE(bw, serial);
+        WriteUInt32BE(bw, gumpId);
+        WriteUInt32BE(bw, buttonId);
+        WriteInt32BE(bw, 0);
+        WriteInt32BE(bw, 0);
+        bw.Flush();
+
+        var bytes = ms.ToArray();
+        var length = (ushort)bytes.Length;
+        bytes[1] = (byte)(length >> 8);
+        bytes[2] = (byte)(length & 0xFF);
+
+        return bytes;
+    }
+
+    private static void WriteUInt32BE(BinaryWriter writer, uint value)
+    {
+        writer.Write((byte)(value >> 24));
+        writer.Write((byte)(value >> 16));
+        writer.Write((byte)(value >> 8));
+        writer.Write((byte)value);
+    }
+
+    private static void WriteInt32BE(BinaryWriter writer, int value)
+        => WriteUInt32BE(writer, unchecked((uint)value));
 }

--- a/tests/Moongate.Tests/Server/Attributes/PacketHandlerRegistrationAttributeTests.cs
+++ b/tests/Moongate.Tests/Server/Attributes/PacketHandlerRegistrationAttributeTests.cs
@@ -17,6 +17,7 @@ public class PacketHandlerRegistrationAttributeTests
             typeof(PlayerStatusHandler),
             typeof(MovementHandler),
             typeof(SpeechHandler),
+            typeof(GumpHandler),
             typeof(ToolTipHandler),
             typeof(ItemHandler)
         };
@@ -60,6 +61,7 @@ public class PacketHandlerRegistrationAttributeTests
         AssertMappings(typeof(PlayerStatusHandler), PacketDefinition.GetPlayerStatusPacket);
         AssertMappings(typeof(MovementHandler), PacketDefinition.MoveRequestPacket);
         AssertMappings(typeof(SpeechHandler), PacketDefinition.UnicodeSpeechPacket, PacketDefinition.OpenChatWindowPacket);
+        AssertMappings(typeof(GumpHandler), PacketDefinition.GumpMenuSelectionPacket);
         AssertMappings(typeof(ToolTipHandler), PacketDefinition.MegaClilocPacket);
         AssertMappings(
             typeof(ItemHandler),

--- a/tests/Moongate.Tests/Server/Handlers/ItemHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/ItemHandlerTests.cs
@@ -471,6 +471,66 @@ public class ItemHandlerTests
         );
     }
 
+    [Test]
+    public async Task HandleAsync_WhenItemDeletedFromBackpack_ShouldRefreshBackpackContainer()
+    {
+        var eventBus = new NetworkServiceTestGameEventBusService();
+        var itemService = new ItemHandlerTestItemService();
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+        var handler = new ItemHandler(
+            queue,
+            itemService,
+            eventBus,
+            sessionService,
+            new PlayerDragService(),
+            new RegionDataLoaderTestSpatialWorldService(),
+            new ItemHandlerTestMobileService()
+        );
+
+        var backpackId = (Serial)0x40000001u;
+        itemService.ItemsById[backpackId] = new()
+        {
+            Id = backpackId,
+            ItemId = 0x0E75,
+            GumpId = 0x0042
+        };
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000002u,
+            Character = new()
+            {
+                Id = (Serial)0x00000002u,
+                BackpackId = backpackId
+            }
+        };
+        sessionService.Add(session);
+
+        await handler.HandleAsync(
+            new ItemDeletedEvent(
+                sessionId: 0,
+                itemId: (Serial)0x40000099u,
+                oldContainerId: backpackId,
+                oldLocation: new Point3D(10, 10, 0),
+                mapId: 0
+            )
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.SessionId, Is.EqualTo(session.SessionId));
+                Assert.That(outbound.Packet, Is.TypeOf<DrawContainerAndAddItemCombinedPacket>());
+                var draw = (DrawContainerAndAddItemCombinedPacket)outbound.Packet;
+                Assert.That(draw.Container, Is.Not.Null);
+                Assert.That(draw.Container!.Id, Is.EqualTo(backpackId));
+            }
+        );
+    }
+
     private sealed class ItemHandlerTestItemService : IItemService
     {
         public Dictionary<Serial, UOItemEntity> ItemsById { get; } = [];

--- a/tests/Moongate.Tests/Server/Handlers/ToolTipHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/ToolTipHandlerTests.cs
@@ -440,9 +440,47 @@ public class ToolTipHandlerTests
             {
                 Assert.That(firstDequeued, Is.True);
                 Assert.That(secondDequeued, Is.True);
-                Assert.That(ReferenceEquals(firstOutbound.Packet, secondOutbound.Packet), Is.True);
+                Assert.That(ReferenceEquals(firstOutbound.Packet, secondOutbound.Packet), Is.False);
             }
         );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_ShouldKeepCacheUsable_AfterSentPacketIsDisposed()
+    {
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var persistenceService = new TestPersistenceService();
+        var itemSerial = (Serial)0x40000033u;
+        await persistenceService.UnitOfWork.Items.UpsertAsync(
+            new()
+            {
+                Id = itemSerial,
+                Name = "Dispose Cache Test",
+                ItemId = 0x0EED,
+                Amount = 10,
+                Hue = 0x0021
+            }
+        );
+
+        var handler = new ToolTipHandler(queue, persistenceService);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client));
+        var request = BuildRequestPacket(itemSerial.Value);
+
+        await handler.HandlePacketAsync(session, request);
+        var firstDequeued = queue.TryDequeue(out var firstOutbound);
+        Assert.That(firstDequeued, Is.True);
+
+        if (firstOutbound.Packet is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        await handler.HandlePacketAsync(session, request);
+        var secondDequeued = queue.TryDequeue(out var secondOutbound);
+        Assert.That(secondDequeued, Is.True);
+
+        Assert.DoesNotThrow(() => _ = DeserializeResponse(secondOutbound.Packet));
     }
 
     [Test]

--- a/tests/Moongate.Tests/Server/Services/Entities/EntityFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Entities/EntityFactoryServiceTests.cs
@@ -55,7 +55,7 @@ public class EntityFactoryServiceTests
                 Assert.That(item.Name, Is.EqualTo("Shirt"));
                 Assert.That(item.Weight, Is.EqualTo(6));
                 Assert.That(item.IsStackable, Is.False);
-                Assert.That(item.Rarity, Is.EqualTo(ItemRarity.Common));
+                Assert.That(item.Rarity, Is.EqualTo(ItemRarity.None));
                 Assert.That(item.ItemId, Is.EqualTo(0x1517));
                 Assert.That(item.Hue, Is.EqualTo(100));
                 Assert.That(item.ScriptId, Is.EqualTo("none"));
@@ -187,7 +187,7 @@ public class EntityFactoryServiceTests
                 Assert.That(backpack.Name, Is.EqualTo("Backpack"));
                 Assert.That(backpack.Weight, Is.EqualTo(1));
                 Assert.That(backpack.IsStackable, Is.False);
-                Assert.That(backpack.Rarity, Is.EqualTo(ItemRarity.Common));
+                Assert.That(backpack.Rarity, Is.EqualTo(ItemRarity.None));
                 Assert.That(backpack.ItemId, Is.EqualTo(0x0E75));
                 Assert.That(backpack.ScriptId, Is.EqualTo("none"));
             }

--- a/tests/Moongate.Tests/Server/Services/Entities/ItemFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Entities/ItemFactoryServiceTests.cs
@@ -180,7 +180,8 @@ public class ItemFactoryServiceTests
                 GoldValue = GoldValueSpec.FromValue(0),
                 LootType = LootType.Regular,
                 ScriptId = "items.test_item",
-                Weight = 6
+                Weight = 6,
+                Rarity = ItemRarity.Legendary
             }
         );
 
@@ -197,6 +198,7 @@ public class ItemFactoryServiceTests
                 Assert.That(item.GumpId, Is.EqualTo(0x0042));
                 Assert.That(item.Hue, Is.EqualTo(77));
                 Assert.That(item.Weight, Is.EqualTo(6));
+                Assert.That(item.Rarity, Is.EqualTo(ItemRarity.Legendary));
                 Assert.That(item.ScriptId, Is.EqualTo("items.test_item"));
                 Assert.That(item.Location, Is.EqualTo(Point3D.Zero));
                 Assert.That(item.ParentContainerId, Is.EqualTo(Moongate.UO.Data.Ids.Serial.Zero));

--- a/tests/Moongate.Tests/Server/Services/Items/ItemScriptDispatcherTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Items/ItemScriptDispatcherTests.cs
@@ -226,4 +226,79 @@ public class ItemScriptDispatcherTests
 
         Assert.That(dispatched, Is.False);
     }
+
+    [Test]
+    public async Task DispatchAsync_WhenScriptIdIsNone_ShouldFallbackToNormalizedItemNameTable()
+    {
+        using var temp = new TempDirectory();
+        var directories = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDirectory = directories[DirectoryType.Scripts];
+        Directory.CreateDirectory(scriptsDirectory);
+        var scriptEngine = new LuaScriptEngineService(
+            directories,
+            [],
+            new Container(),
+            new(temp.Path, scriptsDirectory, "0.1.0"),
+            []
+        );
+        await scriptEngine.StartAsync();
+        scriptEngine.ExecuteScript(
+            """
+            brick = {
+              on_double_click = function(ctx)
+                _item_dispatch_called = "brick-double"
+              end
+            }
+            """
+        );
+        var dispatcher = new ItemScriptDispatcher(
+            scriptEngine,
+            new ItemScriptDispatcherTestItemService(),
+            new FakeGameNetworkSessionService()
+        );
+        var context = new ItemScriptContext(
+            null,
+            new UOItemEntity
+            {
+                ScriptId = "none",
+                Name = "Brick"
+            },
+            "double_click"
+        );
+
+        var dispatched = await dispatcher.DispatchAsync(context);
+        var result = scriptEngine.ExecuteFunction("(function() return _item_dispatch_called end)()");
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(dispatched, Is.True);
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Data, Is.EqualTo("brick-double"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task DispatchAsync_ShouldReturnFalse_WhenMoonSharpRuntimeIsUnavailable()
+    {
+        var scriptEngine = new ItemScriptDispatcherTestScriptEngineService();
+        var dispatcher = new ItemScriptDispatcher(
+            scriptEngine,
+            new ItemScriptDispatcherTestItemService(),
+            new FakeGameNetworkSessionService()
+        );
+        var context = new ItemScriptContext(
+            null,
+            new UOItemEntity
+            {
+                ScriptId = "items.healing_potion"
+            },
+            "single_click"
+        );
+
+        var dispatched = await dispatcher.DispatchAsync(context);
+
+        Assert.That(dispatched, Is.False);
+    }
 }


### PR DESCRIPTION
…entions

feat(scripting): add gump callback dispatch pipeline for 0xB1 responses

- add IGumpScriptDispatcherService + GumpScriptDispatcherService for Lua callback routing

- add GumpHandler for GumpMenuSelectionPacket (0xB1) and register packet mapping

- extend gump module with gump.send(...) and gump.on(...) for chained gump flows

- add item scripts apple.lua and brick.lua and wire them in scripts/init.lua

feat(config): add Lua file watcher toggle in server config

- add MoongateConfig.Scripting.EnableFileWatcher

- pass watcher flag through LuaEngineConfig and ServiceRegistrationPhase

- merge Scripting config in InfrastructurePhase and document in moongate.json/config docs

feat(items): support ItemTemplateDefinition rarity mapping

- map template rarity to created item entities in ItemFactoryService

- update entity/item factory tests to reflect default None when rarity is unspecified

fix(items): refresh containers after scripted item delete

- add ItemDeletedEvent published by ItemService.DeleteItemAsync

- handle ItemDeletedEvent in ItemHandler to enqueue updated container/backpack packets

fix(packets): avoid disposed ObjectPropertyList reuse from tooltip cache

- cache immutable tooltip templates and clone per outbound send

- dispose replaced/removed cached entries safely

- add regression tests for disposed cached tooltip scenarios

refactor(scripting): align ItemScriptDispatcher with brain table dispatch model

- remove string-eval table dispatch and resolve/call Lua table functions directly via MoonSharp

- add script convention fallback: if scriptId == 'none', resolve by normalized item name

docs(readme,scripting): synchronize item dispatch and gump conventions

- document scriptId fallback conventions and item hook aliases

- add README and docs examples for chained gumps (button -> follow-up gump)