### PR TITLE
feat: add enhanced client session support

### DIFF
--- a/docs/articles/networking/client-encryption.md
+++ b/docs/articles/networking/client-encryption.md
@@ -50,6 +50,21 @@ Moongate supports:
 
 The game-server path intentionally uses the legacy UO MD5-derived XOR state because that is part of the historical client protocol and is required for compatibility.
 
+## Enhanced Client Session Shape
+
+Enhanced-client support stays separate from transport encryption:
+
+- `0xE1` `ClientType` updates the session client capability
+- `0xBD` `ClientVersion` can also promote the session into an enhanced-capable mode
+- `GameNetworkSession` exposes `ClientType` and `IsEnhancedClient`
+
+Moongate currently uses that session capability to:
+
+- set the KR/UO3D-compatible flags on the `0xA9` character list
+- prefer the new mobile-incoming format for enhanced sessions during world sync and movement visibility updates
+
+Encryption and enhanced-client support are intentionally orthogonal. An enhanced-capable client can still connect plain when `encryptionMode` allows it.
+
 ## Configuration Example
 
 ```json

--- a/docs/articles/networking/packets.md
+++ b/docs/articles/networking/packets.md
@@ -91,6 +91,7 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0x91` | Game Login | C -> S | `GameLoginPacket` | `handler` | `LoginHandler` | Game-server auth |
 | `0x5D` | Login Character | C -> S | `LoginCharacterPacket` | `handler` | `LoginHandler` | Character enter world |
 | `0xBD` | Client Version | C -> S | `ClientVersionPacket` | `handler` | `LoginHandler` | Stores negotiated client version |
+| `0xE1` | Client Type | C -> S | `ClientTypePacket` | `handler` | `LoginHandler`, `GeneralInformationHandler` | Stores session client capabilities for KR/SA/EC-aware flows |
 | `0xF8` | Character Creation | C -> S | `CharacterCreationPacket` | `handler` | `CharacterHandler` | Modern creation flow |
 | `0x72` | Request War Mode / War Mode | both | `RequestWarModePacket`, `WarModePacket` | `handler` + `outgoing` | `CharacterHandler` | Inbound toggle request and outbound war-mode state reply share opcode `0x72`; outgoing packet is intentionally not registry-decorated to avoid direction-agnostic opcode collision |
 | `0x02` | Move Request | C -> S | `MoveRequestPacket` | `handler` | `MovementHandler` | Core movement |
@@ -166,6 +167,12 @@ Current notable outgoing packet classes:
 - `PlayerStatusPacket`
   - modern `7.x` status layout
   - reads effective mobile state from `UOMobileEntity`
+- `CharactersStartingLocationsPacket`
+  - outgoing `0xA9`
+  - sets the KR/UO3D-compatible flags when `session.IsEnhancedClient` is true
+- `MobileIncomingPacket`
+  - outgoing `0x78`
+  - chooses the new mobile format from the recipient session capability instead of assuming one global client shape
 - `PaperdollPacket`
   - outgoing `0x88`
   - serializes the paperdoll display name using the fame/karma reputation title table

--- a/src/Moongate.Network.Packets/Incoming/Login/ClientTypePacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/Login/ClientTypePacket.cs
@@ -2,6 +2,7 @@ using Moongate.Network.Packets.Attributes;
 using Moongate.Network.Packets.Base;
 using Moongate.Network.Packets.Types.Packets;
 using Moongate.Network.Spans;
+using Moongate.UO.Data.Version;
 
 namespace Moongate.Network.Packets.Incoming.Login;
 
@@ -12,9 +13,36 @@ namespace Moongate.Network.Packets.Incoming.Login;
 /// </summary>
 public class ClientTypePacket : BaseGameNetworkPacket
 {
+    public uint AdvertisedClientType { get; private set; }
+
+    public ClientType ResolvedClientType { get; private set; } = ClientType.Classic;
+
     public ClientTypePacket()
         : base(0xE1) { }
 
     protected override bool ParsePayload(ref SpanReader reader)
-        => true;
+    {
+        if (reader.Remaining < 8)
+        {
+            return false;
+        }
+
+        var declaredLength = reader.ReadUInt16();
+
+        if (declaredLength < 7 || declaredLength - 3 > reader.Remaining)
+        {
+            return false;
+        }
+
+        _ = reader.ReadUInt16();
+        AdvertisedClientType = reader.ReadUInt32();
+        ResolvedClientType = AdvertisedClientType switch
+        {
+            0x02 => ClientType.KR,
+            0x03 => ClientType.SA,
+            _ => ClientType.Classic
+        };
+
+        return true;
+    }
 }

--- a/src/Moongate.Network.Packets/Outgoing/Login/CharactersStartingLocationsPacket.cs
+++ b/src/Moongate.Network.Packets/Outgoing/Login/CharactersStartingLocationsPacket.cs
@@ -16,6 +16,8 @@ namespace Moongate.Network.Packets.Outgoing.Login;
 /// </summary>
 public class CharactersStartingLocationsPacket : BaseGameNetworkPacket
 {
+    public bool IsEnhancedClient { get; set; }
+
     public List<CityInfo> Cities { get; } = [];
 
     public List<CharacterEntry?> Characters { get; } = [];
@@ -120,6 +122,11 @@ public class CharactersStartingLocationsPacket : BaseGameNetworkPacket
                         : CharacterListFlags.ExpansionEJ;
 
         flags |= CharacterListFlags.SixthCharacterSlot | CharacterListFlags.SeventhCharacterSlot;
+
+        if (IsEnhancedClient)
+        {
+            flags |= CharacterListFlags.KR | CharacterListFlags.UO3DClientType;
+        }
 
         writer.Write((int)flags);
         writer.Write((short)-1);

--- a/src/Moongate.Server/Data/Session/GameNetworkSession.cs
+++ b/src/Moongate.Server/Data/Session/GameNetworkSession.cs
@@ -97,6 +97,16 @@ public sealed class GameNetworkSession
     public ClientVersion? ClientVersion { get; private set; }
 
     /// <summary>
+    /// Gets the resolved client type for this session.
+    /// </summary>
+    public ClientType ClientType { get; private set; } = ClientType.Classic;
+
+    /// <summary>
+    /// Gets whether the session represents an enhanced-style client.
+    /// </summary>
+    public bool IsEnhancedClient { get; private set; }
+
+    /// <summary>
     /// Gets the selected in-game character serial, when available.
     /// </summary>
     public uint? CharacterSerial { get; private set; }
@@ -255,6 +265,26 @@ public sealed class GameNetworkSession
         lock (_stateSync)
         {
             ClientVersion = clientVersion;
+
+            if (ClientType == ClientType.Classic && clientVersion.Type != ClientType.Classic)
+            {
+                ClientType = clientVersion.Type;
+            }
+
+            IsEnhancedClient = ClientType is ClientType.KR or ClientType.SA or ClientType.UOTD;
+        }
+    }
+
+    /// <summary>
+    /// Stores the client type reported by the client.
+    /// </summary>
+    /// <param name="clientType">Reported client type.</param>
+    public void SetClientType(ClientType clientType)
+    {
+        lock (_stateSync)
+        {
+            ClientType = clientType;
+            IsEnhancedClient = clientType is ClientType.KR or ClientType.SA or ClientType.UOTD;
         }
     }
 

--- a/src/Moongate.Server/Handlers/GeneralInformationHandler.cs
+++ b/src/Moongate.Server/Handlers/GeneralInformationHandler.cs
@@ -51,6 +51,10 @@ public class GeneralInformationHandler : BasePacketListener
                 await HandleAction3DClientAsync(session, payload);
 
                 break;
+            case GeneralInformationSubcommandType.ClientType:
+                HandleClientType(session, payload);
+
+                break;
             case GeneralInformationSubcommandType.StatLockChange:
                 await HandleStatLockChangeAsync(session, payload);
 
@@ -78,6 +82,24 @@ public class GeneralInformationHandler : BasePacketListener
         }
 
         return true;
+    }
+
+    private static void HandleClientType(GameSession session, ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length < 4)
+        {
+            return;
+        }
+
+        var rawClientType = BinaryPrimitives.ReadUInt32BigEndian(payload);
+        var clientType = rawClientType switch
+        {
+            0x02u => ClientType.KR,
+            0x03u => ClientType.SA,
+            _ => ClientType.Classic
+        };
+
+        session.NetworkSession.SetClientType(clientType);
     }
 
     private ValueTask HandleAction3DClientAsync(GameSession session, ReadOnlySpan<byte> payload)

--- a/src/Moongate.Server/Handlers/LoginHandler.cs
+++ b/src/Moongate.Server/Handlers/LoginHandler.cs
@@ -29,6 +29,7 @@ namespace Moongate.Server.Handlers;
  RegisterPacketHandler(PacketDefinition.ServerSelectPacket),
  RegisterPacketHandler(PacketDefinition.GameLoginPacket),
  RegisterPacketHandler(PacketDefinition.LoginCharacterPacket),
+ RegisterPacketHandler(PacketDefinition.ClientTypePacket),
  RegisterPacketHandler(PacketDefinition.ClientVersionPacket)]
 
 /// <summary>
@@ -122,6 +123,11 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
             return await HandleLoginCharacterPacketAsync(session, loginCharacterPacket);
         }
 
+        if (packet is ClientTypePacket clientTypePacket)
+        {
+            return HandleClientTypePacketAsync(session, clientTypePacket);
+        }
+
         if (packet is ClientVersionPacket clientVersionPacket)
         {
             return HandleClientVersionPacketAsync(session, clientVersionPacket);
@@ -198,6 +204,20 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         return true;
     }
 
+    private bool HandleClientTypePacketAsync(GameSession session, ClientTypePacket clientTypePacket)
+    {
+        session.NetworkSession.SetClientType(clientTypePacket.ResolvedClientType);
+
+        _logger.Debug(
+            "Received ClientTypePacket from session {SessionId}: advertised=0x{AdvertisedClientType:X8} resolved={ClientType}",
+            session.SessionId,
+            clientTypePacket.AdvertisedClientType,
+            clientTypePacket.ResolvedClientType
+        );
+
+        return true;
+    }
+
     private async Task<bool> HandleGameLoginPacketAsync(GameSession session, GameLoginPacket gameLoginPacket)
     {
         _logger.Debug(
@@ -220,7 +240,10 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
 
         session.NetworkSession.EnableCompression();
 
-        var characterListPacket = new CharactersStartingLocationsPacket();
+        var characterListPacket = new CharactersStartingLocationsPacket
+        {
+            IsEnhancedClient = session.NetworkSession.IsEnhancedClient
+        };
         characterListPacket.Cities.AddRange(StartingCities.AvailableStartingCities);
 
         var characters = await _characterService.GetCharactersForAccountAsync(session.AccountId);

--- a/src/Moongate.Server/Handlers/MobileHandler.cs
+++ b/src/Moongate.Server/Handlers/MobileHandler.cs
@@ -387,7 +387,12 @@ public class MobileHandler
 
             _outgoingPacketQueue.Enqueue(
                 session.SessionId,
-                new MobileIncomingPacket(mobileEntity, otherMobile, true, true)
+                new MobileIncomingPacket(
+                    mobileEntity,
+                    otherMobile,
+                    true,
+                    session.NetworkSession.IsEnhancedClient
+                )
                 {
                     ResolvedNotoriety = _notorietyService.Compute(mobileEntity, otherMobile)
                 }

--- a/src/Moongate.Server/Services/Characters/PlayerLoginWorldSyncService.cs
+++ b/src/Moongate.Server/Services/Characters/PlayerLoginWorldSyncService.cs
@@ -212,7 +212,7 @@ public sealed class PlayerLoginWorldSyncService : IPlayerLoginWorldSyncService
 
             _outgoingPacketQueue.Enqueue(
                 session.SessionId,
-                new MobileIncomingPacket(mobileEntity, otherMobile, true, false)
+                new MobileIncomingPacket(mobileEntity, otherMobile, true, session.NetworkSession.IsEnhancedClient)
                 {
                     ResolvedNotoriety = _notorietyService.Compute(mobileEntity, otherMobile)
                 }
@@ -310,7 +310,7 @@ public sealed class PlayerLoginWorldSyncService : IPlayerLoginWorldSyncService
 
             _outgoingPacketQueue.Enqueue(
                 session.SessionId,
-                new MobileIncomingPacket(mobileEntity, otherMobile, true, false)
+                new MobileIncomingPacket(mobileEntity, otherMobile, true, session.NetworkSession.IsEnhancedClient)
                 {
                     ResolvedNotoriety = _notorietyService.Compute(mobileEntity, otherMobile)
                 }

--- a/src/Moongate.Server/Services/Events/DispatchEventsService.cs
+++ b/src/Moongate.Server/Services/Events/DispatchEventsService.cs
@@ -265,7 +265,12 @@ public sealed class DispatchEventsService
             {
                 _outgoingPacketQueue.Enqueue(
                     playerSession.SessionId,
-                    new MobileIncomingPacket(playerSession.Character, mobile, stygianAbyss)
+                    new MobileIncomingPacket(
+                        playerSession.Character,
+                        mobile,
+                        stygianAbyss,
+                        playerSession.NetworkSession.IsEnhancedClient
+                    )
                     {
                         ResolvedNotoriety = _notorietyService.Compute(playerSession.Character, mobile)
                     }

--- a/tests/Moongate.Tests/Network/Packets/CharactersStartingLocationsPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/CharactersStartingLocationsPacketTests.cs
@@ -2,6 +2,7 @@ using Moongate.Network.Packets.Outgoing.Login;
 using Moongate.Network.Spans;
 using Moongate.UO.Data.Packets.Data;
 using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
 
 namespace Moongate.Tests.Network.Packets;
 
@@ -76,6 +77,35 @@ public class CharactersStartingLocationsPacketTests
                 Assert.That((flags & 0x40) != 0, Is.True);   // SixthCharacterSlot
                 Assert.That((flags & 0x1000) != 0, Is.True); // SeventhCharacterSlot
                 Assert.That(terminator, Is.EqualTo(-1));
+            }
+        );
+    }
+
+    [Test]
+    public void Write_WhenEnhancedClientIsEnabled_ShouldIncludeKrAndUo3DFlags()
+    {
+        var packet = new CharactersStartingLocationsPacket
+        {
+            IsEnhancedClient = true
+        };
+        packet.FillCharacters([new CharacterEntry("alpha")]);
+
+        var writer = new SpanWriter(1024, true);
+        packet.Write(ref writer);
+        var data = writer.ToArray();
+        writer.Dispose();
+
+        var flagsOffset = 3 + 1 + 7 * 60 + 1;
+        var flags = (CharacterListFlags)((data[flagsOffset] << 24) |
+                                         (data[flagsOffset + 1] << 16) |
+                                         (data[flagsOffset + 2] << 8) |
+                                         data[flagsOffset + 3]);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(flags.HasFlag(CharacterListFlags.KR), Is.True);
+                Assert.That(flags.HasFlag(CharacterListFlags.UO3DClientType), Is.True);
             }
         );
     }

--- a/tests/Moongate.Tests/Network/Packets/ClientTypePacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ClientTypePacketTests.cs
@@ -1,0 +1,33 @@
+using Moongate.Network.Packets.Incoming.Login;
+
+namespace Moongate.Tests.Network.Packets;
+
+public class ClientTypePacketTests
+{
+    [TestCase(new byte[] { 0xE1, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 }, 0x02u)]
+    [TestCase(new byte[] { 0xE1, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03 }, 0x03u)]
+    public void TryParse_ShouldReadAdvertisedClientType(byte[] raw, uint advertisedClientType)
+    {
+        var packet = new ClientTypePacket();
+
+        var ok = packet.TryParse(raw);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(packet.AdvertisedClientType, Is.EqualTo(advertisedClientType));
+            }
+        );
+    }
+
+    [Test]
+    public void TryParse_ShouldFail_WhenPayloadIsTooShort()
+    {
+        var packet = new ClientTypePacket();
+
+        var ok = packet.TryParse([0xE1, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00]);
+
+        Assert.That(ok, Is.False);
+    }
+}

--- a/tests/Moongate.Tests/Server/Data/Session/GameNetworkSessionTests.cs
+++ b/tests/Moongate.Tests/Server/Data/Session/GameNetworkSessionTests.cs
@@ -57,4 +57,55 @@ public sealed class GameNetworkSessionTests
 
         Assert.That(session.ClientVersion, Is.SameAs(version));
     }
+
+    [Test]
+    public void SetClientVersion_WhenVersionIsEnhanced_ShouldMarkSessionAsEnhanced()
+    {
+        using var client = new MoongateTCPClient(new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameNetworkSession(client);
+
+        session.SetClientVersion(new ClientVersion("67.0.114.0"));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(session.ClientType, Is.EqualTo(ClientType.SA));
+                Assert.That(session.IsEnhancedClient, Is.True);
+            }
+        );
+    }
+
+    [Test]
+    public void SetClientType_WhenClientTypeIsKr_ShouldMarkSessionAsEnhanced()
+    {
+        using var client = new MoongateTCPClient(new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameNetworkSession(client);
+
+        session.SetClientType(ClientType.KR);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(session.ClientType, Is.EqualTo(ClientType.KR));
+                Assert.That(session.IsEnhancedClient, Is.True);
+            }
+        );
+    }
+
+    [Test]
+    public void SetClientType_WhenClientTypeIsClassic_ShouldNotMarkSessionAsEnhanced()
+    {
+        using var client = new MoongateTCPClient(new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameNetworkSession(client);
+
+        session.SetClientType(ClientType.Classic);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(session.ClientType, Is.EqualTo(ClientType.Classic));
+                Assert.That(session.IsEnhancedClient, Is.False);
+            }
+        );
+    }
 }

--- a/tests/Moongate.Tests/Server/Handlers/GeneralInformationHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/GeneralInformationHandlerTests.cs
@@ -11,6 +11,7 @@ using Moongate.Tests.Server.Support;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Version;
 
 namespace Moongate.Tests.Server.Handlers;
 
@@ -266,6 +267,30 @@ public class GeneralInformationHandlerTests
                 Assert.That(gameEvent.SessionId, Is.EqualTo(session.SessionId));
                 Assert.That(gameEvent.SpellId, Is.EqualTo((ushort)0x002D));
                 Assert.That(gameEvent.TargetSerial, Is.EqualTo((Serial)0x00000005u));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_ShouldStoreEnhancedClientType_ForClientTypeSubcommand()
+    {
+        var eventBus = new NetworkServiceTestGameEventBusService();
+        var handler = new GeneralInformationHandler(new BasePacketListenerTestOutgoingPacketQueue(), eventBus);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client));
+        var packet = GeneralInformationPacket.Create(
+            GeneralInformationSubcommandType.ClientType,
+            new byte[] { 0x00, 0x00, 0x00, 0x03, 0x00 }
+        );
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(session.NetworkSession.ClientType, Is.EqualTo(ClientType.SA));
+                Assert.That(session.NetworkSession.IsEnhancedClient, Is.True);
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
@@ -235,6 +235,26 @@ public class LoginHandlerTests
     }
 
     [Test]
+    public async Task HandlePacketAsync_WhenClientTypePacketIsReceived_ShouldStoreEnhancedClientTypeInNetworkSession()
+    {
+        var handler = CreateHandler();
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client));
+        var packet = new ClientTypePacket();
+        Assert.That(packet.TryParse([0xE1, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03]), Is.True);
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(session.NetworkSession.IsEnhancedClient, Is.True);
+            }
+        );
+    }
+
+    [Test]
     public async Task HandlePacketAsync_WhenSelectingCharacterAfterGameLogin_ShouldReuseCachedCharacterList()
     {
         var queue = new BasePacketListenerTestOutgoingPacketQueue();

--- a/tests/Moongate.Tests/Server/Handlers/MobileHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/MobileHandlerTests.cs
@@ -421,6 +421,7 @@ public sealed class MobileHandlerTests
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var sessions = new FakeGameNetworkSessionService();
         var movingSession = CreateSession(movingPlayerId);
+        movingSession.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.SA);
         sessions.Add(movingSession);
 
         // Move from sector (7,8) to adjacent sector (8,8) with radius 1
@@ -527,6 +528,7 @@ public sealed class MobileHandlerTests
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var sessions = new FakeGameNetworkSessionService();
         var movingSession = CreateSession(movingPlayerId);
+        movingSession.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.SA);
         sessions.Add(movingSession);
 
         var oldLocation = new Point3D(7 << MapSectorConsts.SectorShift, 7 << MapSectorConsts.SectorShift, 0);
@@ -635,6 +637,7 @@ public sealed class MobileHandlerTests
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var sessions = new FakeGameNetworkSessionService();
         var movingSession = CreateSession(movingPlayerId);
+        movingSession.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.SA);
         sessions.Add(movingSession);
 
         var oldLocation = new Point3D(100, 100, 0);
@@ -717,6 +720,7 @@ public sealed class MobileHandlerTests
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var sessions = new FakeGameNetworkSessionService();
         var movingSession = CreateSession(movingPlayerId);
+        movingSession.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.SA);
         sessions.Add(movingSession);
 
         var oldLocation = new Point3D(100, 100, 0);
@@ -778,6 +782,7 @@ public sealed class MobileHandlerTests
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var sessions = new FakeGameNetworkSessionService();
         var movingSession = CreateSession(movingPlayerId);
+        movingSession.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.SA);
         sessions.Add(movingSession);
 
         var oldLocation = new Point3D(100, 100, 0);
@@ -1788,5 +1793,59 @@ public sealed class MobileHandlerTests
         }
 
         return packets;
+    }
+
+    [Test]
+    public async Task HandleAsync_ForMobilePositionChanged_WhenRecipientIsClassicClient_ShouldUseLegacyMobileIncomingFormat()
+    {
+        var movingPlayerId = (Serial)0x00003000u;
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessions = new FakeGameNetworkSessionService();
+        var movingSession = CreateSession(movingPlayerId);
+        movingSession.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.Classic);
+        sessions.Add(movingSession);
+
+        var oldLocation = new Point3D(100, 100, 0);
+        var newLocation = new Point3D(132, 132, 0);
+        var newSector = new MapSector(1, 8, 8);
+        newSector.AddEntity(
+            new UOMobileEntity
+            {
+                Id = (Serial)0x00009999u,
+                IsPlayer = false,
+                Name = "guard",
+                Location = newLocation,
+                MapId = 1,
+                BaseBody = 0x0190
+            }
+        );
+
+        var spatial = new MobileHandlerTestSpatialWorldService
+        {
+            SectorByLocationResolver = (_, location) => location == oldLocation ? new(1, 6, 6) : newSector
+        };
+        var characterService = new MobileHandlerTestCharacterService(CreatePlayer(movingPlayerId));
+        var speechService = new MobileHandlerTestSpeechService();
+        var handler = new MobileHandler(
+            spatial,
+            characterService,
+            speechService,
+            new DispatchEventsService(spatial, queue, sessions),
+            sessions,
+            queue,
+            new()
+        );
+
+        await handler.HandleAsync(
+            new MobilePositionChangedEvent(movingSession.SessionId, movingPlayerId, 1, 1, oldLocation, newLocation)
+        );
+
+        var mobileIncomingPackets = DequeueAll(queue)
+            .Select(packet => packet.Packet)
+            .OfType<MobileIncomingPacket>()
+            .ToList();
+
+        Assert.That(mobileIncomingPackets, Is.Not.Empty);
+        Assert.That(mobileIncomingPackets.All(packet => packet.NewMobileIncoming), Is.False);
     }
 }

--- a/tests/Moongate.Tests/Server/Services/Characters/PlayerLoginWorldSyncServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Characters/PlayerLoginWorldSyncServiceTests.cs
@@ -413,6 +413,55 @@ public sealed class PlayerLoginWorldSyncServiceTests
     }
 
     [Test]
+    public async Task SyncAsync_WhenSessionIsEnhanced_ShouldUseNewMobileIncomingFormat()
+    {
+        var playerId = (Serial)0x00004040u;
+        var npcId = (Serial)0x00004041u;
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var session = CreateSession(playerId);
+        session.NetworkSession.SetClientType(Moongate.UO.Data.Version.ClientType.SA);
+        var spawnLocation = new Point3D(132, 132, 0);
+        var sectorX = spawnLocation.X >> MapSectorConsts.SectorShift;
+        var sectorY = spawnLocation.Y >> MapSectorConsts.SectorShift;
+        var sector = new MapSector(1, sectorX, sectorY);
+        sector.AddEntity(
+            new UOMobileEntity
+            {
+                Id = npcId,
+                Name = "enhanced-guard",
+                Location = spawnLocation,
+                MapId = 1,
+                BaseBody = 0x0190
+            }
+        );
+
+        var spatial = new PlayerLoginWorldSyncTestSpatialWorldService();
+        spatial.SectorsByCoordinate[(1, sectorX, sectorY)] = sector;
+        spatial.SectorByLocationResolver = (_, location) =>
+                                           {
+                                               var key = (1, location.X >> MapSectorConsts.SectorShift,
+                                                          location.Y >> MapSectorConsts.SectorShift);
+
+                                               return spatial.SectorsByCoordinate.TryGetValue(key, out var resolved)
+                                                          ? resolved
+                                                          : null;
+                                           };
+
+        var character = CreatePlayer(playerId, spawnLocation);
+        session.Character = character;
+        var service = new PlayerLoginWorldSyncService(spatial, queue, new());
+
+        await service.SyncAsync(session, character);
+
+        var mobileIncomingPacket = DequeueAll(queue)
+                                   .Select(packet => packet.Packet)
+                                   .OfType<MobileIncomingPacket>()
+                                   .Single();
+
+        Assert.That(mobileIncomingPacket.NewMobileIncoming, Is.True);
+    }
+
+    [Test]
     public async Task SyncAsync_WhenCorpseIsVisible_ShouldSendCorpseContentsAndClothing()
     {
         var playerId = (Serial)0x00004031u;


### PR DESCRIPTION
## Summary
Add enhanced-client session capability handling so Moongate can react to KR/SA-style clients without changing the full login and UI stack.

## What Changed
- parse and store client type from `0xE1` and general information client-type signaling
- track `ClientType` and `IsEnhancedClient` on `GameNetworkSession`
- set KR/UO3D-compatible flags on the `0xA9` character list for enhanced sessions
- choose the new mobile incoming format from the recipient session during movement and login world sync
- document the enhanced-client session behavior in networking docs

## Validation
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ClientTypePacketTests|FullyQualifiedName~GameNetworkSessionTests|FullyQualifiedName~LoginHandlerTests|FullyQualifiedName~GeneralInformationHandlerTests|FullyQualifiedName~CharactersStartingLocationsPacketTests|FullyQualifiedName~MobileHandlerTests|FullyQualifiedName~PlayerLoginWorldSyncServiceTests"`
- `dotnet build Moongate.slnx`

Refs #110
