### PR TITLE
feat: extend loot generation for tags and corpses

### DIFF
--- a/docs/articles/scripting/api.md
+++ b/docs/articles/scripting/api.md
@@ -497,22 +497,50 @@ Example loot table:
   "id": "loot_test_chest_basic",
   "name": "Loot Test Chest Basic",
   "category": "Test",
+  "rolls": 2,
   "noDropWeight": 0,
   "entries": [
     { "itemTemplateId": "gold", "weight": 5, "amount": 125 },
-    { "itemTemplateId": "bandage", "weight": 3, "amount": 10 }
+    { "itemTag": "resources", "weight": 3, "amount": 25 },
+    { "itemTemplateId": "lockpick", "weight": 2, "amount": 5 }
   ]
 }
 ```
 
+Entry rules:
+
+- each entry may define exactly one of:
+  - `itemTemplateId`
+  - `itemId`
+  - `itemTag`
+- `rolls` defaults to `1`
+- `itemTag` resolves a random item template that already carries that tag
+
 Runtime behavior:
 
 - `lootTables` are rolled the first time the container is opened
+- each loot table can perform multiple weighted rolls via `rolls`
 - generated contents are then persisted like any normal container contents
 - if `loot_refillable = true`, the container can refill later
 - refill is lazy, not timer-driven:
   the container is marked ready only after it becomes empty, and loot is regenerated on a later open once `loot_refill_seconds` has elapsed
 - if the container still has items inside, no refill happens
+
+NPC mobile templates can also declare `lootTables`. When an NPC dies:
+
+- equipped items are moved to the corpse
+- backpack contents are moved to the corpse
+- configured `lootTables` are generated immediately on the corpse in additive mode
+
+Example mobile snippet:
+
+```json
+{
+  "type": "mobile",
+  "id": "zombie_npc",
+  "lootTables": ["undead.low"]
+}
+```
 
 Runtime custom metadata used internally:
 

--- a/moongate_data/templates/loot/test_loot.json
+++ b/moongate_data/templates/loot/test_loot.json
@@ -5,6 +5,7 @@
     "name": "Loot Test Chest Basic",
     "category": "Test",
     "description": "Basic weighted loot table for first-open chest testing.",
+    "rolls": 2,
     "noDropWeight": 0,
     "entries": [
       {
@@ -13,12 +14,7 @@
         "amount": 125
       },
       {
-        "itemTemplateId": "bandage",
-        "weight": 3,
-        "amount": 10
-      },
-      {
-        "itemTemplateId": "arrow",
+        "itemTag": "resources",
         "weight": 3,
         "amount": 25
       },
@@ -29,6 +25,53 @@
       },
       {
         "itemTemplateId": "torch",
+        "weight": 1,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "undead.low",
+    "name": "Undead Low",
+    "category": "Undead",
+    "description": "Low-value additive corpse loot for test undead.",
+    "rolls": 1,
+    "noDropWeight": 3,
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "weight": 5,
+        "amount": 45
+      },
+      {
+        "itemTemplateId": "bandage",
+        "weight": 2,
+        "amount": 4
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "undead.knight",
+    "name": "Undead Knight",
+    "category": "Undead",
+    "description": "Slightly richer additive corpse loot for skeletal knights.",
+    "rolls": 2,
+    "noDropWeight": 1,
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "weight": 5,
+        "amount": 90
+      },
+      {
+        "itemTemplateId": "bandage",
+        "weight": 2,
+        "amount": 6
+      },
+      {
+        "itemTag": "weapons",
         "weight": 1,
         "amount": 1
       }

--- a/moongate_data/templates/mobiles/undead.json
+++ b/moongate_data/templates/mobiles/undead.json
@@ -27,6 +27,7 @@
     "karma": -600,
     "notoriety": "CanBeAttacked",
     "brain": "None",
+    "lootTables": ["undead.low"],
     "fixedEquipment": [],
     "randomEquipment": [],
     "title": "a zombie"
@@ -60,6 +61,7 @@
     "karma": -3000,
     "notoriety": "CanBeAttacked",
     "brain": "None",
+    "lootTables": ["undead.knight"],
     "fixedEquipment": [
       {
         "itemTemplateId": "scimitar",

--- a/src/Moongate.Server/Data/Internal/Scripting/MobileCustomParamKeys.cs
+++ b/src/Moongate.Server/Data/Internal/Scripting/MobileCustomParamKeys.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Server.Data.Internal.Scripting;
+
+public static class MobileCustomParamKeys
+{
+    public static class Loot
+    {
+        public const string LootTables = "mobile_loot_tables";
+    }
+}

--- a/src/Moongate.Server/Interfaces/Services/Items/ILootGenerationService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Items/ILootGenerationService.cs
@@ -1,4 +1,5 @@
 using Moongate.UO.Data.Persistence.Entities;
+using Moongate.Server.Types.Items;
 
 namespace Moongate.Server.Interfaces.Services.Items;
 
@@ -15,6 +16,21 @@ public interface ILootGenerationService
     /// <returns>The latest hydrated container state after generation completes.</returns>
     Task<UOItemEntity> EnsureLootGeneratedAsync(
         UOItemEntity container,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Generates loot directly into the provided container using explicit loot table identifiers.
+    /// </summary>
+    /// <param name="container">Target container.</param>
+    /// <param name="lootTableIds">Loot tables to roll.</param>
+    /// <param name="mode">Generation mode controlling gating semantics.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The latest hydrated container state after generation completes.</returns>
+    Task<UOItemEntity> GenerateForContainerAsync(
+        UOItemEntity container,
+        IReadOnlyList<string> lootTableIds,
+        LootGenerationMode mode,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Moongate.Server/Services/Entities/MobileFactoryService.cs
+++ b/src/Moongate.Server/Services/Entities/MobileFactoryService.cs
@@ -1,4 +1,5 @@
 using Moongate.Network.Packets.Incoming.Login;
+using Moongate.Server.Data.Internal.Scripting;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Persistence;
 using Moongate.UO.Data.Bodies;
@@ -98,6 +99,10 @@ public sealed class MobileFactoryService : IMobileFactoryService
         mobile.RecalculateMaxStats();
         InitializeTemplateSkills(mobile, template);
         mobile.Sounds = new(template.Sounds);
+        if (template.LootTables.Count > 0)
+        {
+            mobile.SetCustomString(MobileCustomParamKeys.Loot.LootTables, string.Join(',', template.LootTables));
+        }
 
         if (template.MaxHits > 0)
         {

--- a/src/Moongate.Server/Services/Interaction/DeathService.cs
+++ b/src/Moongate.Server/Services/Interaction/DeathService.cs
@@ -6,6 +6,7 @@ using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Events;
 using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Items;
 using Moongate.Server.Interfaces.Services.Scripting;
 using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Interfaces.Services.Timing;
@@ -42,6 +43,7 @@ public sealed class DeathService : IDeathService
     private readonly IFameKarmaService _fameKarmaService;
     private readonly MoongateConfig _config;
     private readonly ILuaBrainRunner? _luaBrainRunner;
+    private readonly ILootGenerationService? _lootGenerationService;
 
     public DeathService(
         IMobileService mobileService,
@@ -51,7 +53,8 @@ public sealed class DeathService : IDeathService
         IGameEventBusService gameEventBusService,
         IFameKarmaService fameKarmaService,
         MoongateConfig config,
-        ILuaBrainRunner? luaBrainRunner = null
+        ILuaBrainRunner? luaBrainRunner = null,
+        ILootGenerationService? lootGenerationService = null
     )
     {
         _mobileService = mobileService;
@@ -62,6 +65,7 @@ public sealed class DeathService : IDeathService
         _fameKarmaService = fameKarmaService;
         _config = config;
         _luaBrainRunner = luaBrainRunner;
+        _lootGenerationService = lootGenerationService;
     }
 
     public async Task<bool> ForceDeathAsync(
@@ -115,6 +119,7 @@ public sealed class DeathService : IDeathService
         {
             corpse = await CreateCorpseAsync(victim, cancellationToken);
             await MoveLootToCorpseAsync(victim, corpse, cancellationToken);
+            await GenerateCorpseLootAsync(victim, corpse, cancellationToken);
             _spatialWorldService.AddOrUpdateItem(corpse, corpse.MapId);
             await _spatialWorldService.BroadcastToPlayersInUpdateRadiusAsync(
                 new MobileDeathAnimationPacket(victim.Id, corpse.Id),
@@ -253,6 +258,34 @@ public sealed class DeathService : IDeathService
 
             await MoveItemIntoCorpseAsync(item, corpse, cancellationToken);
         }
+    }
+
+    private async Task GenerateCorpseLootAsync(
+        UOMobileEntity victim,
+        UOItemEntity corpse,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_lootGenerationService is null ||
+            !victim.TryGetCustomString(MobileCustomParamKeys.Loot.LootTables, out var lootTablesRaw) ||
+            string.IsNullOrWhiteSpace(lootTablesRaw))
+        {
+            return;
+        }
+
+        var lootTableIds = lootTablesRaw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        if (lootTableIds.Length == 0)
+        {
+            return;
+        }
+
+        await _lootGenerationService.GenerateForContainerAsync(
+            corpse,
+            lootTableIds,
+            Types.Items.LootGenerationMode.OnDeath,
+            cancellationToken
+        );
     }
 
     private static bool IsLootable(UOItemEntity item)

--- a/src/Moongate.Server/Services/Items/LootGenerationService.cs
+++ b/src/Moongate.Server/Services/Items/LootGenerationService.cs
@@ -3,6 +3,7 @@ using Moongate.Server.Data.Internal.Scripting;
 using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Items;
+using Moongate.Server.Types.Items;
 using Moongate.UO.Data.Containers;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Interfaces.Templates;
@@ -24,16 +25,19 @@ public sealed class LootGenerationService : ILootGenerationService
     private readonly IItemFactoryService _itemFactoryService;
     private readonly IItemService _itemService;
     private readonly ILootTemplateService _lootTemplateService;
+    private readonly IItemTemplateService _itemTemplateService;
 
     public LootGenerationService(
         IItemFactoryService itemFactoryService,
         IItemService itemService,
-        ILootTemplateService lootTemplateService
+        ILootTemplateService lootTemplateService,
+        IItemTemplateService itemTemplateService
     )
     {
         _itemFactoryService = itemFactoryService;
         _itemService = itemService;
         _lootTemplateService = lootTemplateService;
+        _itemTemplateService = itemTemplateService;
     }
 
     public async Task<UOItemEntity> EnsureLootGeneratedAsync(
@@ -66,10 +70,55 @@ public sealed class LootGenerationService : ILootGenerationService
             return container;
         }
 
+        return await GenerateLootAsync(
+            container,
+            containerTemplate.LootTables,
+            LootGenerationMode.FirstOpen,
+            containerTemplate.Id,
+            refillDelay,
+            cancellationToken
+        );
+    }
+
+    public async Task<UOItemEntity> GenerateForContainerAsync(
+        UOItemEntity container,
+        IReadOnlyList<string> lootTableIds,
+        LootGenerationMode mode,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(lootTableIds);
+        _ = cancellationToken;
+
+        if (!container.IsContainer || lootTableIds.Count == 0)
+        {
+            return container;
+        }
+
+        return await GenerateLootAsync(
+            container,
+            lootTableIds,
+            mode,
+            null,
+            null,
+            cancellationToken
+        );
+    }
+
+    private async Task<UOItemEntity> GenerateLootAsync(
+        UOItemEntity container,
+        IReadOnlyList<string> lootTableIds,
+        LootGenerationMode mode,
+        string? sourceTemplateId,
+        TimeSpan? refillDelay,
+        CancellationToken cancellationToken
+    )
+    {
         var layout = CreateLayout(container);
         var createdAnyLoot = false;
 
-        foreach (var lootTableId in containerTemplate.LootTables)
+        foreach (var lootTableId in lootTableIds)
         {
             if (string.IsNullOrWhiteSpace(lootTableId) ||
                 !_lootTemplateService.TryGet(lootTableId.Trim(), out var lootTable) ||
@@ -78,14 +127,7 @@ public sealed class LootGenerationService : ILootGenerationService
                 continue;
             }
 
-            var rolledEntry = RollEntry(lootTable);
-
-            if (rolledEntry is null)
-            {
-                continue;
-            }
-
-            var generatedItems = CreateItemsFromLootEntry(rolledEntry);
+            var generatedItems = CreateItemsFromLootTable(lootTable);
 
             foreach (var generatedItem in generatedItems)
             {
@@ -98,19 +140,23 @@ public sealed class LootGenerationService : ILootGenerationService
         }
 
         var refreshedContainer = await _itemService.GetItemAsync(container.Id) ?? container;
-        refreshedContainer.SetCustomBoolean(ItemCustomParamKeys.Loot.Generated, true);
 
-        if (createdAnyLoot || refillDelay is null)
+        if (mode == LootGenerationMode.FirstOpen)
         {
-            refreshedContainer.RemoveCustomProperty(ItemCustomParamKeys.Loot.RefillReadyAtUtc);
-        }
-        else if (refreshedContainer.Items.Count == 0)
-        {
-            var nextRefillReadyAtUtc = DateTime.UtcNow.Add(refillDelay.Value);
-            refreshedContainer.SetCustomString(
-                ItemCustomParamKeys.Loot.RefillReadyAtUtc,
-                nextRefillReadyAtUtc.ToString("O", CultureInfo.InvariantCulture)
-            );
+            refreshedContainer.SetCustomBoolean(ItemCustomParamKeys.Loot.Generated, true);
+
+            if (createdAnyLoot || refillDelay is null)
+            {
+                refreshedContainer.RemoveCustomProperty(ItemCustomParamKeys.Loot.RefillReadyAtUtc);
+            }
+            else if (refreshedContainer.Items.Count == 0)
+            {
+                var nextRefillReadyAtUtc = DateTime.UtcNow.Add(refillDelay.Value);
+                refreshedContainer.SetCustomString(
+                    ItemCustomParamKeys.Loot.RefillReadyAtUtc,
+                    nextRefillReadyAtUtc.ToString("O", CultureInfo.InvariantCulture)
+                );
+            }
         }
 
         await _itemService.UpsertItemAsync(refreshedContainer);
@@ -120,7 +166,7 @@ public sealed class LootGenerationService : ILootGenerationService
             _logger.Debug(
                 "Generated container loot for container {ContainerId} using template {TemplateId}",
                 container.Id,
-                containerTemplate.Id
+                sourceTemplateId ?? "explicit"
             );
         }
 
@@ -183,11 +229,41 @@ public sealed class LootGenerationService : ILootGenerationService
         return items;
     }
 
+    private List<UOItemEntity> CreateItemsFromLootTable(LootTemplateDefinition lootTable)
+    {
+        var items = new List<UOItemEntity>();
+        var rolls = Math.Max(1, lootTable.Rolls);
+
+        for (var rollIndex = 0; rollIndex < rolls; rollIndex++)
+        {
+            var rolledEntry = RollEntry(lootTable);
+
+            if (rolledEntry is null)
+            {
+                continue;
+            }
+
+            items.AddRange(CreateItemsFromLootEntry(rolledEntry));
+        }
+
+        return items;
+    }
+
     private UOItemEntity? CreateLootItem(LootTemplateEntry entry)
     {
         if (!string.IsNullOrWhiteSpace(entry.ItemTemplateId))
         {
             return _itemFactoryService.CreateItemFromTemplate(entry.ItemTemplateId.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(entry.ItemTag))
+        {
+            var taggedTemplate = ResolveTemplateByTag(entry.ItemTag.Trim());
+
+            if (taggedTemplate is not null)
+            {
+                return _itemFactoryService.CreateItemFromTemplate(taggedTemplate.Id);
+            }
         }
 
         if (string.IsNullOrWhiteSpace(entry.ItemId))
@@ -205,6 +281,21 @@ public sealed class LootGenerationService : ILootGenerationService
         rawItem.IsStackable = tile[UOTileFlag.Generic];
 
         return rawItem;
+    }
+
+    private ItemTemplateDefinition? ResolveTemplateByTag(string itemTag)
+    {
+        var taggedTemplates = _itemTemplateService.GetAll()
+            .Where(template => template.Tags.Any(tag => string.Equals(tag, itemTag, StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(template => template.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (taggedTemplates.Count == 0)
+        {
+            return null;
+        }
+
+        return taggedTemplates[Random.Shared.Next(taggedTemplates.Count)];
     }
 
     private static int ParseItemId(string itemId)
@@ -225,6 +316,7 @@ public sealed class LootGenerationService : ILootGenerationService
                                         .Where(static entry =>
                                             entry.Weight > 0 &&
                                             (!string.IsNullOrWhiteSpace(entry.ItemTemplateId) ||
+                                             !string.IsNullOrWhiteSpace(entry.ItemTag) ||
                                              !string.IsNullOrWhiteSpace(entry.ItemId)))
                                         .ToList();
         var totalWeight = definition.NoDropWeight + eligibleEntries.Sum(static entry => entry.Weight);

--- a/src/Moongate.Server/Types/Items/LootGenerationMode.cs
+++ b/src/Moongate.Server/Types/Items/LootGenerationMode.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Server.Types.Items;
+
+/// <summary>
+/// Selects how loot generation gates and persists generated container content.
+/// </summary>
+public enum LootGenerationMode : byte
+{
+    /// <summary>
+    /// Generates loot lazily the first time a container is opened, with refill semantics.
+    /// </summary>
+    FirstOpen = 0,
+
+    /// <summary>
+    /// Generates loot immediately for a corpse or death container without first-open gating.
+    /// </summary>
+    OnDeath = 1
+}

--- a/src/Moongate.UO.Data/Templates/Loot/LootTemplateDefinition.cs
+++ b/src/Moongate.UO.Data/Templates/Loot/LootTemplateDefinition.cs
@@ -6,6 +6,11 @@ namespace Moongate.UO.Data.Templates.Loot;
 public class LootTemplateDefinition : LootTemplateDefinitionBase
 {
     /// <summary>
+    /// Number of weighted rolls performed for this table.
+    /// </summary>
+    public int Rolls { get; set; } = 1;
+
+    /// <summary>
     /// Relative weight for selecting no item drop (UOX3 "blank").
     /// </summary>
     public int NoDropWeight { get; set; }

--- a/src/Moongate.UO.Data/Templates/Loot/LootTemplateEntry.cs
+++ b/src/Moongate.UO.Data/Templates/Loot/LootTemplateEntry.cs
@@ -21,6 +21,11 @@ public class LootTemplateEntry
     public string? ItemId { get; set; }
 
     /// <summary>
+    /// Optional item template tag used to resolve a random matching item template.
+    /// </summary>
+    public string? ItemTag { get; set; }
+
+    /// <summary>
     /// Fixed quantity produced by this entry.
     /// </summary>
     public int Amount { get; set; } = 1;

--- a/tests/Moongate.Tests/Server/FileLoaders/LootTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/LootTemplateLoaderTests.cs
@@ -1,0 +1,73 @@
+using Moongate.Core.Data.Directories;
+using Moongate.Core.Types;
+using Moongate.Server.FileLoaders;
+using Moongate.Tests.TestSupport;
+using Moongate.UO.Data.Services.Templates;
+
+namespace Moongate.Tests.Server.FileLoaders;
+
+public sealed class LootTemplateLoaderTests
+{
+    [Test]
+    public async Task LoadAsync_WhenTemplateDefinesRollsAndItemTag_ShouldLoadThoseFields()
+    {
+        using var tempDirectory = new TempDirectory();
+        var directoriesConfig = new DirectoriesConfig(
+            tempDirectory.Path,
+            DirectoryType.Data,
+            DirectoryType.Templates,
+            DirectoryType.Scripts,
+            DirectoryType.Save,
+            DirectoryType.Logs,
+            DirectoryType.Cache
+        );
+
+        var lootDirectory = Path.Combine(directoriesConfig[DirectoryType.Templates], "loot");
+        Directory.CreateDirectory(lootDirectory);
+
+        var filePath = Path.Combine(lootDirectory, "undead.json");
+        await File.WriteAllTextAsync(
+            filePath,
+            """
+            [
+              {
+                "type": "loot",
+                "id": "undead.low",
+                "name": "Undead Low",
+                "category": "loot",
+                "description": "Undead corpse loot",
+                "rolls": 2,
+                "noDropWeight": 5,
+                "entries": [
+                  {
+                    "weight": 10,
+                    "itemTag": "weapon.rusty",
+                    "amount": 1
+                  }
+                ]
+              }
+            ]
+            """
+        );
+
+        var lootTemplateService = new LootTemplateService();
+        var loader = new LootTemplateLoader(directoriesConfig, lootTemplateService);
+
+        await loader.LoadAsync();
+
+        Assert.That(lootTemplateService.TryGet("undead.low", out var template), Is.True);
+        Assert.That(template, Is.Not.Null);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(template!.Rolls, Is.EqualTo(2));
+                Assert.That(template.NoDropWeight, Is.EqualTo(5));
+                Assert.That(template.Entries, Has.Count.EqualTo(1));
+                Assert.That(template.Entries[0].ItemTag, Is.EqualTo("weapon.rusty"));
+                Assert.That(template.Entries[0].ItemTemplateId, Is.Null);
+                Assert.That(template.Entries[0].ItemId, Is.Null);
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/Entities/MobileFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Entities/MobileFactoryServiceTests.cs
@@ -2,6 +2,7 @@ using Moongate.Core.Data.Directories;
 using Moongate.Core.Types;
 using Moongate.Network.Packets.Incoming.Login;
 using Moongate.Network.Spans;
+using Moongate.Server.Data.Internal.Scripting;
 using Moongate.Server.Services.Entities;
 using Moongate.Server.Services.Persistence;
 using Moongate.Server.Services.Timing;
@@ -86,6 +87,34 @@ public class MobileFactoryServiceTests
                 Assert.That(markerHue, Is.EqualTo(0x044D));
             }
         );
+    }
+
+    [Test]
+    public async Task CreateMobileFromTemplate_WhenTemplateDefinesLootTables_ShouldProjectThemToRuntimeCustomProperties()
+    {
+        using var temp = new TempDirectory();
+        var persistence = await CreatePersistenceServiceAsync(temp.Path);
+        var templateService = new MobileTemplateService();
+        templateService.Upsert(
+            new()
+            {
+                Id = "loot_mobile",
+                Name = "Loot Mobile",
+                Category = "test",
+                Description = "test",
+                Body = 0x0190,
+                SkinHue = HueSpec.FromValue(0),
+                HairHue = HueSpec.FromValue(0),
+                HairStyle = 0,
+                LootTables = ["undead.low", "gold.small"]
+            }
+        );
+        var service = new MobileFactoryService(templateService, new TestNameService(), persistence);
+
+        var mobile = service.CreateMobileFromTemplate("loot_mobile");
+
+        Assert.That(mobile.TryGetCustomString(MobileCustomParamKeys.Loot.LootTables, out var rawLootTables), Is.True);
+        Assert.That(rawLootTables, Is.EqualTo("undead.low,gold.small"));
     }
 
     [Test]

--- a/tests/Moongate.Tests/Server/Services/Interaction/DeathServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Interaction/DeathServiceTests.cs
@@ -9,9 +9,11 @@ using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Events;
 using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Items;
 using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Interfaces.Services.Timing;
 using Moongate.Server.Services.Interaction;
+using Moongate.Server.Types.Items;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Json.Regions;
@@ -381,6 +383,39 @@ public sealed class DeathServiceTests
         }
     }
 
+    private sealed class LootGenerationServiceSpy : ILootGenerationService
+    {
+        public List<(Serial ContainerId, IReadOnlyList<string> LootTableIds, LootGenerationMode Mode)> Calls { get; } = [];
+
+        public Task<UOItemEntity> EnsureLootGeneratedAsync(
+            UOItemEntity container,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult(container);
+
+        public Task<UOItemEntity> GenerateForContainerAsync(
+            UOItemEntity container,
+            IReadOnlyList<string> lootTableIds,
+            LootGenerationMode mode,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Calls.Add((container.Id, lootTableIds, mode));
+
+            var generatedItem = new UOItemEntity
+            {
+                Id = (Serial)0x40000099u,
+                ItemId = 0x0EED,
+                Name = "generated_gold",
+                Amount = 200,
+                MapId = container.MapId
+            };
+            container.AddItem(generatedItem, new(40, 40));
+
+            return Task.FromResult(container);
+        }
+    }
+
     [Test]
     public async Task ForceDeathAsync_WhenNpcIsAlive_ShouldMarkDeadAndCreateCorpse()
     {
@@ -599,6 +634,95 @@ public sealed class DeathServiceTests
                            .Any(packet => packet.KilledMobileId == victim.Id && packet.CorpseId == corpse.Id),
                     Is.True
                 );
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandleDeathAsync_WhenNpcHasLootTables_ShouldGenerateAdditiveCorpseLootAfterTransfer()
+    {
+        var mobileService = new InMemoryMobileService();
+        var itemService = new InMemoryItemService();
+        var timerService = new TimerServiceSpy();
+        var spatial = new SpatialWorldServiceSpy();
+        var eventBus = new RecordingEventBus();
+        var fameKarmaService = new FameKarmaServiceSpy();
+        var lootGenerationService = new LootGenerationServiceSpy();
+        var config = new MoongateConfig
+        {
+            Game = new MoongateGameConfig
+            {
+                CorpseDecaySeconds = 300
+            }
+        };
+        var victim = new UOMobileEntity
+        {
+            Id = (Serial)0x00000045u,
+            Name = "Skeleton",
+            Body = 0x0032,
+            MapId = 1,
+            Location = new(150, 250, 0),
+            Hits = 0,
+            MaxHits = 40,
+            IsAlive = false
+        };
+        victim.SetCustomString("mobile_loot_tables", "undead.low,gold.small");
+
+        var weapon = new UOItemEntity
+        {
+            Id = (Serial)0x40000021u,
+            ItemId = 0x13B2,
+            MapId = 1
+        };
+        var backpack = new UOItemEntity
+        {
+            Id = (Serial)0x40000022u,
+            ItemId = 0x0E75,
+            MapId = 1
+        };
+        var bandage = new UOItemEntity
+        {
+            Id = (Serial)0x40000023u,
+            ItemId = 0x0E21,
+            Amount = 10,
+            MapId = 1,
+            ParentContainerId = backpack.Id
+        };
+        backpack.AddItem(bandage, new(10, 10));
+        victim.AddEquippedItem(ItemLayerType.OneHanded, weapon);
+        victim.AddEquippedItem(ItemLayerType.Backpack, backpack);
+        victim.BackpackId = backpack.Id;
+        mobileService.Mobiles[victim.Id] = victim;
+        itemService.Items[weapon.Id] = weapon;
+        itemService.Items[backpack.Id] = backpack;
+        itemService.Items[bandage.Id] = bandage;
+
+        IDeathService service = new DeathService(
+            mobileService,
+            itemService,
+            spatial,
+            timerService,
+            eventBus,
+            fameKarmaService,
+            config,
+            lootGenerationService: lootGenerationService
+        );
+
+        var handled = await service.HandleDeathAsync(victim, null);
+
+        var corpse = itemService.Items.Values.Single(item => item.ItemId == 0x2006);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(corpse.Items.Select(static item => item.Id), Contains.Item(weapon.Id));
+                Assert.That(corpse.Items.Select(static item => item.Id), Contains.Item(bandage.Id));
+                Assert.That(corpse.Items.Any(static item => item.Name == "generated_gold"), Is.True);
+                Assert.That(lootGenerationService.Calls, Has.Count.EqualTo(1));
+                Assert.That(lootGenerationService.Calls[0].ContainerId, Is.EqualTo(corpse.Id));
+                Assert.That(lootGenerationService.Calls[0].LootTableIds, Is.EqualTo(new[] { "undead.low", "gold.small" }));
+                Assert.That(lootGenerationService.Calls[0].Mode, Is.EqualTo(LootGenerationMode.OnDeath));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Items/LootGenerationServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Items/LootGenerationServiceTests.cs
@@ -4,14 +4,15 @@ using Moongate.Server.Data.Internal.Scripting;
 using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Services.Items;
+using Moongate.Server.Types.Items;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Interfaces.Templates;
 using Moongate.UO.Data.Persistence.Entities;
 using Moongate.UO.Data.Templates.Items;
 using Moongate.UO.Data.Templates.Loot;
 using Moongate.UO.Data.Tiles;
 using Moongate.UO.Data.Types;
-using Moongate.UO.Data.Interfaces.Templates;
 
 namespace Moongate.Tests.Server.Services.Items;
 
@@ -37,6 +38,18 @@ public sealed class LootGenerationServiceTests
                 };
             }
 
+            if (Templates.TryGetValue(itemTemplateId, out var template))
+            {
+                return new()
+                {
+                    Id = (Serial)_nextSerial++,
+                    ItemId = ParseItemId(template.ItemId),
+                    Name = template.Id,
+                    Amount = 1,
+                    IsStackable = false
+                };
+            }
+
             throw new NotSupportedException($"Unsupported template {itemTemplateId}");
         }
 
@@ -45,6 +58,16 @@ public sealed class LootGenerationServiceTests
 
         public bool TryGetItemTemplate(string itemTemplateId, out ItemTemplateDefinition? template)
             => Templates.TryGetValue(itemTemplateId, out template);
+
+        private static int ParseItemId(string itemId)
+        {
+            if (itemId.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.Parse(itemId.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            }
+
+            return int.Parse(itemId, CultureInfo.InvariantCulture);
+        }
     }
 
     private sealed class TestItemService : IItemService
@@ -153,6 +176,33 @@ public sealed class LootGenerationServiceTests
         }
     }
 
+    private sealed class TestItemTemplateService : IItemTemplateService
+    {
+        public Dictionary<string, ItemTemplateDefinition> Templates { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public int Count => Templates.Count;
+
+        public void Clear()
+            => Templates.Clear();
+
+        public IReadOnlyList<ItemTemplateDefinition> GetAll()
+            => Templates.Values.ToList();
+
+        public bool TryGet(string id, out ItemTemplateDefinition? definition)
+            => Templates.TryGetValue(id, out definition);
+
+        public void Upsert(ItemTemplateDefinition definition)
+            => Templates[definition.Id] = definition;
+
+        public void UpsertRange(IEnumerable<ItemTemplateDefinition> templates)
+        {
+            foreach (var template in templates)
+            {
+                Templates[template.Id] = template;
+            }
+        }
+    }
+
     [Test]
     public async Task EnsureLootGeneratedAsync_WhenRefillWindowHasNotElapsed_ShouldNotRefillEmptyContainer()
     {
@@ -160,7 +210,8 @@ public sealed class LootGenerationServiceTests
         var itemFactory = CreateItemFactory();
         var itemService = new TestItemService();
         var lootTemplateService = CreateLootTemplateService();
-        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService);
+        var itemTemplateService = CreateItemTemplateService();
+        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService, itemTemplateService);
         var container = CreateRefillableContainer(DateTime.UtcNow.AddMinutes(5));
         itemService.ItemsById[container.Id] = container;
 
@@ -187,7 +238,8 @@ public sealed class LootGenerationServiceTests
         var itemFactory = CreateItemFactory();
         var itemService = new TestItemService();
         var lootTemplateService = CreateLootTemplateService();
-        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService);
+        var itemTemplateService = CreateItemTemplateService();
+        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService, itemTemplateService);
         var container = CreateRefillableContainer(DateTime.UtcNow.AddMinutes(-5));
         itemService.ItemsById[container.Id] = container;
 
@@ -209,6 +261,84 @@ public sealed class LootGenerationServiceTests
         );
     }
 
+    [Test]
+    public async Task EnsureLootGeneratedAsync_WhenLootEntryUsesItemTag_ShouldCreateRandomMatchingTemplateItem()
+    {
+        TileData.ItemTable[0x0E75] = new(string.Empty, UOTileFlag.Container, 0, 0, 0, 0, 0, 0);
+        var itemFactory = CreateItemFactory();
+        var itemService = new TestItemService();
+        var lootTemplateService = CreateLootTemplateService();
+        var itemTemplateService = CreateItemTemplateService();
+        lootTemplateService.Templates["loot_test_chest_basic"].Entries =
+        [
+            new LootTemplateEntry
+            {
+                ItemTag = "weapon.ranged",
+                Weight = 1,
+                Amount = 1
+            }
+        ];
+
+        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService, itemTemplateService);
+        var container = CreateRefillableContainer(DateTime.UtcNow.AddMinutes(-5));
+        itemService.ItemsById[container.Id] = container;
+
+        var result = await service.EnsureLootGeneratedAsync(container);
+
+        Assert.That(result.Items, Has.Count.EqualTo(1));
+        Assert.That(result.Items[0].Name, Is.EqualTo("bow"));
+    }
+
+    [Test]
+    public async Task EnsureLootGeneratedAsync_WhenLootTableDefinesMultipleRolls_ShouldCreateItemsForEachRoll()
+    {
+        TileData.ItemTable[0x0E75] = new(string.Empty, UOTileFlag.Container, 0, 0, 0, 0, 0, 0);
+        var itemFactory = CreateItemFactory();
+        var itemService = new TestItemService();
+        var lootTemplateService = CreateLootTemplateService();
+        var itemTemplateService = CreateItemTemplateService();
+        lootTemplateService.Templates["loot_test_chest_basic"].Rolls = 3;
+
+        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService, itemTemplateService);
+        var container = CreateRefillableContainer(DateTime.UtcNow.AddMinutes(-5));
+        itemService.ItemsById[container.Id] = container;
+
+        var result = await service.EnsureLootGeneratedAsync(container);
+
+        Assert.That(result.Items, Has.Count.EqualTo(3));
+        Assert.That(result.Items.All(static item => item.Name == "gold"), Is.True);
+        Assert.That(result.Items.Select(static item => item.Amount), Is.All.EqualTo(125));
+    }
+
+    [Test]
+    public async Task GenerateForContainerAsync_WhenModeIsOnDeath_ShouldBypassFirstOpenLootFlags()
+    {
+        TileData.ItemTable[0x2006] = new(string.Empty, UOTileFlag.Container, 0, 0, 0, 0, 0, 0);
+        var itemFactory = CreateItemFactory();
+        var itemService = new TestItemService();
+        var lootTemplateService = CreateLootTemplateService();
+        var itemTemplateService = CreateItemTemplateService();
+        var service = new LootGenerationService(itemFactory, itemService, lootTemplateService, itemTemplateService);
+        var corpse = new UOItemEntity
+        {
+            Id = (Serial)0x40000050u,
+            ItemId = 0x2006,
+            MapId = 1,
+            Name = "a corpse"
+        };
+        corpse.SetCustomBoolean(ItemCustomParamKeys.Loot.Generated, true);
+        itemService.ItemsById[corpse.Id] = corpse;
+
+        var result = await service.GenerateForContainerAsync(
+            corpse,
+            ["loot_test_chest_basic"],
+            LootGenerationMode.OnDeath
+        );
+
+        Assert.That(result.Items, Has.Count.EqualTo(1));
+        Assert.That(result.Items[0].Name, Is.EqualTo("gold"));
+    }
+
     private static TestItemFactoryService CreateItemFactory()
     {
         var itemFactory = new TestItemFactoryService();
@@ -225,6 +355,15 @@ public sealed class LootGenerationServiceTests
                 ["loot_refillable"] = new() { Type = ItemTemplateParamType.String, Value = "true" },
                 ["loot_refill_seconds"] = new() { Type = ItemTemplateParamType.String, Value = "300" }
             }
+        };
+        itemFactory.Templates["bow"] = new()
+        {
+            Id = "bow",
+            Description = "Bow",
+            GoldValue = GoldValueSpec.FromValue(0),
+            ItemId = "0x13B2",
+            ScriptId = "none",
+            Tags = ["weapon.ranged"]
         };
 
         return itemFactory;
@@ -251,6 +390,22 @@ public sealed class LootGenerationServiceTests
         };
 
         return lootTemplateService;
+    }
+
+    private static TestItemTemplateService CreateItemTemplateService()
+    {
+        var itemTemplateService = new TestItemTemplateService();
+        itemTemplateService.Templates["bow"] = new()
+        {
+            Id = "bow",
+            Description = "Bow",
+            GoldValue = GoldValueSpec.FromValue(0),
+            ItemId = "0x13B2",
+            ScriptId = "none",
+            Tags = ["weapon.ranged"]
+        };
+
+        return itemTemplateService;
     }
 
     private static UOItemEntity CreateRefillableContainer(DateTime refillReadyAtUtc)

--- a/tests/Moongate.Tests/UO/Data/Templates/LootTemplatePolymorphicTests.cs
+++ b/tests/Moongate.Tests/UO/Data/Templates/LootTemplatePolymorphicTests.cs
@@ -35,6 +35,7 @@ public class LootTemplatePolymorphicTests
                        "name": "Bone Armor Loot",
                        "category": "loot",
                        "description": "UOX3 converted loot table",
+                       "rolls": 3,
                        "noDropWeight": 442,
                        "entries": [
                          {
@@ -44,7 +45,7 @@ public class LootTemplatePolymorphicTests
                          },
                          {
                            "weight": 31,
-                           "itemTemplateId": "item.armor.bone_arms",
+                           "itemTag": "armor.bone",
                            "amount": 1
                          }
                        ]
@@ -66,10 +67,11 @@ public class LootTemplatePolymorphicTests
                 Assert.That(result[0], Is.TypeOf<LootTemplateDefinition>());
                 var loot = (LootTemplateDefinition)result[0];
                 Assert.That(loot.Id, Is.EqualTo("bonearmor"));
+                Assert.That(loot.Rolls, Is.EqualTo(3));
                 Assert.That(loot.NoDropWeight, Is.EqualTo(442));
                 Assert.That(loot.Entries.Count, Is.EqualTo(2));
                 Assert.That(loot.Entries[0].ItemId, Is.EqualTo("0x144e"));
-                Assert.That(loot.Entries[1].ItemTemplateId, Is.EqualTo("item.armor.bone_arms"));
+                Assert.That(loot.Entries[1].ItemTag, Is.EqualTo("armor.bone"));
             }
         );
     }


### PR DESCRIPTION
## Summary
- add  and  support to loot templates, with loader and runtime generation coverage
- extend loot generation to support explicit death-mode generation and additive corpse loot from mobile loot tables
- update docs and example templates for multi-roll container loot and NPC corpse loot

## Test Plan
- [x]   Determining projects to restore...
  All projects are up-to-date for restore.
  Moongate.Generators -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Generators/bin/Debug/netstandard2.0/Moongate.Generators.dll
  Moongate.Core -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Core/bin/Debug/net10.0/Moongate.Core.dll
  Moongate.Server.Metrics -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server.Metrics/bin/Debug/net10.0/Moongate.Server.Metrics.dll
  Moongate.Abstractions -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Abstractions/bin/Debug/net10.0/Moongate.Abstractions.dll
  Moongate.Network -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Network/bin/Debug/net10.0/Moongate.Network.dll
  Moongate.Email -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Email/bin/Debug/net10.0/Moongate.Email.dll
  Moongate.UO.Data -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.UO.Data/bin/Debug/net10.0/Moongate.UO.Data.dll
  Moongate.Persistence -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Persistence/bin/Debug/net10.0/Moongate.Persistence.dll
  Moongate.Scripting -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Scripting/bin/Debug/net10.0/Moongate.Scripting.dll
  Moongate.Network.Packets -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Network.Packets/bin/Debug/net10.0/Moongate.Network.Packets.dll
  Moongate.Plugin.Abstractions -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Plugin.Abstractions/bin/Debug/net10.0/Moongate.Plugin.Abstractions.dll
  Moongate.Server.Abstractions -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server.Abstractions/bin/Debug/net10.0/Moongate.Server.Abstractions.dll
  Moongate.Stress -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/tools/Moongate.Stress/bin/Debug/net10.0/Moongate.Stress.dll
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(60,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'PublishAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(103,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'PublishAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(111,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'TryEnqueueBookAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(60,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'PublishAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(103,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'PublishAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(111,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'TryEnqueueBookAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(155,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'PublishAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Services/Items/ItemInteractionService.cs(155,19): warning CA2016: Forward the 'cancellationToken' parameter to the 'PublishAsync' method or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2016) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/Moongate.Server.csproj]
  Moongate.Server -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/bin/Debug/net10.0/Moongate.Server.dll
  Moongate.Tests -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/tests/Moongate.Tests/bin/Debug/net10.0/Moongate.Tests.dll
Test run for /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/tests/Moongate.Tests/bin/Debug/net10.0/Moongate.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    39, Skipped:     0, Total:    39, Duration: 139 ms - Moongate.Tests.dll (net10.0)
- [x]   Determining projects to restore...
  All projects are up-to-date for restore.
  Moongate.Generators -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Generators/bin/Debug/netstandard2.0/Moongate.Generators.dll
  Moongate.Core -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Core/bin/Debug/net10.0/Moongate.Core.dll
  Moongate.Templates -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Templates/bin/Debug/net10.0/Moongate.Templates.dll
  Moongate.Abstractions -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Abstractions/bin/Debug/net10.0/Moongate.Abstractions.dll
  Moongate.Network -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Network/bin/Debug/net10.0/Moongate.Network.dll
  Moongate.Server.Metrics -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server.Metrics/bin/Debug/net10.0/Moongate.Server.Metrics.dll
  Moongate.UO.Data -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.UO.Data/bin/Debug/net10.0/Moongate.UO.Data.dll
  Moongate.Email -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Email/bin/Debug/net10.0/Moongate.Email.dll
  Moongate.Persistence -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Persistence/bin/Debug/net10.0/Moongate.Persistence.dll
  Moongate.Scripting -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Scripting/bin/Debug/net10.0/Moongate.Scripting.dll
  Moongate.Network.Packets -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Network.Packets/bin/Debug/net10.0/Moongate.Network.Packets.dll
  Moongate.Server.Abstractions -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server.Abstractions/bin/Debug/net10.0/Moongate.Server.Abstractions.dll
  Moongate.Stress -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/tools/Moongate.Stress/bin/Debug/net10.0/Moongate.Stress.dll
  Moongate.Plugin.Abstractions -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Plugin.Abstractions/bin/Debug/net10.0/Moongate.Plugin.Abstractions.dll
  Moongate.Benchmarks.Compare -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks.Compare/bin/Debug/net10.0/Moongate.Benchmarks.Compare.dll
  Moongate.Server -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/src/Moongate.Server/bin/Debug/net10.0/Moongate.Server.dll
  Moongate.Tests -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/tests/Moongate.Tests/bin/Debug/net10.0/Moongate.Tests.dll
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/LuaScriptEngineBenchmark.cs(10,14): warning CA1001: Type 'LuaScriptEngineBenchmark' owns disposable field(s) '_engine' but is not disposable (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/Moongate.Benchmarks.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/LuaScriptEngineBenchmark.cs(10,14): warning CA1001: Type 'LuaScriptEngineBenchmark' owns disposable field(s) '_engine' but is not disposable (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/Moongate.Benchmarks.csproj]
  Moongate.Benchmarks -> /Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/bin/Debug/net10.0/Moongate.Benchmarks.dll

Build succeeded.

/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/LuaScriptEngineBenchmark.cs(10,14): warning CA1001: Type 'LuaScriptEngineBenchmark' owns disposable field(s) '_engine' but is not disposable (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/Moongate.Benchmarks.csproj]
/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/LuaScriptEngineBenchmark.cs(10,14): warning CA1001: Type 'LuaScriptEngineBenchmark' owns disposable field(s) '_engine' but is not disposable (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001) [/Users/squid/projects/personal/moongatev2/.worktrees/feature-loot-generation-v2/benchmarks/Moongate.Benchmarks/Moongate.Benchmarks.csproj]
    2 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.86

Closes #123