### PR TITLE
feat: add world emote speech support

### DIFF
--- a/docs/articles/networking/packets.md
+++ b/docs/articles/networking/packets.md
@@ -89,7 +89,7 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0x73` | Ping Message | C -> S | `PingMessagePacket` | `handler` | `PingPongHandler` | Keepalive |
 | `0xC8` | Client View Range | C -> S | `ClientViewRangePacket` | `handler` | `ClientViewRangeHandler` | View range update |
 | `0x34` | Get Player Status | C -> S | `GetPlayerStatusPacket` | `handler` | `PlayerStatusHandler` | `BasicStatus -> 0x11`, `RequestSkills -> 0x3A` |
-| `0xAD` | Unicode Speech | C -> S | `UnicodeSpeechPacket` | `handler` | `SpeechHandler` | In-game commands and speech |
+| `0xAD` | Unicode Speech | C -> S | `UnicodeSpeechPacket` | `handler` | `SpeechHandler` | In-game commands and world speech/emotes; `*text*` is coerced to emote |
 | `0xB5` | Open Chat Window | C -> S | `OpenChatWindowPacket` | `handler` | `ChatHandler` | Opens classic conference chat and creates runtime chat user |
 | `0xB3` | Chat Text | C -> S | `ChatTextPacket` | `handler` | `ChatHandler` | Conference chat actions (`message`, `join`, `pm`, `ignore`, `ops`, `voice`, `kick`, `whois`, `emote`) |
 | `0x6C` | Target Cursor Commands | C -> S | `TargetCursorCommandsPacket` | `handler` | `PlayerTargetService` | Target callbacks |

--- a/docs/articles/scripting/api.md
+++ b/docs/articles/scripting/api.md
@@ -72,6 +72,29 @@ The helper exposes:
 - `tick.run(state, key, now_ms, action?)`
 - `tick.reset(state, key, now_ms, interval_ms?)`
 
+### World Speech And Emotes
+
+Player world speech and NPC speech use the same runtime packet family.
+
+```lua
+local npc = mobile.get(serial)
+if npc then
+    npc:say("Welcome, traveler.")
+    npc:emote("*growls softly*")
+end
+```
+
+Runtime behavior:
+
+- player `UnicodeSpeech` is broadcast to nearby players in world range
+- incoming player text wrapped as `*text*` is coerced to `Emote`
+- `npc:emote(text)` sends `ChatMessageType.Emote` overhead speech
+- current speech ranges are:
+  - `Whisper` -> `1`
+  - `Regular` / `Emote` -> `12`
+  - `Yell` -> `18`
+- NPC brain speech listeners still receive `speech_type`, so Lua can react differently to regular speech versus emotes
+
 ### Item Script: Apple
 
 ```lua

--- a/docs/articles/scripting/modules.md
+++ b/docs/articles/scripting/modules.md
@@ -42,8 +42,17 @@ effect.send_to_player(characterId, x, y, z, itemId, speed, duration, hue, render
 local npc = mobile.get(serial)
 if npc then
   npc:SetEffect(0x3728, 10, 10, 0, 0, 2023)
+  npc:say("Hello there.")
+  npc:emote("*looks furious*")
 end
 ```
+
+Speech-related runtime notes:
+
+- `npc:say(text)` emits regular world speech
+- `npc:emote(text)` emits world emote speech with `ChatMessageType.Emote`
+- player incoming speech uses the same world speech path
+- incoming player text wrapped as `*text*` is treated as an emote automatically
 
 `combat` runtime helpers:
 

--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -158,6 +158,19 @@ function orion.on_speech(ctx)
 end
 ```
 
+### World Emotes
+
+NPC scripts can now emit real world emotes through the mobile proxy:
+
+```lua
+local npc = mobile.get(npc_id)
+if npc then
+    npc:emote("*stares at you*")
+end
+```
+
+Player-side world emotes follow the same speech pipeline. If the incoming player text is wrapped as `*text*`, Moongate treats it as an emote automatically before broadcasting it to nearby players and NPC listeners.
+
 ### Item Script Example
 
 `item.script_id = "apple"` resolves to table `apple` in `scripts/items/apple.lua`.

--- a/src/Moongate.Server/Data/Internal/Entities/LuaMobileProxy.cs
+++ b/src/Moongate.Server/Data/Internal/Entities/LuaMobileProxy.cs
@@ -380,6 +380,20 @@ public sealed class LuaMobileProxy
         return recipients > 0;
     }
 
+    public bool Emote(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var recipients = _speechService.SpeakAsMobileAsync(Mobile, text, messageType: ChatMessageType.Emote)
+                                       .GetAwaiter()
+                                       .GetResult();
+
+        return recipients > 0;
+    }
+
     public void SetEffect(
         int itemId,
         int speed = 10,

--- a/src/Moongate.Server/Data/Internal/Entities/LuaMobileRef.cs
+++ b/src/Moongate.Server/Data/Internal/Entities/LuaMobileRef.cs
@@ -1,6 +1,7 @@
 using Moongate.Server.Interfaces.Services.Sessions;
 using Moongate.Server.Interfaces.Services.Speech;
 using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
 
 namespace Moongate.Server.Data.Internal.Entities;
 
@@ -46,6 +47,20 @@ public sealed class LuaMobileRef
         }
 
         var recipients = _speechService.SpeakAsMobileAsync(_mobile, text).GetAwaiter().GetResult();
+
+        return recipients > 0;
+    }
+
+    public bool Emote(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var recipients = _speechService.SpeakAsMobileAsync(_mobile, text, messageType: ChatMessageType.Emote)
+                                       .GetAwaiter()
+                                       .GetResult();
 
         return recipients > 0;
     }

--- a/src/Moongate.Server/Services/Speech/SpeechService.cs
+++ b/src/Moongate.Server/Services/Speech/SpeechService.cs
@@ -22,6 +22,9 @@ namespace Moongate.Server.Services.Speech;
 public sealed class SpeechService : ISpeechService
 {
     private const int DefaultNpcHearingRange = 12;
+    private const int DefaultSpeechRange = 12;
+    private const int WhisperSpeechRange = 1;
+    private const int YellSpeechRange = 18;
     private readonly ICommandSystemService _commandSystemService;
     private readonly IOutgoingPacketQueue _outgoingPacketQueue;
     private readonly IGameNetworkSessionService _gameNetworkSessionService;
@@ -130,16 +133,28 @@ public sealed class SpeechService : ISpeechService
             return null;
         }
 
-        await PublishSpeechHeardEventsAsync(session, text, speechPacket.MessageType, cancellationToken);
+        if (session.Character is null)
+        {
+            return null;
+        }
 
-        return SpeechMessageFactory.CreateFromSpeaker(
+        var effectiveMessageType = ResolveIncomingMessageType(speechPacket.MessageType, text);
+        var speechRange = ResolveSpeechRange(effectiveMessageType);
+
+        await _dispatchEventsService.DispatchMobileSpeechAsync(
             session.Character,
-            speechPacket.MessageType,
+            text,
+            speechRange,
+            effectiveMessageType,
             speechPacket.Hue,
             speechPacket.Font,
             speechPacket.Language,
-            text
+            cancellationToken
         );
+
+        await PublishSpeechHeardEventsAsync(session, text, effectiveMessageType, cancellationToken);
+
+        return null;
     }
 
     public async Task<bool> SendMessageFromServerAsync(
@@ -265,4 +280,28 @@ public sealed class SpeechService : ISpeechService
             );
         }
     }
+
+    private static ChatMessageType ResolveIncomingMessageType(ChatMessageType messageType, string text)
+    {
+        if (messageType != ChatMessageType.Regular)
+        {
+            return messageType;
+        }
+
+        return IsAsteriskWrappedEmote(text) ? ChatMessageType.Emote : messageType;
+    }
+
+    private static bool IsAsteriskWrappedEmote(string text)
+        => text.Length >= 3 &&
+           text[0] == '*' &&
+           text[^1] == '*' &&
+           !string.IsNullOrWhiteSpace(text[1..^1]);
+
+    private static int ResolveSpeechRange(ChatMessageType messageType)
+        => messageType switch
+        {
+            ChatMessageType.Whisper => WhisperSpeechRange,
+            ChatMessageType.Yell => YellSpeechRange,
+            _ => DefaultSpeechRange
+        };
 }

--- a/tests/Moongate.Tests/Server/Data/Internal/Entities/LuaMobileProxyTests.cs
+++ b/tests/Moongate.Tests/Server/Data/Internal/Entities/LuaMobileProxyTests.cs
@@ -35,6 +35,8 @@ public sealed class LuaMobileProxyTests
 
         public string? LastSpokenText { get; private set; }
 
+        public ChatMessageType LastMessageType { get; private set; } = ChatMessageType.Regular;
+
         public int SpeakAsMobileResult { get; set; } = 1;
 
         public Task<int> BroadcastFromServerAsync(
@@ -115,6 +117,7 @@ public sealed class LuaMobileProxyTests
             LastSpeakAsMobileCallCount++;
             LastSpeaker = speaker;
             LastSpokenText = text;
+            LastMessageType = messageType;
 
             return Task.FromResult(SpeakAsMobileResult);
         }
@@ -783,6 +786,35 @@ public sealed class LuaMobileProxyTests
                 Assert.That(speechService.LastSpeakAsMobileCallCount, Is.EqualTo(1));
                 Assert.That(speechService.LastSpeaker, Is.SameAs(mobile));
                 Assert.That(speechService.LastSpokenText, Is.EqualTo("miaow"));
+                Assert.That(speechService.LastMessageType, Is.EqualTo(ChatMessageType.Regular));
+            }
+        );
+    }
+
+    [Test]
+    public void Emote_ShouldUseSpeakAsMobileAsyncWithEmoteMessageType()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x1234u,
+            MapId = 1,
+            Location = new(100, 200, 5)
+        };
+        var speechService = new LuaMobileProxyTestSpeechService { SpeakAsMobileResult = 2 };
+        var gameNetworkSessionService = new LuaMobileProxyTestGameNetworkSessionService();
+        var spatialWorldService = new LuaMobileProxyTestSpatialWorldService();
+        var proxy = new LuaMobileProxy(mobile, speechService, gameNetworkSessionService, spatialWorldService);
+
+        var sent = proxy.Emote("*grrr*");
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(sent, Is.True);
+                Assert.That(speechService.LastSpeakAsMobileCallCount, Is.EqualTo(1));
+                Assert.That(speechService.LastSpeaker, Is.SameAs(mobile));
+                Assert.That(speechService.LastSpokenText, Is.EqualTo("*grrr*"));
+                Assert.That(speechService.LastMessageType, Is.EqualTo(ChatMessageType.Emote));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Handlers/SpeechHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/SpeechHandlerTests.cs
@@ -15,13 +15,34 @@ namespace Moongate.Tests.Server.Handlers;
 
 public class SpeechHandlerTests
 {
+    private sealed class SpeechHandlerTestsSpatialWorldService : RegionDataLoaderTestSpatialWorldService
+    {
+        public List<GameSession> PlayersInRange { get; } = [];
+
+        public override List<GameSession> GetPlayersInRange(
+            Moongate.UO.Data.Geometry.Point3D location,
+            int range,
+            int mapId,
+            GameSession? excludeSession = null
+        )
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return excludeSession is null
+                       ? [.. PlayersInRange]
+                       : [.. PlayersInRange.Where(session => session != excludeSession)];
+        }
+    }
+
     [Test]
-    public async Task HandlePacketAsync_ShouldEnqueueUnicodeSpeechMessagePacket_ForSenderSession()
+    public async Task HandlePacketAsync_ShouldBroadcastUnicodeSpeechMessagePacket_ToNearbyPlayers()
     {
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var gameNetworkSessionService = new SpeechServiceTestGameNetworkSessionService();
         var gameEventBusService = new NetworkServiceTestGameEventBusService();
-        var spatialWorldService = new RegionDataLoaderTestSpatialWorldService();
+        var spatialWorldService = new SpeechHandlerTestsSpatialWorldService();
         var handler = new SpeechHandler(
             queue,
             new SpeechService(
@@ -34,6 +55,7 @@ public class SpeechHandlerTests
             )
         );
         using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        using var nearbyClient = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
 
         var session = new GameSession(new(client))
         {
@@ -44,6 +66,17 @@ public class SpeechHandlerTests
                 BaseBody = 0x0190
             }
         };
+        var nearbySession = new GameSession(new(nearbyClient))
+        {
+            Character = new()
+            {
+                Id = (Serial)0x00000003,
+                Name = "Jerry",
+                BaseBody = 0x0190
+            }
+        };
+        spatialWorldService.PlayersInRange.Add(session);
+        spatialWorldService.PlayersInRange.Add(nearbySession);
 
         var packet = new UnicodeSpeechPacket
         {
@@ -55,19 +88,21 @@ public class SpeechHandlerTests
         };
 
         var handled = await handler.HandlePacketAsync(session, packet);
-        var dequeued = queue.TryDequeue(out var outbound);
+        var dequeuedA = queue.TryDequeue(out var outboundA);
+        var dequeuedB = queue.TryDequeue(out var outboundB);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(handled, Is.True);
-                Assert.That(dequeued, Is.True);
-                Assert.That(outbound.SessionId, Is.EqualTo(session.SessionId));
-                Assert.That(outbound.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
+                Assert.That(dequeuedA, Is.True);
+                Assert.That(dequeuedB, Is.True);
+                Assert.That(outboundA.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
+                Assert.That(outboundB.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
             }
         );
 
-        var speechMessagePacket = (UnicodeSpeechMessagePacket)outbound.Packet;
+        var speechMessagePacket = (UnicodeSpeechMessagePacket)outboundA.Packet;
 
         Assert.Multiple(
             () =>

--- a/tests/Moongate.Tests/Server/Services/Speech/SpeechServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Speech/SpeechServiceTests.cs
@@ -120,13 +120,79 @@ public class SpeechServiceTests
     }
 
     [Test]
-    public async Task ProcessIncomingSpeechAsync_ShouldReturnEchoPacket_ForRegularSpeech()
+    public async Task ProcessIncomingSpeechAsync_ShouldBroadcastRegularSpeechToNearbyPlayers()
     {
         var commandSystemService = new MockCommandSystemService();
         var outgoingPacketQueue = new BasePacketListenerTestOutgoingPacketQueue();
         var gameNetworkSessionService = new SpeechServiceTestGameNetworkSessionService();
         var gameEventBusService = new GameEventBusService();
-        var spatialWorldService = new RegionDataLoaderTestSpatialWorldService();
+        var spatialWorldService = new SpeechServiceTestsSpatialWorldService();
+        var speechService = new SpeechService(
+            commandSystemService,
+            outgoingPacketQueue,
+            gameNetworkSessionService,
+            gameEventBusService,
+            spatialWorldService,
+            new DispatchEventsService(spatialWorldService, outgoingPacketQueue, gameNetworkSessionService)
+        );
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        using var nearbyClient = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var session = new GameSession(new(client))
+        {
+            Character = new()
+            {
+                Id = (Serial)0x00000002,
+                Name = "Tom",
+                BaseBody = 0x0190
+            }
+        };
+        var nearbySession = new GameSession(new(nearbyClient))
+        {
+            Character = new()
+            {
+                Id = (Serial)0x00000003,
+                Name = "Jerry",
+                BaseBody = 0x0190
+            }
+        };
+        spatialWorldService.PlayersInRange.Add(session);
+        spatialWorldService.PlayersInRange.Add(nearbySession);
+
+        var packet = new UnicodeSpeechPacket
+        {
+            MessageType = ChatMessageType.Regular,
+            Hue = 0x0035,
+            Font = 0x0003,
+            Language = "ENU",
+            Text = "hello"
+        };
+
+        var result = await speechService.ProcessIncomingSpeechAsync(session, packet);
+        var dequeuedA = outgoingPacketQueue.TryDequeue(out var outboundA);
+        var dequeuedB = outgoingPacketQueue.TryDequeue(out var outboundB);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.Null);
+                Assert.That(commandSystemService.ExecuteCallCount, Is.EqualTo(0));
+                Assert.That(dequeuedA, Is.True);
+                Assert.That(dequeuedB, Is.True);
+                Assert.That(outboundA.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
+                Assert.That(outboundB.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
+            }
+        );
+    }
+
+    [Test]
+    public async Task ProcessIncomingSpeechAsync_WhenTextIsWrappedInAsterisks_ShouldBroadcastAsEmote()
+    {
+        var commandSystemService = new MockCommandSystemService();
+        var outgoingPacketQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var gameNetworkSessionService = new SpeechServiceTestGameNetworkSessionService();
+        var gameEventBusService = new GameEventBusService();
+        var spatialWorldService = new SpeechServiceTestsSpatialWorldService();
         var speechService = new SpeechService(
             commandSystemService,
             outgoingPacketQueue,
@@ -146,6 +212,7 @@ public class SpeechServiceTests
                 BaseBody = 0x0190
             }
         };
+        spatialWorldService.PlayersInRange.Add(session);
 
         var packet = new UnicodeSpeechPacket
         {
@@ -153,18 +220,24 @@ public class SpeechServiceTests
             Hue = 0x0035,
             Font = 0x0003,
             Language = "ENU",
-            Text = "hello"
+            Text = "*grrr*"
         };
 
         var result = await speechService.ProcessIncomingSpeechAsync(session, packet);
+        var dequeued = outgoingPacketQueue.TryDequeue(out var outbound);
 
         Assert.Multiple(
             () =>
             {
-                Assert.That(result, Is.TypeOf<UnicodeSpeechMessagePacket>());
-                Assert.That(commandSystemService.ExecuteCallCount, Is.EqualTo(0));
+                Assert.That(result, Is.Null);
+                Assert.That(dequeued, Is.True);
+                Assert.That(outbound.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
             }
         );
+
+        var speechMessagePacket = (UnicodeSpeechMessagePacket)outbound.Packet;
+
+        Assert.That(speechMessagePacket.MessageType, Is.EqualTo(ChatMessageType.Emote));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- broadcast player world speech and emotes to nearby players using the existing mobile speech dispatch path
- coerce incoming `*text*` player speech to world emotes and expose `emote(...)` on Lua mobile references
- document world emote behavior in scripting and networking docs

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --no-restore -v minimal`
- [x] `dotnet build src/Moongate.Server/Moongate.Server.csproj --no-restore -c Release`
