### PR TITLE
feat: purge persisted corpses on startup

### DIFF
--- a/docs/articles/persistence/overview.md
+++ b/docs/articles/persistence/overview.md
@@ -33,11 +33,12 @@ Notes:
 
 1. On startup, the server loads `world.snapshot.bin` if present.
 2. Then it replays valid entries from `world.journal.bin` in sequence order.
-3. During runtime, repository mutations append operations to the journal.
-4. On autosave/shutdown, a fresh snapshot is captured from in-memory state.
-5. The snapshot file write can run off the game loop on the background job service.
-6. After a successful snapshot write, journal entries included in that snapshot are trimmed by sequence id instead of blindly resetting the whole file.
-7. With file lock mode enabled, snapshot/journal handles remain open for process lifetime.
+3. A startup-only hosted service then removes persisted corpse roots (`0x2006` with `is_corpse=true`) and all recursively contained items before normal runtime services continue.
+4. During runtime, repository mutations append operations to the journal.
+5. On autosave/shutdown, a fresh snapshot is captured from in-memory state.
+6. The snapshot file write can run off the game loop on the background job service.
+7. After a successful snapshot write, journal entries included in that snapshot are trimmed by sequence id instead of blindly resetting the whole file.
+8. With file lock mode enabled, snapshot/journal handles remain open for process lifetime.
 
 ## Snapshot
 

--- a/src/Moongate.Abstractions/Types/ServicePriority.cs
+++ b/src/Moongate.Abstractions/Types/ServicePriority.cs
@@ -7,6 +7,7 @@ namespace Moongate.Abstractions.Types;
 public static class ServicePriority
 {
     public const int Persistence = 110;
+    public const int CorpseStartupCleanup = 115;
     public const int FileLoader = 120;
     public const int WorldGenerationStartup = 121;
     public const int GameLoop = 130;

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtension.cs
@@ -63,6 +63,9 @@ public static class AddBootstrapHostedServicesExtension
             )
         );
         container.RegisterMoongateService<IFileLoaderService, FileLoaderService>(ServicePriority.FileLoader);
+        container.RegisterMoongateService<ICorpseStartupCleanupService, CorpseStartupCleanupService>(
+            ServicePriority.CorpseStartupCleanup
+        );
         container.RegisterMoongateService<IGameLoopService, GameLoopService>(ServicePriority.GameLoop);
         container.RegisterMoongateService<IWeatherService, WeatherService>(ServicePriority.GameLoop);
         container.RegisterMoongateService<ILightService, LightService>(ServicePriority.GameLoop);

--- a/src/Moongate.Server/Interfaces/Services/World/ICorpseStartupCleanupService.cs
+++ b/src/Moongate.Server/Interfaces/Services/World/ICorpseStartupCleanupService.cs
@@ -1,0 +1,8 @@
+using Moongate.Abstractions.Interfaces.Services.Base;
+
+namespace Moongate.Server.Interfaces.Services.World;
+
+/// <summary>
+/// Startup hook that removes persisted corpse items before normal runtime begins.
+/// </summary>
+public interface ICorpseStartupCleanupService : IMoongateService;

--- a/src/Moongate.Server/Services/World/CorpseStartupCleanupService.cs
+++ b/src/Moongate.Server/Services/World/CorpseStartupCleanupService.cs
@@ -1,0 +1,198 @@
+using Moongate.Server.Interfaces.Services.Persistence;
+using Moongate.Server.Interfaces.Services.World;
+using Moongate.UO.Data.Constants;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Serilog;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Startup-only cleanup that removes persisted corpse items before runtime services begin.
+/// </summary>
+public sealed class CorpseStartupCleanupService : ICorpseStartupCleanupService
+{
+    private readonly ILogger _logger = Log.ForContext<CorpseStartupCleanupService>();
+    private readonly IPersistenceService _persistenceService;
+
+    public CorpseStartupCleanupService(IPersistenceService persistenceService)
+    {
+        ArgumentNullException.ThrowIfNull(persistenceService);
+
+        _persistenceService = persistenceService;
+    }
+
+    public async Task StartAsync()
+    {
+        var itemRepository = _persistenceService.UnitOfWork.Items;
+        var corpseRoots = await itemRepository.QueryAsync(
+            static item => IsPersistedCorpse(item),
+            static item => item
+        );
+
+        if (corpseRoots.Count == 0)
+        {
+            _logger.Debug("Corpse startup cleanup found no persisted corpses.");
+
+            return;
+        }
+
+        foreach (var corpseRoot in corpseRoots)
+        {
+            await DetachPersistedOwnerReferencesAsync(corpseRoot);
+        }
+
+        var containmentRelations = await itemRepository.QueryAsync(
+            static item => item.ParentContainerId != Serial.Zero,
+            static item => (item.Id, item.ParentContainerId)
+        );
+        var childrenByParent = BuildChildrenLookup(containmentRelations);
+        var removalOrder = BuildRemovalOrder(corpseRoots.Select(static corpse => corpse.Id).ToArray(), childrenByParent);
+        var removedCount = 0;
+
+        foreach (var itemId in removalOrder)
+        {
+            var removed = await itemRepository.RemoveAsync(itemId);
+
+            if (!removed)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to remove persisted corpse item {itemId} during startup cleanup."
+                );
+            }
+
+            removedCount++;
+        }
+
+        if (removedCount == 0)
+        {
+            _logger.Debug("Corpse startup cleanup found persisted corpses but removed no items.");
+
+            return;
+        }
+
+        await _persistenceService.SaveAsync();
+        _logger.Information(
+            "Corpse startup cleanup removed {CorpseRootCount} corpse roots and {RemovedItemCount} total items.",
+            corpseRoots.Count,
+            removedCount
+        );
+    }
+
+    public Task StopAsync()
+        => Task.CompletedTask;
+
+    private static Dictionary<Serial, List<Serial>> BuildChildrenLookup(
+        IReadOnlyList<(Serial ItemId, Serial ParentContainerId)> containmentRelations
+    )
+    {
+        var childrenByParent = new Dictionary<Serial, List<Serial>>();
+
+        foreach (var (itemId, parentContainerId) in containmentRelations)
+        {
+            if (!childrenByParent.TryGetValue(parentContainerId, out var children))
+            {
+                children = [];
+                childrenByParent[parentContainerId] = children;
+            }
+
+            children.Add(itemId);
+        }
+
+        return childrenByParent;
+    }
+
+    private static List<Serial> BuildRemovalOrder(
+        IReadOnlyList<Serial> corpseRootIds,
+        IReadOnlyDictionary<Serial, List<Serial>> childrenByParent
+    )
+    {
+        var removalOrder = new List<Serial>();
+        var visited = new HashSet<Serial>();
+
+        foreach (var corpseRootId in corpseRootIds)
+        {
+            AppendRemovalOrderIterative(corpseRootId, childrenByParent, visited, removalOrder);
+        }
+
+        return removalOrder;
+    }
+
+    private static void AppendRemovalOrderIterative(
+        Serial itemId,
+        IReadOnlyDictionary<Serial, List<Serial>> childrenByParent,
+        HashSet<Serial> visited,
+        ICollection<Serial> removalOrder
+    )
+    {
+        var traversalStack = new Stack<(Serial ItemId, bool IsPostOrder)>();
+        traversalStack.Push((itemId, false));
+
+        while (traversalStack.Count > 0)
+        {
+            var (currentItemId, isPostOrder) = traversalStack.Pop();
+
+            if (isPostOrder)
+            {
+                removalOrder.Add(currentItemId);
+
+                continue;
+            }
+
+            if (!visited.Add(currentItemId))
+            {
+                continue;
+            }
+
+            traversalStack.Push((currentItemId, true));
+
+            if (!childrenByParent.TryGetValue(currentItemId, out var children))
+            {
+                continue;
+            }
+
+            for (var i = children.Count - 1; i >= 0; i--)
+            {
+                traversalStack.Push((children[i], false));
+            }
+        }
+    }
+
+    private async Task DetachPersistedOwnerReferencesAsync(UOItemEntity corpseRoot)
+    {
+        if (corpseRoot.ParentContainerId != Serial.Zero)
+        {
+            var parentContainer = await _persistenceService.UnitOfWork.Items.GetByIdAsync(corpseRoot.ParentContainerId);
+
+            if (parentContainer is not null)
+            {
+                parentContainer.RemoveItem(corpseRoot.Id);
+                await _persistenceService.UnitOfWork.Items.UpsertAsync(parentContainer);
+            }
+        }
+
+        if (corpseRoot.EquippedMobileId == Serial.Zero || corpseRoot.EquippedLayer is null)
+        {
+            return;
+        }
+
+        var mobile = await _persistenceService.UnitOfWork.Mobiles.GetByIdAsync(corpseRoot.EquippedMobileId);
+
+        if (mobile is null)
+        {
+            return;
+        }
+
+        _ = mobile.UnequipItem(corpseRoot.EquippedLayer.Value, corpseRoot);
+        await _persistenceService.UnitOfWork.Mobiles.UpsertAsync(mobile);
+    }
+
+    private static bool IsPersistedCorpse(UOItemEntity item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        return item.ItemId == CorpsePropertyKeys.ItemId &&
+               item.TryGetCustomBoolean(CorpsePropertyKeys.IsCorpse, out var isCorpse) &&
+               isCorpse;
+    }
+}

--- a/tests/Moongate.Tests/Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtensionTests.cs
+++ b/tests/Moongate.Tests/Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtensionTests.cs
@@ -1,0 +1,35 @@
+using DryIoc;
+using Moongate.Abstractions.Data.Internal;
+using Moongate.Abstractions.Types;
+using Moongate.Server.Extensions.Bootstrap;
+using Moongate.Server.Interfaces.Services.World;
+using Moongate.Server.Services.World;
+
+namespace Moongate.Tests.Server.Extensions.Bootstrap;
+
+public class AddBootstrapHostedServicesExtensionTests
+{
+    [Test]
+    public void AddBootstrapHostedServices_ShouldRegisterCorpseStartupCleanupService()
+    {
+        var container = new Container();
+
+        container.AddBootstrapHostedServices();
+
+        var registrations = container.Resolve<List<ServiceRegistrationObject>>();
+        var registration = registrations.SingleOrDefault(
+            x => x.ServiceType == typeof(ICorpseStartupCleanupService)
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(registration, Is.Not.Null);
+                Assert.That(registration!.ImplementationType, Is.EqualTo(typeof(CorpseStartupCleanupService)));
+                Assert.That(registration.Priority, Is.EqualTo(ServicePriority.CorpseStartupCleanup));
+                Assert.That(registration.Priority, Is.GreaterThan(ServicePriority.Persistence));
+                Assert.That(registration.Priority, Is.LessThan(ServicePriority.FileLoader));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Services/World/CorpseStartupCleanupServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/World/CorpseStartupCleanupServiceTests.cs
@@ -1,0 +1,615 @@
+using Moongate.Persistence.Interfaces.Persistence;
+using Moongate.Server.Interfaces.Services.Persistence;
+using Moongate.Server.Services.World;
+using Moongate.UO.Data.Constants;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Services.World;
+
+public sealed class CorpseStartupCleanupServiceTests
+{
+    [Test]
+    public async Task StartAsync_WhenNoPersistedCorpsesExist_ShouldNotRemoveAnythingOrSave()
+    {
+        var persistence = CreatePersistenceService(
+            CreateItem(
+                (Serial)0x40001001u,
+                0x0ABC,
+                false
+            )
+        );
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(0));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.Empty);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenPersistedCorpseExists_ShouldDeleteCorpseAndSave()
+    {
+        var corpse = CreateCorpse((Serial)0x40001010u);
+        var persistence = CreatePersistenceService(corpse);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.EqualTo([corpse.Id]));
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenCorpseIsPersistedInsideContainer_ShouldDetachParentContainerBeforeRemoval()
+    {
+        var container = CreateItem((Serial)0x40001070u, 0x0AC3, false);
+        var corpse = CreateCorpse((Serial)0x40001071u);
+        var child = CreateItem((Serial)0x40001072u, 0x0AC4, false, corpse.Id);
+
+        container.AddItem(corpse, Point2D.Zero);
+        corpse.AddItem(child, Point2D.Zero);
+
+        var persistence = CreatePersistenceService(container, corpse, child);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.EqualTo([child.Id, corpse.Id]));
+                Assert.That(persistence.TestUnitOfWork.Items.UpsertCalls, Contains.Item(container.Id));
+                Assert.That(container.ContainedItemIds, Does.Not.Contain(corpse.Id));
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(container.Id), Is.True);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.False);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(child.Id), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenCorpseHasRecursiveContents_ShouldDeleteChildrenAndRoot()
+    {
+        var corpse = CreateCorpse((Serial)0x40001020u);
+        var chest = CreateItem((Serial)0x40001021u, 0x0ABD, false, corpse.Id);
+        var pouch = CreateItem((Serial)0x40001022u, 0x0ABE, false, chest.Id);
+        corpse.AddItem(chest, Point2D.Zero);
+        chest.AddItem(pouch, Point2D.Zero);
+
+        var persistence = CreatePersistenceService(corpse, chest, pouch);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.EqualTo([pouch.Id, chest.Id, corpse.Id]));
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.False);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(chest.Id), Is.False);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(pouch.Id), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenMultipleCorpseRootsExist_ShouldRemoveAllCorpsesAndSaveOnce()
+    {
+        var corpseOne = CreateCorpse((Serial)0x40001030u);
+        var corpseOneChild = CreateItem((Serial)0x40001031u, 0x0ABF, false, corpseOne.Id);
+        corpseOne.AddItem(corpseOneChild, Point2D.Zero);
+
+        var corpseTwo = CreateCorpse((Serial)0x40001040u);
+        var corpseTwoChild = CreateItem((Serial)0x40001041u, 0x0AC0, false, corpseTwo.Id);
+        corpseTwo.AddItem(corpseTwoChild, Point2D.Zero);
+
+        var persistence = CreatePersistenceService(corpseOne, corpseOneChild, corpseTwo, corpseTwoChild);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Contains.Item(corpseOneChild.Id));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Contains.Item(corpseTwoChild.Id));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Contains.Item(corpseOne.Id));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Contains.Item(corpseTwo.Id));
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenRemovalFails_ShouldThrowAndNotSave()
+    {
+        var corpse = CreateCorpse((Serial)0x40001060u);
+        var child = CreateItem((Serial)0x40001061u, 0x0AC2, false, corpse.Id);
+        corpse.AddItem(child, Point2D.Zero);
+
+        var persistence = CreatePersistenceService(corpse, child);
+        persistence.TestUnitOfWork.Items.FailRemove(child.Id);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await service.StartAsync());
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(exception, Is.Not.Null);
+                Assert.That(exception!.Message, Does.Contain(child.Id.ToString()));
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(0));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.True);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(child.Id), Is.True);
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.EqualTo([child.Id]));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenCorpseHasDeepLinearContents_ShouldDeleteAllDescendantsAndRoot()
+    {
+        var chainLength = 256;
+        var items = new List<UOItemEntity>(chainLength);
+
+        var corpse = CreateCorpse((Serial)0x40001100u);
+        items.Add(corpse);
+
+        var parent = corpse;
+
+        for (var index = 1; index < chainLength; index++)
+        {
+            var id = (Serial)((uint)corpse.Id + (uint)index);
+            var item = CreateItem(id, 0x0AD0 + index, false, parent.Id);
+            parent.AddItem(item, Point2D.Zero);
+            items.Add(item);
+            parent = item;
+        }
+
+        var persistence = CreatePersistenceService(items.ToArray());
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls.Count, Is.EqualTo(chainLength));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls.First(), Is.EqualTo(items[^1].Id));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls.Last(), Is.EqualTo(corpse.Id));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.False);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(parent.Id), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenNonCorpseContainerExists_ShouldLeaveItUntouched()
+    {
+        var container = CreateItem((Serial)0x40001050u, CorpsePropertyKeys.ItemId, false);
+        var child = CreateItem((Serial)0x40001051u, 0x0AC1, false, container.Id);
+        container.AddItem(child, Point2D.Zero);
+
+        var persistence = CreatePersistenceService(container, child);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.Empty);
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(0));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(container.Id), Is.True);
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(child.Id), Is.True);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenCorpseIsInsideSurvivingContainer_ShouldDetachParentReferenceBeforeDelete()
+    {
+        var parentContainer = CreateItem((Serial)0x40001070u, 0x0AC3, false);
+        var corpse = CreateCorpse((Serial)0x40001071u);
+        parentContainer.AddItem(corpse, Point2D.Zero);
+
+        var persistence = CreatePersistenceService(parentContainer, corpse);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        var persistedParent = await persistence.TestUnitOfWork.Items.GetByIdAsync(parentContainer.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.EqualTo([corpse.Id]));
+                Assert.That(persistence.TestUnitOfWork.Items.UpsertCalls, Contains.Item(parentContainer.Id));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.False);
+                Assert.That(persistedParent, Is.Not.Null);
+                Assert.That(persistedParent!.ContainedItemIds, Does.Not.Contain(corpse.Id));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WhenCorpseIsEquippedBySurvivingMobile_ShouldDetachEquipmentReferenceBeforeDelete()
+    {
+        var owner = new UOMobileEntity
+        {
+            Id = (Serial)0x00002000u,
+            Name = "Guard Owner"
+        };
+        var corpse = CreateCorpse((Serial)0x40001073u);
+        owner.EquipItem(ItemLayerType.Cloak, corpse);
+
+        var persistence = CreatePersistenceService([corpse], [owner]);
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StartAsync();
+
+        var persistedOwner = await persistence.TestUnitOfWork.Mobiles.GetByIdAsync(owner.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(1));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.EqualTo([corpse.Id]));
+                Assert.That(persistence.TestUnitOfWork.Mobiles.UpsertCalls, Contains.Item(owner.Id));
+                Assert.That(persistence.TestUnitOfWork.Items.Contains(corpse.Id), Is.False);
+                Assert.That(persistedOwner, Is.Not.Null);
+                Assert.That(persistedOwner!.HasEquippedItem(ItemLayerType.Cloak), Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public async Task StopAsync_ShouldCompleteWithoutSideEffects()
+    {
+        var persistence = CreatePersistenceService();
+        var service = new CorpseStartupCleanupService(persistence);
+
+        await service.StopAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(persistence.SaveCallCount, Is.EqualTo(0));
+                Assert.That(persistence.TestUnitOfWork.Items.RemoveCalls, Is.Empty);
+            }
+        );
+    }
+
+    private static TestPersistenceService CreatePersistenceService(params UOItemEntity[] items)
+    {
+        var repository = new TestItemRepository();
+        repository.Seed(items);
+
+        return new TestPersistenceService(repository, new TestMobileRepository());
+    }
+
+    private static TestPersistenceService CreatePersistenceService(
+        IReadOnlyCollection<UOItemEntity> items,
+        IReadOnlyCollection<UOMobileEntity> mobiles
+    )
+    {
+        var itemRepository = new TestItemRepository();
+        itemRepository.Seed(items);
+
+        var mobileRepository = new TestMobileRepository();
+        mobileRepository.Seed(mobiles);
+
+        return new TestPersistenceService(itemRepository, mobileRepository);
+    }
+
+    private static UOItemEntity CreateCorpse(Serial id)
+    {
+        var corpse = CreateItem(id, CorpsePropertyKeys.ItemId, true);
+        corpse.Name = "a corpse";
+
+        return corpse;
+    }
+
+    private static UOItemEntity CreateItem(Serial id, int itemId, bool isCorpse, Serial parentContainerId = default)
+    {
+        var item = new UOItemEntity
+        {
+            Id = id,
+            ItemId = itemId,
+            ParentContainerId = parentContainerId
+        };
+
+        if (isCorpse)
+        {
+            item.SetCustomBoolean(CorpsePropertyKeys.IsCorpse, true);
+        }
+
+        return item;
+    }
+
+    private sealed class NoOpAccountRepository : IAccountRepository
+    {
+        public ValueTask<bool> AddAsync(UOAccountEntity account, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(false);
+
+        public ValueTask<int> CountAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(0);
+
+        public ValueTask<bool> ExistsAsync(
+            Func<UOAccountEntity, bool> predicate,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult(false);
+
+        public ValueTask<IReadOnlyCollection<UOAccountEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyCollection<UOAccountEntity>>([]);
+
+        public ValueTask<UOAccountEntity?> GetByIdAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<UOAccountEntity?>(null);
+
+        public ValueTask<UOAccountEntity?> GetByUsernameAsync(string username, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<UOAccountEntity?>(null);
+
+        public ValueTask<IReadOnlyList<TResult>> QueryAsync<TResult>(
+            Func<UOAccountEntity, bool> predicate,
+            Func<UOAccountEntity, TResult> selector,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<IReadOnlyList<TResult>>([]);
+
+        public ValueTask<bool> RemoveAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(false);
+
+        public ValueTask UpsertAsync(UOAccountEntity account, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+    }
+
+    private sealed class NoOpBulletinBoardMessageRepository : IBulletinBoardMessageRepository
+    {
+        public ValueTask<IReadOnlyCollection<BulletinBoardMessageEntity>> GetAllAsync(
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<IReadOnlyCollection<BulletinBoardMessageEntity>>([]);
+
+        public ValueTask<IReadOnlyList<BulletinBoardMessageEntity>> GetByBoardIdAsync(
+            Serial boardId,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<IReadOnlyList<BulletinBoardMessageEntity>>([]);
+
+        public ValueTask<BulletinBoardMessageEntity?> GetByIdAsync(
+            Serial messageId,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<BulletinBoardMessageEntity?>(null);
+
+        public ValueTask<bool> RemoveAsync(Serial messageId, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(false);
+
+        public ValueTask UpsertAsync(BulletinBoardMessageEntity message, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+    }
+
+    private sealed class TestMobileRepository : IMobileRepository
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = [];
+
+        public List<Serial> UpsertCalls { get; } = [];
+
+        public void Seed(IEnumerable<UOMobileEntity> mobiles)
+        {
+            foreach (var mobile in mobiles)
+            {
+                _mobiles[mobile.Id] = mobile;
+            }
+        }
+
+        public ValueTask<int> CountAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_mobiles.Count);
+
+        public ValueTask<IReadOnlyCollection<UOMobileEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyCollection<UOMobileEntity>>([.. _mobiles.Values]);
+
+        public ValueTask<UOMobileEntity?> GetByIdAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_mobiles.TryGetValue(id, out var mobile) ? mobile : null);
+
+        public ValueTask<IReadOnlyList<TResult>> QueryAsync<TResult>(
+            Func<UOMobileEntity, bool> predicate,
+            Func<UOMobileEntity, TResult> selector,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<IReadOnlyList<TResult>>([.. _mobiles.Values.Where(predicate).Select(selector)]);
+
+        public ValueTask<bool> RemoveAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_mobiles.Remove(id));
+
+        public ValueTask UpsertAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            UpsertCalls.Add(mobile.Id);
+            _mobiles[mobile.Id] = mobile;
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class NoOpHelpTicketRepository : IHelpTicketRepository
+    {
+        public ValueTask<IReadOnlyCollection<HelpTicketEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyCollection<HelpTicketEntity>>([]);
+
+        public ValueTask<IReadOnlyList<HelpTicketEntity>> GetBySenderCharacterIdAsync(
+            Serial senderCharacterId,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<IReadOnlyList<HelpTicketEntity>>([]);
+
+        public ValueTask<HelpTicketEntity?> GetByIdAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<HelpTicketEntity?>(null);
+
+        public ValueTask<bool> RemoveAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(false);
+
+        public ValueTask UpsertAsync(HelpTicketEntity entity, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+    }
+
+    private sealed class TestItemRepository : IItemRepository
+    {
+        private readonly Dictionary<Serial, UOItemEntity> _items = [];
+        private readonly HashSet<Serial> _removeFailureIds = [];
+
+        public List<Serial> RemoveCalls { get; } = [];
+        public List<Serial> UpsertCalls { get; } = [];
+
+        public bool Contains(Serial id)
+            => _items.ContainsKey(id);
+
+        public void FailRemove(Serial id)
+            => _removeFailureIds.Add(id);
+
+        public void Seed(IEnumerable<UOItemEntity> items)
+        {
+            foreach (var item in items)
+            {
+                _items[item.Id] = item;
+            }
+        }
+
+        public ValueTask BulkUpsertAsync(IReadOnlyList<UOItemEntity> items, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask<int> CountAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_items.Count);
+
+        public ValueTask<IReadOnlyCollection<UOItemEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyCollection<UOItemEntity>>([.. _items.Values]);
+
+        public ValueTask<UOItemEntity?> GetByIdAsync(Serial id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_items.TryGetValue(id, out var item) ? item : null);
+
+        public ValueTask<IReadOnlyList<TResult>> QueryAsync<TResult>(
+            Func<UOItemEntity, bool> predicate,
+            Func<UOItemEntity, TResult> selector,
+            CancellationToken cancellationToken = default
+        )
+            => ValueTask.FromResult<IReadOnlyList<TResult>>([.. _items.Values.Where(predicate).Select(selector)]);
+
+        public ValueTask<bool> RemoveAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            RemoveCalls.Add(id);
+
+            if (_removeFailureIds.Contains(id))
+            {
+                return ValueTask.FromResult(false);
+            }
+
+            return ValueTask.FromResult(_items.Remove(id));
+        }
+
+        public ValueTask UpsertAsync(UOItemEntity item, CancellationToken cancellationToken = default)
+        {
+            UpsertCalls.Add(item.Id);
+            _items[item.Id] = item;
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TestPersistenceService : IPersistenceService
+    {
+        public TestPersistenceService(
+            TestItemRepository items,
+            TestMobileRepository mobiles
+        )
+        {
+            TestUnitOfWork = new TestPersistenceUnitOfWork(items, mobiles);
+        }
+
+        public int SaveCallCount { get; private set; }
+
+        public TestPersistenceUnitOfWork TestUnitOfWork { get; }
+
+        IPersistenceUnitOfWork IPersistenceService.UnitOfWork
+            => TestUnitOfWork;
+
+        public void Dispose() { }
+
+        public Task SaveAsync(CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            SaveCallCount++;
+
+            return Task.CompletedTask;
+        }
+
+        public Task StartAsync()
+            => Task.CompletedTask;
+
+        public Task StopAsync()
+            => Task.CompletedTask;
+    }
+
+    private sealed class TestPersistenceUnitOfWork : IPersistenceUnitOfWork
+    {
+        public TestPersistenceUnitOfWork(
+            TestItemRepository items,
+            TestMobileRepository mobiles
+        )
+        {
+            Accounts = new NoOpAccountRepository();
+            Mobiles = mobiles;
+            Items = items;
+            BulletinBoardMessages = new NoOpBulletinBoardMessageRepository();
+            HelpTickets = new NoOpHelpTicketRepository();
+        }
+
+        public IAccountRepository Accounts { get; }
+
+        public TestMobileRepository Mobiles { get; }
+
+        public TestItemRepository Items { get; }
+
+        public IBulletinBoardMessageRepository BulletinBoardMessages { get; }
+
+        public IHelpTicketRepository HelpTickets { get; }
+
+        IItemRepository IPersistenceUnitOfWork.Items
+            => Items;
+
+        IMobileRepository IPersistenceUnitOfWork.Mobiles
+            => Mobiles;
+
+        public Serial AllocateNextAccountId()
+            => (Serial)1u;
+
+        public Serial AllocateNextItemId()
+            => (Serial)1u;
+
+        public Serial AllocateNextMobileId()
+            => (Serial)1u;
+
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask SaveSnapshotAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add a startup-only hosted service that deletes persisted corpse roots and recursive corpse contents before normal runtime startup continues
- register the cleanup after persistence and before file loading, with targeted tests for recursive deletion, fail-fast behavior, and survivor reference detachment
- document the startup corpse purge in the persistence overview

## Test Plan
- [x] dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~CorpseStartupCleanupServiceTests|FullyQualifiedName~AddBootstrapHostedServicesExtensionTests|FullyQualifiedName~DeathServiceTests|FullyQualifiedName~ItemServiceTests|FullyQualifiedName~PersistenceServiceTests"
- [x] dotnet build src/Moongate.Server/Moongate.Server.csproj

Closes #132
