### PR TITLE
feat: award fame and karma for npc kills

### DIFF
--- a/docs/articles/getting-started/introduction.md
+++ b/docs/articles/getting-started/introduction.md
@@ -114,7 +114,7 @@ Moongate v2 is **actively in development**. The following features are implement
 
 ### Planned
 
-- [x] Combat v1 baseline (melee + ranged auto-attack, combatant state, warmode, timer-wheel scheduling, archery ammo/projectiles)
+- [x] Combat v1 baseline (melee + ranged auto-attack, combatant state, warmode, timer-wheel scheduling, archery ammo/projectiles, PvE fame/karma awards)
 - [ ] Skill system
 - [ ] Item system completion (vendor/trade/economy semantics)
 - [ ] House/shelter system

--- a/docs/articles/getting-started/quickstart.md
+++ b/docs/articles/getting-started/quickstart.md
@@ -66,7 +66,7 @@ Built-in default commands currently include:
 - `send_target` (in-game only, minimum `Regular`)
 - `orion` (in-game only, minimum `Regular`, requests target cursor and spawns Orion on selected tile)
 - `teleport` / `tp` (in-game only, minimum `GameMaster`, usage: `.teleport <mapId> <x> <y> <z>`)
-- `add_item_backpack` / `.add_item_backpack` (in-game only, minimum `GameMaster`, usage: `.add_item_backpack <templateId>`)
+- `add_item_backpack` / `.add_item_backpack` (in-game only, minimum `GameMaster`, usage: `.add_item_backpack <templateId> [amount]`)
 
 Command source and authorization rules:
 

--- a/docs/articles/operations/console-commands.md
+++ b/docs/articles/operations/console-commands.md
@@ -112,10 +112,10 @@ Context: InGame only. Access: Regular.
 
 #### `add_item_backpack`
 
-Spawns an item from a template and places it in the player backpack. Supports autocomplete for template IDs.
+Spawns an item from a template and places it in the player backpack. Supports autocomplete for template IDs and an optional stack amount for stackable items.
 
 ```
-.add_item_backpack <templateId>
+.add_item_backpack <templateId> [amount]
 ```
 
 Resolves the backpack either from `BackpackId` or from the equipped `Backpack` layer item. Context: InGame only. Access: GameMaster.

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -101,6 +101,7 @@ It delegates to `CombatService`, which owns:
 - swing scheduling through `TimerWheelService`
 - melee hit/damage resolution
 - region/map harmful-action gate on actual attack attempt
+- lethal handoff into `DeathService`, including PvE fame/karma awards for player kills against NPCs
 - `npc_state` (typed state variables)
 - `time`, `random`, `mobile` (general runtime helpers)
 

--- a/src/Moongate.Server/Commands/Player/AddItemBackpackCommand.cs
+++ b/src/Moongate.Server/Commands/Player/AddItemBackpackCommand.cs
@@ -16,7 +16,7 @@ namespace Moongate.Server.Commands.Player;
 /// </summary>
 [RegisterConsoleCommand(
     "add_item_backpack|.add_item_backpack",
-    "Add an item template to your backpack. Usage: .add_item_backpack <templateId>",
+    "Add an item template to your backpack. Usage: .add_item_backpack <templateId> [amount]",
     CommandSourceType.InGame,
     AccountType.GameMaster
 )]
@@ -39,9 +39,24 @@ public sealed class AddItemBackpackCommand : ICommandExecutor
 
     public async Task ExecuteCommandAsync(CommandSystemContext context)
     {
-        if (context.Arguments.Length != 1 || string.IsNullOrWhiteSpace(context.Arguments[0]))
+        if (
+            (context.Arguments.Length != 1 && context.Arguments.Length != 2)
+            || string.IsNullOrWhiteSpace(context.Arguments[0])
+        )
         {
-            context.Print("Usage: .add_item_backpack <templateId>");
+            context.Print("Usage: .add_item_backpack <templateId> [amount]");
+
+            return;
+        }
+
+        var amount = 1;
+
+        if (
+            context.Arguments.Length == 2
+            && (!int.TryParse(context.Arguments[1], out amount) || amount <= 0)
+        )
+        {
+            context.Print("Usage: .add_item_backpack <templateId> [amount]");
 
             return;
         }
@@ -76,11 +91,32 @@ public sealed class AddItemBackpackCommand : ICommandExecutor
         try
         {
             var item = await _itemService.SpawnFromTemplateAsync(templateId);
+
+            if (amount > 1)
+            {
+                if (!item.IsStackable)
+                {
+                    context.Print("Failed to add item: template '{0}' is not stackable.", templateId);
+
+                    return;
+                }
+
+                item.Amount = amount;
+                await _itemService.UpsertItemAsync(item);
+            }
+
             var moved = await _itemService.MoveItemToContainerAsync(item.Id, backpackId, new(1, 1), context.SessionId);
 
             if (!moved)
             {
                 context.Print("Failed to add item: could not move item to backpack.");
+
+                return;
+            }
+
+            if (amount > 1)
+            {
+                context.Print("Added '{0}' x{1} to backpack.", templateId, amount);
 
                 return;
             }

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -110,6 +110,7 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<INotorietyService, NotorietyService>(Reuse.Singleton);
         container.Register<ICombatService, CombatService>(Reuse.Singleton);
         container.Register<IDeathService, DeathService>(Reuse.Singleton);
+        container.Register<IFameKarmaService, FameKarmaService>(Reuse.Singleton);
         container.Register<MobileCombatSoundResolver>(Reuse.Singleton);
         container.Register<IPlayerSellBuyService, PlayerSellBuyService>(Reuse.Singleton);
         container.Register<IItemScriptDispatcher, ItemScriptDispatcher>(Reuse.Singleton);

--- a/src/Moongate.Server/Interfaces/Services/Interaction/IFameKarmaService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/IFameKarmaService.cs
@@ -1,0 +1,22 @@
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Server.Interfaces.Services.Interaction;
+
+/// <summary>
+/// Coordinates fame and karma awards after a player kills a non-player mobile.
+/// </summary>
+public interface IFameKarmaService
+{
+    /// <summary>
+    /// Applies fame and karma awards to the killer when the award gate is satisfied.
+    /// </summary>
+    /// <param name="victim">The defeated mobile.</param>
+    /// <param name="killer">The mobile that dealt the killing blow.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the award has been processed.</returns>
+    Task AwardNpcKillAsync(
+        UOMobileEntity victim,
+        UOMobileEntity killer,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Moongate.Server/Services/Interaction/CombatService.cs
+++ b/src/Moongate.Server/Services/Interaction/CombatService.cs
@@ -196,6 +196,7 @@ public sealed class CombatService : ICombatService
 
         if (map is not null &&
             map.Rules.HasFlag(MapRules.HarmfulRestrictions) &&
+            defender.IsPlayer &&
             defender.Notoriety == Notoriety.Innocent)
         {
             return "map_harmful_restrictions";
@@ -571,8 +572,24 @@ public sealed class CombatService : ICombatService
             _ = await _itemService.DeleteItemAsync(deletedStack.Id);
         }
 
+        RefreshConsumedAmmoForSession(attacker.Id, backpack, deletedStack);
         _ = cancellationToken;
         return true;
+    }
+
+    private void RefreshConsumedAmmoForSession(Serial attackerId, UOItemEntity backpack, UOItemEntity? deletedStack)
+    {
+        if (!_gameNetworkSessionService.TryGetByCharacterId(attackerId, out var session))
+        {
+            return;
+        }
+
+        _outgoingPacketQueue.Enqueue(session.SessionId, new AddMultipleItemsToContainerPacket(backpack));
+
+        if (deletedStack is not null)
+        {
+            _outgoingPacketQueue.Enqueue(session.SessionId, new DeleteObjectPacket(deletedStack.Id));
+        }
     }
 
     private static Serial ResolveBackpackId(UOMobileEntity attacker)

--- a/src/Moongate.Server/Services/Interaction/DeathService.cs
+++ b/src/Moongate.Server/Services/Interaction/DeathService.cs
@@ -39,6 +39,7 @@ public sealed class DeathService : IDeathService
     private readonly ISpatialWorldService _spatialWorldService;
     private readonly ITimerService _timerService;
     private readonly IGameEventBusService _gameEventBusService;
+    private readonly IFameKarmaService _fameKarmaService;
     private readonly MoongateConfig _config;
     private readonly ILuaBrainRunner? _luaBrainRunner;
 
@@ -48,6 +49,7 @@ public sealed class DeathService : IDeathService
         ISpatialWorldService spatialWorldService,
         ITimerService timerService,
         IGameEventBusService gameEventBusService,
+        IFameKarmaService fameKarmaService,
         MoongateConfig config,
         ILuaBrainRunner? luaBrainRunner = null
     )
@@ -57,6 +59,7 @@ public sealed class DeathService : IDeathService
         _spatialWorldService = spatialWorldService;
         _timerService = timerService;
         _gameEventBusService = gameEventBusService;
+        _fameKarmaService = fameKarmaService;
         _config = config;
         _luaBrainRunner = luaBrainRunner;
     }
@@ -121,6 +124,11 @@ public sealed class DeathService : IDeathService
             _spatialWorldService.RemoveEntity(victim.Id);
             await _mobileService.DeleteAsync(victim.Id, cancellationToken);
             ScheduleCorpseDecay(corpse);
+        }
+
+        if (killer is not null && !victim.IsPlayer && killer.IsPlayer)
+        {
+            await _fameKarmaService.AwardNpcKillAsync(victim, killer, cancellationToken);
         }
 
         deathPayload = BuildDeathPayload(victim, killer, regionName, corpse);

--- a/src/Moongate.Server/Services/Interaction/FameKarmaService.cs
+++ b/src/Moongate.Server/Services/Interaction/FameKarmaService.cs
@@ -1,0 +1,46 @@
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Server.Services.Interaction;
+
+/// <summary>
+/// Applies fame and karma awards after player-versus-NPC kills.
+/// </summary>
+public sealed class FameKarmaService : IFameKarmaService
+{
+    private readonly IMobileService _mobileService;
+
+    public FameKarmaService(IMobileService mobileService)
+    {
+        _mobileService = mobileService;
+    }
+
+    public async Task AwardNpcKillAsync(
+        UOMobileEntity victim,
+        UOMobileEntity killer,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(victim);
+        ArgumentNullException.ThrowIfNull(killer);
+
+        if (victim.IsPlayer || !killer.IsPlayer)
+        {
+            return;
+        }
+
+        var awardedFame = Math.Max(0, victim.Fame / 100);
+        var awardedKarma = victim.Karma / 100;
+
+        if (awardedFame == 0 && awardedKarma == 0)
+        {
+            return;
+        }
+
+        killer.Fame += awardedFame;
+        killer.Karma += awardedKarma;
+
+        await _mobileService.CreateOrUpdateAsync(killer, cancellationToken);
+    }
+}

--- a/src/Moongate.Server/Services/Items/ItemManipulationService.cs
+++ b/src/Moongate.Server/Services/Items/ItemManipulationService.cs
@@ -248,7 +248,11 @@ public class ItemManipulationService : IItemManipulationService
 
         if (_gameNetworkSessionService.TryGetByCharacterId(characterId, out var sourceSession))
         {
+            sourceSession.Character = mobile;
+            sourceSession.CharacterId = mobile.Id;
+            sourceSession.IsMounted = mobile.IsMounted;
             sessionIdsToNotify.Add(sourceSession.SessionId);
+            Enqueue(sourceSession, new PlayerStatusPacket(mobile, 1));
         }
 
         if (sector is null)

--- a/tests/Moongate.Tests/Server/Commands/Player/AddItemBackpackCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/Player/AddItemBackpackCommandTests.cs
@@ -19,10 +19,14 @@ public sealed class AddItemBackpackCommandTests
 {
     private sealed class AddItemBackpackTestItemService : IItemService
     {
+        private readonly Dictionary<Serial, UOItemEntity> _persistedItems = [];
+
         public int SpawnCalls { get; private set; }
         public int MoveToContainerCalls { get; private set; }
+        public int UpsertCalls { get; private set; }
         public string? LastSpawnTemplateId { get; private set; }
         public Serial LastMoveContainerId { get; private set; }
+        public int? PersistedAmountAtMove { get; private set; }
         public bool MoveToContainerResult { get; set; }
         public UOItemEntity SpawnedItem { get; set; } = new() { Id = (Serial)0x40000100u };
 
@@ -68,6 +72,7 @@ public sealed class AddItemBackpackCommandTests
             _ = sessionId;
             LastMoveContainerId = containerId;
             MoveToContainerCalls++;
+            PersistedAmountAtMove = _persistedItems.TryGetValue(itemId, out var persistedItem) ? persistedItem.Amount : null;
 
             return Task.FromResult(MoveToContainerResult);
         }
@@ -79,6 +84,7 @@ public sealed class AddItemBackpackCommandTests
         {
             LastSpawnTemplateId = itemTemplateId;
             SpawnCalls++;
+            _persistedItems[SpawnedItem.Id] = ClonePersistedItem(SpawnedItem);
 
             return Task.FromResult(SpawnedItem);
         }
@@ -87,10 +93,23 @@ public sealed class AddItemBackpackCommandTests
             => Task.FromResult((false, (UOItemEntity?)null));
 
         public Task UpsertItemAsync(UOItemEntity item)
-            => Task.CompletedTask;
+        {
+            UpsertCalls++;
+            _persistedItems[item.Id] = ClonePersistedItem(item);
+
+            return Task.CompletedTask;
+        }
 
         public Task UpsertItemsAsync(params UOItemEntity[] items)
             => Task.CompletedTask;
+
+        private static UOItemEntity ClonePersistedItem(UOItemEntity item)
+            => new()
+            {
+                Id = item.Id,
+                Amount = item.Amount,
+                IsStackable = item.IsStackable
+            };
     }
 
     private sealed class AddItemBackpackTestGameNetworkSessionService : IGameNetworkSessionService
@@ -181,7 +200,29 @@ public sealed class AddItemBackpackCommandTests
 
         await command.ExecuteCommandAsync(context);
 
-        Assert.That(output[^1], Is.EqualTo("Usage: .add_item_backpack <templateId>"));
+        Assert.That(output[^1], Is.EqualTo("Usage: .add_item_backpack <templateId> [amount]"));
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenAmountIsInvalid_ShouldPrintUsage()
+    {
+        var command = new AddItemBackpackCommand(
+            new AddItemBackpackTestItemService(),
+            new AddItemBackpackTestGameNetworkSessionService(),
+            new AddItemBackpackTestCharacterService()
+        );
+        var output = new List<string>();
+        var context = new CommandSystemContext(
+            "add_item_backpack arrow nope",
+            ["arrow", "nope"],
+            CommandSourceType.InGame,
+            1,
+            (message, _) => output.Add(message)
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.That(output[^1], Is.EqualTo("Usage: .add_item_backpack <templateId> [amount]"));
     }
 
     [Test]
@@ -298,6 +339,116 @@ public sealed class AddItemBackpackCommandTests
                 Assert.That(itemService.MoveToContainerCalls, Is.EqualTo(1));
                 Assert.That(itemService.LastMoveContainerId, Is.EqualTo((Serial)0x40000011u));
                 Assert.That(output[^1], Is.EqualTo("Added 'brick' to backpack."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenStackableAmountIsProvided_ShouldApplyAmount()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        using var client = new MoongateTCPClient(socket);
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000002u
+        };
+        var characterService = new AddItemBackpackTestCharacterService
+        {
+            CharacterToReturn = new()
+            {
+                Id = session.CharacterId,
+                BackpackId = (Serial)0x40000011u
+            }
+        };
+        var spawnedItem = new UOItemEntity
+        {
+            Id = (Serial)0x40000100u,
+            IsStackable = true,
+            Amount = 1
+        };
+        var itemService = new AddItemBackpackTestItemService
+        {
+            SpawnedItem = spawnedItem,
+            MoveToContainerResult = true
+        };
+        var command = new AddItemBackpackCommand(
+            itemService,
+            new AddItemBackpackTestGameNetworkSessionService(session),
+            characterService
+        );
+        var output = new List<string>();
+        var context = new CommandSystemContext(
+            "add_item_backpack arrow 20",
+            ["arrow", "20"],
+            CommandSourceType.InGame,
+            session.SessionId,
+            (message, _) => output.Add(message)
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(itemService.SpawnCalls, Is.EqualTo(1));
+                Assert.That(itemService.UpsertCalls, Is.EqualTo(1));
+                Assert.That(itemService.MoveToContainerCalls, Is.EqualTo(1));
+                Assert.That(itemService.PersistedAmountAtMove, Is.EqualTo(20));
+                Assert.That(spawnedItem.Amount, Is.EqualTo(20));
+                Assert.That(output[^1], Is.EqualTo("Added 'arrow' x20 to backpack."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenNonStackableAmountGreaterThanOne_ShouldReject()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        using var client = new MoongateTCPClient(socket);
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000002u
+        };
+        var characterService = new AddItemBackpackTestCharacterService
+        {
+            CharacterToReturn = new()
+            {
+                Id = session.CharacterId,
+                BackpackId = (Serial)0x40000011u
+            }
+        };
+        var itemService = new AddItemBackpackTestItemService
+        {
+            SpawnedItem = new()
+            {
+                Id = (Serial)0x40000100u,
+                IsStackable = false,
+                Amount = 1
+            },
+            MoveToContainerResult = true
+        };
+        var command = new AddItemBackpackCommand(
+            itemService,
+            new AddItemBackpackTestGameNetworkSessionService(session),
+            characterService
+        );
+        var output = new List<string>();
+        var context = new CommandSystemContext(
+            "add_item_backpack crossbow 20",
+            ["crossbow", "20"],
+            CommandSourceType.InGame,
+            session.SessionId,
+            (message, _) => output.Add(message)
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(itemService.SpawnCalls, Is.EqualTo(1));
+                Assert.That(itemService.MoveToContainerCalls, Is.EqualTo(0));
+                Assert.That(output[^1], Is.EqualTo("Failed to add item: template 'crossbow' is not stackable."));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net.Sockets;
 using Moongate.Network.Client;
 using Moongate.Network.Packets.Interfaces;
 using Moongate.Network.Packets.Outgoing.Combat;
+using Moongate.Network.Packets.Outgoing.Entity;
 using Moongate.Network.Packets.Outgoing.World;
 using Moongate.Server.Data.Events.Base;
 using Moongate.Server.Data.Events.Characters;
@@ -583,16 +584,19 @@ public sealed class CombatServiceTests
 
         var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
         Assert.That(setTarget, Is.True);
+        _ = outgoingQueue.TryDequeue(out _);
 
         timerService.RegisteredTimers[^1].Callback.Invoke();
 
         var projectile = spatial.BroadcastPackets.OfType<GraphicalEffectPacket>().Single();
+        var queuedPackets = DequeuePackets(outgoingQueue);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(defender.Hits, Is.EqualTo(34));
                 Assert.That(arrows.Amount, Is.EqualTo(2));
+                Assert.That(queuedPackets.OfType<AddMultipleItemsToContainerPacket>().Any(), Is.True);
                 Assert.That(projectile.ItemId, Is.EqualTo(0x1BFE));
                 Assert.That(projectile.SourceId, Is.EqualTo(attacker.Id));
                 Assert.That(projectile.TargetId, Is.EqualTo(defender.Id));
@@ -804,6 +808,113 @@ public sealed class CombatServiceTests
                 Assert.That(spatial.BroadcastPackets.OfType<GraphicalEffectPacket>().Count(), Is.EqualTo(1));
                 Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatMissEvent), Is.True);
                 Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatHitEvent), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task ScheduledSwing_WhenRangedWeaponConsumesLastAmmo_ShouldEnqueueDeleteObjectForConsumedStack()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000036u,
+            IsPlayer = true,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50
+        };
+        attacker.SetSkill(UOSkillName.Archery, 1000);
+        var crossbow = new UOItemEntity
+        {
+            Id = (Serial)0x40000038u,
+            ItemId = 0x0F50,
+            EquippedMobileId = attacker.Id,
+            EquippedLayer = ItemLayerType.TwoHanded,
+            WeaponSkill = UOSkillName.Archery,
+            AmmoItemId = 0x1BFB,
+            AmmoEffectId = 0x1BFB,
+            CombatStats = new()
+            {
+                DamageMin = 8,
+                DamageMax = 8,
+                RangeMin = 1,
+                RangeMax = 8
+            }
+        };
+        var backpack = new UOItemEntity
+        {
+            Id = (Serial)0x40000039u,
+            ItemId = 0x0E75,
+            EquippedMobileId = attacker.Id,
+            EquippedLayer = ItemLayerType.Backpack
+        };
+        var bolt = new UOItemEntity
+        {
+            Id = (Serial)0x4000003Au,
+            ItemId = 0x1BFB,
+            Amount = 1,
+            IsStackable = true
+        };
+        backpack.AddItem(bolt, Point2D.Zero);
+        attacker.BackpackId = backpack.Id;
+        attacker.HydrateEquipmentRuntime([crossbow, backpack]);
+
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000037u,
+            MapId = 0,
+            Location = new(105, 100, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+        itemService.Add(backpack);
+        itemService.Add(bolt);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            itemService,
+            new DeathServiceSpy()
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+        _ = outgoingQueue.TryDequeue(out _);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        var queuedPackets = DequeuePackets(outgoingQueue);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(itemService.GetItemAsync(bolt.Id).Result, Is.Null);
+                Assert.That(queuedPackets.OfType<DeleteObjectPacket>().Any(packet => packet.Serial == bolt.Id), Is.True);
             }
         );
     }
@@ -1192,6 +1303,85 @@ public sealed class CombatServiceTests
         );
     }
 
+    [Test]
+    public async Task ScheduledSwing_WhenDefenderIsInnocentNpcOnHarmfulRestrictedMap_ShouldAllowAttack()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService
+        {
+            ResolvedRegion = new JsonTownRegion
+            {
+                Type = "TownRegion",
+                Map = "Trammel",
+                Name = "Britain",
+                GuardsDisabled = false
+            }
+        };
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000040u,
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50,
+            MinWeaponDamage = 6,
+            MaxWeaponDamage = 6,
+            Notoriety = Notoriety.Innocent
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000041u,
+            IsPlayer = false,
+            MapId = 1,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40,
+            Notoriety = Notoriety.Innocent
+        };
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            new InMemoryItemService(),
+            new DeathServiceSpy()
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(defender.Hits, Is.EqualTo(34));
+                Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatHitEvent), Is.True);
+                Assert.That(attacker.CombatantId, Is.EqualTo(defender.Id));
+            }
+        );
+    }
+
     private static void EnsureMapsRegistered()
     {
         if (Map.GetMap(0) is null)
@@ -1203,5 +1393,17 @@ public sealed class CombatServiceTests
         {
             _ = Map.RegisterMap(1, 1, 1, 6144, 4096, SeasonType.Summer, "Trammel", MapRules.TrammelRules);
         }
+    }
+
+    private static List<IGameNetworkPacket> DequeuePackets(BasePacketListenerTestOutgoingPacketQueue queue)
+    {
+        var packets = new List<IGameNetworkPacket>();
+
+        while (queue.TryDequeue(out var outgoing))
+        {
+            packets.Add(outgoing.Packet);
+        }
+
+        return packets;
     }
 }

--- a/tests/Moongate.Tests/Server/Services/Interaction/DeathServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/DeathServiceTests.cs
@@ -364,6 +364,23 @@ public sealed class DeathServiceTests
         public void RegisterListener<TEvent>(IGameEventListener<TEvent> listener) where TEvent : IGameEvent { }
     }
 
+    private sealed class FameKarmaServiceSpy : IFameKarmaService
+    {
+        public List<(UOMobileEntity Victim, UOMobileEntity Killer)> Awards { get; } = [];
+
+        public Task AwardNpcKillAsync(
+            UOMobileEntity victim,
+            UOMobileEntity killer,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = cancellationToken;
+            Awards.Add((victim, killer));
+
+            return Task.CompletedTask;
+        }
+    }
+
     [Test]
     public async Task ForceDeathAsync_WhenNpcIsAlive_ShouldMarkDeadAndCreateCorpse()
     {
@@ -372,6 +389,7 @@ public sealed class DeathServiceTests
         var timerService = new TimerServiceSpy();
         var spatial = new SpatialWorldServiceSpy();
         var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
         var config = new MoongateConfig
         {
             Game = new MoongateGameConfig
@@ -398,6 +416,7 @@ public sealed class DeathServiceTests
             spatial,
             timerService,
             eventBus,
+            fameKarmaService,
             config
         );
 
@@ -422,6 +441,7 @@ public sealed class DeathServiceTests
         var timerService = new TimerServiceSpy();
         var spatial = new SpatialWorldServiceSpy();
         var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
         var config = new MoongateConfig
         {
             Game = new MoongateGameConfig
@@ -448,6 +468,7 @@ public sealed class DeathServiceTests
             spatial,
             timerService,
             eventBus,
+            fameKarmaService,
             config
         );
 
@@ -480,6 +501,7 @@ public sealed class DeathServiceTests
             }
         };
         var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
         var config = new MoongateConfig
         {
             Game = new MoongateGameConfig
@@ -543,6 +565,7 @@ public sealed class DeathServiceTests
             spatial,
             timerService,
             eventBus,
+            fameKarmaService,
             config
         );
 
@@ -588,6 +611,7 @@ public sealed class DeathServiceTests
         var timerService = new TimerServiceSpy();
         var spatial = new SpatialWorldServiceSpy();
         var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
         var config = new MoongateConfig
         {
             Game = new MoongateGameConfig
@@ -614,6 +638,7 @@ public sealed class DeathServiceTests
             spatial,
             timerService,
             eventBus,
+            fameKarmaService,
             config
         );
 
@@ -633,6 +658,125 @@ public sealed class DeathServiceTests
                     spatial.BroadcastPackets.OfType<DeleteObjectPacket>().Any(packet => packet.Serial == corpse.Id),
                     Is.True
                 );
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandleDeathAsync_WhenNpcDiesWithPlayerKiller_ShouldAwardFameAndKarma()
+    {
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new SpatialWorldServiceSpy();
+        var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
+        var config = new MoongateConfig
+        {
+            Game = new MoongateGameConfig
+            {
+                CorpseDecaySeconds = 300
+            }
+        };
+        var victim = new UOMobileEntity
+        {
+            Id = (Serial)0x00000060u,
+            Name = "Ogre",
+            MapId = 1,
+            Location = new(120, 220, 0),
+            Hits = 0,
+            MaxHits = 50,
+            IsAlive = false,
+            Fame = 3000,
+            Karma = -3000
+        };
+        var killer = new UOMobileEntity
+        {
+            Id = (Serial)0x00000061u,
+            Name = "Tommy",
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(121, 220, 0)
+        };
+
+        IDeathService service = new DeathService(
+            mobileService,
+            itemService,
+            spatial,
+            timerService,
+            eventBus,
+            fameKarmaService,
+            config
+        );
+
+        var handled = await service.HandleDeathAsync(victim, killer);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(fameKarmaService.Awards, Has.Count.EqualTo(1));
+                Assert.That(fameKarmaService.Awards[0].Victim, Is.SameAs(victim));
+                Assert.That(fameKarmaService.Awards[0].Killer, Is.SameAs(killer));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandleDeathAsync_WhenPlayerDies_ShouldNotAwardFameAndKarma()
+    {
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new SpatialWorldServiceSpy();
+        var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
+        var config = new MoongateConfig
+        {
+            Game = new MoongateGameConfig
+            {
+                CorpseDecaySeconds = 300
+            }
+        };
+        var victim = new UOMobileEntity
+        {
+            Id = (Serial)0x00000062u,
+            Name = "Victim",
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(130, 230, 0),
+            Hits = 0,
+            MaxHits = 50,
+            IsAlive = false,
+            Fame = 3000,
+            Karma = -3000
+        };
+        var killer = new UOMobileEntity
+        {
+            Id = (Serial)0x00000063u,
+            Name = "Tommy",
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(131, 230, 0)
+        };
+
+        IDeathService service = new DeathService(
+            mobileService,
+            itemService,
+            spatial,
+            timerService,
+            eventBus,
+            fameKarmaService,
+            config
+        );
+
+        var handled = await service.HandleDeathAsync(victim, killer);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(fameKarmaService.Awards, Is.Empty);
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Interaction/FameKarmaServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/FameKarmaServiceTests.cs
@@ -1,0 +1,160 @@
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Services.Interaction;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Tests.Server.Services.Interaction;
+
+public sealed class FameKarmaServiceTests
+{
+    [Test]
+    public async Task AwardNpcKillAsync_WhenVictimIsNpcAndKillerIsPlayer_ShouldAwardAndPersist()
+    {
+        var mobileService = new TestMobileService();
+        var service = new FameKarmaService(mobileService);
+        var victim = CreateMobile(isPlayer: false, fame: 250, karma: -250);
+        var killer = CreateMobile(isPlayer: true, fame: 10, karma: 20);
+
+        await service.AwardNpcKillAsync(victim, killer);
+
+        Assert.That(killer.Fame, Is.EqualTo(12));
+        Assert.That(killer.Karma, Is.EqualTo(18));
+        Assert.That(mobileService.UpdatedMobiles, Has.Count.EqualTo(1));
+        Assert.That(mobileService.UpdatedMobiles[0], Is.SameAs(killer));
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public async Task AwardNpcKillAsync_WhenAwardGateFails_ShouldNotPersist(bool victimIsPlayer, bool killerIsPlayer)
+    {
+        var mobileService = new TestMobileService();
+        var service = new FameKarmaService(mobileService);
+        var victim = CreateMobile(isPlayer: victimIsPlayer, fame: 500, karma: 500);
+        var killer = CreateMobile(isPlayer: killerIsPlayer, fame: 1, karma: 1);
+
+        await service.AwardNpcKillAsync(victim, killer);
+
+        Assert.That(mobileService.UpdatedMobiles, Is.Empty);
+        Assert.That(killer.Fame, Is.EqualTo(1));
+        Assert.That(killer.Karma, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task AwardNpcKillAsync_WhenAwardsAreZero_ShouldNotPersist()
+    {
+        var mobileService = new TestMobileService();
+        var service = new FameKarmaService(mobileService);
+        var victim = CreateMobile(isPlayer: false, fame: 99, karma: 99);
+        var killer = CreateMobile(isPlayer: true, fame: 7, karma: 8);
+
+        await service.AwardNpcKillAsync(victim, killer);
+
+        Assert.That(mobileService.UpdatedMobiles, Is.Empty);
+        Assert.That(killer.Fame, Is.EqualTo(7));
+        Assert.That(killer.Karma, Is.EqualTo(8));
+    }
+
+    [Test]
+    public async Task AwardNpcKillAsync_WhenOnlyFameAwards_ShouldPersistUpdatedKiller()
+    {
+        var mobileService = new TestMobileService();
+        var service = new FameKarmaService(mobileService);
+        var victim = CreateMobile(isPlayer: false, fame: 500, karma: 99);
+        var killer = CreateMobile(isPlayer: true, fame: 11, karma: 22);
+
+        await service.AwardNpcKillAsync(victim, killer);
+
+        Assert.That(killer.Fame, Is.EqualTo(16));
+        Assert.That(killer.Karma, Is.EqualTo(22));
+        Assert.That(mobileService.UpdatedMobiles, Has.Count.EqualTo(1));
+    }
+
+    private static UOMobileEntity CreateMobile(bool isPlayer, int fame, int karma)
+        => new()
+        {
+            Id = (Serial)(isPlayer ? 0x40000001u : 0x00001001u),
+            IsPlayer = isPlayer,
+            Fame = fame,
+            Karma = karma,
+            Location = new Point3D(0, 0, 0)
+        };
+
+    private sealed class TestMobileService : IMobileService
+    {
+        public List<UOMobileEntity> UpdatedMobiles { get; } = [];
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            UpdatedMobiles.Add(mobile);
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = id;
+            _ = cancellationToken;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = id;
+            _ = cancellationToken;
+
+            return Task.FromResult<UOMobileEntity?>(null);
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+            _ = cancellationToken;
+
+            return Task.FromResult(new List<UOMobileEntity>());
+        }
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = templateId;
+            _ = location;
+            _ = mapId;
+            _ = accountId;
+            _ = cancellationToken;
+
+            return Task.FromException<UOMobileEntity>(new NotSupportedException());
+        }
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = templateId;
+            _ = location;
+            _ = mapId;
+            _ = accountId;
+            _ = cancellationToken;
+
+            return Task.FromResult((false, (UOMobileEntity?)null));
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/Items/ItemManipulationServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Items/ItemManipulationServiceTests.cs
@@ -1,0 +1,303 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.Interaction;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Network.Packets.Outgoing.System;
+using Moongate.Server.Data.Items;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Services.Items;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Services.Items;
+
+public sealed class ItemManipulationServiceTests
+{
+    private sealed class ItemManipulationTestItemService : IItemService
+    {
+        private readonly Dictionary<Serial, UOItemEntity> _items = [];
+
+        public bool EquipCalled { get; private set; }
+
+        public void Add(UOItemEntity item)
+            => _items[item.Id] = item;
+
+        public Task BulkUpsertItemsAsync(IReadOnlyList<UOItemEntity> items)
+        {
+            foreach (var item in items)
+            {
+                _items[item.Id] = item;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public UOItemEntity Clone(UOItemEntity item, bool generateNewSerial = true)
+            => throw new NotSupportedException();
+
+        public Task<UOItemEntity?> CloneAsync(Serial itemId, bool generateNewSerial = true)
+            => throw new NotSupportedException();
+
+        public Task<Serial> CreateItemAsync(UOItemEntity item)
+            => throw new NotSupportedException();
+
+        public Task<bool> DeleteItemAsync(Serial itemId)
+        {
+            _items.Remove(itemId);
+
+            return Task.FromResult(true);
+        }
+
+        public Task<DropItemToGroundResult?> DropItemToGroundAsync(
+            Serial itemId,
+            Point3D location,
+            int mapId,
+            long sessionId = 0
+        )
+            => throw new NotSupportedException();
+
+        public Task<bool> EquipItemAsync(Serial itemId, Serial mobileId, ItemLayerType layer)
+        {
+            EquipCalled = true;
+
+            if (_items.TryGetValue(itemId, out var item))
+            {
+                item.EquippedMobileId = mobileId;
+                item.EquippedLayer = layer;
+                item.ParentContainerId = Serial.Zero;
+                item.ContainerPosition = Point2D.Zero;
+            }
+
+            return Task.FromResult(true);
+        }
+
+        public Task<List<UOItemEntity>> GetGroundItemsInSectorAsync(int mapId, int sectorX, int sectorY)
+            => Task.FromResult<List<UOItemEntity>>([]);
+
+        public Task<UOItemEntity?> GetItemAsync(Serial itemId)
+            => Task.FromResult(_items.TryGetValue(itemId, out var item) ? item : null);
+
+        public Task<List<UOItemEntity>> GetItemsInContainerAsync(Serial containerId)
+            => Task.FromResult<List<UOItemEntity>>([]);
+
+        public Task<bool> MoveItemToContainerAsync(Serial itemId, Serial containerId, Point2D position, long sessionId = 0)
+            => throw new NotSupportedException();
+
+        public Task<bool> MoveItemToWorldAsync(Serial itemId, Point3D location, int mapId, long sessionId = 0)
+            => throw new NotSupportedException();
+
+        public Task<UOItemEntity> SpawnFromTemplateAsync(string itemTemplateId)
+            => throw new NotSupportedException();
+
+        public Task<(bool Found, UOItemEntity? Item)> TryToGetItemAsync(Serial itemId)
+            => Task.FromResult((_items.TryGetValue(itemId, out var item), item));
+
+        public Task UpsertItemAsync(UOItemEntity item)
+        {
+            _items[item.Id] = item;
+
+            return Task.CompletedTask;
+        }
+
+        public Task UpsertItemsAsync(params UOItemEntity[] items)
+            => BulkUpsertItemsAsync(items);
+    }
+
+    private sealed class ItemManipulationTestMobileService : IMobileService
+    {
+        public UOMobileEntity? Mobile { get; set; }
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+            => Task.FromResult(Mobile);
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult<List<UOMobileEntity>>([]);
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => throw new NotSupportedException();
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => throw new NotSupportedException();
+    }
+
+    private sealed class ItemManipulationTestSpatialWorldService : ISpatialWorldService
+    {
+        public void AddOrUpdateItem(UOItemEntity item, int mapId) { }
+        public void AddOrUpdateMobile(UOMobileEntity mobile) { }
+        public void AddRegion(JsonRegion region) { }
+
+        public Task<int> BroadcastToPlayersAsync(
+            Moongate.Network.Packets.Interfaces.IGameNetworkPacket packet,
+            int mapId,
+            Point3D location,
+            int? range = null,
+            long? excludeSessionId = null
+        )
+            => Task.FromResult(0);
+
+        public List<MapSector> GetActiveSectors()
+            => [];
+
+        public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
+            => [];
+
+        public int GetMusic(int mapId, Point3D location)
+            => 0;
+
+        public List<UOItemEntity> GetNearbyItems(Point3D location, int range, int mapId)
+            => [];
+
+        public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
+            => [];
+
+        public List<GameSession> GetPlayersInRange(Point3D location, int range, int mapId, GameSession? excludeSession = null)
+            => [];
+
+        public List<UOMobileEntity> GetPlayersInSector(int mapId, int sectorX, int sectorY)
+            => [];
+
+        public JsonRegion? GetRegionById(int regionId)
+            => null;
+
+        public MapSector? GetSectorByLocation(int mapId, Point3D location)
+            => null;
+
+        public SectorSystemStats GetStats()
+            => new();
+
+        public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation) { }
+        public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation) { }
+        public void RemoveEntity(Serial serial) { }
+    }
+
+    [Test]
+    public async Task HandleDropWearItemAsync_WhenWeaponIsEquipped_ShouldRefreshSessionCharacterAndStatusPacket()
+    {
+        var itemService = new ItemManipulationTestItemService();
+        var eventBus = new NetworkServiceTestGameEventBusService();
+        var dragService = new PlayerDragService();
+        var spatialWorldService = new ItemManipulationTestSpatialWorldService();
+        var mobileService = new ItemManipulationTestMobileService();
+        var sessionService = new FakeGameNetworkSessionService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+
+        var characterId = (Serial)0x00000020u;
+        var bowId = (Serial)0x40000020u;
+        var bow = new UOItemEntity
+        {
+            Id = bowId,
+            ItemId = 0x13B2,
+            CombatStats = new()
+            {
+                DamageMin = 18,
+                DamageMax = 33,
+                RangeMin = 1,
+                RangeMax = 10
+            },
+            WeaponSkill = UOSkillName.Archery,
+            AmmoItemId = 0x0F3F,
+            AmmoEffectId = 0x1BFE
+        };
+        itemService.Add(bow);
+
+        var persistedMobile = new UOMobileEntity
+        {
+            Id = characterId,
+            MapId = 0,
+            Location = new(100, 100, 0)
+        };
+        persistedMobile.EquippedItemIds[ItemLayerType.TwoHanded] = bowId;
+        mobileService.Mobile = persistedMobile;
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = characterId,
+            Character = new UOMobileEntity
+            {
+                Id = characterId,
+                MapId = 0,
+                Location = new(100, 100, 0),
+                MinWeaponDamage = 1,
+                MaxWeaponDamage = 4
+            }
+        };
+        sessionService.Add(session);
+
+        var service = new ItemManipulationService(
+            itemService,
+            eventBus,
+            dragService,
+            spatialWorldService,
+            mobileService,
+            sessionService,
+            outgoingQueue
+        );
+
+        var packet = new DropWearItemPacket
+        {
+            ItemSerial = bowId,
+            PlayerSerial = characterId,
+            Layer = ItemLayerType.TwoHanded
+        };
+
+        var result = await service.HandleDropWearItemAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(itemService.EquipCalled, Is.True);
+                Assert.That(session.Character, Is.SameAs(persistedMobile));
+                Assert.That(session.Character!.MinWeaponDamage, Is.EqualTo(18));
+                Assert.That(session.Character.MaxWeaponDamage, Is.EqualTo(33));
+                Assert.That(session.Character.GetEquippedItemsRuntime().Single().Id, Is.EqualTo(bowId));
+            }
+        );
+
+        var packets = new List<object>();
+
+        while (outgoingQueue.TryDequeue(out var outbound))
+        {
+            packets.Add(outbound.Packet);
+        }
+
+        var statusPacket = packets.OfType<PlayerStatusPacket>().Single();
+
+        Assert.That(statusPacket.Mobile, Is.SameAs(persistedMobile));
+    }
+}


### PR DESCRIPTION
## Summary
- add `IFameKarmaService` and `FameKarmaService` to handle PvE fame/karma kill rewards
- integrate the reward flow into `DeathService` for player kills against NPCs only
- add focused tests for the service and death-path integration, and update docs to reflect the supported PvE scope

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~FameKarmaServiceTests|FullyQualifiedName~DeathServiceTests|FullyQualifiedName~ScheduledSwing_WhenHitIsLethal_ShouldDelegateToDeathService"`
- [x] `dotnet build Moongate.slnx`

Refs #83
