### PR TITLE
docs(getting-started): align CLI flags with kebab-case options

### DIFF
--- a/docs/articles/getting-started/configuration.md
+++ b/docs/articles/getting-started/configuration.md
@@ -15,17 +15,17 @@ Priority order:
 
 Current `Program` command signature supports:
 
-- `--showHeader` (`bool`, default `true`)
-- `--rootDirectory` (`string`)
-- `--uoDirectory` (`string`)
+- `--show-header` (`bool`, default `true`)
+- `--root-directory` (`string`)
+- `--uo-directory` (`string`)
 - `--loglevel` (`LogLevelType`, default `Debug`)
 
 Example:
 
 ```bash
 dotnet run --project src/Moongate.Server -- \
-  --rootDirectory /opt/moongate \
-  --uoDirectory /opt/uo \
+  --root-directory /opt/moongate \
+  --uo-directory /opt/uo \
   --loglevel Information
 ```
 

--- a/docs/articles/getting-started/installation.md
+++ b/docs/articles/getting-started/installation.md
@@ -6,7 +6,7 @@ Install and run Moongate v2 with the current runtime requirements.
 
 - .NET SDK 10.0.x
 - Git
-- Ultima Online data directory (path passed with `--uoDirectory` or `MOONGATE_UO_DIRECTORY`)
+- Ultima Online data directory (path passed with `--uo-directory` or `MOONGATE_UO_DIRECTORY`)
 
 ## Clone And Build
 
@@ -21,8 +21,8 @@ dotnet build -c Release
 
 ```bash
 dotnet run --project src/Moongate.Server -- \
-  --rootDirectory ./moongate \
-  --uoDirectory /path/to/uo \
+  --root-directory ./moongate \
+  --uo-directory /path/to/uo \
   --loglevel Information
 ```
 

--- a/docs/articles/getting-started/quickstart.md
+++ b/docs/articles/getting-started/quickstart.md
@@ -28,8 +28,8 @@ You must provide UO directory (CLI or env var).
 
 ```bash
 dotnet run --project src/Moongate.Server -- \
-  --rootDirectory ./moongate \
-  --uoDirectory /path/to/uo
+  --root-directory ./moongate \
+  --uo-directory /path/to/uo
 ```
 
 Or with env var:
@@ -118,7 +118,7 @@ docker run --rm -it \
 
 ## Troubleshooting
 
-- If startup fails with UO directory error, set `--uoDirectory` or `MOONGATE_UO_DIRECTORY`.
+- If startup fails with UO directory error, set `--uo-directory` or `MOONGATE_UO_DIRECTORY`.
 - If ports are busy, stop conflicting process or remap ports.
 
 ---


### PR DESCRIPTION
- replace rootDirectory/uoDirectory examples with root-directory/uo-directory

- update configuration reference for current Program command signature

- update troubleshooting/install notes to match actual CLI flags