### PR TITLE
feat: add npc self-bandage behavior

### DIFF
--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -22,7 +22,8 @@ moongate_data/scripts/ai/
 │   ├── evade.lua
 │   ├── follow.lua
 │   ├── idle.lua
-│   └── ranged_keep_distance.lua
+│   ├── ranged_keep_distance.lua
+│   └── self_bandage.lua
 └── brains/
     ├── guard.lua
     └── utility_npc.lua
@@ -63,8 +64,9 @@ The utility runner selects the highest score, applies anti-jitter hold (`min_hol
 
 ## Guard Brain Example
 
-`guard.lua` uses three isolated behaviors:
+`guard.lua` uses these isolated behaviors:
 
+- `self_bandage`
 - `evade`
 - `follow` for melee guards
 - `ranged_keep_distance` for archer guards
@@ -113,6 +115,11 @@ Current built-in behavior modules under `moongate_data/scripts/ai/behaviors/` ar
   - If the target is too far, it uses `steering.follow(...)`
   - Inside the preferred band, it stops movement and keeps the combat target active
   - Clears `follow_target_serial` if the combat target can no longer be armed
+- `self_bandage`
+  - Reads `self_bandage_hp_threshold` and `self_bandage_score_bonus`
+  - Requires a real `bandage` stack in the NPC backpack
+  - Starts a delayed self-heal through the `healing` module
+  - Keeps a high score while the bandage timer is in flight so the brain does not thrash
 - `idle`
   - Fallback behavior when nothing else scores higher
   - Keeps the brain alive without chasing or retreating
@@ -127,6 +134,8 @@ Behavior state is stored per NPC using `npc_state` module keys, for example:
 - `evade_hp_threshold`
 - `preferred_min_range`
 - `preferred_max_range`
+- `self_bandage_hp_threshold`
+- `self_bandage_score_bonus`
 - `guard_seen_<serial>`
 - `guard_engaged_<serial>`
 
@@ -170,6 +179,7 @@ Current core modules for behavior scripts:
 - `perception` (distance, nearby friend/enemy lookup, range checks)
 - `steering` (follow/evade/wander/stop movement primitives)
 - `combat` (target selection into the server combat loop; `set_target` / `clear_target`)
+- `healing` (self-bandage start/status helpers)
 
 `combat.set_target(...)` does not calculate hit or damage in Lua.
 It delegates to `CombatService`, which owns:
@@ -179,8 +189,20 @@ It delegates to `CombatService`, which owns:
 - melee hit/damage resolution
 - region/map harmful-action gate on actual attack attempt
 - lethal handoff into `DeathService`, including PvE fame/karma awards for player kills against NPCs
+- delayed self-bandage completion through `BandageService`
 - `npc_state` (typed state variables)
 - `time`, `random`, `mobile` (general runtime helpers)
+
+## Self Bandage Notes
+
+`self_bandage` is intentionally narrow in v1:
+
+- only self-heal, never target another mobile
+- consumes `1` `bandage` immediately when the timer starts
+- heals after a short fixed delay in C#
+- does not cure poison, resurrect, or create dirty bandages
+
+The behavior does nothing unless the NPC already has a backpack and at least one `bandage` item inside it.
 
 ## Best Practices
 

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -79,7 +79,7 @@ At each tick:
 
 On speech events, the guard can set `follow_target_serial` in blackboard state.
 On in-range events, the guard can greet a player once per entry and start combat when a hostile target enters range.
-On ranged guard templates, `params.guard_role = "ranged"` switches the brain to a 4-6 tile spacing behavior.
+On ranged guard templates, `params.guard_role = "ranged"` switches the brain to a 4-6 tile spacing behavior and a longer hostile-acquisition radius.
 
 Current `in_range` payload fields include:
 
@@ -95,6 +95,28 @@ Current `in_range` payload fields include:
 - `range`
 - `location`
 
+## Built-In Behaviors
+
+Current built-in behavior modules under `moongate_data/scripts/ai/behaviors/` are:
+
+- `evade`
+  - Reads `evade_from_serial`, `evade_desired_range`, and `evade_hp_threshold`
+  - Moves away from the current threat when the threat is too close or HP is low
+- `follow`
+  - Reads `follow_target_serial` and `follow_stop_range`
+  - Chases the target until it reaches the configured stop distance
+  - Reasserts `combat.set_target(...)` while following so the C# combat loop stays armed
+  - Clears `follow_target_serial` if the combat target can no longer be armed
+- `ranged_keep_distance`
+  - Reads `follow_target_serial`, `preferred_min_range`, and `preferred_max_range`
+  - If the target is too close, it uses `steering.evade(...)`
+  - If the target is too far, it uses `steering.follow(...)`
+  - Inside the preferred band, it stops movement and keeps the combat target active
+  - Clears `follow_target_serial` if the combat target can no longer be armed
+- `idle`
+  - Fallback behavior when nothing else scores higher
+  - Keeps the brain alive without chasing or retreating
+
 ## State (Blackboard)
 
 Behavior state is stored per NPC using `npc_state` module keys, for example:
@@ -103,8 +125,43 @@ Behavior state is stored per NPC using `npc_state` module keys, for example:
 - `follow_stop_range`
 - `evade_desired_range`
 - `evade_hp_threshold`
+- `preferred_min_range`
+- `preferred_max_range`
+- `guard_seen_<serial>`
+- `guard_engaged_<serial>`
 
 This keeps behavior logic stateless and reusable.
+
+The guard brain initializes defaults only when a key is missing. That keeps the scripts KISS while still allowing runtime tuning to override blackboard values without being overwritten every tick.
+
+## Guard Ranges
+
+There are three different ranges involved in guard combat:
+
+1. Acquisition range
+   - This is the distance at which the Lua brain receives `in_range` for a hostile target.
+   - Melee guards use `3` tiles.
+   - Guards with `params.guard_role = "ranged"` use `10` tiles.
+2. Preferred movement band
+   - Archer guards try to stay between `4` and `6` tiles from the target.
+   - Melee guards use `follow_stop_range = 1`.
+3. Actual weapon attack range
+   - This is resolved by `CombatService` from the equipped weapon profile.
+   - The current bow template uses `maxRange = 10`.
+   - Melee weapons without explicit range metadata fall back to `1`.
+
+These ranges are intentionally separate:
+
+- acquisition determines when the brain reacts
+- preferred band determines where the behavior wants to stand
+- weapon range determines whether the attack can actually fire
+
+For guards this means:
+
+- warrior guards notice hostiles at `3`, chase, and attack in melee
+- archer guards can notice hostiles earlier, position at `4-6`, and still fire out to the bow maximum range
+
+When a hostile leaves range, the guard brain now clears both `follow_target_serial` and the active combat target. That avoids stale target state lingering after `out_range`.
 
 ## Runtime Modules Used by Behaviors
 

--- a/moongate_data/scripts/ai/behaviors/follow.lua
+++ b/moongate_data/scripts/ai/behaviors/follow.lua
@@ -25,6 +25,11 @@ function M.run(npc_serial, _ctx)
         return 250
     end
 
+    if combat.set_target(npc_serial, target_serial) ~= true then
+        npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)
+        return 250
+    end
+
     local stop_range = tonumber(npc_state.get_var(npc_serial, FOLLOW_STOP_RANGE_KEY) or 1) or 1
     steering.follow(npc_serial, target_serial, math.max(0, math.floor(stop_range)))
     return 250

--- a/moongate_data/scripts/ai/behaviors/init.lua
+++ b/moongate_data/scripts/ai/behaviors/init.lua
@@ -2,5 +2,6 @@ require("ai.behaviors.follow")
 require("ai.behaviors.evade")
 require("ai.behaviors.idle")
 require("ai.behaviors.ranged_keep_distance")
+require("ai.behaviors.self_bandage")
 
 return true

--- a/moongate_data/scripts/ai/behaviors/ranged_keep_distance.lua
+++ b/moongate_data/scripts/ai/behaviors/ranged_keep_distance.lua
@@ -50,6 +50,11 @@ function M.run(npc_serial, _ctx)
         return 250
     end
 
+    if combat.set_target(npc_serial, target_serial) ~= true then
+        npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)
+        return 250
+    end
+
     local distance = perception.distance(npc_serial, target_serial)
     if distance < 0 then
         return 250

--- a/moongate_data/scripts/ai/behaviors/self_bandage.lua
+++ b/moongate_data/scripts/ai/behaviors/self_bandage.lua
@@ -1,0 +1,43 @@
+local behavior = require("ai.behavior")
+
+local HP_THRESHOLD_KEY = "self_bandage_hp_threshold"
+local SCORE_BONUS_KEY = "self_bandage_score_bonus"
+
+local M = {}
+
+function M.score(npc_serial, _ctx)
+    if healing.is_bandaging(npc_serial) == true then
+        return 95
+    end
+
+    if healing.has_bandage(npc_serial) ~= true then
+        return 0
+    end
+
+    local hp_percent = npc_state.get_hp_percent(npc_serial)
+    local hp_threshold = tonumber(npc_state.get_var(npc_serial, HP_THRESHOLD_KEY) or 0.45) or 0.45
+    if hp_percent <= 0 or hp_percent > hp_threshold then
+        return 0
+    end
+
+    local score_bonus = tonumber(npc_state.get_var(npc_serial, SCORE_BONUS_KEY) or 70) or 70
+    local missing_hp_bonus = math.floor((1.0 - hp_percent) * 20)
+
+    return score_bonus + missing_hp_bonus
+end
+
+function M.run(npc_serial, _ctx)
+    if healing.is_bandaging(npc_serial) == true then
+        return 500
+    end
+
+    if healing.begin_self_bandage(npc_serial) == true then
+        return 500
+    end
+
+    return 250
+end
+
+behavior.register("self_bandage", M)
+
+return M

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -19,12 +19,14 @@ end
 
 -- Logical behavior order. The winner is selected by score.
 local MELEE_BEHAVIORS = {
+    "self_bandage",
     "evade",
     "follow",
     "idle",
 }
 
 local RANGED_BEHAVIORS = {
+    "self_bandage",
     "evade",
     "ranged_keep_distance",
     "idle",
@@ -56,6 +58,8 @@ local function initialize_defaults(npc_serial)
 
     -- Below this HP threshold, evade gets a score bonus
     set_default("evade_hp_threshold", 0.40)
+    set_default("self_bandage_hp_threshold", 0.45)
+    set_default("self_bandage_score_bonus", 70)
 
     if is_ranged_guard(npc_serial) then
         set_default("preferred_min_range", 4)

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -44,20 +44,27 @@ end
 
 -- Initialize minimal blackboard values for behaviors.
 local function initialize_defaults(npc_serial)
-    -- Desired distance while evading
-    npc_state.set_var(npc_serial, "evade_desired_range", 7)
+    local function set_default(key, value)
+        if npc_state.get_var(npc_serial, key) == nil then
+            npc_state.set_var(npc_serial, key, value)
+        end
+    end
+
+    -- Guards should not kite by default. Ranged positioning is handled by
+    -- ranged_keep_distance, and low-hp retreat is handled by evade_hp_threshold.
+    set_default("evade_desired_range", 0)
 
     -- Below this HP threshold, evade gets a score bonus
-    npc_state.set_var(npc_serial, "evade_hp_threshold", 0.40)
+    set_default("evade_hp_threshold", 0.40)
 
     if is_ranged_guard(npc_serial) then
-        npc_state.set_var(npc_serial, "preferred_min_range", 4)
-        npc_state.set_var(npc_serial, "preferred_max_range", 6)
+        set_default("preferred_min_range", 4)
+        set_default("preferred_max_range", 6)
         return
     end
 
     -- Minimum distance while following a target
-    npc_state.set_var(npc_serial, "follow_stop_range", 1)
+    set_default("follow_stop_range", 1)
 end
 
 function guard.brain_loop(npc_serial)
@@ -126,9 +133,10 @@ function guard.on_in_range(npc_serial, source_serial, event_obj)
     if source_is_enemy and npc_state.get_var(npc_serial, engaged_key) ~= true then
         npc:set_target(source)
         npc:set_war_mode(true)
-        combat.set_target(npc_serial, source_serial)
-        npc_state.set_var(npc_serial, "follow_target_serial", source_serial)
-        npc_state.set_var(npc_serial, engaged_key, true)
+        if combat.set_target(npc_serial, source_serial) == true then
+            npc_state.set_var(npc_serial, "follow_target_serial", source_serial)
+            npc_state.set_var(npc_serial, engaged_key, true)
+        end
     end
 
     utility_runner.on_event(npc_serial, {}, "in_range", source_serial, event_obj)
@@ -137,6 +145,8 @@ end
 function guard.on_out_range(npc_serial, source_serial, event_obj)
     npc_state.set_var(npc_serial, get_seen_key(source_serial), nil)
     npc_state.set_var(npc_serial, get_engaged_key(source_serial), nil)
+    npc_state.set_var(npc_serial, "follow_target_serial", nil)
+    combat.clear_target(npc_serial)
     utility_runner.on_event(npc_serial, {}, "out_range", source_serial, event_obj)
 end
 

--- a/moongate_data/templates/items/modernuo/skill_items.json
+++ b/moongate_data/templates/items/modernuo/skill_items.json
@@ -216,6 +216,7 @@
     "hue": "0",
     "goldValue": "0",
     "weight": 0.1,
+    "stackable": true,
     "scriptId": "items.bandage",
     "isMovable": true,
     "tags": [

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -109,6 +109,7 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<IHelpTicketService, HelpTicketService>(Reuse.Singleton);
         container.Register<INotorietyService, NotorietyService>(Reuse.Singleton);
         container.Register<ICombatService, CombatService>(Reuse.Singleton);
+        container.Register<IBandageService, BandageService>(Reuse.Singleton);
         container.Register<IDeathService, DeathService>(Reuse.Singleton);
         container.Register<IFameKarmaService, FameKarmaService>(Reuse.Singleton);
         container.Register<MobileCombatSoundResolver>(Reuse.Singleton);

--- a/src/Moongate.Server/Interfaces/Services/Interaction/IBandageService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/IBandageService.cs
@@ -1,0 +1,32 @@
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Interfaces.Services.Interaction;
+
+/// <summary>
+/// Coordinates delayed self-bandage heals for mobiles.
+/// </summary>
+public interface IBandageService
+{
+    /// <summary>
+    /// Attempts to start a self-bandage on the specified mobile.
+    /// </summary>
+    /// <param name="mobileId">Mobile serial identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true" /> when the self-bandage was started; otherwise <see langword="false" />.</returns>
+    Task<bool> BeginSelfBandageAsync(Serial mobileId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns whether the specified mobile currently has an in-flight bandage timer.
+    /// </summary>
+    /// <param name="mobileId">Mobile serial identifier.</param>
+    /// <returns><see langword="true" /> when the mobile is currently bandaging; otherwise <see langword="false" />.</returns>
+    bool IsBandaging(Serial mobileId);
+
+    /// <summary>
+    /// Returns whether the specified mobile currently has at least one bandage in its backpack.
+    /// </summary>
+    /// <param name="mobileId">Mobile serial identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true" /> when a bandage stack exists; otherwise <see langword="false" />.</returns>
+    Task<bool> HasBandageAsync(Serial mobileId, CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Server/Modules/HealingModule.cs
+++ b/src/Moongate.Server/Modules/HealingModule.cs
@@ -1,0 +1,32 @@
+using Moongate.Scripting.Attributes.Scripts;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Modules;
+
+[ScriptModule("healing", "Provides self-bandage helpers for Lua brains.")]
+
+/// <summary>
+/// Exposes minimal self-bandage helpers to Lua brains.
+/// </summary>
+public sealed class HealingModule
+{
+    private readonly IBandageService _bandageService;
+
+    public HealingModule(IBandageService bandageService)
+    {
+        _bandageService = bandageService;
+    }
+
+    [ScriptFunction("begin_self_bandage", "Attempts to start a delayed self-bandage on the npc.")]
+    public bool BeginSelfBandage(uint npcSerial)
+        => _bandageService.BeginSelfBandageAsync((Serial)npcSerial).GetAwaiter().GetResult();
+
+    [ScriptFunction("has_bandage", "Returns true when the npc has at least one bandage in its backpack.")]
+    public bool HasBandage(uint npcSerial)
+        => _bandageService.HasBandageAsync((Serial)npcSerial).GetAwaiter().GetResult();
+
+    [ScriptFunction("is_bandaging", "Returns true when the npc currently has an in-flight self-bandage.")]
+    public bool IsBandaging(uint npcSerial)
+        => _bandageService.IsBandaging((Serial)npcSerial);
+}

--- a/src/Moongate.Server/Services/Interaction/BandageService.cs
+++ b/src/Moongate.Server/Services/Interaction/BandageService.cs
@@ -1,0 +1,242 @@
+using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Interfaces.Services.Timing;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Services.Interaction;
+
+public sealed class BandageService : IBandageService
+{
+    private const int BandageItemId = 0x0E21;
+    private const int HealAmount = 12;
+    private static readonly TimeSpan BandageDelay = TimeSpan.FromSeconds(3);
+
+    private readonly ITimerService _timerService;
+    private readonly IMobileService _mobileService;
+    private readonly IItemService _itemService;
+    private readonly ISpatialWorldService _spatialWorldService;
+    private readonly Lock _syncRoot = new();
+    private readonly Dictionary<Serial, string> _inFlightTimers = [];
+
+    public BandageService(
+        ITimerService timerService,
+        IMobileService mobileService,
+        IItemService itemService,
+        ISpatialWorldService spatialWorldService
+    )
+    {
+        _timerService = timerService;
+        _mobileService = mobileService;
+        _itemService = itemService;
+        _spatialWorldService = spatialWorldService;
+    }
+
+    public async Task<bool> BeginSelfBandageAsync(Serial mobileId, CancellationToken cancellationToken = default)
+    {
+        if (mobileId == Serial.Zero || IsBandaging(mobileId))
+        {
+            return false;
+        }
+
+        var mobile = await ResolveMobileAsync(mobileId, cancellationToken);
+
+        if (mobile is null || !mobile.IsAlive || mobile.Hits >= mobile.MaxHits)
+        {
+            return false;
+        }
+
+        if (!TryGetBackpack(mobile, out var backpack))
+        {
+            return false;
+        }
+
+        if (!TryConsumeBandage(backpack, out var changedStack, out var deletedStack))
+        {
+            return false;
+        }
+
+        if (changedStack is not null)
+        {
+            await _itemService.UpsertItemAsync(changedStack);
+        }
+
+        if (deletedStack is not null)
+        {
+            _ = await _itemService.DeleteItemAsync(deletedStack.Id);
+        }
+
+        var timerName = GetTimerName(mobileId);
+        var timerId = _timerService.RegisterTimer(
+            timerName,
+            BandageDelay,
+            () => CompleteSelfBandage(mobileId),
+            BandageDelay
+        );
+
+        lock (_syncRoot)
+        {
+            _inFlightTimers[mobileId] = timerId;
+        }
+
+        return true;
+    }
+
+    public bool IsBandaging(Serial mobileId)
+    {
+        lock (_syncRoot)
+        {
+            return _inFlightTimers.ContainsKey(mobileId);
+        }
+    }
+
+    public async Task<bool> HasBandageAsync(Serial mobileId, CancellationToken cancellationToken = default)
+    {
+        if (mobileId == Serial.Zero)
+        {
+            return false;
+        }
+
+        var mobile = await ResolveMobileAsync(mobileId, cancellationToken);
+
+        if (mobile is null || !TryGetBackpack(mobile, out var backpack))
+        {
+            return false;
+        }
+
+        return ContainsBandage(backpack);
+    }
+
+    private void CompleteSelfBandage(Serial mobileId)
+    {
+        ClearInFlight(mobileId);
+
+        var mobile = ResolveMobile(mobileId);
+
+        if (mobile is null || !mobile.IsAlive || mobile.Hits >= mobile.MaxHits)
+        {
+            return;
+        }
+
+        mobile.Hits = Math.Min(mobile.MaxHits, mobile.Hits + HealAmount);
+        _mobileService.CreateOrUpdateAsync(mobile).GetAwaiter().GetResult();
+    }
+
+    private void ClearInFlight(Serial mobileId)
+    {
+        lock (_syncRoot)
+        {
+            _inFlightTimers.Remove(mobileId);
+        }
+    }
+
+    private static bool ContainsBandage(UOItemEntity container)
+    {
+        for (var index = container.Items.Count - 1; index >= 0; index--)
+        {
+            var child = container.Items[index];
+
+            if (child.ItemId == BandageItemId)
+            {
+                return true;
+            }
+
+            if (ContainsBandage(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetTimerName(Serial mobileId)
+        => $"bandage:{(uint)mobileId}";
+
+    private static bool TryConsumeBandage(
+        UOItemEntity container,
+        out UOItemEntity? changedStack,
+        out UOItemEntity? deletedStack
+    )
+    {
+        changedStack = null;
+        deletedStack = null;
+
+        for (var index = container.Items.Count - 1; index >= 0; index--)
+        {
+            var child = container.Items[index];
+
+            if (child.ItemId == BandageItemId)
+            {
+                child.Amount--;
+
+                if (child.Amount <= 0)
+                {
+                    container.RemoveItem(child.Id);
+                    deletedStack = child;
+                }
+                else
+                {
+                    changedStack = child;
+                }
+
+                return true;
+            }
+
+            if (TryConsumeBandage(child, out changedStack, out deletedStack))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<UOMobileEntity?> ResolveMobileAsync(Serial mobileId, CancellationToken cancellationToken)
+    {
+        var mobile = ResolveMobile(mobileId);
+
+        if (mobile is not null)
+        {
+            return mobile;
+        }
+
+        return await _mobileService.GetAsync(mobileId, cancellationToken);
+    }
+
+    private UOMobileEntity? ResolveMobile(Serial mobileId)
+    {
+        foreach (var sector in _spatialWorldService.GetActiveSectors())
+        {
+            var mobile = sector.GetEntity<UOMobileEntity>(mobileId);
+
+            if (mobile is not null)
+            {
+                return mobile;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetBackpack(UOMobileEntity mobile, out UOItemEntity backpack)
+    {
+        backpack = null!;
+
+        foreach (var equippedItem in mobile.GetEquippedItemsRuntime())
+        {
+            if (equippedItem.EquippedLayer == ItemLayerType.Backpack ||
+                equippedItem.Id == mobile.BackpackId)
+            {
+                backpack = equippedItem;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Moongate.Server/Services/Interaction/CombatService.cs
+++ b/src/Moongate.Server/Services/Interaction/CombatService.cs
@@ -84,6 +84,11 @@ public sealed class CombatService : ICombatService
             return false;
         }
 
+        if (attacker.CombatantId == defender.Id && attacker.Warmode && HasScheduledSwing(attacker.Id))
+        {
+            return true;
+        }
+
         var nowUtc = DateTime.UtcNow;
         attacker.ExpireAggressors(nowUtc, AggressorTimeout);
         defender.ExpireAggressors(nowUtc, AggressorTimeout);
@@ -134,6 +139,14 @@ public sealed class CombatService : ICombatService
         lock (_syncRoot)
         {
             _combatSequences.Remove(attackerId);
+        }
+    }
+
+    private bool HasScheduledSwing(Serial attackerId)
+    {
+        lock (_syncRoot)
+        {
+            return _combatSequences.ContainsKey(attackerId);
         }
     }
 
@@ -274,7 +287,47 @@ public sealed class CombatService : ICombatService
             return session.Character;
         }
 
-        return await _mobileService.GetAsync(mobileId, cancellationToken);
+        var persistedMobile = await _mobileService.GetAsync(mobileId, cancellationToken);
+        var liveMobile = TryResolveLiveMobile(mobileId, persistedMobile);
+
+        return liveMobile ?? persistedMobile;
+    }
+
+    private UOMobileEntity? TryResolveLiveMobile(Serial mobileId, UOMobileEntity? persistedMobile)
+    {
+        if (persistedMobile is not null)
+        {
+            var sector = _spatialWorldService.GetSectorByLocation(persistedMobile.MapId, persistedMobile.Location);
+            var sectorMobile = sector?.GetEntity<UOMobileEntity>(mobileId);
+
+            if (sectorMobile is not null)
+            {
+                return sectorMobile;
+            }
+
+            var nearbyMobile = _spatialWorldService.GetNearbyMobiles(
+                persistedMobile.Location,
+                MapSectorConsts.MaxViewRange,
+                persistedMobile.MapId
+            ).FirstOrDefault(mobile => mobile.Id == mobileId);
+
+            if (nearbyMobile is not null)
+            {
+                return nearbyMobile;
+            }
+        }
+
+        foreach (var sector in _spatialWorldService.GetActiveSectors())
+        {
+            var sectorMobile = sector.GetEntity<UOMobileEntity>(mobileId);
+
+            if (sectorMobile is not null)
+            {
+                return sectorMobile;
+            }
+        }
+
+        return null;
     }
 
     private static UOItemEntity? ResolveWeapon(UOMobileEntity attacker)
@@ -366,6 +419,26 @@ public sealed class CombatService : ICombatService
         }
     }
 
+    private async ValueTask FaceTowardDefenderAsync(UOMobileEntity attacker, UOMobileEntity defender)
+    {
+        var desiredDirection = Point3D.GetBaseDirection(attacker.Location.GetDirectionTo(defender.Location));
+        var currentDirection = Point3D.GetBaseDirection(attacker.Direction);
+
+        if (desiredDirection == currentDirection)
+        {
+            return;
+        }
+
+        attacker.Direction = desiredDirection;
+        SyncRuntimeMobile(attacker);
+
+        await _spatialWorldService.BroadcastToPlayersInUpdateRadiusAsync(
+            new MobileMovingPacket(attacker),
+            attacker.MapId,
+            attacker.Location
+        );
+    }
+
     private async ValueTask ExecuteSwingAsync(Serial attackerId, int expectedSequence)
     {
         lock (_syncRoot)
@@ -391,6 +464,8 @@ public sealed class CombatService : ICombatService
             await ClearCombatantAsync(attackerId);
             return;
         }
+
+        await FaceTowardDefenderAsync(attacker, defender);
 
         var delay = ResolveSwingDelay(attacker);
         var attackProfile = ResolveAttackProfile(attacker);
@@ -570,7 +645,7 @@ public sealed class CombatService : ICombatService
 
         if (!ContainsAmmo(quiver, ammoItemId) && !ContainsAmmo(backpack, ammoItemId))
         {
-            return false;
+            return !attacker.IsPlayer;
         }
 
         if (attackProfile.LowerAmmoCost > 0 &&

--- a/src/Moongate.Server/Services/Scripting/Internal/LuaBrainStateStore.cs
+++ b/src/Moongate.Server/Services/Scripting/Internal/LuaBrainStateStore.cs
@@ -13,6 +13,7 @@ namespace Moongate.Server.Services.Scripting.Internal;
 internal sealed class LuaBrainStateStore
 {
     private readonly Dictionary<Serial, LuaBrainRuntimeState> _states = [];
+    private readonly Dictionary<Serial, UOMobileEntity> _observedMobiles = [];
     private readonly Lock _sync = new();
 
     public void Clear()
@@ -20,6 +21,7 @@ internal sealed class LuaBrainStateStore
         lock (_sync)
         {
             _states.Clear();
+            _observedMobiles.Clear();
         }
     }
 
@@ -140,7 +142,7 @@ internal sealed class LuaBrainStateStore
         }
     }
 
-    public bool TryResolveSourceMobile(Serial mobileId, int mapId, Point3D location, out UOMobileEntity? sourceMobile)
+    public bool TryResolveTrackedMobile(Serial mobileId, out UOMobileEntity? sourceMobile)
     {
         lock (_sync)
         {
@@ -150,17 +152,26 @@ internal sealed class LuaBrainStateStore
 
                 return true;
             }
+
+            if (_observedMobiles.TryGetValue(mobileId, out var observedMobile))
+            {
+                sourceMobile = observedMobile;
+
+                return true;
+            }
         }
 
-        sourceMobile = new()
-        {
-            Id = mobileId,
-            MapId = mapId,
-            Location = location,
-            IsPlayer = true
-        };
+        sourceMobile = null;
 
-        return true;
+        return false;
+    }
+
+    public void UpsertObservedMobile(UOMobileEntity mobile)
+    {
+        lock (_sync)
+        {
+            _observedMobiles[mobile.Id] = mobile;
+        }
     }
 
     public void UpdateTrackedMobilePosition(Serial mobileId, int mapId, Point3D location)
@@ -171,6 +182,12 @@ internal sealed class LuaBrainStateStore
             {
                 tracked.Mobile.MapId = mapId;
                 tracked.Mobile.Location = location;
+            }
+
+            if (_observedMobiles.TryGetValue(mobileId, out var observed))
+            {
+                observed.MapId = mapId;
+                observed.Location = location;
             }
         }
     }

--- a/src/Moongate.Server/Services/Scripting/LuaBrainRunner.cs
+++ b/src/Moongate.Server/Services/Scripting/LuaBrainRunner.cs
@@ -34,7 +34,8 @@ public sealed class LuaBrainRunner
       IGameEventListener<MobilePositionChangedEvent>,
       IGameEventListener<MobileSpawnedFromSpawnerEvent>
 {
-    private const int InRangeEnterDistance = 3;
+    private const int DefaultInRangeEnterDistance = 3;
+    private const int RangedGuardInRangeEnterDistance = 10;
     private const int DefaultTickMilliseconds = 250;
     private const int FaultRetryMilliseconds = 1000;
 
@@ -76,7 +77,7 @@ public sealed class LuaBrainRunner
         => _stateStore.EnqueueDeath(mobileId, deathContext);
 
     /// <inheritdoc />
-    public void EnqueueInRange(Serial listenerNpcId, UOMobileEntity sourceMobile, int range = InRangeEnterDistance)
+    public void EnqueueInRange(Serial listenerNpcId, UOMobileEntity sourceMobile, int range = DefaultInRangeEnterDistance)
         => _stateStore.EnqueueInRange(listenerNpcId, sourceMobile, range);
 
     /// <inheritdoc />
@@ -117,6 +118,7 @@ public sealed class LuaBrainRunner
     public Task HandleAsync(MobileAddedInWorldEvent gameEvent, CancellationToken cancellationToken = default)
     {
         _ = cancellationToken;
+        _stateStore.UpsertObservedMobile(gameEvent.Mobile);
         NotifyInRangeForAddedMobile(gameEvent.Mobile);
 
         if (gameEvent.Mobile.IsPlayer)
@@ -326,43 +328,29 @@ public sealed class LuaBrainRunner
 
     private void NotifyInRangeForAddedMobile(UOMobileEntity sourceMobile)
     {
-        if (!_stateStore.TryResolveSourceMobile(
-                sourceMobile.Id,
-                sourceMobile.MapId,
-                sourceMobile.Location,
-                out var resolved
-            ) ||
-            resolved is null)
-        {
-            return;
-        }
-
         var snapshot = _stateStore.GetAllStates();
 
         foreach (var state in snapshot)
         {
-            if (state.MobileId == resolved.Id || state.Mobile.MapId != resolved.MapId)
+            if (state.MobileId == sourceMobile.Id || state.Mobile.MapId != sourceMobile.MapId)
             {
                 continue;
             }
 
-            if (!state.Mobile.Location.InRange(resolved.Location, InRangeEnterDistance))
+            var acquisitionRange = ResolveAcquisitionRange(state.Mobile);
+
+            if (!state.Mobile.Location.InRange(sourceMobile.Location, acquisitionRange))
             {
                 continue;
             }
 
-            _stateStore.EnqueueInRange(state.MobileId, resolved, InRangeEnterDistance);
+            _stateStore.EnqueueInRange(state.MobileId, sourceMobile, acquisitionRange);
         }
     }
 
     private void NotifyInRangeForMovedMobile(MobilePositionChangedEvent gameEvent)
     {
-        if (!_stateStore.TryResolveSourceMobile(
-                gameEvent.MobileId,
-                gameEvent.MapId,
-                gameEvent.NewLocation,
-                out var sourceMobile
-            ) ||
+        if (!_stateStore.TryResolveTrackedMobile(gameEvent.MobileId, out var sourceMobile) ||
             sourceMobile is null)
         {
             return;
@@ -377,21 +365,33 @@ public sealed class LuaBrainRunner
                 continue;
             }
 
+            var acquisitionRange = ResolveAcquisitionRange(state.Mobile);
             var isInRangeNow = state.Mobile.MapId == gameEvent.MapId &&
-                               state.Mobile.Location.InRange(gameEvent.NewLocation, InRangeEnterDistance);
+                               state.Mobile.Location.InRange(gameEvent.NewLocation, acquisitionRange);
             var wasInRangeBefore = state.Mobile.MapId == gameEvent.OldMapId &&
-                                   state.Mobile.Location.InRange(gameEvent.OldLocation, InRangeEnterDistance);
+                                   state.Mobile.Location.InRange(gameEvent.OldLocation, acquisitionRange);
 
             if (!wasInRangeBefore && isInRangeNow)
             {
-                _stateStore.EnqueueInRange(state.MobileId, sourceMobile, InRangeEnterDistance);
+                _stateStore.EnqueueInRange(state.MobileId, sourceMobile, acquisitionRange);
             }
 
             if (wasInRangeBefore && !isInRangeNow)
             {
-                _stateStore.EnqueueOutRange(state.MobileId, sourceMobile, InRangeEnterDistance);
+                _stateStore.EnqueueOutRange(state.MobileId, sourceMobile, acquisitionRange);
             }
         }
+    }
+
+    private static int ResolveAcquisitionRange(UOMobileEntity mobile)
+    {
+        if (mobile.TryGetCustomString("guard_role", out var guardRole) &&
+            string.Equals(guardRole, "ranged", StringComparison.OrdinalIgnoreCase))
+        {
+            return RangedGuardInRangeEnterDistance;
+        }
+
+        return DefaultInRangeEnterDistance;
     }
 
     private string ResolveBrainTableName(string brainId)

--- a/tests/Moongate.Tests/Server/Modules/HealingModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/HealingModuleTests.cs
@@ -1,0 +1,66 @@
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Modules;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Server.Modules;
+
+public sealed class HealingModuleTests
+{
+    private sealed class RecordingBandageService : IBandageService
+    {
+        public Serial LastBeginMobileId { get; private set; }
+        public Serial LastHasBandageMobileId { get; private set; }
+        public Serial LastIsBandagingMobileId { get; private set; }
+        public bool BeginResult { get; set; }
+        public bool HasBandageResult { get; set; }
+        public bool IsBandagingResult { get; set; }
+
+        public Task<bool> BeginSelfBandageAsync(Serial mobileId, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            LastBeginMobileId = mobileId;
+            return Task.FromResult(BeginResult);
+        }
+
+        public Task<bool> HasBandageAsync(Serial mobileId, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            LastHasBandageMobileId = mobileId;
+            return Task.FromResult(HasBandageResult);
+        }
+
+        public bool IsBandaging(Serial mobileId)
+        {
+            LastIsBandagingMobileId = mobileId;
+            return IsBandagingResult;
+        }
+    }
+
+    [Test]
+    public void Methods_ShouldDelegateToBandageService()
+    {
+        var bandageService = new RecordingBandageService
+        {
+            BeginResult = true,
+            HasBandageResult = true,
+            IsBandagingResult = true
+        };
+        var module = new HealingModule(bandageService);
+
+        var began = module.BeginSelfBandage(0x401);
+        var hasBandage = module.HasBandage(0x401);
+        var isBandaging = module.IsBandaging(0x401);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(began, Is.True);
+                Assert.That(hasBandage, Is.True);
+                Assert.That(isBandaging, Is.True);
+                Assert.That(bandageService.LastBeginMobileId, Is.EqualTo((Serial)0x401u));
+                Assert.That(bandageService.LastHasBandageMobileId, Is.EqualTo((Serial)0x401u));
+                Assert.That(bandageService.LastIsBandagingMobileId, Is.EqualTo((Serial)0x401u));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/Interaction/BandageServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/BandageServiceTests.cs
@@ -1,0 +1,479 @@
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Server.Data.Items;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Interfaces.Services.Timing;
+using Moongate.Server.Services.Interaction;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Tests.Server.Services.Interaction;
+
+public sealed class BandageServiceTests
+{
+    private sealed class TimerServiceSpy : ITimerService
+    {
+        public sealed record RegisteredTimer(string Id, string Name, TimeSpan Interval, TimeSpan? Delay, Action Callback);
+
+        private int _nextId;
+
+        public List<RegisteredTimer> RegisteredTimers { get; } = [];
+
+        public void ProcessTick() { }
+
+        public string RegisterTimer(
+            string name,
+            TimeSpan interval,
+            Action callback,
+            TimeSpan? delay = null,
+            bool repeat = false
+        )
+        {
+            _ = repeat;
+
+            var timer = new RegisteredTimer($"timer-{++_nextId}", name, interval, delay, callback);
+            RegisteredTimers.Add(timer);
+
+            return timer.Id;
+        }
+
+        public void UnregisterAllTimers()
+            => RegisteredTimers.Clear();
+
+        public bool UnregisterTimer(string timerId)
+            => RegisteredTimers.RemoveAll(timer => timer.Id == timerId) > 0;
+
+        public int UnregisterTimersByName(string name)
+            => RegisteredTimers.RemoveAll(timer => timer.Name == name);
+
+        public int UpdateTicksDelta(long timestampMilliseconds)
+        {
+            _ = timestampMilliseconds;
+            return 0;
+        }
+    }
+
+    private sealed class InMemoryMobileService : IMobileService
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = new();
+
+        public int CreateOrUpdateCalls { get; private set; }
+
+        public void Add(UOMobileEntity mobile)
+            => _mobiles[mobile.Id] = mobile;
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            CreateOrUpdateCalls++;
+            _mobiles[mobile.Id] = mobile;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            return Task.FromResult(_mobiles.Remove(id));
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles.TryGetValue(id, out var mobile);
+
+            return Task.FromResult(mobile);
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+            _ = cancellationToken;
+            return Task.FromResult(new List<UOMobileEntity>());
+        }
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromException<UOMobileEntity>(new NotSupportedException());
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult((false, (UOMobileEntity?)null));
+    }
+
+    private sealed class InMemoryItemService : IItemService
+    {
+        private readonly Dictionary<Serial, UOItemEntity> _items = new();
+
+        public int UpsertCalls { get; private set; }
+        public int DeleteCalls { get; private set; }
+
+        public void Add(UOItemEntity item)
+            => _items[item.Id] = item;
+
+        public Task BulkUpsertItemsAsync(IReadOnlyList<UOItemEntity> items)
+            => Task.CompletedTask;
+
+        public UOItemEntity Clone(UOItemEntity item, bool generateNewSerial = true)
+            => throw new NotSupportedException();
+
+        public Task<UOItemEntity?> CloneAsync(Serial itemId, bool generateNewSerial = true)
+            => Task.FromException<UOItemEntity?>(new NotSupportedException());
+
+        public Task<Serial> CreateItemAsync(UOItemEntity item)
+            => Task.FromException<Serial>(new NotSupportedException());
+
+        public Task<bool> DeleteItemAsync(Serial itemId)
+        {
+            DeleteCalls++;
+            return Task.FromResult(_items.Remove(itemId));
+        }
+
+        public Task<DropItemToGroundResult?> DropItemToGroundAsync(
+            Serial itemId,
+            Point3D location,
+            int mapId,
+            long sessionId = 0
+        )
+            => Task.FromException<DropItemToGroundResult?>(new NotSupportedException());
+
+        public Task<bool> EquipItemAsync(Serial itemId, Serial mobileId, ItemLayerType layer)
+            => Task.FromException<bool>(new NotSupportedException());
+
+        public Task<List<UOItemEntity>> GetGroundItemsInSectorAsync(int mapId, int sectorX, int sectorY)
+            => Task.FromResult(new List<UOItemEntity>());
+
+        public Task<UOItemEntity?> GetItemAsync(Serial itemId)
+        {
+            _items.TryGetValue(itemId, out var item);
+            return Task.FromResult(item);
+        }
+
+        public Task<List<UOItemEntity>> GetItemsInContainerAsync(Serial containerId)
+            => Task.FromResult(_items.Values.Where(item => item.ParentContainerId == containerId).ToList());
+
+        public Task<bool> MoveItemToContainerAsync(
+            Serial itemId,
+            Serial containerId,
+            Point2D position,
+            long sessionId = 0
+        )
+            => Task.FromException<bool>(new NotSupportedException());
+
+        public Task<bool> MoveItemToWorldAsync(Serial itemId, Point3D location, int mapId, long sessionId = 0)
+            => Task.FromException<bool>(new NotSupportedException());
+
+        public Task<UOItemEntity> SpawnFromTemplateAsync(string itemTemplateId)
+            => Task.FromException<UOItemEntity>(new NotSupportedException());
+
+        public Task<(bool Found, UOItemEntity? Item)> TryToGetItemAsync(Serial itemId)
+            => Task.FromResult(_items.TryGetValue(itemId, out var item) ? (true, item) : (false, (UOItemEntity?)null));
+
+        public Task UpsertItemAsync(UOItemEntity item)
+        {
+            UpsertCalls++;
+            _items[item.Id] = item;
+            return Task.CompletedTask;
+        }
+
+        public Task UpsertItemsAsync(params UOItemEntity[] items)
+            => Task.CompletedTask;
+    }
+
+    private sealed class SpatialWorldServiceSpy : ISpatialWorldService
+    {
+        private readonly Dictionary<(int MapId, int SectorX, int SectorY), MapSector> _sectors = new();
+
+        public void AddOrUpdateItem(UOItemEntity item, int mapId)
+            => _ = (item, mapId);
+
+        public void AddOrUpdateMobile(UOMobileEntity mobile)
+        {
+            var sectorX = mobile.Location.X >> MapSectorConsts.SectorShift;
+            var sectorY = mobile.Location.Y >> MapSectorConsts.SectorShift;
+            var key = (mobile.MapId, sectorX, sectorY);
+
+            if (!_sectors.TryGetValue(key, out var sector))
+            {
+                sector = new MapSector(mobile.MapId, sectorX, sectorY);
+                _sectors[key] = sector;
+            }
+
+            sector.AddEntity(mobile);
+        }
+
+        public void AddRegion(JsonRegion region)
+            => _ = region;
+
+        public Task<int> BroadcastToPlayersAsync(
+            IGameNetworkPacket packet,
+            int mapId,
+            Point3D location,
+            int? range = null,
+            long? excludeSessionId = null
+        )
+            => Task.FromResult(0);
+
+        public List<MapSector> GetActiveSectors()
+            => [.. _sectors.Values];
+
+        public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
+            => [];
+
+        public int GetMusic(int mapId, Point3D location)
+            => 0;
+
+        public List<UOItemEntity> GetNearbyItems(Point3D location, int range, int mapId)
+            => [];
+
+        public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
+            => _sectors.Values
+                       .Where(sector => sector.MapIndex == mapId)
+                       .SelectMany(sector => sector.GetMobiles())
+                       .Where(mobile => mobile.Location.InRange(location, range))
+                       .ToList();
+
+        public List<GameSession> GetPlayersInRange(
+            Point3D location,
+            int range,
+            int mapId,
+            GameSession? excludeSession = null
+        )
+            => [];
+
+        public List<UOMobileEntity> GetPlayersInSector(int mapId, int sectorX, int sectorY)
+            => [];
+
+        public JsonRegion? GetRegionById(int regionId)
+            => null;
+
+        public MapSector? GetSectorByLocation(int mapId, Point3D location)
+        {
+            var key = (mapId, location.X >> MapSectorConsts.SectorShift, location.Y >> MapSectorConsts.SectorShift);
+            return _sectors.GetValueOrDefault(key);
+        }
+
+        public SectorSystemStats GetStats()
+            => new();
+
+        public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation) { }
+
+        public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation) { }
+
+        public void RemoveEntity(Serial serial) { }
+    }
+
+    [Test]
+    public async Task BeginSelfBandageAsync_WhenBandageExists_ShouldConsumeOneAndRegisterTimer()
+    {
+        var timerService = new TimerServiceSpy();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var spatialWorldService = new SpatialWorldServiceSpy();
+        var service = new BandageService(timerService, mobileService, itemService, spatialWorldService);
+        var mobile = CreateMobileWithBackpack();
+        var bandage = CreateBandage((Serial)0x710u, 5);
+        var backpack = mobile.GetEquippedItemsRuntime().Single();
+
+        backpack.AddItem(bandage, new(10, 10));
+        mobileService.Add(mobile);
+        itemService.Add(bandage);
+        spatialWorldService.AddOrUpdateMobile(mobile);
+
+        var started = await service.BeginSelfBandageAsync(mobile.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(started, Is.True);
+                Assert.That(service.IsBandaging(mobile.Id), Is.True);
+                Assert.That(bandage.Amount, Is.EqualTo(4));
+                Assert.That(itemService.UpsertCalls, Is.EqualTo(1));
+                Assert.That(timerService.RegisteredTimers.Count, Is.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
+    public async Task BeginSelfBandageAsync_WhenNoBandageExists_ShouldReturnFalse()
+    {
+        var timerService = new TimerServiceSpy();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var spatialWorldService = new SpatialWorldServiceSpy();
+        var service = new BandageService(timerService, mobileService, itemService, spatialWorldService);
+        var mobile = CreateMobileWithBackpack();
+
+        mobileService.Add(mobile);
+        spatialWorldService.AddOrUpdateMobile(mobile);
+
+        var started = await service.BeginSelfBandageAsync(mobile.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(started, Is.False);
+                Assert.That(service.IsBandaging(mobile.Id), Is.False);
+                Assert.That(timerService.RegisteredTimers, Is.Empty);
+            }
+        );
+    }
+
+    [Test]
+    public async Task BeginSelfBandageAsync_WhenAlreadyBandaging_ShouldReturnFalse()
+    {
+        var timerService = new TimerServiceSpy();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var spatialWorldService = new SpatialWorldServiceSpy();
+        var service = new BandageService(timerService, mobileService, itemService, spatialWorldService);
+        var mobile = CreateMobileWithBackpack();
+        var bandage = CreateBandage((Serial)0x720u, 5);
+        var backpack = mobile.GetEquippedItemsRuntime().Single();
+
+        backpack.AddItem(bandage, new(10, 10));
+        mobileService.Add(mobile);
+        itemService.Add(bandage);
+        spatialWorldService.AddOrUpdateMobile(mobile);
+
+        var firstStart = await service.BeginSelfBandageAsync(mobile.Id);
+        var secondStart = await service.BeginSelfBandageAsync(mobile.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(firstStart, Is.True);
+                Assert.That(secondStart, Is.False);
+                Assert.That(bandage.Amount, Is.EqualTo(4));
+                Assert.That(timerService.RegisteredTimers.Count, Is.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
+    public async Task RegisteredTimerCallback_WhenMobileAlive_ShouldHealAndClearInFlightState()
+    {
+        var timerService = new TimerServiceSpy();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var spatialWorldService = new SpatialWorldServiceSpy();
+        var service = new BandageService(timerService, mobileService, itemService, spatialWorldService);
+        var mobile = CreateMobileWithBackpack();
+        var bandage = CreateBandage((Serial)0x730u, 1);
+        var backpack = mobile.GetEquippedItemsRuntime().Single();
+
+        mobile.Hits = 30;
+        backpack.AddItem(bandage, new(10, 10));
+        mobileService.Add(mobile);
+        itemService.Add(bandage);
+        spatialWorldService.AddOrUpdateMobile(mobile);
+
+        _ = await service.BeginSelfBandageAsync(mobile.Id);
+        timerService.RegisteredTimers.Single().Callback();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.Hits, Is.EqualTo(42));
+                Assert.That(service.IsBandaging(mobile.Id), Is.False);
+                Assert.That(itemService.DeleteCalls, Is.EqualTo(1));
+                Assert.That(mobileService.CreateOrUpdateCalls, Is.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
+    public async Task RegisteredTimerCallback_WhenMobileDead_ShouldNotHealButShouldClearInFlightState()
+    {
+        var timerService = new TimerServiceSpy();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var spatialWorldService = new SpatialWorldServiceSpy();
+        var service = new BandageService(timerService, mobileService, itemService, spatialWorldService);
+        var mobile = CreateMobileWithBackpack();
+        var bandage = CreateBandage((Serial)0x740u, 1);
+        var backpack = mobile.GetEquippedItemsRuntime().Single();
+
+        mobile.Hits = 30;
+        backpack.AddItem(bandage, new(10, 10));
+        mobileService.Add(mobile);
+        itemService.Add(bandage);
+        spatialWorldService.AddOrUpdateMobile(mobile);
+
+        _ = await service.BeginSelfBandageAsync(mobile.Id);
+        mobile.Hits = 0;
+        mobile.IsAlive = false;
+        timerService.RegisteredTimers.Single().Callback();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.Hits, Is.EqualTo(0));
+                Assert.That(service.IsBandaging(mobile.Id), Is.False);
+                Assert.That(mobileService.CreateOrUpdateCalls, Is.EqualTo(0));
+            }
+        );
+    }
+
+    private static UOMobileEntity CreateMobileWithBackpack()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x700u,
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 100,
+            IsAlive = true,
+            Name = "guard"
+        };
+        var backpack = new UOItemEntity
+        {
+            Id = (Serial)0x701u,
+            ItemId = 0x0E75,
+            Name = "Backpack",
+            IsStackable = false
+        };
+
+        mobile.AddEquippedItem(ItemLayerType.Backpack, backpack);
+        mobile.BackpackId = backpack.Id;
+
+        return mobile;
+    }
+
+    private static UOItemEntity CreateBandage(Serial id, int amount)
+        => new()
+        {
+            Id = id,
+            ItemId = 0x0E21,
+            Name = "Bandage",
+            IsStackable = true,
+            Amount = amount,
+            Weight = 1
+        };
+}

--- a/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
@@ -20,12 +20,14 @@ using Moongate.Server.Interfaces.Services.Timing;
 using Moongate.Server.Services.Interaction;
 using Moongate.Tests.Server.Services.Spatial;
 using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Bodies;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Json.Regions;
 using Moongate.UO.Data.Maps;
 using Moongate.UO.Data.Persistence.Entities;
 using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
 
 namespace Moongate.Tests.Server.Services.Interaction;
 
@@ -89,6 +91,7 @@ public sealed class CombatServiceTests
     private sealed class InMemoryMobileService : IMobileService
     {
         private readonly Dictionary<Serial, UOMobileEntity> _mobiles = new();
+        public Func<Serial, UOMobileEntity?, UOMobileEntity?>? OnGetAsync { get; set; }
 
         public void Add(UOMobileEntity mobile)
             => _mobiles[mobile.Id] = mobile;
@@ -111,7 +114,7 @@ public sealed class CombatServiceTests
         {
             _ = cancellationToken;
             _mobiles.TryGetValue(id, out var mobile);
-            return Task.FromResult(mobile);
+            return Task.FromResult(OnGetAsync?.Invoke(id, mobile) ?? mobile);
         }
 
         public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
@@ -254,11 +257,29 @@ public sealed class CombatServiceTests
 
     private sealed class CombatTestSpatialWorldService : ISpatialWorldService
     {
+        private readonly Dictionary<(int MapId, int SectorX, int SectorY), MapSector> _sectors = [];
+
         public JsonRegion? ResolvedRegion { get; set; }
         public List<IGameNetworkPacket> BroadcastPackets { get; } = [];
 
         public void AddOrUpdateItem(UOItemEntity item, int mapId) { }
-        public void AddOrUpdateMobile(UOMobileEntity mobile) { }
+
+        public void AddOrUpdateMobile(UOMobileEntity mobile)
+        {
+            RemoveEntity(mobile.Id);
+            var sectorX = mobile.Location.X >> MapSectorConsts.SectorShift;
+            var sectorY = mobile.Location.Y >> MapSectorConsts.SectorShift;
+            var key = (mobile.MapId, sectorX, sectorY);
+
+            if (!_sectors.TryGetValue(key, out var sector))
+            {
+                sector = new MapSector(mobile.MapId, sectorX, sectorY);
+                _sectors[key] = sector;
+            }
+
+            sector.AddEntity(mobile);
+        }
+
         public void AddRegion(JsonRegion region) { }
 
         public Task<int> BroadcastToPlayersAsync(
@@ -278,10 +299,29 @@ public sealed class CombatServiceTests
         }
 
         public List<MapSector> GetActiveSectors()
-            => [];
+            => _sectors.Values.ToList();
 
         public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
-            => [];
+        {
+            var mobiles = new List<UOMobileEntity>();
+
+            foreach (var sector in _sectors.Values)
+            {
+                if (sector.MapIndex != mapId)
+                {
+                    continue;
+                }
+
+                if (Math.Abs(sector.SectorX - centerSectorX) > radius || Math.Abs(sector.SectorY - centerSectorY) > radius)
+                {
+                    continue;
+                }
+
+                mobiles.AddRange(sector.GetMobiles());
+            }
+
+            return mobiles;
+        }
 
         public int GetMusic(int mapId, Point3D location)
             => 0;
@@ -290,7 +330,10 @@ public sealed class CombatServiceTests
             => [];
 
         public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
-            => [];
+            => _sectors.Values
+                       .Where(sector => sector.MapIndex == mapId)
+                       .SelectMany(sector => sector.GetEntitiesInRange<UOMobileEntity>(location, range))
+                       .ToList();
 
         public List<GameSession> GetPlayersInRange(Point3D location, int range, int mapId, GameSession? excludeSession = null)
             => [];
@@ -309,7 +352,18 @@ public sealed class CombatServiceTests
 
         public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation) { }
         public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation) { }
-        public void RemoveEntity(Serial serial) { }
+        public void RemoveEntity(Serial serial)
+        {
+            foreach (var sector in _sectors.Values)
+            {
+                var mobile = sector.GetEntity<UOMobileEntity>(serial);
+
+                if (mobile is not null)
+                {
+                    sector.RemoveEntity(mobile);
+                }
+            }
+        }
 
         public JsonRegion? ResolveRegion(int mapId, Point3D location)
         {
@@ -609,6 +663,95 @@ public sealed class CombatServiceTests
     }
 
     [Test]
+    public async Task ScheduledSwing_WhenNpcArcherWeaponExistsOnlyInSpatialRuntime_ShouldStillUseRangedCombatProfile()
+    {
+        EnsureMapsRegistered();
+        Body.Types = new UOBodyType[0x200];
+        Body.Types[0x0190] = UOBodyType.Human;
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var liveAttacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000050u,
+            IsPlayer = false,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Direction = DirectionType.West,
+            BaseBody = 0x0190,
+            Hits = 50,
+            MaxHits = 50
+        };
+        liveAttacker.SetSkill(UOSkillName.Archery, 1000);
+        var bow = new UOItemEntity
+        {
+            Id = (Serial)0x40000050u,
+            ItemId = 0x13B2,
+            EquippedMobileId = liveAttacker.Id,
+            EquippedLayer = ItemLayerType.TwoHanded,
+            WeaponSkill = UOSkillName.Archery,
+            AmmoItemId = 0x0F3F,
+            AmmoEffectId = 0x1BFE,
+            CombatStats = new()
+            {
+                DamageMin = 6,
+                DamageMax = 6,
+                RangeMin = 1,
+                RangeMax = 10
+            }
+        };
+        liveAttacker.HydrateEquipmentRuntime([bow]);
+
+        var liveDefender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000051u,
+            IsPlayer = false,
+            MapId = 0,
+            Location = new(105, 100, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+
+        spatial.AddOrUpdateMobile(liveAttacker);
+        spatial.AddOrUpdateMobile(liveDefender);
+        mobileService.Add(CreatePersistenceClone(liveAttacker));
+        mobileService.Add(CreatePersistenceClone(liveDefender));
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            new InMemoryItemService(),
+            new DeathServiceSpy()
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(liveAttacker.Id, liveDefender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(liveDefender.Hits, Is.EqualTo(34));
+                Assert.That(liveAttacker.Direction, Is.EqualTo(DirectionType.East));
+                Assert.That(spatial.BroadcastPackets.OfType<GraphicalEffectPacket>().Any(), Is.True);
+                Assert.That(spatial.BroadcastPackets.OfType<FightOccurringPacket>().Any(), Is.True);
+                Assert.That(spatial.BroadcastPackets.OfType<MobileMovingPacket>().Any(packet => packet.Mobile?.Id == liveAttacker.Id), Is.True);
+                Assert.That(eventBus.Events.Any(gameEvent => gameEvent is MobilePlayAnimationEvent), Is.True);
+                Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatHitEvent), Is.True);
+            }
+        );
+    }
+
+    [Test]
     public async Task ScheduledSwing_WhenRangedWeaponHasNoAmmo_ShouldClearCombatantWithoutApplyingDamage()
     {
         EnsureMapsRegistered();
@@ -700,6 +843,159 @@ public sealed class CombatServiceTests
                 Assert.That(defender.Hits, Is.EqualTo(40));
                 Assert.That(spatial.BroadcastPackets.OfType<GraphicalEffectPacket>(), Is.Empty);
                 Assert.That(eventBus.Events.Any(gameEvent => gameEvent is CombatHitEvent or CombatMissEvent), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task TrySetCombatantAsync_WhenAlreadyTargetingSameDefender_ShouldNotRescheduleSwing()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000038u,
+            IsPlayer = false,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50
+        };
+        var sword = new UOItemEntity
+        {
+            Id = (Serial)0x40000038u,
+            EquippedMobileId = attacker.Id,
+            EquippedLayer = ItemLayerType.OneHanded,
+            CombatStats = new()
+            {
+                DamageMin = 6,
+                DamageMax = 6,
+                RangeMin = 1,
+                RangeMax = 1,
+                AttackSpeed = 30
+            }
+        };
+        attacker.HydrateEquipmentRuntime([sword]);
+
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000039u,
+            MapId = 0,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            itemService,
+            new DeathServiceSpy()
+        );
+
+        var firstSetTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        var firstNextCombatAtUtc = attacker.NextCombatAtUtc;
+        var firstRegisteredTimerCount = timerService.RegisteredTimers.Count;
+
+        var secondSetTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(firstSetTarget, Is.True);
+                Assert.That(secondSetTarget, Is.True);
+                Assert.That(timerService.RegisteredTimers, Has.Count.EqualTo(firstRegisteredTimerCount));
+                Assert.That(attacker.NextCombatAtUtc, Is.EqualTo(firstNextCombatAtUtc));
+            }
+        );
+    }
+
+    [Test]
+    public async Task TrySetCombatantAsync_WhenWarmodeAndCombatantArePresetWithoutScheduledSwing_ShouldStillScheduleFirstAttack()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x0000003Au,
+            IsPlayer = false,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50,
+            CombatantId = (Serial)0x0000003Bu,
+            Warmode = true
+        };
+        var sword = new UOItemEntity
+        {
+            Id = (Serial)0x4000003Bu,
+            EquippedMobileId = attacker.Id,
+            EquippedLayer = ItemLayerType.OneHanded,
+            CombatStats = new()
+            {
+                DamageMin = 6,
+                DamageMax = 6,
+                RangeMin = 1,
+                RangeMax = 1,
+                AttackSpeed = 30
+            }
+        };
+        attacker.HydrateEquipmentRuntime([sword]);
+
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x0000003Bu,
+            MapId = 0,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+        spatial.AddOrUpdateMobile(attacker);
+        spatial.AddOrUpdateMobile(defender);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            itemService,
+            new DeathServiceSpy()
+        );
+
+        var result = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(timerService.RegisteredTimers, Has.Count.EqualTo(1));
+                Assert.That(timerService.RegisteredTimers[0].Name, Is.EqualTo($"combat:{(uint)attacker.Id}"));
             }
         );
     }
@@ -1698,6 +1994,79 @@ public sealed class CombatServiceTests
         );
     }
 
+    [Test]
+    public async Task ScheduledSwing_WhenAttackerIsNotFacingDefender_ShouldTurnTowardTargetAndBroadcastFacingUpdate()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000052u,
+            IsPlayer = true,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Direction = DirectionType.South,
+            Hits = 50,
+            MaxHits = 50,
+            MinWeaponDamage = 6,
+            MaxWeaponDamage = 6
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000053u,
+            IsPlayer = false,
+            MapId = 0,
+            Location = new(100, 99, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+        spatial.AddOrUpdateMobile(attacker);
+        spatial.AddOrUpdateMobile(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            new InMemoryItemService(),
+            new DeathServiceSpy()
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+
+        var facingUpdate = spatial.BroadcastPackets.OfType<MobileMovingPacket>().Single(packet => packet.Mobile?.Id == attacker.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(attacker.Direction, Is.EqualTo(DirectionType.North));
+                Assert.That(facingUpdate.Mobile!.Direction, Is.EqualTo(DirectionType.North));
+            }
+        );
+    }
+
     private static void EnsureMapsRegistered()
     {
         if (Map.GetMap(0) is null)
@@ -1722,4 +2091,56 @@ public sealed class CombatServiceTests
 
         return packets;
     }
+
+    private static UOMobileEntity CreatePersistenceClone(UOMobileEntity mobile)
+        => new()
+        {
+            Id = mobile.Id,
+            AccountId = mobile.AccountId,
+            Name = mobile.Name,
+            Title = mobile.Title,
+            BrainId = mobile.BrainId,
+            Location = mobile.Location,
+            MapId = mobile.MapId,
+            Direction = mobile.Direction,
+            IsPlayer = mobile.IsPlayer,
+            IsAlive = mobile.IsAlive,
+            Gender = mobile.Gender,
+            RaceIndex = mobile.RaceIndex,
+            ProfessionId = mobile.ProfessionId,
+            SkinHue = mobile.SkinHue,
+            HairStyle = mobile.HairStyle,
+            HairHue = mobile.HairHue,
+            FacialHairStyle = mobile.FacialHairStyle,
+            FacialHairHue = mobile.FacialHairHue,
+            BaseBody = mobile.BaseBody,
+            BaseStats = mobile.BaseStats,
+            BaseResistances = mobile.BaseResistances,
+            Resources = mobile.Resources,
+            EquipmentModifiers = mobile.EquipmentModifiers,
+            RuntimeModifiers = mobile.RuntimeModifiers,
+            ModifierCaps = mobile.ModifierCaps,
+            BackpackId = mobile.BackpackId,
+            EquippedItemIds = new(mobile.EquippedItemIds),
+            IsWarMode = mobile.IsWarMode,
+            Hunger = mobile.Hunger,
+            Thirst = mobile.Thirst,
+            Fame = mobile.Fame,
+            Karma = mobile.Karma,
+            Kills = mobile.Kills,
+            IsHidden = mobile.IsHidden,
+            IsFrozen = mobile.IsFrozen,
+            IsParalyzed = mobile.IsParalyzed,
+            IsFlying = mobile.IsFlying,
+            IgnoreMobiles = mobile.IgnoreMobiles,
+            IsPoisoned = mobile.IsPoisoned,
+            IsBlessed = mobile.IsBlessed,
+            IsInvulnerable = mobile.IsInvulnerable,
+            Notoriety = mobile.Notoriety,
+            CombatantId = mobile.CombatantId,
+            NextCombatAtUtc = mobile.NextCombatAtUtc,
+            LastCombatAtUtc = mobile.LastCombatAtUtc,
+            MinWeaponDamage = mobile.MinWeaponDamage,
+            MaxWeaponDamage = mobile.MaxWeaponDamage
+        };
 }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -20,6 +20,8 @@ public sealed class GuardBrainAssetTests
                 Assert.That(script, Does.Contain("npc:set_target(source)"));
                 Assert.That(script, Does.Contain("npc:set_war_mode(true)"));
                 Assert.That(script, Does.Contain("combat.set_target(npc_serial, source_serial)"));
+                Assert.That(script, Does.Contain("local function set_default(key, value)"));
+                Assert.That(script, Does.Contain("set_default(\"evade_desired_range\", 0)"));
             }
         );
     }
@@ -33,6 +35,9 @@ public sealed class GuardBrainAssetTests
         var behaviorInitPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "init.lua");
         var behaviorInit = File.ReadAllText(behaviorInitPath);
         var behaviorPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "ranged_keep_distance.lua");
+        var followBehaviorPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "follow.lua");
+        var rangedKeepDistance = File.ReadAllText(behaviorPath);
+        var followBehavior = File.ReadAllText(followBehaviorPath);
 
         Assert.Multiple(
             () =>
@@ -43,6 +48,16 @@ public sealed class GuardBrainAssetTests
                 Assert.That(script, Does.Contain("guard_role"));
                 Assert.That(script, Does.Contain("preferred_min_range"));
                 Assert.That(script, Does.Contain("preferred_max_range"));
+                Assert.That(script, Does.Contain("local function set_default(key, value)"));
+                Assert.That(script, Does.Contain("combat.clear_target(npc_serial)"));
+                Assert.That(rangedKeepDistance, Does.Contain("combat.set_target(npc_serial, target_serial)"));
+                Assert.That(rangedKeepDistance, Does.Contain("if combat.set_target(npc_serial, target_serial) ~= true then"));
+                Assert.That(rangedKeepDistance, Does.Contain("npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)"));
+                Assert.That(followBehavior, Does.Contain("combat.set_target(npc_serial, target_serial)"));
+                Assert.That(followBehavior, Does.Contain("if combat.set_target(npc_serial, target_serial) ~= true then"));
+                Assert.That(followBehavior, Does.Contain("npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)"));
+                Assert.That(rangedKeepDistance, Does.Not.Contain("require(\"combat\")"));
+                Assert.That(followBehavior, Does.Not.Contain("require(\"combat\")"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -22,6 +22,9 @@ public sealed class GuardBrainAssetTests
                 Assert.That(script, Does.Contain("combat.set_target(npc_serial, source_serial)"));
                 Assert.That(script, Does.Contain("local function set_default(key, value)"));
                 Assert.That(script, Does.Contain("set_default(\"evade_desired_range\", 0)"));
+                Assert.That(script, Does.Contain("\"self_bandage\""));
+                Assert.That(script, Does.Contain("set_default(\"self_bandage_hp_threshold\", 0.45)"));
+                Assert.That(script, Does.Contain("set_default(\"self_bandage_score_bonus\", 70)"));
             }
         );
     }
@@ -36,14 +39,17 @@ public sealed class GuardBrainAssetTests
         var behaviorInit = File.ReadAllText(behaviorInitPath);
         var behaviorPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "ranged_keep_distance.lua");
         var followBehaviorPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "follow.lua");
+        var selfBandageBehaviorPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "self_bandage.lua");
         var rangedKeepDistance = File.ReadAllText(behaviorPath);
         var followBehavior = File.ReadAllText(followBehaviorPath);
+        var selfBandageBehavior = File.ReadAllText(selfBandageBehaviorPath);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(File.Exists(behaviorPath), Is.True);
                 Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.ranged_keep_distance\")"));
+                Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.self_bandage\")"));
                 Assert.That(script, Does.Contain("\"ranged_keep_distance\""));
                 Assert.That(script, Does.Contain("guard_role"));
                 Assert.That(script, Does.Contain("preferred_min_range"));
@@ -58,6 +64,10 @@ public sealed class GuardBrainAssetTests
                 Assert.That(followBehavior, Does.Contain("npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)"));
                 Assert.That(rangedKeepDistance, Does.Not.Contain("require(\"combat\")"));
                 Assert.That(followBehavior, Does.Not.Contain("require(\"combat\")"));
+                Assert.That(selfBandageBehavior, Does.Contain("healing.begin_self_bandage(npc_serial)"));
+                Assert.That(selfBandageBehavior, Does.Contain("healing.has_bandage(npc_serial)"));
+                Assert.That(selfBandageBehavior, Does.Contain("healing.is_bandaging(npc_serial)"));
+                Assert.That(selfBandageBehavior, Does.Contain("behavior.register(\"self_bandage\", M)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
@@ -279,11 +279,13 @@ public sealed class LuaBrainRunnerTests
         {
             Id = (Serial)0x600,
             Name = "traveler",
-            IsPlayer = true,
+            IsPlayer = false,
+            BrainId = "traveler_brain",
             MapId = 1,
             Location = new(120, 100, 0)
         };
         runner.Register(npc, npc.BrainId);
+        runner.Register(source, source.BrainId);
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
         source.Location = new(102, 100, 0);
@@ -317,6 +319,165 @@ public sealed class LuaBrainRunnerTests
     }
 
     [Test]
+    public async Task HandleAsync_WhenEnemyMobileWithoutBrainIsAdded_ShouldPreserveEnemyPayload()
+    {
+        using var temp = new TempDirectory();
+        var timerService = new LuaBrainRunnerTimerServiceSpy();
+        var scriptEngine = new ItemScriptDispatcherTestScriptEngineService();
+        var directories = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var runner = new LuaBrainRunner(timerService, scriptEngine, new LuaBrainRegistryStub(), directories);
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x700,
+            Name = "guard",
+            BrainId = "guard",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var zombie = new UOMobileEntity
+        {
+            Id = (Serial)0x701,
+            Name = "zombie",
+            IsPlayer = false,
+            MapId = 1,
+            Location = new(101, 100, 0),
+            Notoriety = Notoriety.CanBeAttacked
+        };
+
+        runner.Register(guard, guard.BrainId);
+        await runner.HandleAsync(new MobileAddedInWorldEvent(zombie, zombie.BrainId));
+        await runner.TickAllAsync(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        var eventCall = scriptEngine.Calls.First(
+            call => call.FunctionName == "on_event" && call.Args.Length > 0 && Equals(call.Args[0], "in_range")
+        );
+        var payload = (Dictionary<string, object>)eventCall.Args[2]!;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(payload["source_is_player"], Is.EqualTo(false));
+                Assert.That(payload["source_is_enemy"], Is.EqualTo(true));
+                Assert.That(payload["source_notoriety"], Is.EqualTo(nameof(Notoriety.CanBeAttacked)));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenEnemyMobileWithoutBrainMovesIntoRange_ShouldPreserveEnemyPayload()
+    {
+        using var temp = new TempDirectory();
+        var timerService = new LuaBrainRunnerTimerServiceSpy();
+        var scriptEngine = new ItemScriptDispatcherTestScriptEngineService();
+        var directories = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var runner = new LuaBrainRunner(timerService, scriptEngine, new LuaBrainRegistryStub(), directories);
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x710,
+            Name = "guard",
+            BrainId = "guard",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var zombie = new UOMobileEntity
+        {
+            Id = (Serial)0x711,
+            Name = "zombie",
+            IsPlayer = false,
+            MapId = 1,
+            Location = new(120, 100, 0),
+            Notoriety = Notoriety.CanBeAttacked
+        };
+
+        runner.Register(guard, guard.BrainId);
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await runner.HandleAsync(new MobileAddedInWorldEvent(zombie, zombie.BrainId));
+        await runner.TickAllAsync(now);
+        scriptEngine.Calls.Clear();
+
+        zombie.Location = new(102, 100, 0);
+        await runner.HandleAsync(new MobilePositionChangedEvent(1, zombie.Id, 1, 1, new(120, 100, 0), zombie.Location));
+        await runner.TickAllAsync(now + 1000);
+
+        var eventCall = scriptEngine.Calls.First(
+            call => call.FunctionName == "on_event" && call.Args.Length > 0 && Equals(call.Args[0], "in_range")
+        );
+        var payload = (Dictionary<string, object>)eventCall.Args[2]!;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(payload["source_is_player"], Is.EqualTo(false));
+                Assert.That(payload["source_is_enemy"], Is.EqualTo(true));
+                Assert.That(payload["source_notoriety"], Is.EqualTo(nameof(Notoriety.CanBeAttacked)));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenEnemyMobileIsWithinRangedGuardAcquisitionRange_ShouldNotifyRangedGuardButNotMeleeGuard()
+    {
+        using var temp = new TempDirectory();
+        var timerService = new LuaBrainRunnerTimerServiceSpy();
+        var scriptEngine = new ItemScriptDispatcherTestScriptEngineService();
+        var directories = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var runner = new LuaBrainRunner(timerService, scriptEngine, new LuaBrainRegistryStub(), directories);
+        var archerGuard = new UOMobileEntity
+        {
+            Id = (Serial)0x720,
+            Name = "archer_guard",
+            BrainId = "guard",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var warriorGuard = new UOMobileEntity
+        {
+            Id = (Serial)0x721,
+            Name = "warrior_guard",
+            BrainId = "guard",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var zombie = new UOMobileEntity
+        {
+            Id = (Serial)0x722,
+            Name = "zombie",
+            IsPlayer = false,
+            MapId = 1,
+            Location = new(106, 100, 0),
+            Notoriety = Notoriety.CanBeAttacked
+        };
+
+        archerGuard.SetCustomString("guard_role", "ranged");
+
+        runner.Register(archerGuard, archerGuard.BrainId);
+        runner.Register(warriorGuard, warriorGuard.BrainId);
+
+        await runner.HandleAsync(new MobileAddedInWorldEvent(zombie, zombie.BrainId));
+        await runner.TickAllAsync(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+        var inRangeEvents = scriptEngine.Calls
+                                        .Where(
+                                            call => call.FunctionName == "on_event" &&
+                                                    call.Args.Length > 0 &&
+                                                    Equals(call.Args[0], "in_range")
+                                        )
+                                        .ToList();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(inRangeEvents.Count, Is.EqualTo(1));
+
+                if (inRangeEvents.Count == 1)
+                {
+                    Assert.That(inRangeEvents[0].Args[1], Is.EqualTo((uint)zombie.Id));
+                }
+            }
+        );
+    }
+
+    [Test]
     public async Task HandleAsync_WhenMobileMovesOutNpcRange_ShouldInvokeOnEventOutRange()
     {
         using var temp = new TempDirectory();
@@ -336,11 +497,13 @@ public sealed class LuaBrainRunnerTests
         {
             Id = (Serial)0x620,
             Name = "traveler",
-            IsPlayer = true,
+            IsPlayer = false,
+            BrainId = "traveler_brain",
             MapId = 1,
             Location = new(102, 100, 0)
         };
         runner.Register(npc, npc.BrainId);
+        runner.Register(source, source.BrainId);
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
         // Prime in-range state.
@@ -387,11 +550,13 @@ public sealed class LuaBrainRunnerTests
         {
             Id = (Serial)0x610,
             Name = "traveler",
-            IsPlayer = true,
+            IsPlayer = false,
+            BrainId = "traveler_brain",
             MapId = 1,
             Location = new(120, 100, 0)
         };
         runner.Register(npc, npc.BrainId);
+        runner.Register(source, source.BrainId);
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
         source.Location = new(102, 100, 0);


### PR DESCRIPTION
## Summary
- add delayed NPC self-bandage support through a new 
- expose a minimal  Lua module and  behavior
- wire the behavior into the guard brain and document the new behavior contract

## Testing
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~BandageServiceTests|FullyQualifiedName~HealingModuleTests|FullyQualifiedName~GuardBrainAssetTests"
- dotnet build src/Moongate.Server/Moongate.Server.csproj

Closes #112