### PR TITLE
feat: add combat-driven skill gain

### DIFF
--- a/docs/articles/getting-started/introduction.md
+++ b/docs/articles/getting-started/introduction.md
@@ -114,7 +114,7 @@ Moongate v2 is **actively in development**. The following features are implement
 
 ### Planned
 
-- [x] Combat v1 baseline (melee + ranged auto-attack, combatant state, warmode, timer-wheel scheduling, archery ammo/projectiles, cloak-layer quivers, PvE fame/karma awards)
+- [x] Combat v1 baseline (melee + ranged auto-attack, combatant state, warmode, timer-wheel scheduling, archery ammo/projectiles, cloak-layer quivers, PvE fame/karma awards, combat-driven skill gain for weapon skill, Tactics, and Anatomy)
 - [ ] Skill system
 - [ ] Item system completion (vendor/trade/economy semantics)
 - [ ] House/shelter system

--- a/docs/articles/getting-started/introduction.md
+++ b/docs/articles/getting-started/introduction.md
@@ -114,7 +114,7 @@ Moongate v2 is **actively in development**. The following features are implement
 
 ### Planned
 
-- [x] Combat v1 baseline (melee + ranged auto-attack, combatant state, warmode, timer-wheel scheduling, archery ammo/projectiles, cloak-layer quivers, PvE fame/karma awards, combat-driven skill gain for weapon skill, Tactics, and Anatomy)
+- [x] Combat v1 baseline (melee + ranged auto-attack, combatant state, warmode, timer-wheel scheduling, archery ammo/projectiles, cloak-layer quivers, PvE fame/karma awards, combat-driven skill gain for weapon skill, Tactics, and Anatomy, player anti-macro throttling, and stat gain with persisted stat locks)
 - [ ] Skill system
 - [ ] Item system completion (vendor/trade/economy semantics)
 - [ ] House/shelter system

--- a/docs/articles/networking/packets.md
+++ b/docs/articles/networking/packets.md
@@ -102,7 +102,7 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0xB5` | Open Chat Window | C -> S | `OpenChatWindowPacket` | `handler` | `ChatHandler` | Opens classic conference chat and creates runtime chat user |
 | `0xB3` | Chat Text | C -> S | `ChatTextPacket` | `handler` | `ChatHandler` | Conference chat actions (`message`, `join`, `pm`, `ignore`, `ops`, `voice`, `kick`, `whois`, `emote`) |
 | `0x6C` | Target Cursor Commands | C -> S | `TargetCursorCommandsPacket` | `handler` | `PlayerTargetService` | Target callbacks |
-| `0xBF` | General Information | C -> S | `GeneralInformationPacket` | `handler` | `GeneralInformationHandler` | Includes context menu / stat lock subcommands |
+| `0xBF` | General Information | C -> S | `GeneralInformationPacket` | `handler` | `GeneralInformationHandler` | Includes context menu / stat lock subcommands; stat lock requests are persisted onto the active character |
 | `0xD6` | Mega Cliloc | C -> S | `MegaClilocPacket` | `handler` | `ToolTipHandler` | Tooltip requests |
 | `0xB1` | Gump Menu Selection | C -> S | `GumpMenuSelectionPacket` | `handler` | `GumpHandler` | Gump button replies |
 | `0x9B` | Request Help | C -> S | `RequestHelpPacket` | `handler` | `HelpHandler -> HelpRequestService` | Opens the Lua help-ticket wizard and submits persisted tickets through `help_tickets` |
@@ -138,7 +138,7 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0x2F` | Fight Occuring | S -> C | `FightOccurringPacket` | `outgoing` | `CombatService` | Broadcast when a scheduled melee swing is attempted |
 | `0xAA` | Allow/Refuse Attack | S -> C | `ChangeCombatantPacket` | `outgoing` | `CombatService` | Current combatant serial or `Serial.Zero` |
 | `0xB2` | Chat Command | S -> C | `ChatCommandPacket` | `outgoing` | `ChatSystemService` | Classic conference chat responses and UI updates |
-| `0x3A` | Send Skills | S -> C | `SkillListPacket` | `outgoing` | `PlayerStatusHandler`, `CombatService` | Full skill list with lock state, also reused after combat-driven skill gains |
+| `0x3A` | Send Skills | S -> C | `SkillListPacket` | `outgoing` | `PlayerStatusHandler`, `CombatService` | Full skill list with lock state, reused after combat-driven skill gains and any resulting stat progression |
 | `0x23` | Dragging Of Item | S -> C | `DraggingOfItemPacket` | `outgoing` | item drag flow | Drag visual |
 | `0xAE` | Unicode Speech Message | S -> C | `UnicodeSpeechMessagePacket` | `outgoing` | speech/system messages | Server speech |
 | `0xB0` | Generic Gump | S -> C | `GenericGumpPacket` | `outgoing` | gump flow | Standard gump |

--- a/docs/articles/networking/packets.md
+++ b/docs/articles/networking/packets.md
@@ -138,7 +138,7 @@ This matrix tracks the packet subset that is already present in Moongate or stil
 | `0x2F` | Fight Occuring | S -> C | `FightOccurringPacket` | `outgoing` | `CombatService` | Broadcast when a scheduled melee swing is attempted |
 | `0xAA` | Allow/Refuse Attack | S -> C | `ChangeCombatantPacket` | `outgoing` | `CombatService` | Current combatant serial or `Serial.Zero` |
 | `0xB2` | Chat Command | S -> C | `ChatCommandPacket` | `outgoing` | `ChatSystemService` | Classic conference chat responses and UI updates |
-| `0x3A` | Send Skills | S -> C | `SkillListPacket` | `outgoing` | `PlayerStatusHandler` | Full skill list with lock state |
+| `0x3A` | Send Skills | S -> C | `SkillListPacket` | `outgoing` | `PlayerStatusHandler`, `CombatService` | Full skill list with lock state, also reused after combat-driven skill gains |
 | `0x23` | Dragging Of Item | S -> C | `DraggingOfItemPacket` | `outgoing` | item drag flow | Drag visual |
 | `0xAE` | Unicode Speech Message | S -> C | `UnicodeSpeechMessagePacket` | `outgoing` | speech/system messages | Server speech |
 | `0xB0` | Generic Gump | S -> C | `GenericGumpPacket` | `outgoing` | gump flow | Standard gump |

--- a/docs/articles/networking/pol-packet-coverage.md
+++ b/docs/articles/networking/pol-packet-coverage.md
@@ -39,7 +39,7 @@ It is meant for gap analysis against the POL packet catalog, not just for docume
 | `0x24` | Draw container | S -> C | `?Packet=0x24` | `DrawContainerPacket` | `outgoing` | container flow | Container open packet |
 | `0x2E` | Worn item | S -> C | `?Packet=0x2E` | `WornItemPacket` | `outgoing` | equipment sync | Equipped visuals |
 | `0x34` | Get player status | C -> S | `?Packet=0x34` | `GetPlayerStatusPacket` | `handler` | `PlayerStatusHandler` | `BasicStatus -> 0x11`, `RequestSkills -> 0x3A` |
-| `0x3A` | Send skills | both | `?Packet=0x3A` | `SkillListPacket` | `outgoing` | `PlayerStatusHandler`, `CombatService` | Moongate sends the full skill list on explicit requests and after combat-driven skill gains; no inbound listener |
+| `0x3A` | Send skills | both | `?Packet=0x3A` | `SkillListPacket` | `outgoing` | `PlayerStatusHandler`, `CombatService` | Moongate sends the full skill list on explicit requests and after combat-driven skill gains/stat progression; no inbound listener |
 | `0x3C` | Add multiple items to container | S -> C | `?Packet=0x3C` | `AddMultipleItemsToContainerPacket` | `outgoing` | container flow | Batched container contents |
 | `0x4E` | Personal light level | S -> C | `?Packet=0x4E` | `PersonalLightLevelPacket` | `outgoing` | world presentation | Client light state |
 | `0x4F` | Overall light level | S -> C | `?Packet=0x4F` | `OverallLightLevelPacket` | `outgoing` | world presentation | Global light state |
@@ -74,7 +74,7 @@ It is meant for gap analysis against the POL packet catalog, not just for docume
 | `0xB9` | Enable locked client features | S -> C | `?Packet=0xB9` | `SupportFeaturesPacket` | `outgoing` | login flow | Client feature flags |
 | `0xBC` | Season | S -> C | `?Packet=0xBC` | `SeasonPacket` | `outgoing` | world presentation | Season state |
 | `0xBD` | Client version | C -> S | `?Packet=0xBD` | `ClientVersionPacket` | `handler` | `LoginHandler` | Stores client version |
-| `0xBF` | General information | C -> S | `?Packet=0xBF` | `GeneralInformationPacket` | `handler` | `GeneralInformationHandler` | Context menus, stat locks, targeted actions |
+| `0xBF` | General information | C -> S | `?Packet=0xBF` | `GeneralInformationPacket` | `handler` | `GeneralInformationHandler` | Context menus, persisted stat-lock updates, targeted actions |
 | `0xC0` | Hued effect | S -> C | `?Packet=0xC0` | `HuedEffectPacket` | `outgoing` | world presentation | Colored effect |
 | `0xC7` | Particle effect | S -> C | `?Packet=0xC7` | `ParticleEffectPacket` | `outgoing` | world presentation | Particle effect |
 | `0xC8` | Client view range | C -> S | `?Packet=0xC8` | `ClientViewRangePacket` | `handler` | `ClientViewRangeHandler` | View range update |

--- a/docs/articles/networking/pol-packet-coverage.md
+++ b/docs/articles/networking/pol-packet-coverage.md
@@ -39,7 +39,7 @@ It is meant for gap analysis against the POL packet catalog, not just for docume
 | `0x24` | Draw container | S -> C | `?Packet=0x24` | `DrawContainerPacket` | `outgoing` | container flow | Container open packet |
 | `0x2E` | Worn item | S -> C | `?Packet=0x2E` | `WornItemPacket` | `outgoing` | equipment sync | Equipped visuals |
 | `0x34` | Get player status | C -> S | `?Packet=0x34` | `GetPlayerStatusPacket` | `handler` | `PlayerStatusHandler` | `BasicStatus -> 0x11`, `RequestSkills -> 0x3A` |
-| `0x3A` | Send skills | both | `?Packet=0x3A` | `SkillListPacket` | `outgoing` | `PlayerStatusHandler` | Moongate sends the skill list; no inbound listener |
+| `0x3A` | Send skills | both | `?Packet=0x3A` | `SkillListPacket` | `outgoing` | `PlayerStatusHandler`, `CombatService` | Moongate sends the full skill list on explicit requests and after combat-driven skill gains; no inbound listener |
 | `0x3C` | Add multiple items to container | S -> C | `?Packet=0x3C` | `AddMultipleItemsToContainerPacket` | `outgoing` | container flow | Batched container contents |
 | `0x4E` | Personal light level | S -> C | `?Packet=0x4E` | `PersonalLightLevelPacket` | `outgoing` | world presentation | Client light state |
 | `0x4F` | Overall light level | S -> C | `?Packet=0x4F` | `OverallLightLevelPacket` | `outgoing` | world presentation | Global light state |

--- a/src/Moongate.Server/Data/Interaction/SkillGainContext.cs
+++ b/src/Moongate.Server/Data/Interaction/SkillGainContext.cs
@@ -1,0 +1,9 @@
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Server.Data.Interaction;
+
+/// <summary>
+/// Carries action context used by skill gain policies such as anti-macro.
+/// </summary>
+public sealed record SkillGainContext(Point3D Location, Serial? TargetId);

--- a/src/Moongate.Server/Data/Interaction/SkillGainResult.cs
+++ b/src/Moongate.Server/Data/Interaction/SkillGainResult.cs
@@ -1,0 +1,12 @@
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Data.Interaction;
+
+/// <summary>
+/// Describes the outcome of a single skill gain attempt.
+/// </summary>
+public sealed record SkillGainResult(
+    UOSkillName SkillName,
+    bool SkillIncreased,
+    UOSkillName? LoweredSkillName
+);

--- a/src/Moongate.Server/Data/Interaction/StatGainResult.cs
+++ b/src/Moongate.Server/Data/Interaction/StatGainResult.cs
@@ -1,0 +1,12 @@
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Data.Interaction;
+
+/// <summary>
+/// Describes the outcome of a stat gain attempt triggered by skill gain.
+/// </summary>
+public sealed record StatGainResult(
+    bool StatIncreased,
+    Stat? GainedStat,
+    Stat? LoweredStat
+);

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -108,6 +108,8 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<IHelpRequestService, HelpRequestService>(Reuse.Singleton);
         container.Register<IHelpTicketService, HelpTicketService>(Reuse.Singleton);
         container.Register<INotorietyService, NotorietyService>(Reuse.Singleton);
+        container.Register<ISkillAntiMacroService, SkillAntiMacroService>(Reuse.Singleton);
+        container.Register<IStatGainService, StatGainService>(Reuse.Singleton);
         container.Register<ISkillGainService, SkillGainService>(Reuse.Singleton);
         container.Register<ICombatService, CombatService>(Reuse.Singleton);
         container.Register<IBandageService, BandageService>(Reuse.Singleton);

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -108,6 +108,7 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<IHelpRequestService, HelpRequestService>(Reuse.Singleton);
         container.Register<IHelpTicketService, HelpTicketService>(Reuse.Singleton);
         container.Register<INotorietyService, NotorietyService>(Reuse.Singleton);
+        container.Register<ISkillGainService, SkillGainService>(Reuse.Singleton);
         container.Register<ICombatService, CombatService>(Reuse.Singleton);
         container.Register<IBandageService, BandageService>(Reuse.Singleton);
         container.Register<IDeathService, DeathService>(Reuse.Singleton);

--- a/src/Moongate.Server/Handlers/CharacterStatLockHandler.cs
+++ b/src/Moongate.Server/Handlers/CharacterStatLockHandler.cs
@@ -1,0 +1,59 @@
+using Moongate.Abstractions.Interfaces.Services.Base;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Events.Characters;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Sessions;
+
+namespace Moongate.Server.Handlers;
+
+[RegisterGameEventListener]
+public sealed class CharacterStatLockHandler
+    : IGameEventListener<StatLockChangeRequestedEvent>,
+      IMoongateService
+{
+    private readonly IMobileService _mobileService;
+    private readonly IGameNetworkSessionService _gameNetworkSessionService;
+
+    public CharacterStatLockHandler(
+        IOutgoingPacketQueue outgoingPacketQueue,
+        IMobileService mobileService,
+        IGameNetworkSessionService gameNetworkSessionService
+    )
+    {
+        _ = outgoingPacketQueue;
+        _mobileService = mobileService;
+        _gameNetworkSessionService = gameNetworkSessionService;
+    }
+
+    public async Task HandleAsync(StatLockChangeRequestedEvent gameEvent, CancellationToken cancellationToken = default)
+    {
+        if (!_gameNetworkSessionService.TryGet(gameEvent.SessionId, out var session))
+        {
+            return;
+        }
+
+        var mobile = session.Character;
+
+        if (mobile is null && session.CharacterId != Moongate.UO.Data.Ids.Serial.Zero)
+        {
+            mobile = await _mobileService.GetAsync(session.CharacterId, cancellationToken);
+        }
+
+        if (mobile is null)
+        {
+            return;
+        }
+
+        mobile.SetStatLock(gameEvent.Stat, gameEvent.LockState);
+        await _mobileService.CreateOrUpdateAsync(mobile, cancellationToken);
+        session.Character = mobile;
+    }
+
+    public Task StartAsync()
+        => Task.CompletedTask;
+
+    public Task StopAsync()
+        => Task.CompletedTask;
+}

--- a/src/Moongate.Server/Interfaces/Services/Interaction/ISkillAntiMacroService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/ISkillAntiMacroService.cs
@@ -1,0 +1,20 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Interfaces.Services.Interaction;
+
+/// <summary>
+/// Applies runtime anti-macro rules to skill gain attempts.
+/// </summary>
+public interface ISkillAntiMacroService
+{
+    /// <summary>
+    /// Determines whether the current gain attempt should remain eligible.
+    /// </summary>
+    /// <param name="mobile">The mobile attempting to gain the skill.</param>
+    /// <param name="skillName">The skill being trained.</param>
+    /// <param name="context">The action context for the gain attempt.</param>
+    /// <returns><c>true</c> when gain may continue; otherwise <c>false</c>.</returns>
+    bool AllowGain(UOMobileEntity mobile, UOSkillName skillName, SkillGainContext? context);
+}

--- a/src/Moongate.Server/Interfaces/Services/Interaction/ISkillGainService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/ISkillGainService.cs
@@ -1,0 +1,21 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Interfaces.Services.Interaction;
+
+/// <summary>
+/// Applies combat-driven skill gain rules to mobiles.
+/// </summary>
+public interface ISkillGainService
+{
+    /// <summary>
+    /// Attempts to increase the requested skill using the supplied action difficulty context.
+    /// </summary>
+    /// <param name="mobile">The mobile whose skill should be evaluated.</param>
+    /// <param name="skillName">The skill being trained.</param>
+    /// <param name="successChance">The normalized success chance for the action.</param>
+    /// <param name="wasSuccessful"><c>true</c> when the action succeeded; otherwise <c>false</c>.</param>
+    /// <returns>The applied gain result.</returns>
+    SkillGainResult TryGain(UOMobileEntity mobile, UOSkillName skillName, double successChance, bool wasSuccessful);
+}

--- a/src/Moongate.Server/Interfaces/Services/Interaction/ISkillGainService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/ISkillGainService.cs
@@ -16,6 +16,13 @@ public interface ISkillGainService
     /// <param name="skillName">The skill being trained.</param>
     /// <param name="successChance">The normalized success chance for the action.</param>
     /// <param name="wasSuccessful"><c>true</c> when the action succeeded; otherwise <c>false</c>.</param>
+    /// <param name="context">Optional action context used by gain policies.</param>
     /// <returns>The applied gain result.</returns>
-    SkillGainResult TryGain(UOMobileEntity mobile, UOSkillName skillName, double successChance, bool wasSuccessful);
+    SkillGainResult TryGain(
+        UOMobileEntity mobile,
+        UOSkillName skillName,
+        double successChance,
+        bool wasSuccessful,
+        SkillGainContext? context = null
+    );
 }

--- a/src/Moongate.Server/Interfaces/Services/Interaction/IStatGainService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Interaction/IStatGainService.cs
@@ -1,0 +1,19 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Interfaces.Services.Interaction;
+
+/// <summary>
+/// Applies stat gain rules triggered by successful skill gains.
+/// </summary>
+public interface IStatGainService
+{
+    /// <summary>
+    /// Attempts to apply a stat gain for the specified skill.
+    /// </summary>
+    /// <param name="mobile">The mobile whose stats may change.</param>
+    /// <param name="skillName">The skill that triggered the stat gain attempt.</param>
+    /// <returns>The applied stat gain result.</returns>
+    StatGainResult TryApply(UOMobileEntity mobile, UOSkillName skillName);
+}

--- a/src/Moongate.Server/Services/Interaction/CombatService.cs
+++ b/src/Moongate.Server/Services/Interaction/CombatService.cs
@@ -1,6 +1,7 @@
 using Moongate.Network.Packets.Outgoing.Combat;
 using Moongate.Network.Packets.Outgoing.Entity;
 using Moongate.Network.Packets.Outgoing.World;
+using Moongate.Server.Data.Interaction;
 using Moongate.Server.Data.Events.Characters;
 using Moongate.Server.Data.Events.Combat;
 using Moongate.Server.Data.Session;
@@ -64,7 +65,7 @@ public sealed class CombatService : ICombatService
             gameEventBusService,
             itemService,
             deathService,
-            new SkillGainService()
+            new SkillGainService(new SkillAntiMacroService(), new StatGainService())
         )
     {
     }
@@ -644,11 +645,12 @@ public sealed class CombatService : ICombatService
     private bool TryApplyCombatSkillGain(UOMobileEntity attacker, UOMobileEntity defender, bool wasSuccessful)
     {
         var successChance = ResolveHitScore(attacker, defender);
+        var context = new SkillGainContext(attacker.Location, defender.Id);
         var changed = false;
 
-        changed |= _skillGainService.TryGain(attacker, ResolveAttackSkill(attacker), successChance, wasSuccessful).SkillIncreased;
-        changed |= _skillGainService.TryGain(attacker, UOSkillName.Tactics, successChance, wasSuccessful).SkillIncreased;
-        changed |= _skillGainService.TryGain(attacker, UOSkillName.Anatomy, successChance, wasSuccessful).SkillIncreased;
+        changed |= _skillGainService.TryGain(attacker, ResolveAttackSkill(attacker), successChance, wasSuccessful, context).SkillIncreased;
+        changed |= _skillGainService.TryGain(attacker, UOSkillName.Tactics, successChance, wasSuccessful, context).SkillIncreased;
+        changed |= _skillGainService.TryGain(attacker, UOSkillName.Anatomy, successChance, wasSuccessful, context).SkillIncreased;
 
         return changed;
     }

--- a/src/Moongate.Server/Services/Interaction/CombatService.cs
+++ b/src/Moongate.Server/Services/Interaction/CombatService.cs
@@ -41,6 +41,7 @@ public sealed class CombatService : ICombatService
     private readonly IGameEventBusService _gameEventBusService;
     private readonly IItemService _itemService;
     private readonly IDeathService _deathService;
+    private readonly ISkillGainService _skillGainService;
     private readonly Lock _syncRoot = new();
     private readonly Dictionary<Serial, int> _combatSequences = [];
 
@@ -54,6 +55,31 @@ public sealed class CombatService : ICombatService
         IItemService itemService,
         IDeathService deathService
     )
+        : this(
+            mobileService,
+            gameNetworkSessionService,
+            outgoingPacketQueue,
+            timerService,
+            spatialWorldService,
+            gameEventBusService,
+            itemService,
+            deathService,
+            new SkillGainService()
+        )
+    {
+    }
+
+    public CombatService(
+        IMobileService mobileService,
+        IGameNetworkSessionService gameNetworkSessionService,
+        IOutgoingPacketQueue outgoingPacketQueue,
+        ITimerService timerService,
+        ISpatialWorldService spatialWorldService,
+        IGameEventBusService gameEventBusService,
+        IItemService itemService,
+        IDeathService deathService,
+        ISkillGainService skillGainService
+    )
     {
         _mobileService = mobileService;
         _gameNetworkSessionService = gameNetworkSessionService;
@@ -63,6 +89,7 @@ public sealed class CombatService : ICombatService
         _gameEventBusService = gameEventBusService;
         _itemService = itemService;
         _deathService = deathService;
+        _skillGainService = skillGainService;
     }
 
     public async Task<bool> TrySetCombatantAsync(
@@ -553,7 +580,9 @@ public sealed class CombatService : ICombatService
         attacker.LastCombatAtUtc = nowUtc;
         defender.LastCombatAtUtc = nowUtc;
 
-        if (ResolveHit(attacker, defender))
+        var wasSuccessful = ResolveHit(attacker, defender);
+
+        if (wasSuccessful)
         {
             var damage = ResolveDamage(attacker, attackProfile);
             defender.Hits = Math.Max(0, defender.Hits - damage);
@@ -585,10 +614,17 @@ public sealed class CombatService : ICombatService
             );
         }
 
+        var skillsChanged = TryApplyCombatSkillGain(attacker, defender, wasSuccessful);
         attacker.NextCombatAtUtc = nowUtc.Add(delay);
 
         await PersistMobileAsync(attacker, CancellationToken.None);
         await PersistMobileAsync(defender, CancellationToken.None);
+
+        if (skillsChanged &&
+            _gameNetworkSessionService.TryGetByCharacterId(attacker.Id, out var attackerSession))
+        {
+            _outgoingPacketQueue.Enqueue(attackerSession.SessionId, new SkillListPacket(attacker));
+        }
 
         if (_gameNetworkSessionService.TryGetByCharacterId(defender.Id, out var defenderSession))
         {
@@ -603,6 +639,18 @@ public sealed class CombatService : ICombatService
         }
 
         ScheduleSwing(attacker.Id, delay);
+    }
+
+    private bool TryApplyCombatSkillGain(UOMobileEntity attacker, UOMobileEntity defender, bool wasSuccessful)
+    {
+        var successChance = ResolveHitScore(attacker, defender);
+        var changed = false;
+
+        changed |= _skillGainService.TryGain(attacker, ResolveAttackSkill(attacker), successChance, wasSuccessful).SkillIncreased;
+        changed |= _skillGainService.TryGain(attacker, UOSkillName.Tactics, successChance, wasSuccessful).SkillIncreased;
+        changed |= _skillGainService.TryGain(attacker, UOSkillName.Anatomy, successChance, wasSuccessful).SkillIncreased;
+
+        return changed;
     }
 
     private static void RefreshAggression(

--- a/src/Moongate.Server/Services/Interaction/SkillAntiMacroService.cs
+++ b/src/Moongate.Server/Services/Interaction/SkillAntiMacroService.cs
@@ -1,0 +1,68 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Services.Interaction;
+
+public sealed class SkillAntiMacroService : ISkillAntiMacroService
+{
+    private const int BucketSize = 8;
+    private const int MaxAllowedRepeats = 3;
+    private static readonly TimeSpan RepeatWindow = TimeSpan.FromSeconds(8);
+
+    private readonly Func<DateTime> _utcNowProvider;
+    private readonly Dictionary<SkillAntiMacroKey, SkillAntiMacroEntry> _entries = [];
+
+    public SkillAntiMacroService()
+        : this(static () => DateTime.UtcNow)
+    {
+    }
+
+    internal SkillAntiMacroService(Func<DateTime> utcNowProvider)
+    {
+        ArgumentNullException.ThrowIfNull(utcNowProvider);
+        _utcNowProvider = utcNowProvider;
+    }
+
+    public bool AllowGain(UOMobileEntity mobile, UOSkillName skillName, SkillGainContext? context)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        if (!mobile.IsPlayer || context is null)
+        {
+            return true;
+        }
+
+        var nowUtc = _utcNowProvider();
+        var key = new SkillAntiMacroKey(
+            mobile.Id,
+            skillName,
+            context.TargetId ?? Serial.Zero,
+            context.Location.X / BucketSize,
+            context.Location.Y / BucketSize
+        );
+
+        if (!_entries.TryGetValue(key, out var entry) || nowUtc - entry.LastAttemptAtUtc > RepeatWindow)
+        {
+            _entries[key] = new SkillAntiMacroEntry(1, nowUtc);
+            return true;
+        }
+
+        var nextRepeatCount = entry.RepeatCount + 1;
+        _entries[key] = new SkillAntiMacroEntry(nextRepeatCount, nowUtc);
+
+        return nextRepeatCount <= MaxAllowedRepeats;
+    }
+
+    private readonly record struct SkillAntiMacroKey(
+        Serial MobileId,
+        UOSkillName SkillName,
+        Serial TargetId,
+        int BucketX,
+        int BucketY
+    );
+
+    private readonly record struct SkillAntiMacroEntry(int RepeatCount, DateTime LastAttemptAtUtc);
+}

--- a/src/Moongate.Server/Services/Interaction/SkillGainService.cs
+++ b/src/Moongate.Server/Services/Interaction/SkillGainService.cs
@@ -1,0 +1,112 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Services.Interaction;
+
+public sealed class SkillGainService : ISkillGainService
+{
+    private const int GainAmount = 1;
+    private readonly Func<double> _nextDouble;
+
+    public SkillGainService()
+        : this(static () => Random.Shared.NextDouble())
+    {
+    }
+
+    internal SkillGainService(Func<double> nextDouble)
+    {
+        ArgumentNullException.ThrowIfNull(nextDouble);
+        _nextDouble = nextDouble;
+    }
+
+    public SkillGainResult TryGain(UOMobileEntity mobile, UOSkillName skillName, double successChance, bool wasSuccessful)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        var skill = mobile.GetSkill(skillName);
+
+        if (skill is null || skill.Lock != UOSkillLock.Up)
+        {
+            return new(skillName, false, null);
+        }
+
+        var currentBase = (int)Math.Round(skill.Base);
+        var skillCap = Math.Max(1, skill.Cap);
+
+        if (currentBase >= skillCap)
+        {
+            return new(skillName, false, null);
+        }
+
+        var normalizedSuccessChance = Math.Clamp(successChance, 0.0, 1.0);
+        var capRoomFactor = (skillCap - currentBase) / (double)skillCap;
+        var difficultyFactor = 1.0 - normalizedSuccessChance;
+        var successModifier = wasSuccessful ? 0.25 : 0.10;
+        var gainFactor = skill.Skill?.GainFactor ?? ResolveGainFactor(skillName);
+        var gainChance = Math.Clamp(((capRoomFactor + difficultyFactor + successModifier) / 3.0) * gainFactor, 0.01, 0.95);
+
+        if (_nextDouble() > gainChance)
+        {
+            return new(skillName, false, null);
+        }
+
+        UOSkillName? loweredSkillName = null;
+
+        if (mobile.GetTotalSkillBaseFixedPoint() + GainAmount > mobile.TotalSkillCapFixedPoint)
+        {
+            loweredSkillName = TryLowerDownLockedSkill(mobile, skillName, GainAmount);
+
+            if (loweredSkillName is null)
+            {
+                return new(skillName, false, null);
+            }
+        }
+
+        skill.Base = Math.Min(currentBase + GainAmount, skillCap);
+        skill.Value = skill.Base;
+
+        return new(skillName, true, loweredSkillName);
+    }
+
+    private static UOSkillName? TryLowerDownLockedSkill(UOMobileEntity mobile, UOSkillName excludedSkill, int amount)
+    {
+        foreach (var skillEntry in mobile.Skills.OrderBy(static pair => (int)pair.Key))
+        {
+            if (skillEntry.Key == excludedSkill)
+            {
+                continue;
+            }
+
+            var entry = skillEntry.Value;
+            var currentBase = (int)Math.Round(entry.Base);
+
+            if (entry.Lock != UOSkillLock.Down || currentBase < amount)
+            {
+                continue;
+            }
+
+            entry.Base = currentBase - amount;
+            entry.Value = entry.Base;
+
+            return skillEntry.Key;
+        }
+
+        return null;
+    }
+
+    private static double ResolveGainFactor(UOSkillName skillName)
+    {
+        foreach (var skillInfo in SkillInfo.Table)
+        {
+            if (skillInfo.SkillID == (int)skillName)
+            {
+                return skillInfo.GainFactor;
+            }
+        }
+
+        return 1.0;
+    }
+}

--- a/src/Moongate.Server/Services/Interaction/SkillGainService.cs
+++ b/src/Moongate.Server/Services/Interaction/SkillGainService.cs
@@ -10,19 +10,40 @@ public sealed class SkillGainService : ISkillGainService
 {
     private const int GainAmount = 1;
     private readonly Func<double> _nextDouble;
+    private readonly ISkillAntiMacroService _skillAntiMacroService;
+    private readonly IStatGainService _statGainService;
 
-    public SkillGainService()
-        : this(static () => Random.Shared.NextDouble())
+    public SkillGainService(ISkillAntiMacroService skillAntiMacroService, IStatGainService statGainService)
+        : this(static () => Random.Shared.NextDouble(), skillAntiMacroService, statGainService)
     {
     }
 
     internal SkillGainService(Func<double> nextDouble)
+        : this(nextDouble, new SkillAntiMacroService(static () => DateTime.UtcNow), new StatGainService(static () => 1.0, static () => 0.0))
     {
-        ArgumentNullException.ThrowIfNull(nextDouble);
-        _nextDouble = nextDouble;
     }
 
-    public SkillGainResult TryGain(UOMobileEntity mobile, UOSkillName skillName, double successChance, bool wasSuccessful)
+    internal SkillGainService(
+        Func<double> nextDouble,
+        ISkillAntiMacroService skillAntiMacroService,
+        IStatGainService statGainService
+    )
+    {
+        ArgumentNullException.ThrowIfNull(nextDouble);
+        ArgumentNullException.ThrowIfNull(skillAntiMacroService);
+        ArgumentNullException.ThrowIfNull(statGainService);
+        _nextDouble = nextDouble;
+        _skillAntiMacroService = skillAntiMacroService;
+        _statGainService = statGainService;
+    }
+
+    public SkillGainResult TryGain(
+        UOMobileEntity mobile,
+        UOSkillName skillName,
+        double successChance,
+        bool wasSuccessful,
+        SkillGainContext? context = null
+    )
     {
         ArgumentNullException.ThrowIfNull(mobile);
 
@@ -37,6 +58,11 @@ public sealed class SkillGainService : ISkillGainService
         var skillCap = Math.Max(1, skill.Cap);
 
         if (currentBase >= skillCap)
+        {
+            return new(skillName, false, null);
+        }
+
+        if (!_skillAntiMacroService.AllowGain(mobile, skillName, context))
         {
             return new(skillName, false, null);
         }
@@ -67,6 +93,7 @@ public sealed class SkillGainService : ISkillGainService
 
         skill.Base = Math.Min(currentBase + GainAmount, skillCap);
         skill.Value = skill.Base;
+        _ = _statGainService.TryApply(mobile, skillName);
 
         return new(skillName, true, loweredSkillName);
     }

--- a/src/Moongate.Server/Services/Interaction/StatGainService.cs
+++ b/src/Moongate.Server/Services/Interaction/StatGainService.cs
@@ -1,0 +1,165 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Services.Interaction;
+
+public sealed class StatGainService : IStatGainService
+{
+    private const int GainAmount = 1;
+    private const double StatGainChance = 0.05;
+    private const double PrimaryStatBias = 0.75;
+    private const int MinimumLowerableStatValue = 10;
+
+    private readonly Func<double> _attemptRollProvider;
+    private readonly Func<double> _selectionRollProvider;
+
+    public StatGainService()
+        : this(static () => Random.Shared.NextDouble(), static () => Random.Shared.NextDouble())
+    {
+    }
+
+    internal StatGainService(Func<double> attemptRollProvider, Func<double> selectionRollProvider)
+    {
+        ArgumentNullException.ThrowIfNull(attemptRollProvider);
+        ArgumentNullException.ThrowIfNull(selectionRollProvider);
+        _attemptRollProvider = attemptRollProvider;
+        _selectionRollProvider = selectionRollProvider;
+    }
+
+    public StatGainResult TryApply(UOMobileEntity mobile, UOSkillName skillName)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        if (_attemptRollProvider() > StatGainChance)
+        {
+            return new(false, null, null);
+        }
+
+        if (!TryResolveSkillInfo(skillName, out var skillInfo))
+        {
+            return new(false, null, null);
+        }
+
+        var preferredStat = _selectionRollProvider() <= PrimaryStatBias
+            ? skillInfo.PrimaryStat
+            : skillInfo.SecondaryStat;
+        var fallbackStat = preferredStat == skillInfo.PrimaryStat ? skillInfo.SecondaryStat : skillInfo.PrimaryStat;
+
+        if (TryIncreaseStat(mobile, preferredStat, out var loweredPrimary))
+        {
+            return new(true, preferredStat, loweredPrimary);
+        }
+
+        if (fallbackStat == preferredStat)
+        {
+            return new(false, null, null);
+        }
+
+        if (TryIncreaseStat(mobile, fallbackStat, out var loweredSecondary))
+        {
+            return new(true, fallbackStat, loweredSecondary);
+        }
+
+        return new(false, null, null);
+    }
+
+    private static bool TryResolveSkillInfo(UOSkillName skillName, out SkillInfo skillInfo)
+    {
+        foreach (var entry in SkillInfo.Table)
+        {
+            if (entry.SkillID == (int)skillName)
+            {
+                skillInfo = entry;
+                return true;
+            }
+        }
+
+        skillInfo = default!;
+        return false;
+    }
+
+    private static bool TryIncreaseStat(UOMobileEntity mobile, Stat stat, out Stat? loweredStat)
+    {
+        loweredStat = null;
+
+        if (mobile.GetStatLock(stat) != UOSkillLock.Up)
+        {
+            return false;
+        }
+
+        if (mobile.GetTotalBaseStats() + GainAmount > mobile.StatCap)
+        {
+            loweredStat = TryLowerDownLockedStat(mobile, stat);
+
+            if (loweredStat is null)
+            {
+                return false;
+            }
+        }
+
+        SetStatValue(mobile, stat, GetStatValue(mobile, stat) + GainAmount);
+        mobile.RecalculateMaxStats();
+
+        return true;
+    }
+
+    private static Stat? TryLowerDownLockedStat(UOMobileEntity mobile, Stat excludedStat)
+    {
+        foreach (var candidate in Enum.GetValues<Stat>())
+        {
+            if (candidate == excludedStat)
+            {
+                continue;
+            }
+
+            if (mobile.GetStatLock(candidate) != UOSkillLock.Down)
+            {
+                continue;
+            }
+
+            var currentValue = GetStatValue(mobile, candidate);
+
+            if (currentValue <= MinimumLowerableStatValue)
+            {
+                continue;
+            }
+
+            SetStatValue(mobile, candidate, currentValue - GainAmount);
+            mobile.RecalculateMaxStats();
+
+            return candidate;
+        }
+
+        return null;
+    }
+
+    private static int GetStatValue(UOMobileEntity mobile, Stat stat)
+        => stat switch
+        {
+            Stat.Strength => mobile.Strength,
+            Stat.Dexterity => mobile.Dexterity,
+            Stat.Intelligence => mobile.Intelligence,
+            _ => throw new ArgumentOutOfRangeException(nameof(stat), stat, null)
+        };
+
+    private static void SetStatValue(UOMobileEntity mobile, Stat stat, int value)
+    {
+        switch (stat)
+        {
+            case Stat.Strength:
+                mobile.Strength = value;
+                break;
+            case Stat.Dexterity:
+                mobile.Dexterity = value;
+                break;
+            case Stat.Intelligence:
+                mobile.Intelligence = value;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(stat), stat, null);
+        }
+    }
+}

--- a/src/Moongate.UO.Data/Persistence/Entities/UOMobileEntity.cs
+++ b/src/Moongate.UO.Data/Persistence/Entities/UOMobileEntity.cs
@@ -22,6 +22,7 @@ public partial class UOMobileEntity : IMobileEntity
     private const int NonHumanMaxWeightBase = 40;
     private const int GoldItemId = 0x0EED;
     private const int DefaultSkillCap = 1000;
+    private const int DefaultTotalSkillCap = 7000;
     private const int DefaultUnarmedMinWeaponDamage = 1;
     private const int DefaultUnarmedMaxWeaponDamage = 4;
     private const uint MountVirtualSerialMask = 0x3EEEEEEE;
@@ -637,6 +638,12 @@ public partial class UOMobileEntity : IMobileEntity
             return baseWeight + (int)(3.5 * EffectiveStrength);
         }
     }
+
+    /// <summary>
+    /// Gets the default total skill cap in fixed-point units.
+    /// </summary>
+    [MemoryPackIgnore]
+    public int TotalSkillCapFixedPoint => DefaultTotalSkillCap;
 
     /// <summary>
     /// Gets persisted custom mobile properties.
@@ -1303,6 +1310,21 @@ public partial class UOMobileEntity : IMobileEntity
         Skills[skillName] = entry;
 
         return entry;
+    }
+
+    /// <summary>
+    /// Gets the total of all persisted skill base values in fixed-point units.
+    /// </summary>
+    public int GetTotalSkillBaseFixedPoint()
+    {
+        var total = 0;
+
+        foreach (var skill in Skills.Values)
+        {
+            total += (int)Math.Round(skill.Base);
+        }
+
+        return total;
     }
 
     /// <summary>

--- a/src/Moongate.UO.Data/Persistence/Entities/UOMobileEntity.cs
+++ b/src/Moongate.UO.Data/Persistence/Entities/UOMobileEntity.cs
@@ -341,6 +341,24 @@ public partial class UOMobileEntity : IMobileEntity
     public int StatCap { get; set; } = 225;
 
     /// <summary>
+    /// Gets or sets the strength stat lock state.
+    /// </summary>
+    [MemoryPackOrder(61)]
+    public UOSkillLock StrengthLock { get; set; } = UOSkillLock.Up;
+
+    /// <summary>
+    /// Gets or sets the dexterity stat lock state.
+    /// </summary>
+    [MemoryPackOrder(62)]
+    public UOSkillLock DexterityLock { get; set; } = UOSkillLock.Up;
+
+    /// <summary>
+    /// Gets or sets the intelligence stat lock state.
+    /// </summary>
+    [MemoryPackOrder(63)]
+    public UOSkillLock IntelligenceLock { get; set; } = UOSkillLock.Up;
+
+    /// <summary>
     /// Gets or sets the current follower slot usage.
     /// </summary>
     [MemoryPackOrder(28)]
@@ -1325,6 +1343,45 @@ public partial class UOMobileEntity : IMobileEntity
         }
 
         return total;
+    }
+
+    /// <summary>
+    /// Gets the sum of the base strength, dexterity, and intelligence stats.
+    /// </summary>
+    public int GetTotalBaseStats()
+        => Strength + Dexterity + Intelligence;
+
+    /// <summary>
+    /// Gets the lock state for the requested core stat.
+    /// </summary>
+    public UOSkillLock GetStatLock(Stat stat)
+        => stat switch
+        {
+            Stat.Strength => StrengthLock,
+            Stat.Dexterity => DexterityLock,
+            Stat.Intelligence => IntelligenceLock,
+            _ => throw new ArgumentOutOfRangeException(nameof(stat), stat, null)
+        };
+
+    /// <summary>
+    /// Sets the lock state for the requested core stat.
+    /// </summary>
+    public void SetStatLock(Stat stat, UOSkillLock lockState)
+    {
+        switch (stat)
+        {
+            case Stat.Strength:
+                StrengthLock = lockState;
+                break;
+            case Stat.Dexterity:
+                DexterityLock = lockState;
+                break;
+            case Stat.Intelligence:
+                IntelligenceLock = lockState;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(stat), stat, null);
+        }
     }
 
     /// <summary>

--- a/tests/Moongate.Tests/Server/Handlers/CharacterStatLockHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/CharacterStatLockHandlerTests.cs
@@ -1,0 +1,93 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Server.Data.Events.Characters;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Handlers;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Tests.Server.Support;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Handlers;
+
+public sealed class CharacterStatLockHandlerTests
+{
+    [Test]
+    public async Task HandleAsync_WhenRequestIsValid_ShouldPersistStrengthLock()
+    {
+        var mobileService = new InMemoryMobileService();
+        var sessionService = new FakeGameNetworkSessionService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x00000001,
+            Strength = 50,
+            Dexterity = 50,
+            Intelligence = 25
+        };
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = mobile.Id,
+            Character = mobile
+        };
+
+        mobileService.Add(mobile);
+        sessionService.Add(session);
+
+        var handler = new CharacterStatLockHandler(outgoingQueue, mobileService, sessionService);
+
+        await handler.HandleAsync(new StatLockChangeRequestedEvent(session.SessionId, Stat.Strength, UOSkillLock.Down));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.StrengthLock, Is.EqualTo(UOSkillLock.Down));
+                Assert.That(session.Character!.StrengthLock, Is.EqualTo(UOSkillLock.Down));
+            }
+        );
+    }
+
+    private sealed class InMemoryMobileService : IMobileService
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = new();
+
+        public void Add(UOMobileEntity mobile)
+            => _mobiles[mobile.Id] = mobile;
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles[mobile.Id] = mobile;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            return Task.FromResult(_mobiles.Remove(id));
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles.TryGetValue(id, out var mobile);
+            return Task.FromResult(mobile);
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(int mapId, int sectorX, int sectorY, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<UOMobileEntity>());
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(string templateId, Moongate.UO.Data.Geometry.Point3D location, int mapId, Serial? accountId = null, CancellationToken cancellationToken = default)
+            => Task.FromException<UOMobileEntity>(new NotSupportedException());
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(string templateId, Moongate.UO.Data.Geometry.Point3D location, int mapId, Serial? accountId = null, CancellationToken cancellationToken = default)
+            => Task.FromResult((false, (UOMobileEntity?)null));
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
@@ -258,7 +258,7 @@ public sealed class CombatServiceTests
 
     private sealed class SkillGainServiceSpy : ISkillGainService
     {
-        public List<(Serial MobileId, UOSkillName SkillName, double SuccessChance, bool WasSuccessful)> Calls { get; } = [];
+        public List<(Serial MobileId, UOSkillName SkillName, double SuccessChance, bool WasSuccessful, SkillGainContext? Context)> Calls { get; } = [];
 
         public bool MutateSkillOnCall { get; set; }
 
@@ -266,10 +266,11 @@ public sealed class CombatServiceTests
             UOMobileEntity mobile,
             UOSkillName skillName,
             double successChance,
-            bool wasSuccessful
+            bool wasSuccessful,
+            SkillGainContext? context = null
         )
         {
-            Calls.Add((mobile.Id, skillName, successChance, wasSuccessful));
+            Calls.Add((mobile.Id, skillName, successChance, wasSuccessful, context));
 
             if (MutateSkillOnCall)
             {

--- a/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/CombatServiceTests.cs
@@ -4,6 +4,7 @@ using Moongate.Network.Packets.Interfaces;
 using Moongate.Network.Packets.Outgoing.Combat;
 using Moongate.Network.Packets.Outgoing.Entity;
 using Moongate.Network.Packets.Outgoing.World;
+using Moongate.Server.Data.Interaction;
 using Moongate.Server.Data.Events.Base;
 using Moongate.Server.Data.Events.Characters;
 using Moongate.Server.Data.Events.Combat;
@@ -252,6 +253,36 @@ public sealed class CombatServiceTests
             Calls.Add((victim, killer));
 
             return Task.FromResult(true);
+        }
+    }
+
+    private sealed class SkillGainServiceSpy : ISkillGainService
+    {
+        public List<(Serial MobileId, UOSkillName SkillName, double SuccessChance, bool WasSuccessful)> Calls { get; } = [];
+
+        public bool MutateSkillOnCall { get; set; }
+
+        public SkillGainResult TryGain(
+            UOMobileEntity mobile,
+            UOSkillName skillName,
+            double successChance,
+            bool wasSuccessful
+        )
+        {
+            Calls.Add((mobile.Id, skillName, successChance, wasSuccessful));
+
+            if (MutateSkillOnCall)
+            {
+                var entry = mobile.GetSkill(skillName);
+
+                if (entry is not null)
+                {
+                    entry.Base += 1;
+                    entry.Value += 1;
+                }
+            }
+
+            return new SkillGainResult(skillName, MutateSkillOnCall, null);
         }
     }
 
@@ -542,6 +573,92 @@ public sealed class CombatServiceTests
                 Assert.That(hitEvent.Defender, Is.SameAs(defender));
                 Assert.That(aggressiveActionEvent.Attacker, Is.SameAs(attacker));
                 Assert.That(aggressiveActionEvent.Defender, Is.SameAs(defender));
+            }
+        );
+    }
+
+    [Test]
+    public async Task ScheduledSwing_WhenPlayerAttackResolves_ShouldAttemptCombatSkillGainAndRefreshSkillList()
+    {
+        EnsureMapsRegistered();
+        var mobileService = new InMemoryMobileService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new CombatTestSpatialWorldService();
+        var eventBus = new RecordingGameEventBusService();
+        var outgoingQueue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+        var skillGainService = new SkillGainServiceSpy
+        {
+            MutateSkillOnCall = true
+        };
+
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x00000031u,
+            IsPlayer = true,
+            MapId = 0,
+            Location = new(100, 100, 0),
+            Hits = 50,
+            MaxHits = 50,
+            MinWeaponDamage = 6,
+            MaxWeaponDamage = 6
+        };
+        attacker.InitializeSkills();
+        attacker.SetSkill(UOSkillName.Wrestling, 500);
+        attacker.SetSkill(UOSkillName.Tactics, 500);
+        attacker.SetSkill(UOSkillName.Anatomy, 500);
+
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x00000032u,
+            MapId = 0,
+            Location = new(101, 100, 0),
+            Hits = 40,
+            MaxHits = 40
+        };
+        mobileService.Add(attacker);
+        mobileService.Add(defender);
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = attacker.Id,
+            Character = attacker
+        };
+        sessionService.Add(session);
+
+        ICombatService service = new CombatService(
+            mobileService,
+            sessionService,
+            outgoingQueue,
+            timerService,
+            spatial,
+            eventBus,
+            new InMemoryItemService(),
+            new DeathServiceSpy(),
+            skillGainService
+        );
+
+        var setTarget = await service.TrySetCombatantAsync(attacker.Id, defender.Id);
+        Assert.That(setTarget, Is.True);
+
+        timerService.RegisteredTimers[^1].Callback.Invoke();
+        var outboundPackets = new List<IGameNetworkPacket>();
+
+        while (outgoingQueue.TryDequeue(out var outbound))
+        {
+            outboundPackets.Add(outbound.Packet);
+        }
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(skillGainService.Calls, Has.Count.EqualTo(3));
+                Assert.That(skillGainService.Calls.Select(static call => call.SkillName), Is.EquivalentTo(
+                    new[] { UOSkillName.Wrestling, UOSkillName.Tactics, UOSkillName.Anatomy }
+                ));
+                Assert.That(session.Character!.GetSkill(UOSkillName.Wrestling)!.Base, Is.EqualTo(501));
+                Assert.That(outboundPackets.Any(static packet => packet is SkillListPacket), Is.True);
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Interaction/SkillAntiMacroServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/SkillAntiMacroServiceTests.cs
@@ -1,0 +1,71 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.Server.Services.Interaction;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Services.Interaction;
+
+public sealed class SkillAntiMacroServiceTests
+{
+    [Test]
+    public void AllowGain_WhenNpcRepeatsSameContext_ShouldRemainAllowed()
+    {
+        var now = DateTime.UtcNow;
+        var service = new SkillAntiMacroService(() => now);
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x00000001,
+            IsPlayer = false,
+            Location = new(100, 100, 0)
+        };
+        var context = new SkillGainContext(mobile.Location, (Serial)0x00000002);
+
+        for (var index = 0; index < 6; index++)
+        {
+            Assert.That(service.AllowGain(mobile, UOSkillName.Archery, context), Is.True);
+        }
+    }
+
+    [Test]
+    public void AllowGain_WhenPlayerRepeatsSameSkillTargetAndBucket_ShouldEventuallyBlock()
+    {
+        var now = DateTime.UtcNow;
+        var service = new SkillAntiMacroService(() => now);
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x00000003,
+            IsPlayer = true,
+            Location = new(100, 100, 0)
+        };
+        var context = new SkillGainContext(mobile.Location, (Serial)0x00000004);
+
+        Assert.That(service.AllowGain(mobile, UOSkillName.Archery, context), Is.True);
+        Assert.That(service.AllowGain(mobile, UOSkillName.Archery, context), Is.True);
+        Assert.That(service.AllowGain(mobile, UOSkillName.Archery, context), Is.True);
+        Assert.That(service.AllowGain(mobile, UOSkillName.Archery, context), Is.False);
+    }
+
+    [Test]
+    public void AllowGain_WhenPlayerChangesBucket_ShouldResetAllowance()
+    {
+        var now = DateTime.UtcNow;
+        var service = new SkillAntiMacroService(() => now);
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x00000005,
+            IsPlayer = true,
+            Location = new(100, 100, 0)
+        };
+        var repeatedContext = new SkillGainContext(mobile.Location, (Serial)0x00000006);
+
+        _ = service.AllowGain(mobile, UOSkillName.Archery, repeatedContext);
+        _ = service.AllowGain(mobile, UOSkillName.Archery, repeatedContext);
+        _ = service.AllowGain(mobile, UOSkillName.Archery, repeatedContext);
+
+        var movedContext = new SkillGainContext(new Point3D(108, 108, 0), (Serial)0x00000006);
+
+        Assert.That(service.AllowGain(mobile, UOSkillName.Archery, movedContext), Is.True);
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/Interaction/SkillGainServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/SkillGainServiceTests.cs
@@ -1,0 +1,152 @@
+using Moongate.Server.Services.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Services.Interaction;
+
+public sealed class SkillGainServiceTests
+{
+    [SetUp]
+    public void SetUp()
+        => SkillInfo.Table =
+        [
+            new(
+                (int)UOSkillName.Archery,
+                "Archery",
+                0,
+                100,
+                0,
+                "Archer",
+                0,
+                0,
+                0,
+                1,
+                "Archery",
+                Stat.Dexterity,
+                Stat.Strength
+            ),
+            new(
+                (int)UOSkillName.Anatomy,
+                "Anatomy",
+                100,
+                0,
+                0,
+                "Anatomist",
+                0,
+                0,
+                0,
+                1,
+                "Anatomy",
+                Stat.Strength,
+                Stat.Intelligence
+            ),
+            new(
+                (int)UOSkillName.Tactics,
+                "Tactics",
+                0,
+                100,
+                0,
+                "Tactician",
+                0,
+                0,
+                0,
+                1,
+                "Tactics",
+                Stat.Dexterity,
+                Stat.Strength
+            )
+        ];
+
+    [Test]
+    public void TryGain_WhenSkillLockIsNotUp_ShouldNotChangeSkill()
+    {
+        var mobile = CreateMobile();
+        mobile.SetSkill(UOSkillName.Archery, 500, lockState: UOSkillLock.Locked);
+        var service = new SkillGainService(() => 0.0);
+
+        var result = service.TryGain(mobile, UOSkillName.Archery, 0.25, true);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.SkillIncreased, Is.False);
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(500));
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Value, Is.EqualTo(500));
+            }
+        );
+    }
+
+    [Test]
+    public void TryGain_WhenGainSucceeds_ShouldIncreaseBaseAndValueByOne()
+    {
+        var mobile = CreateMobile();
+        mobile.SetSkill(UOSkillName.Archery, 100);
+        var service = new SkillGainService(() => 0.0);
+
+        var result = service.TryGain(mobile, UOSkillName.Archery, 0.0, true);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.SkillIncreased, Is.True);
+                Assert.That(result.SkillName, Is.EqualTo(UOSkillName.Archery));
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(101));
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Value, Is.EqualTo(101));
+            }
+        );
+    }
+
+    [Test]
+    public void TryGain_WhenTotalSkillCapWouldOverflow_ShouldLowerFirstDownLockedSkill()
+    {
+        var mobile = CreateMobile();
+        mobile.SetSkill(UOSkillName.Archery, 1000, cap: 1100);
+        mobile.SetSkill(UOSkillName.Anatomy, 1000, lockState: UOSkillLock.Down);
+        mobile.SetSkill(UOSkillName.Tactics, 5000, lockState: UOSkillLock.Locked);
+        var service = new SkillGainService(() => 0.0);
+
+        var result = service.TryGain(mobile, UOSkillName.Archery, 0.0, true);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.SkillIncreased, Is.True);
+                Assert.That(result.LoweredSkillName, Is.EqualTo(UOSkillName.Anatomy));
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(1001));
+                Assert.That(mobile.GetSkill(UOSkillName.Anatomy)!.Base, Is.EqualTo(999));
+                Assert.That(mobile.GetTotalSkillBaseFixedPoint(), Is.EqualTo(7000));
+            }
+        );
+    }
+
+    [Test]
+    public void TryGain_WhenTotalSkillCapWouldOverflowAndNoDownSkillExists_ShouldNotGain()
+    {
+        var mobile = CreateMobile();
+        mobile.SetSkill(UOSkillName.Archery, 1000);
+        mobile.SetSkill(UOSkillName.Anatomy, 1000, lockState: UOSkillLock.Locked);
+        mobile.SetSkill(UOSkillName.Tactics, 5000, lockState: UOSkillLock.Locked);
+        var service = new SkillGainService(() => 0.0);
+
+        var result = service.TryGain(mobile, UOSkillName.Archery, 0.0, true);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.SkillIncreased, Is.False);
+                Assert.That(result.LoweredSkillName, Is.Null);
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(1000));
+                Assert.That(mobile.GetTotalSkillBaseFixedPoint(), Is.EqualTo(7000));
+            }
+        );
+    }
+
+    private static UOMobileEntity CreateMobile()
+    {
+        var mobile = new UOMobileEntity();
+        mobile.InitializeSkills();
+
+        return mobile;
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/Interaction/SkillGainServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/SkillGainServiceTests.cs
@@ -1,4 +1,7 @@
+using Moongate.Server.Data.Interaction;
 using Moongate.Server.Services.Interaction;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Persistence.Entities;
 using Moongate.UO.Data.Skills;
 using Moongate.UO.Data.Types;
@@ -138,6 +141,57 @@ public sealed class SkillGainServiceTests
                 Assert.That(result.LoweredSkillName, Is.Null);
                 Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(1000));
                 Assert.That(mobile.GetTotalSkillBaseFixedPoint(), Is.EqualTo(7000));
+            }
+        );
+    }
+
+    [Test]
+    public void TryGain_WhenAntiMacroBlocksRepeatedPlayerContext_ShouldStopFurtherGain()
+    {
+        var now = new DateTime(2026, 3, 22, 12, 0, 0, DateTimeKind.Utc);
+        var mobile = CreateMobile();
+        mobile.Id = (Serial)0x00000044;
+        mobile.IsPlayer = true;
+        mobile.Location = new Point3D(100, 100, 0);
+        mobile.SetSkill(UOSkillName.Archery, 100);
+
+        var antiMacroService = new SkillAntiMacroService(() => now);
+        var statGainService = new StatGainService(() => 1.0, () => 0.0);
+        var service = new SkillGainService(() => 0.0, antiMacroService, statGainService);
+        var context = new SkillGainContext(mobile.Location, (Serial)0x00000055);
+
+        _ = service.TryGain(mobile, UOSkillName.Archery, 0.0, true, context);
+        _ = service.TryGain(mobile, UOSkillName.Archery, 0.0, true, context);
+        _ = service.TryGain(mobile, UOSkillName.Archery, 0.0, true, context);
+        var blocked = service.TryGain(mobile, UOSkillName.Archery, 0.0, true, context);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(blocked.SkillIncreased, Is.False);
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(103));
+            }
+        );
+    }
+
+    [Test]
+    public void TryGain_WhenSkillGainSucceeds_ShouldAlsoApplyStatGain()
+    {
+        var mobile = CreateMobile();
+        mobile.SetSkill(UOSkillName.Archery, 100);
+
+        var antiMacroService = new SkillAntiMacroService(() => DateTime.UtcNow);
+        var statGainService = new StatGainService(() => 0.0, () => 0.0);
+        var service = new SkillGainService(() => 0.0, antiMacroService, statGainService);
+
+        var result = service.TryGain(mobile, UOSkillName.Archery, 0.0, true);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.SkillIncreased, Is.True);
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(101));
+                Assert.That(mobile.Dexterity, Is.EqualTo(1));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Interaction/StatGainServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/StatGainServiceTests.cs
@@ -1,0 +1,140 @@
+using Moongate.Server.Services.Interaction;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Services.Interaction;
+
+public sealed class StatGainServiceTests
+{
+    [SetUp]
+    public void SetUp()
+        => SkillInfo.Table =
+        [
+            new(
+                (int)UOSkillName.Archery,
+                "Archery",
+                0,
+                100,
+                0,
+                "Archer",
+                0,
+                0,
+                0,
+                1,
+                "Archery",
+                Stat.Dexterity,
+                Stat.Strength
+            ),
+            new(
+                (int)UOSkillName.Anatomy,
+                "Anatomy",
+                100,
+                0,
+                0,
+                "Anatomist",
+                0,
+                0,
+                0,
+                1,
+                "Anatomy",
+                Stat.Strength,
+                Stat.Intelligence
+            )
+        ];
+
+    [Test]
+    public void TryApply_WhenPrimaryStatRollWins_ShouldIncreasePrimaryStat()
+    {
+        var mobile = CreateMobile();
+        var service = new StatGainService(() => 0.0, () => 0.0);
+
+        var result = service.TryApply(mobile, UOSkillName.Archery);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.StatIncreased, Is.True);
+                Assert.That(result.GainedStat, Is.EqualTo(Stat.Dexterity));
+                Assert.That(mobile.Dexterity, Is.EqualTo(51));
+            }
+        );
+    }
+
+    [Test]
+    public void TryApply_WhenPrimaryStatLocked_ShouldFallbackToSecondaryIfAvailable()
+    {
+        var mobile = CreateMobile();
+        mobile.DexterityLock = UOSkillLock.Locked;
+        var service = new StatGainService(() => 0.0, () => 0.0);
+
+        var result = service.TryApply(mobile, UOSkillName.Archery);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.StatIncreased, Is.True);
+                Assert.That(result.GainedStat, Is.EqualTo(Stat.Strength));
+                Assert.That(mobile.Strength, Is.EqualTo(51));
+            }
+        );
+    }
+
+    [Test]
+    public void TryApply_WhenStatCapIsFull_ShouldLowerDownLockedOtherStat()
+    {
+        var mobile = CreateMobile();
+        mobile.Strength = 100;
+        mobile.Dexterity = 100;
+        mobile.Intelligence = 25;
+        mobile.StatCap = 225;
+        mobile.StrengthLock = UOSkillLock.Down;
+        var service = new StatGainService(() => 0.0, () => 0.0);
+
+        var result = service.TryApply(mobile, UOSkillName.Archery);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.StatIncreased, Is.True);
+                Assert.That(result.GainedStat, Is.EqualTo(Stat.Dexterity));
+                Assert.That(result.LoweredStat, Is.EqualTo(Stat.Strength));
+                Assert.That(mobile.Strength, Is.EqualTo(99));
+                Assert.That(mobile.Dexterity, Is.EqualTo(101));
+                Assert.That(mobile.GetTotalBaseStats(), Is.EqualTo(225));
+            }
+        );
+    }
+
+    [Test]
+    public void TryApply_WhenStatCapIsFullAndNoDownLockedStatExists_ShouldNotIncrease()
+    {
+        var mobile = CreateMobile();
+        mobile.Strength = 100;
+        mobile.Dexterity = 100;
+        mobile.Intelligence = 25;
+        mobile.StatCap = 225;
+        mobile.StrengthLock = UOSkillLock.Locked;
+        mobile.IntelligenceLock = UOSkillLock.Locked;
+        var service = new StatGainService(() => 0.0, () => 0.0);
+
+        var result = service.TryApply(mobile, UOSkillName.Archery);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.StatIncreased, Is.False);
+                Assert.That(mobile.Dexterity, Is.EqualTo(100));
+                Assert.That(mobile.GetTotalBaseStats(), Is.EqualTo(225));
+            }
+        );
+    }
+
+    private static UOMobileEntity CreateMobile()
+        => new()
+        {
+            Strength = 50,
+            Dexterity = 50,
+            Intelligence = 25
+        };
+}

--- a/tests/Moongate.Tests/UO/Data/Persistence/Entities/UOMobileEntityTests.cs
+++ b/tests/Moongate.Tests/UO/Data/Persistence/Entities/UOMobileEntityTests.cs
@@ -841,6 +841,27 @@ public class UOMobileEntityTests
     }
 
     [Test]
+    public void StatLocks_ShouldDefaultToUp_AndTotalBaseStatsShouldSumCoreStats()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Strength = 50,
+            Dexterity = 40,
+            Intelligence = 30
+        };
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mobile.StrengthLock, Is.EqualTo(UOSkillLock.Up));
+                Assert.That(mobile.DexterityLock, Is.EqualTo(UOSkillLock.Up));
+                Assert.That(mobile.IntelligenceLock, Is.EqualTo(UOSkillLock.Up));
+                Assert.That(mobile.GetTotalBaseStats(), Is.EqualTo(120));
+            }
+        );
+    }
+
+    [Test]
     public void TypedMobileState_ShouldBeInitializedByDefault()
     {
         var mobile = new UOMobileEntity();

--- a/tests/Moongate.Tests/UO/Data/Persistence/Entities/UOMobileEntityTests.cs
+++ b/tests/Moongate.Tests/UO/Data/Persistence/Entities/UOMobileEntityTests.cs
@@ -825,6 +825,22 @@ public class UOMobileEntityTests
     }
 
     [Test]
+    public void GetTotalSkillBaseFixedPoint_ShouldSumSkillBases()
+    {
+        SkillInfo.Table =
+        [
+            new(0, "Alchemy", 0, 0, 100, "Alchemist", 0, 0, 0, 1, "Alchemy", Stat.Intelligence, Stat.Intelligence),
+            new(1, "Anatomy", 100, 0, 0, "Biologist", 0, 0, 0, 1, "Anatomy", Stat.Strength, Stat.Intelligence)
+        ];
+        var mobile = new UOMobileEntity();
+        mobile.InitializeSkills();
+        mobile.SetSkill(UOSkillName.Alchemy, 500);
+        mobile.SetSkill(UOSkillName.Anatomy, 725, 700);
+
+        Assert.That(mobile.GetTotalSkillBaseFixedPoint(), Is.EqualTo(1200));
+    }
+
+    [Test]
     public void TypedMobileState_ShouldBeInitializedByDefault()
     {
         var mobile = new UOMobileEntity();


### PR DESCRIPTION
## Summary
Add combat-driven skill gain v1 for both players and NPCs.

## What changed
- add `ISkillGainService` and `SkillGainService`
- apply skill gain for weapon skill, `Tactics`, and `Anatomy` from combat
- respect per-skill caps, lock state, and a deterministic total skill cap policy
- refresh the full `0x3A` skill list for active player sessions after combat gains
- update docs and tests

## Scope
- combat-only skill gain v1
- no anti-macro yet
- no stat gain yet

Closes #116
