### PR TITLE
ci: optimize pull request workflow load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,13 @@
 name: Coverage
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,11 +1,13 @@
 name: Code Quality
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,15 @@
 name: Security Audit
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
+  schedule:
+    - cron: '17 3 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/third-party-notices.yml
+++ b/.github/workflows/third-party-notices.yml
@@ -1,11 +1,15 @@
 name: Third-Party Notices
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
+  schedule:
+    - cron: '47 3 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ I am actively looking for contributors and reviewers.
 
 ## Release Automation
 
+- Pull requests run the `CI` workflow only, to keep feedback fast.
+- Coverage, security audit, and third-party notices run on `main`, with scheduled/manual execution for the heavier audits.
 - GitHub releases are mirrored to Discord via the `GitHub Release Assets` workflow.
 - Configure the repository secret `DISCORD_CHANGELOG_WEBHOOK_URL` to enable changelog posting.
 - Release notes are sourced from `CHANGELOG.md` and posted to Discord after the GitHub release is created.


### PR DESCRIPTION
## Summary
- run only the CI workflow on pull requests
- move heavier coverage/security/notices checks off PRs and add scheduled audits
- add workflow concurrency cancellation and document the new CI behavior
- 
- ## Test Plan
- ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/coverage.yml .github/workflows/quality.yml .github/workflows/security.yml .github/workflows/third-party-notices.yml].each { |p| YAML.load_file(p); puts "OK #{p}" }'
- 
Closes #99