### PR TITLE
fix: align enhanced client login handshake

### DIFF
--- a/docs/articles/networking/client-encryption.md
+++ b/docs/articles/networking/client-encryption.md
@@ -55,12 +55,14 @@ The game-server path intentionally uses the legacy UO MD5-derived XOR state beca
 Enhanced-client support stays separate from transport encryption:
 
 - `0xE1` `ClientType` updates the session client capability
+- `0xE1` can also carry the client version string on Enhanced Client handshakes, and Moongate now stores it when present
 - `0xBD` `ClientVersion` can also promote the session into an enhanced-capable mode
 - `GameNetworkSession` exposes `ClientType` and `IsEnhancedClient`
 
 Moongate currently uses that session capability to:
 
-- set the KR/UO3D-compatible flags on the `0xA9` character list
+- parse Enhanced Client `0xE1` handshakes that include the client version string
+- keep `0xA9` / `0xB9` on the same modern wire shape used for current `7.x` clients
 - prefer the new mobile-incoming format for enhanced sessions during world sync and movement visibility updates
 
 Encryption and enhanced-client support are intentionally orthogonal. An enhanced-capable client can still connect plain when `encryptionMode` allows it.

--- a/docs/articles/networking/packets.md
+++ b/docs/articles/networking/packets.md
@@ -169,7 +169,7 @@ Current notable outgoing packet classes:
   - reads effective mobile state from `UOMobileEntity`
 - `CharactersStartingLocationsPacket`
   - outgoing `0xA9`
-  - sets the KR/UO3D-compatible flags when `session.IsEnhancedClient` is true
+  - uses the modern `7.x` character-list shape without forcing extra KR/UO3D bits beyond the expansion flags
 - `MobileIncomingPacket`
   - outgoing `0x78`
   - chooses the new mobile format from the recipient session capability instead of assuming one global client shape

--- a/docs/articles/networking/pol-packet-coverage.md
+++ b/docs/articles/networking/pol-packet-coverage.md
@@ -119,7 +119,7 @@ It is meant for gap analysis against the POL packet catalog, not just for docume
 | `0xD1` | Logout status | C -> S | `?Packet=0xD1` | `LogoutStatusPacket` | `parse-only` | No dedicated logout listener |
 | `0xD4` | Book header new | C -> S | `?Packet=0xD4` | `BookHeaderNewPacket` | `handler` | `ItemHandler -> ItemBookService` | Writable `title` / `author` save for client `7.x` |
 | `0xD7` | Generic AOS commands | C -> S | `?Packet=0xD7` | `GenericAosCommandsPacket` | `parse-only` | AoS subcommands not wired |
-| `0xE1` | Client type | C -> S | `?Packet=0xE1` | `ClientTypePacket` | `parse-only` | Client-type-specific behavior missing |
+| `0xE1` | Client type | C -> S | `?Packet=0xE1` | `ClientTypePacket` | `handler` | `LoginHandler` | Stores session client capability and also accepts the Enhanced Client variant that carries the version string; runtime then drives `0x78` sync shape |
 | `0xEC` | Equip macro | C -> S | `?Packet=0xEC` | `EquipMacroPacket` | `parse-only` | KR macro flow missing |
 | `0xED` | Unequip macro | C -> S | `?Packet=0xED` | `UnequipItemMacroPacket` | `parse-only` | KR macro flow missing |
 | `0xF0` | KR movement request | C -> S | `?Packet=0xF0` | `NewMovementRequestPacket` | `parse-only` | Alternate movement path not wired |

--- a/docs/articles/networking/protocol.md
+++ b/docs/articles/networking/protocol.md
@@ -62,7 +62,7 @@ On repeated violations, session is disconnected.
 - `0x8C` Server Redirect (`Length=11`, fixed)
 - `0x1B` Login Confirm (`Length=37`, fixed)
 - `0xA9` Character / Starting Locations (variable)
-- `0xB9` Support Features (`Length=5`, fixed)
+- `0xB9` Support Features (`Length=3` or `5`, variable)
 - `0x55` Login Complete (`Length=1`, fixed)
 - `0x22` Move Confirm (`Length=3`, fixed)
 - `0x21` Move Deny (`Length=8`, fixed)

--- a/src/Moongate.Network.Packets/Incoming/Login/ClientTypePacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/Login/ClientTypePacket.cs
@@ -17,25 +17,42 @@ public class ClientTypePacket : BaseGameNetworkPacket
 
     public ClientType ResolvedClientType { get; private set; } = ClientType.Classic;
 
+    public string VersionString { get; private set; } = string.Empty;
+
     public ClientTypePacket()
         : base(0xE1) { }
 
     protected override bool ParsePayload(ref SpanReader reader)
     {
-        if (reader.Remaining < 8)
+        if (reader.Remaining < 4)
         {
             return false;
         }
 
         var declaredLength = reader.ReadUInt16();
 
-        if (declaredLength < 7 || declaredLength - 3 > reader.Remaining)
+        if (declaredLength < 5)
         {
             return false;
         }
 
-        _ = reader.ReadUInt16();
-        AdvertisedClientType = reader.ReadUInt32();
+        if (reader.Remaining > 6)
+        {
+            AdvertisedClientType = reader.ReadUInt16();
+            VersionString = reader.Remaining == 0 ? string.Empty : reader.ReadAscii(reader.Remaining).TrimEnd('\0').Trim();
+        }
+        else
+        {
+            if (reader.Remaining < 6)
+            {
+                return false;
+            }
+
+            _ = reader.ReadUInt16();
+            AdvertisedClientType = reader.ReadUInt32();
+            VersionString = string.Empty;
+        }
+
         ResolvedClientType = AdvertisedClientType switch
         {
             0x02 => ClientType.KR,

--- a/src/Moongate.Network.Packets/Outgoing/Login/CharactersStartingLocationsPacket.cs
+++ b/src/Moongate.Network.Packets/Outgoing/Login/CharactersStartingLocationsPacket.cs
@@ -123,11 +123,6 @@ public class CharactersStartingLocationsPacket : BaseGameNetworkPacket
 
         flags |= CharacterListFlags.SixthCharacterSlot | CharacterListFlags.SeventhCharacterSlot;
 
-        if (IsEnhancedClient)
-        {
-            flags |= CharacterListFlags.KR | CharacterListFlags.UO3DClientType;
-        }
-
         writer.Write((int)flags);
         writer.Write((short)-1);
     }

--- a/src/Moongate.Network.Packets/Outgoing/Login/SupportFeaturesPacket.cs
+++ b/src/Moongate.Network.Packets/Outgoing/Login/SupportFeaturesPacket.cs
@@ -7,43 +7,47 @@ using Moongate.UO.Data.Types;
 
 namespace Moongate.Network.Packets.Outgoing.Login;
 
-[PacketHandler(0xB9, PacketSizing.Fixed, Length = 5, Description = "Enable locked client features")]
+[PacketHandler(0xB9, PacketSizing.Variable, Description = "Enable locked client features")]
 
 /// <summary>
 /// Represents SupportFeaturesPacket.
 /// </summary>
 public class SupportFeaturesPacket : BaseGameNetworkPacket
 {
+    private const int ExtendedLength = 5;
+    private const int LegacyLength = 3;
+
     public FeatureFlags Flags { get; set; }
 
-    public SupportFeaturesPacket()
-        : this(GetDefaultFlags()) { }
+    public bool UseExtendedFormat { get; set; }
 
-    public SupportFeaturesPacket(FeatureFlags flags)
-        : base(0xB9, 5)
+    public SupportFeaturesPacket()
+        : this(GetDefaultFlags(), true) { }
+
+    public SupportFeaturesPacket(FeatureFlags flags, bool useExtendedFormat)
+        : base(0xB9, useExtendedFormat ? ExtendedLength : LegacyLength)
     {
         Flags = flags;
+        UseExtendedFormat = useExtendedFormat;
     }
 
     public override void Write(ref SpanWriter writer)
     {
         writer.Write(OpCode);
-        writer.Write((uint)Flags);
+
+        if (UseExtendedFormat)
+        {
+            writer.Write((uint)Flags);
+        }
+        else
+        {
+            writer.Write((ushort)Flags);
+        }
     }
 
     protected override bool ParsePayload(ref SpanReader reader)
         => true;
 
     private static FeatureFlags GetDefaultFlags()
-    {
-        var flags =
-            ExpansionInfo.Table is { Length: > 0 }
-                ? ExpansionInfo.CoreExpansion.SupportedFeatures
-                : FeatureFlags.ExpansionEJ;
-
-        flags |= FeatureFlags.LiveAccount;
-        flags |= FeatureFlags.SeventhCharacterSlot;
-
-        return flags;
-    }
+        => ExpansionInfo.Table is { Length: > 0 } ? ExpansionInfo.CoreExpansion.SupportedFeatures : FeatureFlags.ExpansionEJ;
 }

--- a/src/Moongate.Server/Handlers/CharacterHandler.cs
+++ b/src/Moongate.Server/Handlers/CharacterHandler.cs
@@ -23,6 +23,7 @@ using Moongate.Server.Listeners.Base;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Persistence.Entities;
 using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Version;
 using Serilog;
 
 namespace Moongate.Server.Handlers;
@@ -115,7 +116,7 @@ public class CharacterHandler : BasePacketListener, IGameEventListener<Character
 
         Enqueue(session, new ClientVersionPacket());
         Enqueue(session, new LoginConfirmPacket(character));
-        Enqueue(session, new SupportFeaturesPacket());
+        Enqueue(session, new SupportFeaturesPacket(GetSupportFeatureFlags(), UseExtendedSupportFeatures(session)));
         Enqueue(session, new DrawPlayerPacket(character));
         Enqueue(session, new MovementSpeedControlPacket(MovementSpeedControlType.Disable));
         Enqueue(session, new PlayerStatusPacket(character, 1));
@@ -151,6 +152,14 @@ public class CharacterHandler : BasePacketListener, IGameEventListener<Character
 
         return true;
     }
+
+    private static FeatureFlags GetSupportFeatureFlags()
+        => Moongate.UO.Data.Expansions.ExpansionInfo.Table is { Length: > 0 }
+            ? Moongate.UO.Data.Expansions.ExpansionInfo.CoreExpansion.SupportedFeatures
+            : FeatureFlags.ExpansionEJ;
+
+    private static bool UseExtendedSupportFeatures(GameSession session)
+        => session.NetworkSession.ClientVersion?.ProtocolChanges.HasFlag(ProtocolChanges.ExtendedSupportedFeatures) ?? true;
 
     protected override async Task<bool> HandleCoreAsync(GameSession session, IGameNetworkPacket packet)
     {

--- a/src/Moongate.Server/Handlers/LoginHandler.cs
+++ b/src/Moongate.Server/Handlers/LoginHandler.cs
@@ -183,11 +183,19 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
     {
         session.NetworkSession.SetClientType(clientTypePacket.ResolvedClientType);
 
+        if (!string.IsNullOrWhiteSpace(clientTypePacket.VersionString))
+        {
+            var clientVersion = new ClientVersion(clientTypePacket.VersionString);
+            session.SetClientVersion(clientVersion);
+            session.NetworkSession.SetClientVersion(clientVersion);
+        }
+
         _logger.Debug(
-            "Received ClientTypePacket from session {SessionId}: advertised=0x{AdvertisedClientType:X8} resolved={ClientType}",
+            "Received ClientTypePacket from session {SessionId}: advertised=0x{AdvertisedClientType:X8} resolved={ClientType} version={ClientVersion}",
             session.SessionId,
             clientTypePacket.AdvertisedClientType,
-            clientTypePacket.ResolvedClientType
+            clientTypePacket.ResolvedClientType,
+            string.IsNullOrWhiteSpace(clientTypePacket.VersionString) ? "<none>" : clientTypePacket.VersionString
         );
 
         return true;
@@ -250,7 +258,7 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         session.AccountCharactersCache = characters;
         characterListPacket.FillCharacters(characters);
 
-        Enqueue(session, new SupportFeaturesPacket());
+        Enqueue(session, new SupportFeaturesPacket(GetSupportFeatureFlags(), UseExtendedSupportFeatures(session)));
         Enqueue(session, characterListPacket);
 
         return true;
@@ -339,4 +347,12 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
 
         return IPAddress.Loopback;
     }
+
+    private static FeatureFlags GetSupportFeatureFlags()
+        => Moongate.UO.Data.Expansions.ExpansionInfo.Table is { Length: > 0 }
+            ? Moongate.UO.Data.Expansions.ExpansionInfo.CoreExpansion.SupportedFeatures
+            : FeatureFlags.ExpansionEJ;
+
+    private static bool UseExtendedSupportFeatures(GameSession session)
+        => session.NetworkSession.ClientVersion?.ProtocolChanges.HasFlag(ProtocolChanges.ExtendedSupportedFeatures) ?? true;
 }

--- a/tests/Moongate.Tests/Network/Packets/CharactersStartingLocationsPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/CharactersStartingLocationsPacketTests.cs
@@ -44,7 +44,7 @@ public class CharactersStartingLocationsPacketTests
     }
 
     [Test]
-    public void Write_WhenEnhancedClientIsEnabled_ShouldIncludeKrAndUo3DFlags()
+    public void Write_WhenEnhancedClientIsEnabled_ShouldNotForceKrAndUo3DFlags()
     {
         var packet = new CharactersStartingLocationsPacket
         {
@@ -66,8 +66,8 @@ public class CharactersStartingLocationsPacketTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(flags.HasFlag(CharacterListFlags.KR), Is.True);
-                Assert.That(flags.HasFlag(CharacterListFlags.UO3DClientType), Is.True);
+                Assert.That(flags.HasFlag(CharacterListFlags.KR), Is.False);
+                Assert.That(flags.HasFlag(CharacterListFlags.UO3DClientType), Is.False);
             }
         );
     }

--- a/tests/Moongate.Tests/Network/Packets/ClientTypePacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ClientTypePacketTests.cs
@@ -30,4 +30,38 @@ public class ClientTypePacketTests
             }
         );
     }
+
+    [Test]
+    public void TryParse_ShouldReadEnhancedClientTypeAndVersion_WhenPacketCarriesVersionString()
+    {
+        var packet = new ClientTypePacket();
+
+        var ok = packet.TryParse(
+            [
+                0xE1,
+                0x00,
+                0x0D,
+                0x00,
+                0x03,
+                (byte)'7',
+                (byte)'.',
+                (byte)'0',
+                (byte)'.',
+                (byte)'6',
+                (byte)'1',
+                (byte)'.',
+                (byte)'0'
+            ]
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(packet.AdvertisedClientType, Is.EqualTo(0x03u));
+                Assert.That(packet.ResolvedClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
+                Assert.That(packet.VersionString, Is.EqualTo("7.0.61.0"));
+            }
+        );
+    }
 }

--- a/tests/Moongate.Tests/Network/Packets/SupportFeaturesPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/SupportFeaturesPacketTests.cs
@@ -8,10 +8,10 @@ namespace Moongate.Tests.Network.Packets;
 public class SupportFeaturesPacketTests
 {
     [Test]
-    public void Write_ShouldSerializeOpcodeAndFeatureFlags()
+    public void Write_WhenExtendedFormatIsEnabled_ShouldSerializeOpcodeAnd32BitFeatureFlags()
     {
         const FeatureFlags flags = FeatureFlags.LiveAccount | FeatureFlags.SeventhCharacterSlot;
-        var packet = new SupportFeaturesPacket(flags);
+        var packet = new SupportFeaturesPacket(flags, true);
 
         var writer = new SpanWriter(16, true);
         packet.Write(ref writer);
@@ -26,6 +26,30 @@ public class SupportFeaturesPacketTests
                 Assert.That(
                     BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(1, 4)),
                     Is.EqualTo((uint)flags)
+                );
+            }
+        );
+    }
+
+    [Test]
+    public void Write_WhenExtendedFormatIsDisabled_ShouldSerializeOpcodeAnd16BitFeatureFlags()
+    {
+        const FeatureFlags flags = FeatureFlags.LiveAccount | FeatureFlags.SE;
+        var packet = new SupportFeaturesPacket(flags, false);
+
+        var writer = new SpanWriter(16, true);
+        packet.Write(ref writer);
+        var data = writer.ToArray();
+        writer.Dispose();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(data.Length, Is.EqualTo(3));
+                Assert.That(data[0], Is.EqualTo(0xB9));
+                Assert.That(
+                    BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(1, 2)),
+                    Is.EqualTo((ushort)flags)
                 );
             }
         );

--- a/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
@@ -184,6 +184,47 @@ public class LoginHandlerTests
     }
 
     [Test]
+    public async Task HandlePacketAsync_WhenClientTypePacketCarriesVersionString_ShouldStoreEnhancedClientVersionInSession()
+    {
+        var handler = CreateHandler();
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client));
+        var packet = new ClientTypePacket();
+        Assert.That(
+            packet.TryParse(
+                [
+                    0xE1,
+                    0x00,
+                    0x0D,
+                    0x00,
+                    0x03,
+                    (byte)'7',
+                    (byte)'.',
+                    (byte)'0',
+                    (byte)'.',
+                    (byte)'6',
+                    (byte)'1',
+                    (byte)'.',
+                    (byte)'0'
+                ]
+            ),
+            Is.True
+        );
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(session.NetworkSession.ClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
+                Assert.That(session.NetworkSession.IsEnhancedClient, Is.True);
+                Assert.That(session.NetworkSession.ClientVersion?.SourceString, Is.EqualTo("7.0.61.0"));
+            }
+        );
+    }
+
+    [Test]
     public async Task HandlePacketAsync_WhenClientVersionPacketIsEmpty_ShouldNotStoreClientVersion()
     {
         var handler = CreateHandler();


### PR DESCRIPTION
## Summary
- parse the long-form enhanced client 0xE1 packet and persist the advertised client version during login
- align 0xA9 and 0xB9 output closer to ModernUO by removing forced KR/UO3D flags and using version-aware support feature framing
- update tests and networking docs for the enhanced client handshake path

## Test Plan
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ClientTypePacketTests|FullyQualifiedName~LoginHandlerTests|FullyQualifiedName~GameNetworkSessionTests|FullyQualifiedName~GeneralInformationHandlerTests|FullyQualifiedName~CharactersStartingLocationsPacketTests|FullyQualifiedName~SupportFeaturesPacketTests|FullyQualifiedName~CharacterHandlerTests|FullyQualifiedName~PlayerLoginWorldSyncServiceTests"
- dotnet build src/Moongate.Server/Moongate.Server.csproj

Closes #110
