### PR TITLE
feat: add combat system v1

### DIFF
--- a/docs/articles/getting-started/introduction.md
+++ b/docs/articles/getting-started/introduction.md
@@ -115,7 +115,7 @@ Moongate v2 is **actively in development**. The following features are implement
 
 ### Planned
 
-- [ ] Combat mechanics
+- [x] Combat v1 baseline (melee auto-attack, combatant state, warmode, timer-wheel scheduling)
 - [ ] Skill system
 - [ ] Item system completion (vendor/trade/economy semantics)
 - [ ] House/shelter system

--- a/docs/articles/networking/packet-reference/0x05.md
+++ b/docs/articles/networking/packet-reference/0x05.md
@@ -16,7 +16,17 @@ Do not edit manually. Re-run the generator instead.
 
 ## Current Moongate Behavior
 
-Moongate currently has packet classes for this opcode.
+`RequestAttackPacket` is now wired to `RequestAttackHandler -> CombatService`.
+
+Current behavior:
+
+- resolves the requested defender serial
+- sets `CombatantId` on the attacker
+- forces warmode on the attacker
+- schedules the first melee swing through `ITimerService` / `TimerWheelService`
+- sends outbound `0xAA Change Combatant` to the attacker client
+
+The actual region/map harmful-action gate is evaluated later, when the scheduled swing tries to resolve.
 
 ## Packet Build
 

--- a/docs/articles/networking/packet-reference/0x2F.md
+++ b/docs/articles/networking/packet-reference/0x2F.md
@@ -4,7 +4,7 @@ Do not edit manually. Re-run the generator instead.
 -->
 # Fight Occuring (0x2F)
 
-- Status: `placeholder`
+- Status: `implemented`
 - Direction: `Server`
 - Length: `10 bytes`
 - POL reference: <https://docs.polserver.com/packets/index.php?Packet=0x2F>
@@ -12,11 +12,18 @@ Do not edit manually. Re-run the generator instead.
 
 ## Moongate Packet Classes
 
-- None yet
+- `FightOccurringPacket` (Outgoing, Fixed, length `10`) from `src/Moongate.Network.Packets/Outgoing/Combat/FightOccurringPacket.cs`
 
 ## Current Moongate Behavior
 
-Moongate does not currently implement this opcode. This page is a placeholder generated from the POL catalog.
+Moongate emits this packet from `CombatService` when a scheduled melee swing is attempted.
+
+Current behavior:
+
+- sent to nearby players through the spatial broadcast path
+- carries attacker and defender serials
+- used together with server-side hit/damage resolution
+- region harmful-action checks happen before this packet is emitted
 
 ## Packet Build
 

--- a/docs/articles/networking/packet-reference/0xAA.md
+++ b/docs/articles/networking/packet-reference/0xAA.md
@@ -4,7 +4,7 @@ Do not edit manually. Re-run the generator instead.
 -->
 # Allow/Refuse Attack (0xAA)
 
-- Status: `placeholder`
+- Status: `implemented`
 - Direction: `Server`
 - Length: `5 Bytes`
 - POL reference: <https://docs.polserver.com/packets/index.php?Packet=0xAA>
@@ -12,11 +12,17 @@ Do not edit manually. Re-run the generator instead.
 
 ## Moongate Packet Classes
 
-- None yet
+- `ChangeCombatantPacket` (Outgoing, Fixed, length `5`) from `src/Moongate.Network.Packets/Outgoing/Combat/ChangeCombatantPacket.cs`
 
 ## Current Moongate Behavior
 
-Moongate does not currently implement this opcode. This page is a placeholder generated from the POL catalog.
+Moongate emits this packet when combat target state changes.
+
+Current behavior:
+
+- attacker receives defender serial when `CombatService.TrySetCombatantAsync(...)` succeeds
+- attacker receives `Serial.Zero` when combat target is cleared
+- `CharacterHandler` also clears the combatant when the player explicitly turns war mode off
 
 ## Packet Build
 

--- a/docs/articles/networking/packet-reference/index.md
+++ b/docs/articles/networking/packet-reference/index.md
@@ -51,7 +51,7 @@ Generated packet pages: `201`
 | `0x2C` | Resurrection Menu | `implemented` | Both | 2 bytes | ResurrectionMenuPacket | [0x2C.md](0x2C.md) |
 | `0x2D` | Mob Attributes | `placeholder` | Server | 17 bytes | None | [0x2D.md](0x2D.md) |
 | `0x2E` | Worn Item | `implemented` | Server | 15 bytes | WornItemPacket | [0x2E.md](0x2E.md) |
-| `0x2F` | Fight Occuring | `placeholder` | Server | 10 bytes | None | [0x2F.md](0x2F.md) |
+| `0x2F` | Fight Occuring | `implemented` | Server | 10 bytes | FightOccurringPacket | [0x2F.md](0x2F.md) |
 | `0x30` | Attack Ok | `placeholder` | Server | 5 | None | [0x30.md](0x30.md) |
 | `0x31` | Attack Ended | `placeholder` | Server | 1 byte | None | [0x31.md](0x31.md) |
 | `0x32` | Unknown | `placeholder` | Server | 2 Bytes | None | [0x32.md](0x32.md) |
@@ -147,7 +147,7 @@ Generated packet pages: `201`
 | `0xA7` | Request Tip/Notice Window | `implemented` | Client | 4 Bytes | RequestTipNoticeWindowPacket | [0xA7.md](0xA7.md) |
 | `0xA8` | Game Server List | `implemented` | Server | Variable | ServerListPacket | [0xA8.md](0xA8.md) |
 | `0xA9` | Characters / Starting Locations | `implemented` | Server | Variable | CharactersStartingLocationsPacket | [0xA9.md](0xA9.md) |
-| `0xAA` | Allow/Refuse Attack | `placeholder` | Server | 5 Bytes | None | [0xAA.md](0xAA.md) |
+| `0xAA` | Allow/Refuse Attack | `implemented` | Server | 5 Bytes | ChangeCombatantPacket | [0xAA.md](0xAA.md) |
 | `0xAB` | Gump Text Entry Dialog | `placeholder` | Server | Variable | None | [0xAB.md](0xAB.md) |
 | `0xAC` | Gump Text Entry Dialog Reply | `placeholder` | Client | Variable | None | [0xAC.md](0xAC.md) |
 | `0xAD` | Unicode/Ascii speech request | `implemented` | Client | Variable | UnicodeSpeechPacket | [0xAD.md](0xAD.md) |

--- a/docs/articles/networking/packets.md
+++ b/docs/articles/networking/packets.md
@@ -97,6 +97,7 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0xD6` | Mega Cliloc | C -> S | `MegaClilocPacket` | `handler` | `ToolTipHandler` | Tooltip requests |
 | `0xB1` | Gump Menu Selection | C -> S | `GumpMenuSelectionPacket` | `handler` | `GumpHandler` | Gump button replies |
 | `0x9B` | Request Help | C -> S | `RequestHelpPacket` | `handler` | `HelpHandler -> HelpRequestService` | Opens the Lua custom help gump |
+| `0x05` | Request Attack | C -> S | `RequestAttackPacket` | `handler` | `RequestAttackHandler -> CombatService` | Sets combatant, forces warmode, schedules melee swing |
 | `0x06` | Double Click | C -> S | `DoubleClickPacket` | `handler` | `ItemHandler -> ItemInteractionService` | Item use / open flows |
 | `0x09` | Single Click | C -> S | `SingleClickPacket` | `handler` | `ItemHandler -> ItemInteractionService` | Labels / tooltip-side behavior |
 | `0x07` | Pick Up Item | C -> S | `PickUpItemPacket` | `handler` | `ItemHandler -> ItemManipulationService` | Drag start |
@@ -125,6 +126,8 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0x3C` | Add Multiple Items To Container | S -> C | `AddMultipleItemsToContainerPacket` | `outgoing` | container flow | Batched contents |
 | `0x88` | Paperdoll | S -> C | `PaperdollPacket` | `outgoing` | character UI | Paperdoll open |
 | `0x11` | Status Bar Info | S -> C | `PlayerStatusPacket` | `outgoing` | `PlayerStatusHandler` | Modern `7.x` status payload |
+| `0x2F` | Fight Occuring | S -> C | `FightOccurringPacket` | `outgoing` | `CombatService` | Broadcast when a scheduled melee swing is attempted |
+| `0xAA` | Allow/Refuse Attack | S -> C | `ChangeCombatantPacket` | `outgoing` | `CombatService` | Current combatant serial or `Serial.Zero` |
 | `0xB2` | Chat Command | S -> C | `ChatCommandPacket` | `outgoing` | `ChatSystemService` | Classic conference chat responses and UI updates |
 | `0x3A` | Send Skills | S -> C | `SkillListPacket` | `outgoing` | `PlayerStatusHandler` | Full skill list with lock state |
 | `0x23` | Dragging Of Item | S -> C | `DraggingOfItemPacket` | `outgoing` | item drag flow | Drag visual |

--- a/docs/articles/networking/pol-packet-coverage.md
+++ b/docs/articles/networking/pol-packet-coverage.md
@@ -93,7 +93,7 @@ It is meant for gap analysis against the POL packet catalog, not just for docume
 | `0x00` | Legacy create character | C -> S | `?Packet=0x00` | `CreateCharacterPacket` | `parse-only` | Legacy character creation path is not wired |
 | `0x01` | Disconnect notification | C -> S | `?Packet=0x01` | `DisconnectNotificationPacket` | `parse-only` | Session shutdown is not modeled via gameplay listener |
 | `0x03` | Talk request | C -> S | `?Packet=0x03` | `TalkRequestPacket` | `parse-only` | Legacy speech path not wired; Unicode path is used |
-| `0x05` | Request attack | C -> S | `?Packet=0x05` | `RequestAttackPacket` | `parse-only` | No combat targeting flow yet |
+| `0x05` | Request attack | C -> S | `?Packet=0x05` | `RequestAttackPacket` | `handler` | `RequestAttackHandler -> CombatService` | Sets combatant, enters warmode, schedules melee swing |
 | `0x12` | Skill or action use request | C -> S | `?Packet=0x12` | `RequestSkillUsePacket` | `parse-only` | Skill-use flow still missing |
 | `0x2C` | Resurrection menu | both | `?Packet=0x2C` | `ResurrectionMenuPacket` | `parse-only` | No resurrect handler yet |
 | `0x3B` | Buy items | C -> S | `?Packet=0x3B` | `BuyItemsPacket` | `parse-only` | Vendor buy flow missing |
@@ -152,7 +152,7 @@ This section intentionally includes older or lower-priority packets so opcode ra
 | `0x2A` | Blood | S -> C | `?Packet=0x2A` | `missing` | No blood effect packet |
 | `0x2B` | God mode / path packet family | S -> C | `?Packet=0x2B` | `missing` | Not targeted |
 | `0x2D` | Mobile attributes | S -> C | `?Packet=0x2D` | `missing` | No dedicated mob-attributes packet |
-| `0x2F` | Fight occurring | S -> C | `?Packet=0x2F` | `missing` | Combat animation/status flow incomplete |
+| `0x2F` | Fight occurring | S -> C | `?Packet=0x2F` | `FightOccurringPacket` | `outgoing` | `CombatService` | Sent when a scheduled melee swing is attempted |
 | `0x30` | Attack ok | S -> C | `?Packet=0x30` | `missing` | Combat target confirmation not implemented |
 | `0x31` | Attack ended | S -> C | `?Packet=0x31` | `missing` | Combat target clear not implemented |
 | `0x32` | Legacy unknown | S -> C | `?Packet=0x32` | `missing` | Left undocumented/unused in Moongate |
@@ -207,7 +207,7 @@ This section intentionally includes older or lower-priority packets so opcode ra
 | `0xA3` | Client prompt / speech family | S -> C | `?Packet=0xA3` | `missing` | Not modeled |
 | `0xA5` | Open web browser | S -> C | `?Packet=0xA5` | `missing` | Not used |
 | `0xA6` | Tip window | S -> C | `?Packet=0xA6` | `missing` | Tip UI absent |
-| `0xAA` | Open paperdoll alt / skill family | S -> C | `?Packet=0xAA` | `missing` | Not modeled |
+| `0xAA` | Allow/refuse attack | S -> C | `?Packet=0xAA` | `ChangeCombatantPacket` | `outgoing` | `CombatService` | Current combatant serial or `Serial.Zero` |
 | `0xAB` | Text entry dialog | S -> C | `?Packet=0xAB` | `missing` | Text entry flow absent |
 | `0xAC` | Server list alt / game family | S -> C | `?Packet=0xAC` | `missing` | Not modeled |
 | `0xAF` | Death animation | S -> C | `?Packet=0xAF` | `missing` | Packet class exists in Moongate, but no documented runtime flow yet |

--- a/docs/articles/scripting/modules.md
+++ b/docs/articles/scripting/modules.md
@@ -13,6 +13,7 @@ The following modules are available in the default server runtime:
 - `log`
 - `command`
 - `speech`
+- `combat`
 - `mobile`
 - `item`
 - `door`
@@ -42,6 +43,14 @@ local npc = mobile.get(serial)
 if npc then
   npc:SetEffect(0x3728, 10, 10, 0, 0, 2023)
 end
+```
+
+`combat` runtime helpers:
+
+```lua
+combat.set_target(npcSerial, targetSerial) -- hands control to the server combat loop
+combat.clear_target(npcSerial)             -- clears combatant and pending swing
+combat.swing(npcSerial, targetSerial)      -- animation helper only, not authoritative combat
 ```
 
 `gump` supports two modes:

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -91,7 +91,15 @@ Current core modules for behavior scripts:
 
 - `perception` (distance, nearby friend/enemy lookup, range checks)
 - `steering` (follow/evade/wander/stop movement primitives)
-- `combat` (targeting and swing hooks)
+- `combat` (target selection into the server combat loop; `set_target` / `clear_target`)
+
+`combat.set_target(...)` does not calculate hit or damage in Lua.
+It delegates to `CombatService`, which owns:
+
+- warmode and `CombatantId`
+- swing scheduling through `TimerWheelService`
+- melee hit/damage resolution
+- region/map harmful-action gate on actual attack attempt
 - `npc_state` (typed state variables)
 - `time`, `random`, `mobile` (general runtime helpers)
 

--- a/moongate_data/templates/mobiles/undead.json
+++ b/moongate_data/templates/mobiles/undead.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "mobile",
+    "id": "zombie_npc",
+    "category": "monster",
+    "description": "Static zombie template for spawn and combat testing.",
+    "tags": [
+      "monster",
+      "undead",
+      "zombie",
+      "test"
+    ],
+    "body": "0x0003",
+    "skinHue": 0,
+    "hairHue": 0,
+    "hairStyle": 0,
+    "strength": 58,
+    "dexterity": 40,
+    "intelligence": 33,
+    "hits": 35,
+    "mana": 0,
+    "stamina": 40,
+    "minDamage": 3,
+    "maxDamage": 7,
+    "armorRating": 18,
+    "fame": 600,
+    "karma": -600,
+    "notoriety": "Enemy",
+    "brain": "None",
+    "fixedEquipment": [],
+    "randomEquipment": [],
+    "title": "a zombie"
+  }
+]

--- a/src/Moongate.Network.Packets/Incoming/Interaction/RequestAttackPacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/Interaction/RequestAttackPacket.cs
@@ -12,9 +12,20 @@ namespace Moongate.Network.Packets.Incoming.Interaction;
 /// </summary>
 public class RequestAttackPacket : BaseGameNetworkPacket
 {
+    public uint TargetId { get; private set; }
+
     public RequestAttackPacket()
         : base(0x05, 5) { }
 
     protected override bool ParsePayload(ref SpanReader reader)
-        => true;
+    {
+        if (reader.Remaining != 4)
+        {
+            return false;
+        }
+
+        TargetId = reader.ReadUInt32();
+
+        return reader.Remaining == 0;
+    }
 }

--- a/src/Moongate.Network.Packets/Outgoing/Combat/ChangeCombatantPacket.cs
+++ b/src/Moongate.Network.Packets/Outgoing/Combat/ChangeCombatantPacket.cs
@@ -1,0 +1,40 @@
+using Moongate.Network.Packets.Base;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Network.Packets.Outgoing.Combat;
+
+/// <summary>
+/// Outbound change-combatant packet (opcode 0xAA).
+/// </summary>
+public sealed class ChangeCombatantPacket : BaseGameNetworkPacket
+{
+    public Serial CombatantId { get; set; } = Serial.Zero;
+
+    public ChangeCombatantPacket()
+        : base(0xAA, 5) { }
+
+    public ChangeCombatantPacket(Serial combatantId)
+        : this()
+    {
+        CombatantId = combatantId;
+    }
+
+    public override void Write(ref SpanWriter writer)
+    {
+        writer.Write(OpCode);
+        writer.Write(CombatantId.Value);
+    }
+
+    protected override bool ParsePayload(ref SpanReader reader)
+    {
+        if (reader.Remaining != 4)
+        {
+            return false;
+        }
+
+        CombatantId = (Serial)reader.ReadUInt32();
+
+        return reader.Remaining == 0;
+    }
+}

--- a/src/Moongate.Network.Packets/Outgoing/Combat/FightOccurringPacket.cs
+++ b/src/Moongate.Network.Packets/Outgoing/Combat/FightOccurringPacket.cs
@@ -1,0 +1,47 @@
+using Moongate.Network.Packets.Base;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Network.Packets.Outgoing.Combat;
+
+/// <summary>
+/// Outbound swing notification packet (opcode 0x2F).
+/// </summary>
+public sealed class FightOccurringPacket : BaseGameNetworkPacket
+{
+    public Serial AttackerId { get; set; } = Serial.Zero;
+
+    public Serial DefenderId { get; set; } = Serial.Zero;
+
+    public FightOccurringPacket()
+        : base(0x2F, 10) { }
+
+    public FightOccurringPacket(Serial attackerId, Serial defenderId)
+        : this()
+    {
+        AttackerId = attackerId;
+        DefenderId = defenderId;
+    }
+
+    public override void Write(ref SpanWriter writer)
+    {
+        writer.Write(OpCode);
+        writer.Write((byte)0);
+        writer.Write(AttackerId.Value);
+        writer.Write(DefenderId.Value);
+    }
+
+    protected override bool ParsePayload(ref SpanReader reader)
+    {
+        if (reader.Remaining != 9)
+        {
+            return false;
+        }
+
+        _ = reader.ReadByte();
+        AttackerId = (Serial)reader.ReadUInt32();
+        DefenderId = (Serial)reader.ReadUInt32();
+
+        return reader.Remaining == 0;
+    }
+}

--- a/src/Moongate.Server/Data/Events/Combat/CombatAttemptEvent.cs
+++ b/src/Moongate.Server/Data/Events/Combat/CombatAttemptEvent.cs
@@ -1,0 +1,43 @@
+using Moongate.Server.Data.Events.Base;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Data.Events.Combat;
+
+/// <summary>
+/// Raised when the combat loop evaluates whether an attack attempt is allowed in the current region/map context.
+/// </summary>
+public readonly record struct CombatAttemptEvent(
+    GameEventBase BaseEvent,
+    Serial AttackerId,
+    Serial DefenderId,
+    int MapId,
+    Point3D Location,
+    string? RegionName,
+    bool IsGuardedRegion,
+    bool Allowed,
+    string? BlockedReason
+) : IGameEvent
+{
+    public CombatAttemptEvent(
+        Serial attackerId,
+        Serial defenderId,
+        int mapId,
+        Point3D location,
+        string? regionName,
+        bool isGuardedRegion,
+        bool allowed,
+        string? blockedReason
+    )
+        : this(
+            GameEventBase.CreateNow(),
+            attackerId,
+            defenderId,
+            mapId,
+            location,
+            regionName,
+            isGuardedRegion,
+            allowed,
+            blockedReason
+        ) { }
+}

--- a/src/Moongate.Server/Data/Events/Combat/CombatHitEvent.cs
+++ b/src/Moongate.Server/Data/Events/Combat/CombatHitEvent.cs
@@ -1,0 +1,30 @@
+using Moongate.Server.Data.Events.Base;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Server.Data.Events.Combat;
+
+/// <summary>
+/// Raised when a scheduled melee swing hits and applies damage.
+/// </summary>
+public readonly record struct CombatHitEvent(
+    GameEventBase BaseEvent,
+    Serial AttackerId,
+    Serial DefenderId,
+    int MapId,
+    Point3D Location,
+    int Damage,
+    UOMobileEntity Defender
+) : IGameEvent
+{
+    public CombatHitEvent(
+        Serial attackerId,
+        Serial defenderId,
+        int mapId,
+        Point3D location,
+        int damage,
+        UOMobileEntity defender
+    )
+        : this(GameEventBase.CreateNow(), attackerId, defenderId, mapId, location, damage, defender) { }
+}

--- a/src/Moongate.Server/Data/Events/Combat/CombatMissEvent.cs
+++ b/src/Moongate.Server/Data/Events/Combat/CombatMissEvent.cs
@@ -1,0 +1,25 @@
+using Moongate.Server.Data.Events.Base;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Data.Events.Combat;
+
+/// <summary>
+/// Raised when a scheduled melee swing resolves as a miss.
+/// </summary>
+public readonly record struct CombatMissEvent(
+    GameEventBase BaseEvent,
+    Serial AttackerId,
+    Serial DefenderId,
+    int MapId,
+    Point3D Location
+) : IGameEvent
+{
+    public CombatMissEvent(
+        Serial attackerId,
+        Serial defenderId,
+        int mapId,
+        Point3D location
+    )
+        : this(GameEventBase.CreateNow(), attackerId, defenderId, mapId, location) { }
+}

--- a/src/Moongate.Server/Data/Internal/Entities/LuaMobileProxy.cs
+++ b/src/Moongate.Server/Data/Internal/Entities/LuaMobileProxy.cs
@@ -76,7 +76,10 @@ public sealed class LuaMobileProxy
         => _ = spellId;
 
     public void ClearTarget()
-        => _target = null;
+    {
+        _target = null;
+        Mobile.CombatantId = Moongate.UO.Data.Ids.Serial.Zero;
+    }
 
     public bool DisableWar()
     {
@@ -203,7 +206,7 @@ public sealed class LuaMobileProxy
     }
 
     public bool HasTarget()
-        => _target is not null;
+        => Mobile.CombatantId != Moongate.UO.Data.Ids.Serial.Zero || _target is not null;
 
     public bool IsAlive()
         => Mobile.IsAlive;
@@ -418,7 +421,10 @@ public sealed class LuaMobileProxy
     }
 
     public void SetTarget(LuaMobileProxy? target)
-        => _target = target;
+    {
+        _target = target;
+        Mobile.CombatantId = target?.Mobile.Id ?? Moongate.UO.Data.Ids.Serial.Zero;
+    }
 
     public bool SetWarMode(bool isEnabled)
         => isEnabled ? EnableWar() : DisableWar();

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -106,6 +106,7 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<IBulletinBoardService, BulletinBoardService>(Reuse.Singleton);
         container.Register<IContextMenuService, ContextMenuService>(Reuse.Singleton);
         container.Register<IHelpRequestService, HelpRequestService>(Reuse.Singleton);
+        container.Register<ICombatService, CombatService>(Reuse.Singleton);
         container.Register<IPlayerSellBuyService, PlayerSellBuyService>(Reuse.Singleton);
         container.Register<IItemScriptDispatcher, ItemScriptDispatcher>(Reuse.Singleton);
         container.Register<IGumpScriptDispatcherService, GumpScriptDispatcherService>(Reuse.Singleton);

--- a/src/Moongate.Server/Handlers/CharacterHandler.cs
+++ b/src/Moongate.Server/Handlers/CharacterHandler.cs
@@ -15,6 +15,7 @@ using Moongate.Server.Interfaces.Characters;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.EvenLoop;
 using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Interaction;
 using Moongate.Server.Interfaces.Services.Packets;
 using Moongate.Server.Interfaces.Services.Sessions;
 using Moongate.Server.Interfaces.Services.Spatial;
@@ -43,6 +44,7 @@ public class CharacterHandler : BasePacketListener, IGameEventListener<Character
     private readonly IGameEventBusService _gameEventBusService;
 
     private readonly ISpatialWorldService _spatialWorldService;
+    private readonly ICombatService? _combatService;
     private readonly ILightService? _lightService;
     private readonly IBackgroundJobService _backgroundJobService;
 
@@ -53,6 +55,7 @@ public class CharacterHandler : BasePacketListener, IGameEventListener<Character
         IGameEventBusService gameEventBusService,
         IGameNetworkSessionService gameNetworkSessionService,
         ISpatialWorldService spatialWorldService,
+        ICombatService? combatService = null,
         ILightService? lightService = null,
         IBackgroundJobService? backgroundJobService = null
     ) : base(outgoingPacketQueue)
@@ -62,6 +65,7 @@ public class CharacterHandler : BasePacketListener, IGameEventListener<Character
         _gameEventBusService = gameEventBusService;
         _gameNetworkSessionService = gameNetworkSessionService;
         _spatialWorldService = spatialWorldService;
+        _combatService = combatService;
         _lightService = lightService;
         _backgroundJobService = backgroundJobService ?? throw new ArgumentNullException(nameof(backgroundJobService));
 
@@ -202,6 +206,12 @@ public class CharacterHandler : BasePacketListener, IGameEventListener<Character
         }
 
         session.Character.IsWarMode = requestWarModePacket.IsWarMode;
+
+        if (!requestWarModePacket.IsWarMode)
+        {
+            _combatService?.ClearCombatantAsync(session.Character.Id).GetAwaiter().GetResult();
+        }
+
         Enqueue(session, new WarModePacket(session.Character));
 
         return true;

--- a/src/Moongate.Server/Handlers/CombatHitStatusRefreshHandler.cs
+++ b/src/Moongate.Server/Handlers/CombatHitStatusRefreshHandler.cs
@@ -1,0 +1,64 @@
+using Moongate.Abstractions.Interfaces.Services.Base;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Events.Combat;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Server.Handlers;
+
+[RegisterGameEventListener]
+public sealed class CombatHitStatusRefreshHandler : IGameEventListener<CombatHitEvent>, IMoongateService
+{
+    private readonly ISpatialWorldService _spatialWorldService;
+    private readonly IOutgoingPacketQueue _outgoingPacketQueue;
+
+    public CombatHitStatusRefreshHandler(
+        ISpatialWorldService spatialWorldService,
+        IOutgoingPacketQueue outgoingPacketQueue
+    )
+    {
+        _spatialWorldService = spatialWorldService;
+        _outgoingPacketQueue = outgoingPacketQueue;
+    }
+
+    public Task HandleAsync(CombatHitEvent gameEvent, CancellationToken cancellationToken = default)
+    {
+        _ = cancellationToken;
+
+        var defender = gameEvent.Defender;
+
+        if (defender.IsPlayer)
+        {
+            return Task.CompletedTask;
+        }
+
+        var candidates = _spatialWorldService.GetPlayersInRange(
+            defender.Location,
+            MapSectorConsts.MaxViewRange,
+            defender.MapId
+        );
+
+        foreach (var session in candidates)
+        {
+            if (session.Character is null ||
+                session.Character.MapId != defender.MapId ||
+                !session.Character.Location.InRange(defender.Location, session.ViewRange))
+            {
+                continue;
+            }
+
+            _outgoingPacketQueue.Enqueue(session.SessionId, new PlayerStatusPacket(defender, 1));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StartAsync()
+        => Task.CompletedTask;
+
+    public Task StopAsync()
+        => Task.CompletedTask;
+}

--- a/src/Moongate.Server/Handlers/RequestAttackHandler.cs
+++ b/src/Moongate.Server/Handlers/RequestAttackHandler.cs
@@ -1,0 +1,39 @@
+using Moongate.Network.Packets.Data.Packets;
+using Moongate.Network.Packets.Incoming.Interaction;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Listeners.Base;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Handlers;
+
+[RegisterPacketHandler(PacketDefinition.RequestAttackPacket)]
+
+/// <summary>
+/// Handles player attack-target selection.
+/// </summary>
+public sealed class RequestAttackHandler : BasePacketListener
+{
+    private readonly ICombatService _combatService;
+
+    public RequestAttackHandler(IOutgoingPacketQueue outgoingPacketQueue, ICombatService combatService)
+        : base(outgoingPacketQueue)
+    {
+        _combatService = combatService;
+    }
+
+    protected override async Task<bool> HandleCoreAsync(GameSession session, IGameNetworkPacket packet)
+    {
+        if (packet is not RequestAttackPacket requestAttackPacket || session.CharacterId == Serial.Zero)
+        {
+            return true;
+        }
+
+        _ = await _combatService.TrySetCombatantAsync(session.CharacterId, (Serial)requestAttackPacket.TargetId);
+
+        return true;
+    }
+}

--- a/src/Moongate.Server/Interfaces/Services/Interaction/ICombatService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/ICombatService.cs
@@ -1,0 +1,19 @@
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Interfaces.Services.Interaction;
+
+/// <summary>
+/// Coordinates melee combat targeting and swing resolution.
+/// </summary>
+public interface ICombatService
+{
+    /// <summary>
+    /// Tries to set the defender as the attacker's active combat target and schedule the first swing.
+    /// </summary>
+    Task<bool> TrySetCombatantAsync(Serial attackerId, Serial defenderId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears the attacker's active combat target and pending swing.
+    /// </summary>
+    Task<bool> ClearCombatantAsync(Serial attackerId, CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Server/Modules/CombatModule.cs
+++ b/src/Moongate.Server/Modules/CombatModule.cs
@@ -1,6 +1,7 @@
 using Moongate.Scripting.Attributes.Scripts;
 using Moongate.Server.Data.Events.Characters;
 using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Interaction;
 using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Modules.Internal;
 using Moongate.UO.Data.Utils;
@@ -14,17 +15,19 @@ namespace Moongate.Server.Modules;
 /// </summary>
 public sealed class CombatModule
 {
-    private const string TargetSerialKey = "ai_target_serial";
     private readonly ISpatialWorldService _spatialWorldService;
     private readonly IGameEventBusService _gameEventBusService;
+    private readonly ICombatService _combatService;
 
     public CombatModule(
         ISpatialWorldService spatialWorldService,
-        IGameEventBusService gameEventBusService
+        IGameEventBusService gameEventBusService,
+        ICombatService combatService
     )
     {
         _spatialWorldService = spatialWorldService;
         _gameEventBusService = gameEventBusService;
+        _combatService = combatService;
     }
 
     [ScriptFunction("cast", "Spell cast primitive placeholder. Returns false when no cast is executed.")]
@@ -46,7 +49,7 @@ public sealed class CombatModule
             return false;
         }
 
-        return npc!.RemoveCustomProperty(TargetSerialKey);
+        return _combatService.ClearCombatantAsync(npc!.Id).GetAwaiter().GetResult();
     }
 
     [ScriptFunction("set_target", "Sets combat target serial for the given npc.")]
@@ -59,9 +62,9 @@ public sealed class CombatModule
             return false;
         }
 
-        npc!.SetCustomInteger(TargetSerialKey, targetSerial);
-
-        return true;
+        return _combatService.TrySetCombatantAsync(npc!.Id, (Moongate.UO.Data.Ids.Serial)targetSerial)
+                             .GetAwaiter()
+                             .GetResult();
     }
 
     [ScriptFunction("swing", "Broadcasts a swing animation intent when target is in melee range.")]

--- a/src/Moongate.Server/Services/Interaction/CombatService.cs
+++ b/src/Moongate.Server/Services/Interaction/CombatService.cs
@@ -1,0 +1,436 @@
+using Moongate.Network.Packets.Outgoing.Combat;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Network.Packets.Outgoing.World;
+using Moongate.Server.Data.Events.Characters;
+using Moongate.Server.Data.Events.Combat;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Interfaces.Services.Timing;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Server.Services.Interaction;
+
+/// <summary>
+/// Default melee combat orchestrator for player and NPC auto-attacks.
+/// </summary>
+public sealed class CombatService : ICombatService
+{
+    private const int MeleeRange = 1;
+    private const int DefaultMinDamage = 1;
+    private const int DefaultMaxDamage = 4;
+    private const int DefaultAttackSpeed = 30;
+    private static readonly TimeSpan AggressorTimeout = TimeSpan.FromMinutes(2);
+
+    private readonly IMobileService _mobileService;
+    private readonly IGameNetworkSessionService _gameNetworkSessionService;
+    private readonly IOutgoingPacketQueue _outgoingPacketQueue;
+    private readonly ITimerService _timerService;
+    private readonly ISpatialWorldService _spatialWorldService;
+    private readonly IGameEventBusService _gameEventBusService;
+    private readonly Lock _syncRoot = new();
+    private readonly Dictionary<Serial, int> _combatSequences = [];
+
+    public CombatService(
+        IMobileService mobileService,
+        IGameNetworkSessionService gameNetworkSessionService,
+        IOutgoingPacketQueue outgoingPacketQueue,
+        ITimerService timerService,
+        ISpatialWorldService spatialWorldService,
+        IGameEventBusService gameEventBusService
+    )
+    {
+        _mobileService = mobileService;
+        _gameNetworkSessionService = gameNetworkSessionService;
+        _outgoingPacketQueue = outgoingPacketQueue;
+        _timerService = timerService;
+        _spatialWorldService = spatialWorldService;
+        _gameEventBusService = gameEventBusService;
+    }
+
+    public async Task<bool> TrySetCombatantAsync(
+        Serial attackerId,
+        Serial defenderId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (attackerId == Serial.Zero || defenderId == Serial.Zero || attackerId == defenderId)
+        {
+            return false;
+        }
+
+        var attacker = await ResolveMobileAsync(attackerId, cancellationToken);
+        var defender = await ResolveMobileAsync(defenderId, cancellationToken);
+
+        if (attacker is null || defender is null || !attacker.IsAlive || !defender.IsAlive || attacker.MapId != defender.MapId)
+        {
+            return false;
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        attacker.ExpireAggressors(nowUtc, AggressorTimeout);
+        defender.ExpireAggressors(nowUtc, AggressorTimeout);
+        attacker.CombatantId = defender.Id;
+        attacker.Warmode = true;
+
+        var delay = ResolveSwingDelay(attacker);
+        attacker.NextCombatAtUtc = nowUtc.Add(delay);
+
+        await PersistMobileAsync(attacker, cancellationToken);
+        await PublishWarModeChangedAsync(attacker, cancellationToken);
+        SendChangeCombatant(attacker.Id, defender.Id);
+        ScheduleSwing(attacker.Id, delay);
+
+        return true;
+    }
+
+    public async Task<bool> ClearCombatantAsync(Serial attackerId, CancellationToken cancellationToken = default)
+    {
+        if (attackerId == Serial.Zero)
+        {
+            return false;
+        }
+
+        var attacker = await ResolveMobileAsync(attackerId, cancellationToken);
+
+        if (attacker is null)
+        {
+            return false;
+        }
+
+        attacker.ClearCombatState();
+        await PersistMobileAsync(attacker, cancellationToken);
+        CancelSwing(attacker.Id);
+        SendChangeCombatant(attacker.Id, Serial.Zero);
+
+        return true;
+    }
+
+    private void CancelSwing(Serial attackerId)
+    {
+        _timerService.UnregisterTimersByName(GetTimerName(attackerId));
+
+        lock (_syncRoot)
+        {
+            _combatSequences.Remove(attackerId);
+        }
+    }
+
+    private static void ExpireAggressorEntries(UOMobileEntity mobile, DateTime nowUtc)
+        => mobile.ExpireAggressors(nowUtc, AggressorTimeout);
+
+    private static string GetTimerName(Serial attackerId)
+        => $"combat:{(uint)attackerId}";
+
+    private async Task<bool> IsCombatAllowedAsync(
+        UOMobileEntity attacker,
+        UOMobileEntity defender,
+        CancellationToken cancellationToken
+    )
+    {
+        var region = _spatialWorldService.ResolveRegion(attacker.MapId, attacker.Location);
+        var isGuardedRegion = region is JsonGuardedRegion ||
+                              region is JsonTownRegion townRegion && !townRegion.GuardsDisabled;
+        var blockedReason = ResolveBlockedReason(attacker, defender);
+        var allowed = blockedReason is null;
+
+        await _gameEventBusService.PublishAsync(
+            new CombatAttemptEvent(
+                attacker.Id,
+                defender.Id,
+                attacker.MapId,
+                attacker.Location,
+                region?.Name,
+                isGuardedRegion,
+                allowed,
+                blockedReason
+            ),
+            cancellationToken
+        );
+
+        return allowed;
+    }
+
+    private async Task PersistMobileAsync(UOMobileEntity mobile, CancellationToken cancellationToken)
+    {
+        await _mobileService.CreateOrUpdateAsync(mobile, cancellationToken);
+        SyncRuntimeMobile(mobile);
+    }
+
+    private static bool ResolveHit(UOMobileEntity attacker, UOMobileEntity defender)
+        => 50 + attacker.EffectiveHitChanceIncrease >= 50 + defender.EffectiveDefenseChanceIncrease;
+
+    private static string? ResolveBlockedReason(UOMobileEntity attacker, UOMobileEntity defender)
+    {
+        var map = Map.GetMap(attacker.MapId);
+
+        if (map is not null &&
+            map.Rules.HasFlag(MapRules.HarmfulRestrictions) &&
+            defender.Notoriety == Notoriety.Innocent)
+        {
+            return "map_harmful_restrictions";
+        }
+
+        return null;
+    }
+
+    private static int ResolveDamage(UOMobileEntity attacker)
+    {
+        var weapon = ResolveWeapon(attacker);
+        var minDamage = weapon?.CombatStats?.DamageMin ?? attacker.MinWeaponDamage;
+        var maxDamage = weapon?.CombatStats?.DamageMax ?? attacker.MaxWeaponDamage;
+
+        if (minDamage <= 0)
+        {
+            minDamage = DefaultMinDamage;
+        }
+
+        if (maxDamage < minDamage)
+        {
+            maxDamage = minDamage;
+        }
+
+        if (maxDamage == 0)
+        {
+            maxDamage = DefaultMaxDamage;
+        }
+
+        var rolledDamage = Random.Shared.Next(minDamage, maxDamage + 1);
+        var bonusMultiplier = 1.0 + Math.Max(0, attacker.EffectiveDamageIncrease) / 100.0;
+
+        return Math.Max(1, (int)Math.Round(rolledDamage * bonusMultiplier, MidpointRounding.AwayFromZero));
+    }
+
+    private async Task<UOMobileEntity?> ResolveMobileAsync(Serial mobileId, CancellationToken cancellationToken)
+    {
+        if (_gameNetworkSessionService.TryGetByCharacterId(mobileId, out var session) && session.Character is not null)
+        {
+            return session.Character;
+        }
+
+        return await _mobileService.GetAsync(mobileId, cancellationToken);
+    }
+
+    private static UOItemEntity? ResolveWeapon(UOMobileEntity attacker)
+        => attacker.GetEquippedItemsRuntime()
+                   .FirstOrDefault(
+                       item => item.EquippedLayer is ItemLayerType.OneHanded or
+                               ItemLayerType.TwoHanded or
+                               ItemLayerType.FirstValid
+                   );
+
+    private static TimeSpan ResolveSwingDelay(UOMobileEntity attacker)
+    {
+        var weapon = ResolveWeapon(attacker);
+        var attackSpeed = weapon?.CombatStats?.AttackSpeed ?? DefaultAttackSpeed;
+        var speedScale = 1.0 + Math.Max(0, attacker.EffectiveSwingSpeedIncrease) / 100.0;
+        var seconds = Math.Clamp(attackSpeed / 20.0 / speedScale, 0.75, 3.0);
+
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    private void ScheduleSwing(Serial attackerId, TimeSpan delay)
+    {
+        var timerName = GetTimerName(attackerId);
+        _timerService.UnregisterTimersByName(timerName);
+
+        int sequence;
+
+        lock (_syncRoot)
+        {
+            _combatSequences.TryGetValue(attackerId, out var currentSequence);
+            sequence = currentSequence + 1;
+            _combatSequences[attackerId] = sequence;
+        }
+
+        _timerService.RegisterTimer(
+            timerName,
+            delay,
+            () => ExecuteSwingAsync(attackerId, sequence).AsTask().GetAwaiter().GetResult(),
+            delay
+        );
+    }
+
+    private void SendChangeCombatant(Serial attackerId, Serial defenderId)
+    {
+        if (!_gameNetworkSessionService.TryGetByCharacterId(attackerId, out var session))
+        {
+            return;
+        }
+
+        _outgoingPacketQueue.Enqueue(session.SessionId, new ChangeCombatantPacket(defenderId));
+    }
+
+    private async ValueTask PublishWarModeChangedAsync(UOMobileEntity mobile, CancellationToken cancellationToken)
+        => await _gameEventBusService.PublishAsync(new MobileWarModeChangedEvent(mobile), cancellationToken);
+
+    private void SyncRuntimeMobile(UOMobileEntity updatedMobile)
+    {
+        if (_gameNetworkSessionService.TryGetByCharacterId(updatedMobile.Id, out var session))
+        {
+            session.Character = updatedMobile;
+            session.CharacterId = updatedMobile.Id;
+            session.IsMounted = updatedMobile.IsMounted;
+        }
+    }
+
+    private async ValueTask ExecuteSwingAsync(Serial attackerId, int expectedSequence)
+    {
+        lock (_syncRoot)
+        {
+            if (!_combatSequences.TryGetValue(attackerId, out var currentSequence) || currentSequence != expectedSequence)
+            {
+                return;
+            }
+        }
+
+        var attacker = await ResolveMobileAsync(attackerId, CancellationToken.None);
+
+        if (attacker is null || attacker.CombatantId == Serial.Zero || !attacker.IsAlive || !attacker.Warmode)
+        {
+            await ClearCombatantAsync(attackerId);
+            return;
+        }
+
+        var defender = await ResolveMobileAsync(attacker.CombatantId, CancellationToken.None);
+
+        if (defender is null || !defender.IsAlive || attacker.MapId != defender.MapId)
+        {
+            await ClearCombatantAsync(attackerId);
+            return;
+        }
+
+        var delay = ResolveSwingDelay(attacker);
+
+        if (!attacker.Location.InRange(defender.Location, MeleeRange))
+        {
+            attacker.NextCombatAtUtc = DateTime.UtcNow.Add(delay);
+            await PersistMobileAsync(attacker, CancellationToken.None);
+            ScheduleSwing(attacker.Id, delay);
+            return;
+        }
+
+        if (!await IsCombatAllowedAsync(attacker, defender, CancellationToken.None))
+        {
+            await ClearCombatantAsync(attacker.Id);
+            return;
+        }
+
+        await _spatialWorldService.BroadcastToPlayersInUpdateRadiusAsync(
+            new FightOccurringPacket(attacker.Id, defender.Id),
+            attacker.MapId,
+            attacker.Location
+        );
+
+        if (AnimationUtils.TryResolveAnimation(
+                AnimationIntent.SwingPrimary,
+                attacker.Body.Type,
+                attacker.IsMounted,
+                out var animation
+            ))
+        {
+            await _gameEventBusService.PublishAsync(
+                new MobilePlayAnimationEvent(
+                    attacker.Id,
+                    attacker.MapId,
+                    attacker.Location,
+                    animation.Action,
+                    animation.FrameCount,
+                    animation.RepeatCount,
+                    animation.Forward,
+                    animation.Repeat,
+                    animation.Delay
+                )
+            );
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        ExpireAggressorEntries(attacker, nowUtc);
+        ExpireAggressorEntries(defender, nowUtc);
+        RefreshAggression(attacker.Aggressed, attacker.Id, defender.Id, nowUtc);
+        RefreshAggression(defender.Aggressors, attacker.Id, defender.Id, nowUtc);
+        attacker.LastCombatAtUtc = nowUtc;
+        defender.LastCombatAtUtc = nowUtc;
+
+        if (ResolveHit(attacker, defender))
+        {
+            var damage = ResolveDamage(attacker);
+            defender.Hits = Math.Max(0, defender.Hits - damage);
+            defender.IsAlive = defender.Hits > 0;
+
+            await _gameEventBusService.PublishAsync(
+                new CombatHitEvent(
+                    attacker.Id,
+                    defender.Id,
+                    attacker.MapId,
+                    attacker.Location,
+                    damage,
+                    defender
+                )
+            );
+        }
+        else
+        {
+            await _gameEventBusService.PublishAsync(
+                new CombatMissEvent(
+                    attacker.Id,
+                    defender.Id,
+                    attacker.MapId,
+                    attacker.Location
+                )
+            );
+        }
+
+        attacker.NextCombatAtUtc = nowUtc.Add(delay);
+
+        await PersistMobileAsync(attacker, CancellationToken.None);
+        await PersistMobileAsync(defender, CancellationToken.None);
+
+        if (_gameNetworkSessionService.TryGetByCharacterId(defender.Id, out var defenderSession))
+        {
+            _outgoingPacketQueue.Enqueue(defenderSession.SessionId, new PlayerStatusPacket(defender, 1));
+        }
+
+        if (!defender.IsAlive)
+        {
+            await ClearCombatantAsync(attacker.Id);
+            return;
+        }
+
+        ScheduleSwing(attacker.Id, delay);
+    }
+
+    private static void RefreshAggression(
+        List<AggressorInfo> entries,
+        Serial attackerId,
+        Serial defenderId,
+        DateTime nowUtc,
+        bool isCriminal = false,
+        bool canReportMurder = false
+    )
+    {
+        var updatedEntry = new AggressorInfo(attackerId, defenderId, nowUtc, isCriminal, canReportMurder);
+        var index = entries.FindIndex(
+            entry => entry.AttackerId == attackerId &&
+                     entry.DefenderId == defenderId
+        );
+
+        if (index >= 0)
+        {
+            entries[index] = updatedEntry;
+            return;
+        }
+
+        entries.Add(updatedEntry);
+    }
+}

--- a/src/Moongate.UO.Data/Persistence/Entities/AggressorInfo.cs
+++ b/src/Moongate.UO.Data/Persistence/Entities/AggressorInfo.cs
@@ -1,0 +1,14 @@
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.UO.Data.Persistence.Entities;
+
+/// <summary>
+/// Represents a recent aggression relationship between two mobiles.
+/// </summary>
+public readonly record struct AggressorInfo(
+    Serial AttackerId,
+    Serial DefenderId,
+    DateTime LastCombatAtUtc,
+    bool IsCriminal,
+    bool CanReportMurder
+);

--- a/src/Moongate.UO.Data/Persistence/Entities/UOMobileEntity.cs
+++ b/src/Moongate.UO.Data/Persistence/Entities/UOMobileEntity.cs
@@ -304,6 +304,31 @@ public class UOMobileEntity : IMobileEntity
     public int Weight { get; set; }
 
     /// <summary>
+    /// Gets or sets the current combat target.
+    /// </summary>
+    public Serial CombatantId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scheduled next combat resolution time in UTC.
+    /// </summary>
+    public DateTime? NextCombatAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last time this mobile participated in combat in UTC.
+    /// </summary>
+    public DateTime? LastCombatAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets recent incoming aggression records for this mobile.
+    /// </summary>
+    public List<AggressorInfo> Aggressors { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets recent outgoing aggression records for this mobile.
+    /// </summary>
+    public List<AggressorInfo> Aggressed { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the carrying capacity used by the modern status packet.
     /// </summary>
     public int MaxWeight { get; set; }
@@ -499,6 +524,15 @@ public class UOMobileEntity : IMobileEntity
     /// Gets or sets whether the mobile is in war mode.
     /// </summary>
     public bool IsWarMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the legacy warmode alias backed by <see cref="IsWarMode" />.
+    /// </summary>
+    public bool Warmode
+    {
+        get => IsWarMode;
+        set => IsWarMode = value;
+    }
 
     /// <summary>
     /// Gets or sets the hunger level.
@@ -707,6 +741,15 @@ public class UOMobileEntity : IMobileEntity
     /// <param name="item">Equipped item entity.</param>
     public void EquipItem(ItemLayerType layer, UOItemEntity item)
         => AddEquippedItem(layer, item);
+
+    /// <summary>
+    /// Clears the current combat state for this mobile.
+    /// </summary>
+    public void ClearCombatState()
+    {
+        CombatantId = Serial.Zero;
+        NextCombatAtUtc = null;
+    }
 
     /// <summary>
     /// Resolves the current body value, falling back to race defaults when needed.
@@ -957,6 +1000,35 @@ public class UOMobileEntity : IMobileEntity
         {
             RuntimeModifiers = null;
         }
+    }
+
+    /// <summary>
+    /// Refreshes or appends a recent aggression relationship.
+    /// </summary>
+    public void RefreshAggressor(
+        Serial attackerId,
+        Serial defenderId,
+        DateTime nowUtc,
+        bool isCriminal = false,
+        bool canReportMurder = false
+    )
+    {
+        RefreshAggressorList(Aggressors, attackerId, defenderId, nowUtc, isCriminal, canReportMurder);
+        RefreshAggressorList(Aggressed, attackerId, defenderId, nowUtc, isCriminal, canReportMurder);
+    }
+
+    /// <summary>
+    /// Removes expired aggression entries from both aggression collections.
+    /// </summary>
+    public void ExpireAggressors(DateTime nowUtc, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        ExpireAggressorList(Aggressors, nowUtc, timeout);
+        ExpireAggressorList(Aggressed, nowUtc, timeout);
     }
 
     /// <summary>
@@ -1220,6 +1292,31 @@ public class UOMobileEntity : IMobileEntity
         }
 
         return total;
+    }
+
+    private static void ExpireAggressorList(List<AggressorInfo> entries, DateTime nowUtc, TimeSpan timeout)
+        => entries.RemoveAll(entry => nowUtc - entry.LastCombatAtUtc >= timeout);
+
+    private static void RefreshAggressorList(
+        List<AggressorInfo> entries,
+        Serial attackerId,
+        Serial defenderId,
+        DateTime nowUtc,
+        bool isCriminal,
+        bool canReportMurder
+    )
+    {
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (entries[i].AttackerId == attackerId && entries[i].DefenderId == defenderId)
+            {
+                entries[i] = new(attackerId, defenderId, nowUtc, isCriminal, canReportMurder);
+
+                return;
+            }
+        }
+
+        entries.Add(new(attackerId, defenderId, nowUtc, isCriminal, canReportMurder));
     }
 
     private static bool IsZero(MobileModifiers modifiers)

--- a/tests/Moongate.Tests/Network/Packets/ChangeCombatantPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ChangeCombatantPacketTests.cs
@@ -1,0 +1,37 @@
+using System.Buffers.Binary;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Network.Packets.Outgoing.Combat;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Network.Packets;
+
+public sealed class ChangeCombatantPacketTests
+{
+    [Test]
+    public void Write_ShouldSerializeExpectedPayload()
+    {
+        var packet = new ChangeCombatantPacket((Serial)0x00001000u);
+
+        var data = Write(packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(data.Length, Is.EqualTo(5));
+                Assert.That(data[0], Is.EqualTo(0xAA));
+                Assert.That(BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(1, 4)), Is.EqualTo(0x00001000u));
+            }
+        );
+    }
+
+    private static byte[] Write(IGameNetworkPacket packet)
+    {
+        var writer = new SpanWriter(16, true);
+        packet.Write(ref writer);
+        var data = writer.ToArray();
+        writer.Dispose();
+
+        return data;
+    }
+}

--- a/tests/Moongate.Tests/Network/Packets/FightOccurringPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/FightOccurringPacketTests.cs
@@ -1,0 +1,39 @@
+using System.Buffers.Binary;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Network.Packets.Outgoing.Combat;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Network.Packets;
+
+public sealed class FightOccurringPacketTests
+{
+    [Test]
+    public void Write_ShouldSerializeExpectedPayload()
+    {
+        var packet = new FightOccurringPacket((Serial)0x00001000u, (Serial)0x00002000u);
+
+        var data = Write(packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(data.Length, Is.EqualTo(10));
+                Assert.That(data[0], Is.EqualTo(0x2F));
+                Assert.That(data[1], Is.EqualTo(0));
+                Assert.That(BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(2, 4)), Is.EqualTo(0x00001000u));
+                Assert.That(BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(6, 4)), Is.EqualTo(0x00002000u));
+            }
+        );
+    }
+
+    private static byte[] Write(IGameNetworkPacket packet)
+    {
+        var writer = new SpanWriter(16, true);
+        packet.Write(ref writer);
+        var data = writer.ToArray();
+        writer.Dispose();
+
+        return data;
+    }
+}

--- a/tests/Moongate.Tests/Network/Packets/RequestAttackPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/RequestAttackPacketTests.cs
@@ -1,0 +1,35 @@
+using Moongate.Network.Packets.Incoming.Interaction;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Network.Packets;
+
+public sealed class RequestAttackPacketTests
+{
+    [Test]
+    public void TryParse_ShouldReadTargetSerial()
+    {
+        var packet = new RequestAttackPacket();
+        var payload = new byte[] { 0x05, 0x00, 0x00, 0x10, 0x00 };
+
+        var parsed = packet.TryParse(payload);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(parsed, Is.True);
+                Assert.That(packet.TargetId, Is.EqualTo(0x00001000u));
+            }
+        );
+    }
+
+    [Test]
+    public void TryParse_ShouldReturnFalse_WhenLengthIsInvalid()
+    {
+        var packet = new RequestAttackPacket();
+        var payload = new byte[] { 0x05, 0x00, 0x00, 0x10 };
+
+        var parsed = packet.TryParse(payload);
+
+        Assert.That(parsed, Is.False);
+    }
+}

--- a/tests/Moongate.Tests/Server/Data/Internal/Entities/LuaMobileProxyTests.cs
+++ b/tests/Moongate.Tests/Server/Data/Internal/Entities/LuaMobileProxyTests.cs
@@ -1125,4 +1125,59 @@ public sealed class LuaMobileProxyTests
 
         Assert.That(proxy.IsMountable, Is.True);
     }
+
+    [Test]
+    public void SetTarget_ShouldUpdateCombatantStateOnUnderlyingMobile()
+    {
+        var attacker = new UOMobileEntity { Id = (Serial)0x1234u };
+        var defender = new UOMobileEntity { Id = (Serial)0x5678u };
+        var proxy = new LuaMobileProxy(
+            attacker,
+            new LuaMobileProxyTestSpeechService(),
+            new LuaMobileProxyTestGameNetworkSessionService(),
+            new LuaMobileProxyTestSpatialWorldService()
+        );
+        var target = new LuaMobileProxy(
+            defender,
+            new LuaMobileProxyTestSpeechService(),
+            new LuaMobileProxyTestGameNetworkSessionService(),
+            new LuaMobileProxyTestSpatialWorldService()
+        );
+
+        proxy.SetTarget(target);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(proxy.HasTarget(), Is.True);
+                Assert.That(attacker.CombatantId, Is.EqualTo(defender.Id));
+            }
+        );
+    }
+
+    [Test]
+    public void ClearTarget_ShouldResetCombatantStateOnUnderlyingMobile()
+    {
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x1234u,
+            CombatantId = (Serial)0x5678u
+        };
+        var proxy = new LuaMobileProxy(
+            attacker,
+            new LuaMobileProxyTestSpeechService(),
+            new LuaMobileProxyTestGameNetworkSessionService(),
+            new LuaMobileProxyTestSpatialWorldService()
+        );
+
+        proxy.ClearTarget();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(proxy.HasTarget(), Is.False);
+                Assert.That(attacker.CombatantId, Is.EqualTo(Serial.Zero));
+            }
+        );
+    }
 }

--- a/tests/Moongate.Tests/Server/Handlers/CombatHitStatusRefreshHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/CombatHitStatusRefreshHandlerTests.cs
@@ -1,0 +1,117 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Server.Data.Events.Combat;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Handlers;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Tests.Server.Handlers;
+
+public sealed class CombatHitStatusRefreshHandlerTests
+{
+    private sealed class TestSpatialWorldService : RegionDataLoaderTestSpatialWorldService
+    {
+        public List<GameSession> SessionsInRange { get; } = [];
+
+        public override List<GameSession> GetPlayersInRange(
+            Point3D location,
+            int range,
+            int mapId,
+            GameSession? excludeSession = null
+        )
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+            _ = excludeSession;
+
+            return SessionsInRange.ToList();
+        }
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenNpcDefenderIsVisible_ShouldRefreshOnlyVisiblePlayerSessions()
+    {
+        var spatial = new TestSpatialWorldService();
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var handler = new CombatHitStatusRefreshHandler(spatial, outgoing);
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x300,
+            Name = "guard",
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Hits = 34,
+            MaxHits = 40,
+            IsPlayer = false
+        };
+
+        using var nearClient = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        using var farClient = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var nearSession = new GameSession(new(nearClient))
+        {
+            CharacterId = (Serial)0x100,
+            Character = new UOMobileEntity
+            {
+                Id = (Serial)0x100,
+                IsPlayer = true,
+                MapId = 1,
+                Location = new(101, 100, 0)
+            },
+            ViewRange = 18
+        };
+        var farSession = new GameSession(new(farClient))
+        {
+            CharacterId = (Serial)0x200,
+            Character = new UOMobileEntity
+            {
+                Id = (Serial)0x200,
+                IsPlayer = true,
+                MapId = 1,
+                Location = new(150, 150, 0)
+            },
+            ViewRange = 18
+        };
+        spatial.SessionsInRange.Add(nearSession);
+        spatial.SessionsInRange.Add(farSession);
+
+        await handler.HandleAsync(new CombatHitEvent((Serial)0x111, defender.Id, defender.MapId, defender.Location, 6, defender));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(outgoing.TryDequeue(out var first), Is.True);
+                Assert.That(first.SessionId, Is.EqualTo(nearSession.SessionId));
+                Assert.That(first.Packet, Is.TypeOf<PlayerStatusPacket>());
+                Assert.That(((PlayerStatusPacket)first.Packet).Mobile, Is.SameAs(defender));
+                Assert.That(outgoing.CurrentQueueDepth, Is.EqualTo(0));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenDefenderIsPlayer_ShouldDoNothing()
+    {
+        var spatial = new TestSpatialWorldService();
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var handler = new CombatHitStatusRefreshHandler(spatial, outgoing);
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x300,
+            Name = "player",
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Hits = 34,
+            MaxHits = 40,
+            IsPlayer = true
+        };
+
+        await handler.HandleAsync(new CombatHitEvent((Serial)0x111, defender.Id, defender.MapId, defender.Location, 6, defender));
+
+        Assert.That(outgoing.CurrentQueueDepth, Is.EqualTo(0));
+    }
+}

--- a/tests/Moongate.Tests/Server/Handlers/RequestAttackHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/RequestAttackHandlerTests.cs
@@ -1,0 +1,69 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.Interaction;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Handlers;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Server.Handlers;
+
+public sealed class RequestAttackHandlerTests
+{
+    private sealed class RecordingCombatService : ICombatService
+    {
+        public Serial LastAttackerId { get; private set; }
+        public Serial LastDefenderId { get; private set; }
+        public int TrySetCombatantCallCount { get; private set; }
+
+        public Task<bool> ClearCombatantAsync(Serial attackerId, CancellationToken cancellationToken = default)
+        {
+            _ = attackerId;
+            _ = cancellationToken;
+
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> TrySetCombatantAsync(
+            Serial attackerId,
+            Serial defenderId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = cancellationToken;
+            LastAttackerId = attackerId;
+            LastDefenderId = defenderId;
+            TrySetCombatantCallCount++;
+
+            return Task.FromResult(true);
+        }
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_ShouldDelegateToCombatService()
+    {
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var service = new RecordingCombatService();
+        var handler = new RequestAttackHandler(queue, service);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000002u
+        };
+        var packet = new RequestAttackPacket();
+        Assert.That(packet.TryParse(new byte[] { 0x05, 0x00, 0x00, 0x10, 0x00 }), Is.True);
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(service.TrySetCombatantCallCount, Is.EqualTo(1));
+                Assert.That(service.LastAttackerId, Is.EqualTo((Serial)0x00000002u));
+                Assert.That(service.LastDefenderId, Is.EqualTo((Serial)0x00001000u));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/CombatModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/CombatModuleTests.cs
@@ -3,6 +3,7 @@ using Moongate.Server.Data.Events.Base;
 using Moongate.Server.Data.Events.Characters;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Interaction;
 using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Modules;
 using Moongate.UO.Data.Bodies;
@@ -18,6 +19,35 @@ namespace Moongate.Tests.Server.Modules;
 
 public sealed class CombatModuleTests
 {
+    private sealed class RecordingCombatService : ICombatService
+    {
+        public Serial LastAttackerId { get; private set; }
+        public Serial LastDefenderId { get; private set; }
+        public int ClearCalls { get; private set; }
+
+        public Task<bool> ClearCombatantAsync(Serial attackerId, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            LastAttackerId = attackerId;
+            ClearCalls++;
+
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> TrySetCombatantAsync(
+            Serial attackerId,
+            Serial defenderId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = cancellationToken;
+            LastAttackerId = attackerId;
+            LastDefenderId = defenderId;
+
+            return Task.FromResult(true);
+        }
+    }
+
     private sealed class CombatTestGameEventBusService : IGameEventBusService
     {
         public List<IGameEvent> PublishedEvents { get; } = [];
@@ -108,28 +138,27 @@ public sealed class CombatModuleTests
     }
 
     [Test]
-    public void SetTarget_AndClearTarget_ShouldUpdateCustomProperty()
+    public void SetTarget_AndClearTarget_ShouldDelegateToCombatService()
     {
         var spatial = new CombatTestSpatialWorldService();
         var npc = new UOMobileEntity { Id = (Serial)0x401u, MapId = 1, Location = new(100, 100, 0) };
         var target = new UOMobileEntity { Id = (Serial)0x402u, IsPlayer = true, MapId = 1, Location = new(101, 100, 0) };
         spatial.AddMobile(npc);
         spatial.AddMobile(target);
-        var module = new CombatModule(spatial, new CombatTestGameEventBusService());
+        var combatService = new RecordingCombatService();
+        var module = new CombatModule(spatial, new CombatTestGameEventBusService(), combatService);
 
         var set = module.SetTarget((uint)npc.Id, (uint)target.Id);
-        var hasTarget = npc.TryGetCustomInteger("ai_target_serial", out var targetValue);
         var cleared = module.ClearTarget((uint)npc.Id);
-        var hasAfterClear = npc.TryGetCustomInteger("ai_target_serial", out _);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(set, Is.True);
-                Assert.That(hasTarget, Is.True);
-                Assert.That(targetValue, Is.EqualTo((long)(uint)target.Id));
                 Assert.That(cleared, Is.True);
-                Assert.That(hasAfterClear, Is.False);
+                Assert.That(combatService.LastAttackerId, Is.EqualTo(npc.Id));
+                Assert.That(combatService.LastDefenderId, Is.EqualTo(target.Id));
+                Assert.That(combatService.ClearCalls, Is.EqualTo(1));
             }
         );
     }
@@ -152,7 +181,7 @@ public sealed class CombatModuleTests
         spatial.AddMobile(npc);
         spatial.AddMobile(target);
         var eventBus = new CombatTestGameEventBusService();
-        var module = new CombatModule(spatial, eventBus);
+        var module = new CombatModule(spatial, eventBus, new RecordingCombatService());
 
         var swung = module.Swing((uint)npc.Id, (uint)target.Id);
 

--- a/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
@@ -1,0 +1,534 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Network.Packets.Outgoing.Combat;
+using Moongate.Network.Packets.Outgoing.World;
+using Moongate.Server.Data.Events.Base;
+using Moongate.Server.Data.Events.Characters;
+using Moongate.Server.Data.Events.Combat;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Interfaces.Services.Timing;
+using Moongate.Server.Services.Interaction;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Services.Interaction;
+
+public sealed class CombatServiceTests
+{
+    private sealed class TimerServiceSpy : ITimerService
+    {
+        public sealed record RegisteredTimer(
+            string Id,
+            string Name,
+            TimeSpan Interval,
+            TimeSpan? Delay,
+            bool Repeat,
+            Action Callback
+        );
+
+        private int _nextId;
+
+        public List<RegisteredTimer> RegisteredTimers { get; } = [];
+        public List<string> UnregisteredNames { get; } = [];
+
+        public void ProcessTick() { }
+
+        public string RegisterTimer(
+            string name,
+            TimeSpan interval,
+            Action callback,
+            TimeSpan? delay = null,
+            bool repeat = false
+        )
+        {
+            var timer = new RegisteredTimer($"timer-{++_nextId}", name, interval, delay, repeat, callback);
+            RegisteredTimers.Add(timer);
+
+            return timer.Id;
+        }
+
+        public void UnregisterAllTimers()
+            => RegisteredTimers.Clear();
+
+        public bool UnregisterTimer(string timerId)
+        {
+            var removed = RegisteredTimers.RemoveAll(timer => timer.Id == timerId);
+
+            return removed > 0;
+        }
+
+        public int UnregisterTimersByName(string name)
+        {
+            UnregisteredNames.Add(name);
+            return RegisteredTimers.RemoveAll(timer => timer.Name == name);
+        }
+
+        public int UpdateTicksDelta(long timestampMilliseconds)
+        {
+            _ = timestampMilliseconds;
+            return 0;
+        }
+    }
+
+    private sealed class InMemoryMobileService : IMobileService
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = new();
+
+        public void Add(UOMobileEntity mobile)
+            => _mobiles[mobile.Id] = mobile;
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles[mobile.Id] = mobile;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            return Task.FromResult(_mobiles.Remove(id));
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles.TryGetValue(id, out var mobile);
+            return Task.FromResult(mobile);
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+            _ = cancellationToken;
+            return Task.FromResult(new List<UOMobileEntity>());
+        }
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromException<UOMobileEntity>(new NotSupportedException());
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult((false, (UOMobileEntity?)null));
+    }
+
+    private sealed class CombatTestSpatialWorldService : ISpatialWorldService
+    {
+        public JsonRegion? ResolvedRegion { get; set; }
+        public List<IGameNetworkPacket> BroadcastPackets { get; } = [];
+
+        public void AddOrUpdateItem(UOItemEntity item, int mapId) { }
+        public void AddOrUpdateMobile(UOMobileEntity mobile) { }
+        public void AddRegion(JsonRegion region) { }
+
+        public Task<int> BroadcastToPlayersAsync(
+            IGameNetworkPacket packet,
+            int mapId,
+            Point3D location,
+            int? range = null,
+            long? excludeSessionId = null
+        )
+        {
+            _ = mapId;
+            _ = location;
+            _ = range;
+            _ = excludeSessionId;
+            BroadcastPackets.Add(packet);
+            return Task.FromResult(0);
+        }
+
+        public List<MapSector> GetActiveSectors()
+            => [];
+
+        public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
+            => [];
+
+        public int GetMusic(int mapId, Point3D location)
+            => 0;
+
+        public List<UOItemEntity> GetNearbyItems(Point3D location, int range, int mapId)
+            => [];
+
+        public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
+            => [];
+
+        public List<GameSession> GetPlayersInRange(Point3D location, int range, int mapId, GameSession? excludeSession = null)
+            => [];
+
+        public List<UOMobileEntity> GetPlayersInSector(int mapId, int sectorX, int sectorY)
+            => [];
+
+        public JsonRegion? GetRegionById(int regionId)
+            => null;
+
+        public MapSector? GetSectorByLocation(int mapId, Point3D location)
+            => null;
+
+        public SectorSystemStats GetStats()
+            => new();
+
+        public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation) { }
+        public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation) { }
+        public void RemoveEntity(Serial serial) { }
+
+        public JsonRegion? ResolveRegion(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+            return ResolvedRegion;
+        }
+    }
+
+    private sealed class RecordingGameEventBusService : IGameEventBusService
+    {
+        public List<object> Events { get; } = [];
+
+        public ValueTask PublishAsync<TEvent>(TEvent gameEvent, CancellationToken cancellationToken = default)
+            where TEvent : IGameEvent
+        {
+            _ = cancellationToken;
+            Events.Add(gameEvent!);
+            return ValueTask.CompletedTask;
+        }
+
+        public void RegisterListener<TEvent>(IGameEventListener<TEvent> listener) where TEvent : IGameEvent
+            => _ = listener;
+    }
+
+    [Test]
+    public async Task TrySetCombatantAsync_ShouldSetCombatantWarmodeAndScheduleTimer()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000002u,
+            IsPlayer = true,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000003u,
+            MapId = 0,
+            Location = new(101, 100, 0),
+            Hits = 50,
+            MaxHits = 50
+        };
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus
+        );
+
+        var result = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(attacker.CombatantId, Is.EqualTo(defender.Id));
+                Assert.That(attacker.Warmode, Is.True);
+                Assert.That(timerService.RegisteredTimers, Has.Count.EqualTo(1));
+                Assert.That(timerService.RegisteredTimers[0].Name, Is.EqualTo($"combat:{(uint)attacker.Id}"));
+                Assert.That(eventBus.Events.Any(gameEvent => gameEvent is MobileWarModeChangedEvent), Is.True);
+            }
+        );
+
+        Assert.That(outgoingQueue.TryDequeue(out var outgoing), Is.True);
+        Assert.That(outgoing.Packet, Is.TypeOf<ChangeCombatantPacket>());
+        Assert.That(((ChangeCombatantPacket)outgoing.Packet).CombatantId, Is.EqualTo(defender.Id));
+    }
+
+    [Test]
+    public async Task ScheduledSwing_WhenTargetInRange_ShouldBroadcastFightPacketAndApplyDamage()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000002u,
+            IsPlayer = true,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50,
+            MinWeaponDamage = 6,
+            MaxWeaponDamage = 6
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000003u,
+            MapId = 0,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(spatial.BroadcastPackets.Any(packet => packet is FightOccurringPacket), Is.True);
+                Assert.That(defender.Hits, Is.EqualTo(34));
+                Assert.That(attacker.Aggressed, Has.Count.EqualTo(1));
+                Assert.That(defender.Aggressors, Has.Count.EqualTo(1));
+                Assert.That(attacker.LastCombatAtUtc, Is.Not.Null);
+                Assert.That(defender.LastCombatAtUtc, Is.Not.Null);
+                Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatHitEvent), Is.True);
+                Assert.That(timerService.RegisteredTimers, Has.Count.EqualTo(1));
+                Assert.That(timerService.UnregisteredNames, Contains.Item($"combat:{(uint)attacker.Id}"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task ScheduledSwing_WhenHitRollFails_ShouldPublishMissEventWithoutApplyingDamage()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000002u,
+            IsPlayer = true,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50,
+            RuntimeModifiers = new()
+            {
+                HitChanceIncrease = -20
+            },
+            MinWeaponDamage = 6,
+            MaxWeaponDamage = 6
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000003u,
+            MapId = 0,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40,
+            RuntimeModifiers = new()
+            {
+                DefenseChanceIncrease = 25
+            }
+        };
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(spatial.BroadcastPackets.Any(packet => packet is FightOccurringPacket), Is.True);
+                Assert.That(defender.Hits, Is.EqualTo(40));
+                Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatMissEvent), Is.True);
+                Assert.That(attacker.LastCombatAtUtc, Is.Not.Null);
+                Assert.That(defender.LastCombatAtUtc, Is.Not.Null);
+                Assert.That(timerService.RegisteredTimers, Has.Count.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
+    public async Task ScheduledSwing_WhenMapDisallowsHarmfulAction_ShouldClearCombatantAndPublishAttemptEvent()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService
+        {
+            ResolvedRegion = new JsonTownRegion
+            {
+                Type = "TownRegion",
+                Map = "Trammel",
+                Name = "Britain",
+                GuardsDisabled = false
+            }
+        };
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000002u,
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50,
+            Notoriety = Notoriety.Innocent
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000003u,
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40,
+            Notoriety = Notoriety.Innocent
+        };
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(attacker.CombatantId, Is.EqualTo(Serial.Zero));
+                Assert.That(defender.Hits, Is.EqualTo(40));
+                Assert.That(
+                    eventBus.Events.Any(gameEvent => gameEvent.GetType().Name == "CombatAttemptEvent"),
+                    Is.True
+                );
+            }
+        );
+    }
+
+    private static void EnsureMapsRegistered()
+    {
+        if (Map.GetMap(0) is null)
+        {
+            _ = Map.RegisterMap(0, 0, 0, 6144, 4096, SeasonType.Summer, "Felucca", MapRules.FeluccaRules);
+        }
+
+        if (Map.GetMap(1) is null)
+        {
+            _ = Map.RegisterMap(1, 1, 1, 6144, 4096, SeasonType.Summer, "Trammel", MapRules.TrammelRules);
+        }
+    }
+}

--- a/tests/Moongate.Tests/UO/Data/Persistence/Entities/UOMobileEntityTests.cs
+++ b/tests/Moongate.Tests/UO/Data/Persistence/Entities/UOMobileEntityTests.cs
@@ -38,6 +38,87 @@ public class UOMobileEntityTests
     }
 
     [Test]
+    public void CombatState_ShouldDefaultToNoCombatantAndEmptyAggressorLists()
+    {
+        var mobile = new UOMobileEntity();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.CombatantId, Is.EqualTo(Serial.Zero));
+                Assert.That(mobile.Warmode, Is.False);
+                Assert.That(mobile.NextCombatAtUtc, Is.Null);
+                Assert.That(mobile.LastCombatAtUtc, Is.Null);
+                Assert.That(mobile.Aggressors, Is.Empty);
+                Assert.That(mobile.Aggressed, Is.Empty);
+            }
+        );
+    }
+
+    [Test]
+    public void WarmodeAlias_ShouldMapToIsWarMode()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Warmode = true
+        };
+
+        Assert.That(mobile.IsWarMode, Is.True);
+
+        mobile.IsWarMode = false;
+
+        Assert.That(mobile.Warmode, Is.False);
+    }
+
+    [Test]
+    public void RefreshAggressor_ShouldAddAndUpdateExistingEntries()
+    {
+        var now = new DateTime(2026, 3, 18, 12, 0, 0, DateTimeKind.Utc);
+        var later = now.AddSeconds(30);
+        var attackerId = (Serial)0x00000010;
+        var defenderId = (Serial)0x00000020;
+        var mobile = new UOMobileEntity();
+
+        mobile.RefreshAggressor(attackerId, defenderId, now);
+        mobile.RefreshAggressor(attackerId, defenderId, later, isCriminal: true);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.Aggressors, Has.Count.EqualTo(1));
+                Assert.That(mobile.Aggressed, Has.Count.EqualTo(1));
+                Assert.That(mobile.Aggressors[0].LastCombatAtUtc, Is.EqualTo(later));
+                Assert.That(mobile.Aggressors[0].IsCriminal, Is.True);
+                Assert.That(mobile.Aggressed[0].LastCombatAtUtc, Is.EqualTo(later));
+            }
+        );
+    }
+
+    [Test]
+    public void ExpireAggressors_ShouldRemoveTimedOutEntries()
+    {
+        var now = new DateTime(2026, 3, 18, 12, 0, 0, DateTimeKind.Utc);
+        var mobile = new UOMobileEntity();
+
+        mobile.Aggressors.Add(new((Serial)0x10, (Serial)0x20, now.AddMinutes(-3), false, false));
+        mobile.Aggressors.Add(new((Serial)0x11, (Serial)0x21, now.AddSeconds(-30), false, false));
+        mobile.Aggressed.Add(new((Serial)0x12, (Serial)0x22, now.AddMinutes(-4), false, false));
+        mobile.Aggressed.Add(new((Serial)0x13, (Serial)0x23, now.AddSeconds(-10), false, false));
+
+        mobile.ExpireAggressors(now, TimeSpan.FromMinutes(2));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.Aggressors, Has.Count.EqualTo(1));
+                Assert.That(mobile.Aggressors[0].AttackerId, Is.EqualTo((Serial)0x11));
+                Assert.That(mobile.Aggressed, Has.Count.EqualTo(1));
+                Assert.That(mobile.Aggressed[0].AttackerId, Is.EqualTo((Serial)0x13));
+            }
+        );
+    }
+
+    [Test]
     public void ApplyAndRemoveRuntimeModifier_ShouldUpdateEffectiveValues()
     {
         var mobile = new UOMobileEntity


### PR DESCRIPTION
## Summary
- add melee combat v1 with combatant state, timer-wheel swing scheduling, runtime aggressor tracking, and region-gated attack resolution
- implement request attack plus outgoing combat packet flow (`0x05`, `0x2F`, `0xAA`) and align the Lua combat module with the server combat loop
- refresh visible NPC status bars on combat hits and add a static `zombie_npc` template for spawn testing

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --no-restore -v minimal`
- [x] `dotnet build src/Moongate.Server/Moongate.Server.csproj --no-restore -c Release`
