### PR TITLE
feat: enhance command execution with user authorization checks

### DIFF
--- a/src/Moongate.Server/Http/Extensions/MoongateHttpRouteExtensions.cs
+++ b/src/Moongate.Server/Http/Extensions/MoongateHttpRouteExtensions.cs
@@ -344,14 +344,17 @@ internal static class MoongateHttpRouteExtensions
                              "/execute",
                              (
                                  MoongateHttpExecuteCommandRequest request,
+                                 ClaimsPrincipal user,
                                  CancellationToken cancellationToken
-                             ) => HandleExecuteCommand(context, request, cancellationToken)
+                             ) => HandleExecuteCommand(context, request, user, cancellationToken)
                          )
                          .WithName("CommandsExecute")
                          .WithSummary("Executes a console command and returns final output lines.")
                          .Accepts<MoongateHttpExecuteCommandRequest>("application/json")
                          .Produces<MoongateHttpExecuteCommandResponse>()
-                         .Produces(StatusCodes.Status400BadRequest);
+                         .Produces(StatusCodes.Status400BadRequest)
+                         .Produces(StatusCodes.Status401Unauthorized)
+                         .Produces(StatusCodes.Status403Forbidden);
         }
 
         if (context.ItemTemplateService is not null || context.ArtService is not null)
@@ -576,9 +579,15 @@ internal static class MoongateHttpRouteExtensions
     private static IResult HandleExecuteCommand(
         MoongateHttpRouteContext context,
         MoongateHttpExecuteCommandRequest request,
+        ClaimsPrincipal user,
         CancellationToken cancellationToken
     )
     {
+        if (!IsAdministrativeUser(user))
+        {
+            return user.Identity?.IsAuthenticated == true ? TypedResults.Forbid() : TypedResults.Unauthorized();
+        }
+
         if (string.IsNullOrWhiteSpace(request.Command))
         {
             return TypedResults.BadRequest("command is required");


### PR DESCRIPTION
**File:** src/Moongate.Server/Http/Extensions/MoongateHttpRouteExtensions.cs
**Severity:** Critical
**Category:** Input Validation
**Description:**
`POST /api/commands/execute` is protected by bare `RequireAuthorization()` (any authenticated user, line 338), not an admin-role policy. Inside `HandleExecuteCommand` (line 576) the command is dispatched as `CommandSourceType.Console` with a null account context. Console source implies operator-level privilege. A regular player with a valid JWT token can execute arbitrary server console commands at operator privilege.

The fix applies the pattern already used by 8+ other admin-guarded handlers in the same file. No new infrastructure needed.
