### PR TITLE
feat: add weapon combat sounds and blood hit effects

### DIFF
--- a/docs/articles/architecture/events.md
+++ b/docs/articles/architecture/events.md
@@ -62,6 +62,22 @@ Typical pattern:
 3. listener enqueues network packet(s) into `IOutgoingPacketQueue`
 4. game loop flushes queue via `IOutboundPacketSender`
 
+## Combat Event Fan-Out
+
+Combat uses the game event bus to attach audiovisual behavior without coupling it to `CombatService`.
+
+Examples:
+
+- `CombatStartedEvent`
+  - attacker start-attack sound remains mobile-owned
+- `CombatHitEvent`
+  - attacker hit sound resolves from the equipped weapon first, then mobile fallback
+  - defender defend/hurt sound remains mobile-owned
+  - blood uses a transient `MobilePlayEffectEvent`, not a persistent world blood item
+- `CombatMissEvent`
+  - attacker miss sound resolves from the equipped weapon first, then mobile fallback
+  - defender sound remains mobile-owned
+
 ## Practical Rule
 
 - Use message bus for cross-thread transport handoff.

--- a/docs/articles/operations/stress-test.md
+++ b/docs/articles/operations/stress-test.md
@@ -27,6 +27,7 @@ Each client executes the full UO login handshake:
 3. Sends account login packet (`0x80`) with username/password
 4. Receives server list (`0xA8`), sends server select (`0xA0`, index 0)
 5. Receives redirect packet (`0x8C`) with game server IP, port, and session key
+6. Login-server socket closes and the client reconnects to the game server
 
 ### Phase 4: Game Entry
 

--- a/moongate_data/templates/items/weapons.json
+++ b/moongate_data/templates/items/weapons.json
@@ -25,7 +25,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -53,7 +55,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -81,7 +85,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -110,7 +116,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -140,7 +148,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -169,7 +179,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -199,7 +211,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -228,7 +242,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -257,7 +273,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -286,7 +304,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -315,7 +335,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -344,7 +366,9 @@
     "weaponSkill": "Fencing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -373,7 +397,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 1334,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -402,7 +428,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -430,7 +458,9 @@
     "hitPoints": 5,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -458,7 +488,9 @@
     "weaponSkill": "Throwing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 1491,
+    "missSound": 1492
   },
   {
     "type": "item",
@@ -489,7 +521,9 @@
     "hitPoints": 60,
     "layer": "TwoHanded",
     "dexterity": 0,
-    "intelligence": 0
+    "intelligence": 0,
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -518,7 +552,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -547,7 +583,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -575,7 +613,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -603,7 +643,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -632,7 +674,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -661,7 +705,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -692,7 +738,9 @@
     "hitPoints": 70,
     "layer": "TwoHanded",
     "dexterity": 0,
-    "intelligence": 0
+    "intelligence": 0,
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -720,7 +768,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -749,7 +799,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -780,7 +832,9 @@
     "hitPoints": 80,
     "layer": "TwoHanded",
     "dexterity": 0,
-    "intelligence": 0
+    "intelligence": 0,
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -809,7 +863,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -837,7 +893,9 @@
     "weaponSkill": "Throwing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 1491,
+    "missSound": 1492
   },
   {
     "type": "item",
@@ -866,7 +924,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -895,7 +955,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -923,7 +985,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -952,7 +1016,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -981,7 +1047,9 @@
     "weaponSkill": "Macing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1009,7 +1077,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1038,7 +1108,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1067,7 +1139,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1096,7 +1170,9 @@
     "weaponSkill": "Swords",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 567,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1125,7 +1201,9 @@
     "weaponSkill": "Fencing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1154,7 +1232,9 @@
     "weaponSkill": "Swords",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1185,7 +1265,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1214,7 +1296,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1243,7 +1327,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1271,7 +1357,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1300,7 +1388,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1328,7 +1418,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1356,7 +1448,9 @@
     "hitPoints": 110,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1386,7 +1480,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1415,7 +1511,9 @@
     "weaponSkill": "Swords",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 567,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1443,7 +1541,9 @@
     "hitPoints": 70,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1472,7 +1572,9 @@
     "weaponSkill": "Macing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1501,7 +1603,9 @@
     "weaponSkill": "Swords",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1530,7 +1634,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1558,7 +1664,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1587,7 +1695,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1616,7 +1726,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1644,7 +1756,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1673,7 +1787,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1704,7 +1820,9 @@
     "hitPoints": 100,
     "layer": "TwoHanded",
     "dexterity": 0,
-    "intelligence": 0
+    "intelligence": 0,
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1732,7 +1850,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1760,7 +1880,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1788,7 +1910,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1819,7 +1943,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1848,7 +1974,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1877,7 +2005,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -1905,7 +2035,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -1934,7 +2066,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1963,7 +2097,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -1992,7 +2128,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2021,7 +2159,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -2050,7 +2190,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2078,7 +2220,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2108,7 +2252,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2138,7 +2284,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2167,7 +2315,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -2195,7 +2345,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2224,7 +2376,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2252,7 +2406,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2280,7 +2436,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2308,7 +2466,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2336,7 +2496,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2364,7 +2526,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2395,7 +2559,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2424,7 +2590,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2454,7 +2622,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2483,7 +2653,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -2512,7 +2684,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 1333,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2540,7 +2714,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2569,7 +2745,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2598,7 +2776,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -2627,7 +2807,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2656,7 +2838,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2685,7 +2869,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2714,7 +2900,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2744,7 +2932,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2775,7 +2965,9 @@
     "hitPoints": 80,
     "layer": "TwoHanded",
     "dexterity": 0,
-    "intelligence": 0
+    "intelligence": 0,
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -2803,7 +2995,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2832,7 +3026,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2860,7 +3056,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2888,7 +3086,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2917,7 +3117,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 562
   },
   {
     "type": "item",
@@ -2945,7 +3147,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -2974,7 +3178,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3003,7 +3209,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -3032,7 +3240,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3061,7 +3271,9 @@
     "weaponSkill": "Macing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3089,7 +3301,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3118,7 +3332,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3147,7 +3363,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3175,7 +3393,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3203,7 +3423,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3232,7 +3454,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3262,7 +3486,9 @@
     "baseRange": 1,
     "maxRange": 10,
     "ammo": "0x0F3F",
-    "ammoFx": "0x1BFE"
+    "ammoFx": "0x1BFE",
+    "hitSound": 564,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3290,7 +3516,9 @@
     "weaponSkill": "Throwing",
     "baseRange": 1,
     "maxRange": 1,
-    "speed": 0
+    "speed": 0,
+    "hitSound": 1491,
+    "missSound": 1492
   },
   {
     "type": "item",
@@ -3319,7 +3547,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3347,7 +3577,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3376,7 +3608,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 568,
+    "missSound": 562
   },
   {
     "type": "item",
@@ -3405,7 +3639,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3434,7 +3670,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3463,7 +3701,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -3491,7 +3731,9 @@
     "hitPoints": 60,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3520,7 +3762,9 @@
     "maxRange": 1,
     "lowDamage": 0,
     "highDamage": 0,
-    "speed": 0
+    "speed": 0,
+    "hitSound": null,
+    "missSound": null
   },
   {
     "type": "item",
@@ -3548,7 +3792,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3577,7 +3823,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 572,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3605,7 +3853,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3633,7 +3883,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3661,7 +3913,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3689,7 +3943,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3717,7 +3973,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3745,7 +4003,9 @@
     "hitPoints": 60,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3774,7 +4034,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 562,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -3803,7 +4065,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 567,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -3832,7 +4096,9 @@
     "intelligence": 0,
     "weaponSkill": "Swords",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 570
   },
   {
     "type": "item",
@@ -3861,7 +4127,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3890,7 +4158,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3919,7 +4189,9 @@
     "intelligence": 0,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 566,
+    "missSound": 568
   },
   {
     "type": "item",
@@ -3948,7 +4220,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -3977,7 +4251,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -4006,7 +4282,9 @@
     "intelligence": 0,
     "weaponSkill": "Macing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 563,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -4034,7 +4312,9 @@
     "hitPoints": 60,
     "weaponSkill": "Fencing",
     "baseRange": 1,
-    "maxRange": 1
+    "maxRange": 1,
+    "hitSound": 571,
+    "missSound": 569
   },
   {
     "type": "item",
@@ -4065,6 +4345,8 @@
     "hitPoints": 60,
     "layer": "TwoHanded",
     "dexterity": 0,
-    "intelligence": 0
+    "intelligence": 0,
+    "hitSound": 564,
+    "missSound": 568
   }
 ]

--- a/scripts/sync_modernuo_shields_weapons.py
+++ b/scripts/sync_modernuo_shields_weapons.py
@@ -39,6 +39,11 @@ NUMERIC_OVERRIDE_PATTERNS = {
     "defMaxRange": re.compile(r"public\s+override\s+int\s+DefMaxRange\s*=>\s*(?P<expr>[^;]+);", re.MULTILINE),
     "aosMaxRange": re.compile(r"public\s+override\s+int\s+AosMaxRange\s*=>\s*(?P<expr>[^;]+);", re.MULTILINE),
     "effectId": re.compile(r"public\s+override\s+int\s+EffectID\s*=>\s*(?P<expr>[^;]+);", re.MULTILINE),
+    "hitSound": re.compile(r"public\s+(?:override|virtual)\s+int\s+DefHitSound\s*=>\s*(?P<expr>[^;]+);", re.MULTILINE),
+    "missSound": re.compile(
+        r"public\s+(?:override|virtual)\s+int\s+DefMissSound\s*=>\s*(?P<expr>[^;]+);",
+        re.MULTILINE,
+    ),
 }
 WEAPON_SKILL_PATTERN = re.compile(r"public\s+override\s+SkillName\s+DefSkill\s*=>\s*SkillName\.(?P<value>\w+)\s*;", re.MULTILINE)
 ANIMATION_PATTERN = re.compile(r"public\s+override\s+WeaponAnimation\s+DefAnimation\s*=>\s*WeaponAnimation\.(?P<value>\w+)\s*;", re.MULTILINE)
@@ -311,6 +316,8 @@ def build_weapon_metadata(definitions: Dict[str, ClassDefinition], definition: C
     if max_range is None:
         max_range = resolve_recursive_numeric(definitions, definition.name, "defMaxRange")
     max_range = max_range or 1
+    hit_sound = resolve_recursive_numeric(definitions, definition.name, "hitSound")
+    miss_sound = resolve_recursive_numeric(definitions, definition.name, "missSound")
     ammo, ammo_fx = resolve_ammo(definitions, definition.name)
     layer = resolve_layer(definitions, definition.name)
     tags = ["modernuo", "weapons"]
@@ -346,6 +353,8 @@ def build_weapon_metadata(definitions: Dict[str, ClassDefinition], definition: C
         "lowDamage": low_damage,
         "highDamage": high_damage,
         "speed": speed,
+        "hitSound": hit_sound,
+        "missSound": miss_sound,
         "tags": tags,
     }
 
@@ -454,6 +463,8 @@ def sync_weapon_template_file(template_file: Path, metadata_by_id: Dict[str, Dic
         template["lowDamage"] = metadata["lowDamage"]
         template["highDamage"] = metadata["highDamage"]
         template["speed"] = metadata["speed"]
+        template["hitSound"] = metadata["hitSound"]
+        template["missSound"] = metadata["missSound"]
         template["tags"] = merge_tags(template.get("tags"), list(metadata["tags"]))
 
         if metadata["weight"]:
@@ -492,6 +503,8 @@ def sync_weapon_template_file(template_file: Path, metadata_by_id: Dict[str, Dic
             "lowDamage": metadata["lowDamage"],
             "highDamage": metadata["highDamage"],
             "speed": metadata["speed"],
+            "hitSound": metadata["hitSound"],
+            "missSound": metadata["missSound"],
             "strength": metadata["strength"],
             "dexterity": metadata["dexterity"],
             "intelligence": metadata["intelligence"],

--- a/scripts/tests/test_sync_modernuo_shields_weapons.py
+++ b/scripts/tests/test_sync_modernuo_shields_weapons.py
@@ -58,6 +58,8 @@ class ScanWeaponMetadataTests(unittest.TestCase):
                         }
 
                         public override SkillName DefSkill => SkillName.Archery;
+                        public override int DefHitSound => 0x0234;
+                        public override int DefMissSound => 0x0238;
                     }
                 }
                 """,
@@ -101,6 +103,8 @@ class ScanWeaponMetadataTests(unittest.TestCase):
             self.assertEqual("Archery", bow["weaponSkill"])
             self.assertEqual("0x0F3F", bow["ammo"])
             self.assertEqual("0x1BFE", bow["ammoFx"])
+            self.assertEqual(0x0234, bow["hitSound"])
+            self.assertEqual(0x0238, bow["missSound"])
             self.assertEqual(1, bow["baseRange"])
             self.assertEqual(10, bow["maxRange"])
             self.assertEqual(30, bow["strength"])
@@ -108,6 +112,55 @@ class ScanWeaponMetadataTests(unittest.TestCase):
             self.assertEqual(41, bow["highDamage"])
             self.assertEqual(25, bow["speed"])
             self.assertEqual(60, bow["hitPoints"])
+
+    def test_extracts_concrete_weapon_sound_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            (root / "BaseWeapon.cs").write_text(
+                """
+                namespace Server.Items
+                {
+                    public abstract partial class BaseWeapon : Item
+                    {
+                        public virtual int DefHitSound => 0x0222;
+                        public virtual int DefMissSound => 0x0223;
+                    }
+                }
+                """,
+                encoding="utf-8",
+            )
+            (root / "WarAxe.cs").write_text(
+                """
+                namespace Server.Items
+                {
+                    public partial class WarAxe : BaseWeapon
+                    {
+                        [Constructible]
+                        public WarAxe() : base(0x13B0)
+                        {
+                        }
+
+                        public override double DefaultWeight => 8.0;
+                        public override SkillName DefSkill => SkillName.Swords;
+                        public override int AosStrReq => 35;
+                        public override int AosMinDamage => 15;
+                        public override int AosMaxDamage => 17;
+                        public override int AosSpeed => 33;
+                        public override int DefMaxRange => 1;
+                        public override int InitMaxHits => 110;
+                        public override int DefHitSound => 0x0233;
+                        public override int DefMissSound => 0x0239;
+                    }
+                }
+                """,
+                encoding="utf-8",
+            )
+
+            metadata = scan_weapon_metadata(root)
+            war_axe = metadata["war_axe"]
+
+            self.assertEqual(0x0233, war_axe["hitSound"])
+            self.assertEqual(0x0239, war_axe["missSound"])
 
 
 class SyncShieldTemplateFileTests(unittest.TestCase):
@@ -197,6 +250,8 @@ class SyncWeaponTemplateFileTests(unittest.TestCase):
                         "lowDamage": 9,
                         "highDamage": 41,
                         "speed": 25,
+                        "hitSound": 0x0234,
+                        "missSound": 0x0238,
                         "weight": 6,
                         "name": "Bow",
                         "tags": ["modernuo", "weapons", "flippable"],
@@ -216,6 +271,8 @@ class SyncWeaponTemplateFileTests(unittest.TestCase):
                         "lowDamage": 15,
                         "highDamage": 17,
                         "speed": 33,
+                        "hitSound": 0x0233,
+                        "missSound": 0x0239,
                         "weight": 6,
                         "name": "Guardian Axe",
                         "tags": ["modernuo", "weapons", "flippable"],
@@ -233,10 +290,14 @@ class SyncWeaponTemplateFileTests(unittest.TestCase):
             self.assertEqual("Archery", bow["weaponSkill"])
             self.assertEqual("0x0F3F", bow["ammo"])
             self.assertEqual("0x1BFE", bow["ammoFx"])
+            self.assertEqual(0x0234, bow["hitSound"])
+            self.assertEqual(0x0238, bow["missSound"])
             self.assertEqual("guardian_axe", guardian_axe["id"])
             self.assertEqual("Guardian Axe", guardian_axe["name"])
             self.assertEqual("", guardian_axe["description"])
             self.assertEqual("TwoHanded", guardian_axe["layer"])
+            self.assertEqual(0x0233, guardian_axe["hitSound"])
+            self.assertEqual(0x0239, guardian_axe["missSound"])
             self.assertEqual(["modernuo", "weapons", "flippable"], guardian_axe["tags"])
 
 

--- a/src/Moongate.Server/Data/Internal/Interaction/MobileCombatSoundResolver.cs
+++ b/src/Moongate.Server/Data/Internal/Interaction/MobileCombatSoundResolver.cs
@@ -15,6 +15,30 @@ public sealed class MobileCombatSoundResolver
         [MobileSoundType.Defend] = 0x0140
     };
 
+    public bool TryResolveHitSound(UOMobileEntity attacker, out int soundId)
+    {
+        ArgumentNullException.ThrowIfNull(attacker);
+
+        if (TryResolveWeaponSound(attacker, static item => item.HitSound, out soundId))
+        {
+            return true;
+        }
+
+        return TryResolve(attacker, MobileSoundType.Attack, out soundId);
+    }
+
+    public bool TryResolveMissSound(UOMobileEntity attacker, out int soundId)
+    {
+        ArgumentNullException.ThrowIfNull(attacker);
+
+        if (TryResolveWeaponSound(attacker, static item => item.MissSound, out soundId))
+        {
+            return true;
+        }
+
+        return TryResolve(attacker, MobileSoundType.Attack, out soundId);
+    }
+
     public bool TryResolve(UOMobileEntity mobile, MobileSoundType type, out int soundId)
     {
         ArgumentNullException.ThrowIfNull(mobile);
@@ -25,5 +49,40 @@ public sealed class MobileCombatSoundResolver
         }
 
         return _fallbacks.TryGetValue(type, out soundId);
+    }
+
+    private static bool TryResolveWeaponSound(
+        UOMobileEntity attacker,
+        Func<UOItemEntity, int?> selector,
+        out int soundId
+    )
+    {
+        foreach (var equippedItem in attacker.GetEquippedItemsRuntime())
+        {
+            if (equippedItem.EquippedLayer is not (ItemLayerType.OneHanded or ItemLayerType.TwoHanded))
+            {
+                continue;
+            }
+
+            if (!equippedItem.WeaponSkill.HasValue)
+            {
+                continue;
+            }
+
+            var candidate = selector(equippedItem);
+
+            if (!candidate.HasValue)
+            {
+                continue;
+            }
+
+            soundId = candidate.Value;
+
+            return true;
+        }
+
+        soundId = default;
+
+        return false;
     }
 }

--- a/src/Moongate.Server/FileLoaders/ItemTemplateLoader.cs
+++ b/src/Moongate.Server/FileLoaders/ItemTemplateLoader.cs
@@ -229,6 +229,8 @@ public sealed class ItemTemplateLoader : IFileLoader
         child.AmmoFx = InheritInt(child.AmmoFx, parent.AmmoFx, Defaults.AmmoFx);
         child.MaxRange = InheritInt(child.MaxRange, parent.MaxRange, Defaults.MaxRange);
         child.BaseRange = InheritInt(child.BaseRange, parent.BaseRange, Defaults.BaseRange);
+        child.HitSound ??= parent.HitSound;
+        child.MissSound ??= parent.MissSound;
 
         child.IsQuiver = InheritBool(child.IsQuiver, parent.IsQuiver, Defaults.IsQuiver);
         child.Dyeable = InheritBool(child.Dyeable, parent.Dyeable, Defaults.Dyeable);

--- a/src/Moongate.Server/Handlers/CombatBloodEffectHandler.cs
+++ b/src/Moongate.Server/Handlers/CombatBloodEffectHandler.cs
@@ -1,0 +1,43 @@
+using Moongate.Abstractions.Interfaces.Services.Base;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Events.Combat;
+using Moongate.Server.Data.Events.Speech;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Server.Handlers;
+
+[RegisterGameEventListener]
+public sealed class CombatBloodEffectHandler : IGameEventListener<CombatHitEvent>, IMoongateService
+{
+    private readonly IGameEventBusService _gameEventBusService;
+
+    public CombatBloodEffectHandler(IGameEventBusService gameEventBusService)
+    {
+        _gameEventBusService = gameEventBusService;
+    }
+
+    public async Task HandleAsync(CombatHitEvent gameEvent, CancellationToken cancellationToken = default)
+    {
+        if (gameEvent.Damage <= 0)
+        {
+            return;
+        }
+
+        await _gameEventBusService.PublishAsync(
+            new MobilePlayEffectEvent(
+                gameEvent.Defender.Id,
+                gameEvent.Defender.MapId,
+                gameEvent.Defender.Location,
+                EffectsUtils.BloodSplash
+            ),
+            cancellationToken
+        );
+    }
+
+    public Task StartAsync()
+        => Task.CompletedTask;
+
+    public Task StopAsync()
+        => Task.CompletedTask;
+}

--- a/src/Moongate.Server/Handlers/CombatHitSoundHandler.cs
+++ b/src/Moongate.Server/Handlers/CombatHitSoundHandler.cs
@@ -26,7 +26,7 @@ public sealed class CombatHitSoundHandler : IGameEventListener<CombatHitEvent>, 
 
     public async Task HandleAsync(CombatHitEvent gameEvent, CancellationToken cancellationToken = default)
     {
-        await PublishIfResolvedAsync(gameEvent.Attacker, MobileSoundType.Attack, cancellationToken);
+        await PublishAttackerSoundAsync(gameEvent.Attacker, cancellationToken);
         await PublishIfResolvedAsync(gameEvent.Defender, MobileSoundType.Defend, cancellationToken);
     }
 
@@ -49,6 +49,19 @@ public sealed class CombatHitSoundHandler : IGameEventListener<CombatHitEvent>, 
 
         await _gameEventBusService.PublishAsync(
             new MobilePlaySoundEvent(mobile.Id, mobile.MapId, mobile.Location, (ushort)soundId),
+            cancellationToken
+        );
+    }
+
+    public async Task PublishAttackerSoundAsync(UOMobileEntity attacker, CancellationToken cancellationToken)
+    {
+        if (!_resolver.TryResolveHitSound(attacker, out var soundId))
+        {
+            return;
+        }
+
+        await _gameEventBusService.PublishAsync(
+            new MobilePlaySoundEvent(attacker.Id, attacker.MapId, attacker.Location, (ushort)soundId),
             cancellationToken
         );
     }

--- a/src/Moongate.Server/Handlers/CombatMissSoundHandler.cs
+++ b/src/Moongate.Server/Handlers/CombatMissSoundHandler.cs
@@ -26,7 +26,7 @@ public sealed class CombatMissSoundHandler : IGameEventListener<CombatMissEvent>
 
     public async Task HandleAsync(CombatMissEvent gameEvent, CancellationToken cancellationToken = default)
     {
-        await PublishIfResolvedAsync(gameEvent.Attacker, MobileSoundType.Attack, cancellationToken);
+        await PublishAttackerSoundAsync(gameEvent.Attacker, cancellationToken);
         await PublishIfResolvedAsync(gameEvent.Defender, MobileSoundType.Defend, cancellationToken);
     }
 
@@ -35,6 +35,19 @@ public sealed class CombatMissSoundHandler : IGameEventListener<CombatMissEvent>
 
     public Task StopAsync()
         => Task.CompletedTask;
+
+    private async Task PublishAttackerSoundAsync(UOMobileEntity attacker, CancellationToken cancellationToken)
+    {
+        if (!_resolver.TryResolveMissSound(attacker, out var soundId))
+        {
+            return;
+        }
+
+        await _gameEventBusService.PublishAsync(
+            new MobilePlaySoundEvent(attacker.Id, attacker.MapId, attacker.Location, (ushort)soundId),
+            cancellationToken
+        );
+    }
 
     private async Task PublishIfResolvedAsync(
         UOMobileEntity mobile,

--- a/src/Moongate.Server/Handlers/LoginHandler.cs
+++ b/src/Moongate.Server/Handlers/LoginHandler.cs
@@ -7,6 +7,7 @@ using Moongate.Network.Packets.Outgoing.Speech;
 using Moongate.Server.Attributes;
 using Moongate.Server.Data.Config;
 using Moongate.Server.Data.Events.Characters;
+using Moongate.Server.Data.Packets;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Data.Version;
 using Moongate.Server.Interfaces.Characters;
@@ -44,6 +45,7 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
     private readonly IGameEventBusService _gameEventBusService;
 
     private readonly IGameNetworkSessionService _gameNetworkSessionService;
+    private readonly IOutboundPacketSender _outboundPacketSender;
 
     private readonly MoongateConfig _serverConfig;
 
@@ -53,7 +55,8 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         ICharacterService characterService,
         IGameEventBusService gameEventBusService,
         MoongateConfig serverConfig,
-        IGameNetworkSessionService gameNetworkSessionService
+        IGameNetworkSessionService gameNetworkSessionService,
+        IOutboundPacketSender outboundPacketSender
     ) : base(outgoingPacketQueue)
     {
         _accountService = accountService;
@@ -61,6 +64,7 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         _gameEventBusService = gameEventBusService;
         _serverConfig = serverConfig;
         _gameNetworkSessionService = gameNetworkSessionService;
+        _outboundPacketSender = outboundPacketSender;
     }
 
     public Task HandleAsync(PlayerCharacterLoggedInEvent gameEvent, CancellationToken cancellationToken = default)
@@ -305,28 +309,56 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         return Task.FromResult(true);
     }
 
-    private Task<bool> HandleServerSelectPacketAsync(GameSession session, ServerSelectPacket _)
+    private async Task<bool> HandleServerSelectPacketAsync(GameSession session, ServerSelectPacket packet)
     {
         try
         {
-            var sessionKey = new Random().Next();
+            var sessionKey = Random.Shared.Next();
+            var shardAddress = ResolveShardAddress(session);
 
             var connectToServer = new ServerRedirectPacket
             {
-                IPAddress = ResolveShardAddress(session),
+                IPAddress = shardAddress,
                 Port = 2593,
                 SessionKey = (uint)sessionKey
             };
 
             session.NetworkSession.SetSeed((uint)sessionKey);
 
-            Enqueue(session, connectToServer);
+            _logger.Debug(
+                "Received ServerSelectPacket from session {SessionId} with shard index {ShardIndex}; redirecting to {IPAddress}:{Port} with session key 0x{SessionKey:X8}",
+                session.SessionId,
+                packet.SelectedServerIndex,
+                shardAddress,
+                connectToServer.Port,
+                connectToServer.SessionKey
+            );
 
-            return Task.FromResult(true);
+            var client = session.NetworkSession.Client;
+
+            if (client is null)
+            {
+                _logger.Warning(
+                    "Session {SessionId} has no attached client during server select redirect.",
+                    session.SessionId
+                );
+
+                return true;
+            }
+
+            _ = await _outboundPacketSender.SendAsync(
+                client,
+                new OutgoingGamePacket(session.SessionId, connectToServer, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()),
+                CancellationToken.None
+            );
+
+            await client.CloseAsync();
+
+            return true;
         }
         catch (Exception exception)
         {
-            return Task.FromException<bool>(exception);
+            throw;
         }
     }
 

--- a/src/Moongate.Server/Services/Entities/ItemFactoryService.cs
+++ b/src/Moongate.Server/Services/Entities/ItemFactoryService.cs
@@ -72,6 +72,8 @@ public sealed class ItemFactoryService : IItemFactoryService
             QuiverLowerAmmoCost = template.LowerAmmoCost,
             QuiverDamageIncrease = template.QuiverDamageIncrease,
             QuiverWeightReduction = template.WeightReduction,
+            HitSound = template.HitSound,
+            MissSound = template.MissSound,
             Location = Point3D.Zero,
             ParentContainerId = Serial.Zero,
             ContainerPosition = Point2D.Zero,

--- a/src/Moongate.UO.Data/Persistence/Entities/UOItemEntity.cs
+++ b/src/Moongate.UO.Data/Persistence/Entities/UOItemEntity.cs
@@ -119,6 +119,18 @@ public partial class UOItemEntity : IItemEntity
     public int QuiverWeightReduction { get; set; }
 
     /// <summary>
+    /// Gets or sets the weapon hit sound emitted for successful attacks.
+    /// </summary>
+    [MemoryPackOrder(29)]
+    public int? HitSound { get; set; }
+
+    /// <summary>
+    /// Gets or sets the weapon miss sound emitted for failed attacks.
+    /// </summary>
+    [MemoryPackOrder(30)]
+    public int? MissSound { get; set; }
+
+    /// <summary>
     /// Gets or sets parent container serial when the item is inside a container.
     /// </summary>
     [MemoryPackOrder(16)]
@@ -290,6 +302,8 @@ public partial class UOItemEntity : IItemEntity
         hash.Add(QuiverLowerAmmoCost);
         hash.Add(QuiverDamageIncrease);
         hash.Add(QuiverWeightReduction);
+        hash.Add(HitSound);
+        hash.Add(MissSound);
         hash.Add(ParentContainerId);
         hash.Add(ContainerPosition);
         hash.Add(EquippedMobileId);

--- a/src/Moongate.UO.Data/Templates/Items/ItemTemplateDefinition.cs
+++ b/src/Moongate.UO.Data/Templates/Items/ItemTemplateDefinition.cs
@@ -119,6 +119,10 @@ public class ItemTemplateDefinition : ItemTemplateDefinitionBase
 
     public int BaseRange { get; set; }
 
+    public int? HitSound { get; set; }
+
+    public int? MissSound { get; set; }
+
     [JsonConverter(typeof(JsonStringEnumConverter<LootType>))]
     public LootType LootType { get; set; }
 

--- a/tests/Moongate.Tests/Server/FileLoaders/ItemTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/ItemTemplateLoaderTests.cs
@@ -407,6 +407,86 @@ public class ItemTemplateLoaderTests
     }
 
     [Test]
+    public async Task LoadAsync_WhenBaseItemHasWeaponSounds_ShouldInheritFromParent()
+    {
+        using var tempDirectory = new TempDirectory();
+        var directoriesConfig = new DirectoriesConfig(
+            tempDirectory.Path,
+            DirectoryType.Data,
+            DirectoryType.Templates,
+            DirectoryType.Scripts,
+            DirectoryType.Save,
+            DirectoryType.Logs,
+            DirectoryType.Cache
+        );
+
+        var itemsDirectory = Path.Combine(directoriesConfig[DirectoryType.Templates], "items", "weapons");
+        Directory.CreateDirectory(itemsDirectory);
+
+        var filePath = Path.Combine(itemsDirectory, "weapon_sounds.json");
+        await File.WriteAllTextAsync(
+            filePath,
+            """
+            [
+              {
+                "type": "item",
+                "category": "weapons",
+                "id": "base_bow",
+                "name": "Base Bow",
+                "description": "base",
+                "container": [],
+                "dyeable": false,
+                "goldValue": "0",
+                "hue": "0",
+                "isMovable": true,
+                "itemId": "0x13B2",
+                "lootType": "Regular",
+                "scriptId": "none",
+                "tags": ["weapon"],
+                "hitSound": 564,
+                "missSound": 568,
+                "weight": 6.0
+              },
+              {
+                "type": "item",
+                "category": "weapons",
+                "id": "derived_bow",
+                "base_item": "base_bow",
+                "name": "Derived Bow",
+                "description": "derived",
+                "container": [],
+                "dyeable": false,
+                "goldValue": "0",
+                "hue": "0",
+                "isMovable": true,
+                "itemId": "0x13B3",
+                "lootType": "Regular",
+                "scriptId": "none",
+                "tags": ["weapon"],
+                "weight": 6.0
+              }
+            ]
+            """
+        );
+
+        var itemTemplateService = new ItemTemplateService();
+        var loader = new ItemTemplateLoader(directoriesConfig, itemTemplateService);
+
+        await loader.LoadAsync();
+
+        Assert.That(itemTemplateService.TryGet("derived_bow", out var template), Is.True);
+        Assert.That(template, Is.Not.Null);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(template!.HitSound, Is.EqualTo(564));
+                Assert.That(template.MissSound, Is.EqualTo(568));
+            }
+        );
+    }
+
+    [Test]
     public async Task LoadAsync_WhenBaseItemIsDefined_ShouldInheritParentValues()
     {
         using var tempDirectory = new TempDirectory();

--- a/tests/Moongate.Tests/Server/Handlers/CombatBloodEffectHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/CombatBloodEffectHandlerTests.cs
@@ -1,0 +1,67 @@
+using Moongate.Server.Data.Events.Base;
+using Moongate.Server.Data.Events.Combat;
+using Moongate.Server.Data.Events.Speech;
+using Moongate.Server.Handlers;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Tests.Server.Handlers;
+
+public sealed class CombatBloodEffectHandlerTests
+{
+    private sealed class RecordingGameEventBusService : IGameEventBusService
+    {
+        public List<object> Events { get; } = [];
+
+        public ValueTask PublishAsync<TEvent>(TEvent gameEvent, CancellationToken cancellationToken = default)
+            where TEvent : IGameEvent
+        {
+            _ = cancellationToken;
+            Events.Add(gameEvent!);
+
+            return ValueTask.CompletedTask;
+        }
+
+        public void RegisterListener<TEvent>(IGameEventListener<TEvent> listener) where TEvent : IGameEvent
+            => _ = listener;
+    }
+
+    [Test]
+    public async Task HandleAsync_ShouldPublishBloodSplashForDefenderLocation()
+    {
+        var eventBus = new RecordingGameEventBusService();
+        var handler = new CombatBloodEffectHandler(eventBus);
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x0100,
+            MapId = 1,
+            Location = new Point3D(100, 100, 0)
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x0200,
+            MapId = 1,
+            Location = new Point3D(101, 100, 0)
+        };
+
+        await handler.HandleAsync(new CombatHitEvent(attacker.Id, defender.Id, 1, attacker.Location, 6, attacker, defender));
+
+        Assert.That(eventBus.Events, Has.Count.EqualTo(1));
+        Assert.That(eventBus.Events[0], Is.TypeOf<MobilePlayEffectEvent>());
+
+        var effectEvent = (MobilePlayEffectEvent)eventBus.Events[0];
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(effectEvent.MobileId, Is.EqualTo(defender.Id));
+                Assert.That(effectEvent.MapId, Is.EqualTo(defender.MapId));
+                Assert.That(effectEvent.Location, Is.EqualTo(defender.Location));
+                Assert.That(effectEvent.ItemId, Is.EqualTo(EffectsUtils.BloodSplash));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Handlers/CombatHitSoundHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/CombatHitSoundHandlerTests.cs
@@ -66,4 +66,53 @@ public sealed class CombatHitSoundHandlerTests
             }
         );
     }
+
+    [Test]
+    public async Task HandleAsync_ShouldPreferEquippedWeaponHitSoundForAttacker()
+    {
+        var eventBus = new RecordingGameEventBusService();
+        var resolver = new MobileCombatSoundResolver();
+        var handler = new CombatHitSoundHandler(resolver, eventBus);
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x0100,
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Sounds =
+            {
+                [MobileSoundType.Attack] = 0x023B
+            }
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x0200,
+            MapId = 1,
+            Location = new(101, 100, 0),
+            Sounds =
+            {
+                [MobileSoundType.Defend] = 0x0140
+            }
+        };
+        attacker.AddEquippedItem(
+            ItemLayerType.TwoHanded,
+            new UOItemEntity
+            {
+                Id = (Serial)0x0300,
+                ItemId = 0x13B2,
+                HitSound = 0x0234,
+                WeaponSkill = UOSkillName.Archery
+            }
+        );
+
+        await handler.HandleAsync(new(attacker.Id, defender.Id, attacker.MapId, attacker.Location, 6, attacker, defender));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(eventBus.Events, Has.Count.EqualTo(2));
+                Assert.That(((MobilePlaySoundEvent)eventBus.Events[0]).SoundModel, Is.EqualTo((ushort)0x0234));
+                Assert.That(((MobilePlaySoundEvent)eventBus.Events[1]).SoundModel, Is.EqualTo((ushort)0x0140));
+            }
+        );
+    }
 }

--- a/tests/Moongate.Tests/Server/Handlers/CombatMissSoundHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/CombatMissSoundHandlerTests.cs
@@ -66,4 +66,53 @@ public sealed class CombatMissSoundHandlerTests
             }
         );
     }
+
+    [Test]
+    public async Task HandleAsync_ShouldPreferEquippedWeaponMissSoundForAttacker()
+    {
+        var eventBus = new RecordingGameEventBusService();
+        var resolver = new MobileCombatSoundResolver();
+        var handler = new CombatMissSoundHandler(resolver, eventBus);
+        var attacker = new UOMobileEntity
+        {
+            Id = (Serial)0x0100,
+            MapId = 1,
+            Location = new(100, 100, 0),
+            Sounds =
+            {
+                [MobileSoundType.Attack] = 0x023B
+            }
+        };
+        var defender = new UOMobileEntity
+        {
+            Id = (Serial)0x0200,
+            MapId = 1,
+            Location = new(101, 100, 0),
+            Sounds =
+            {
+                [MobileSoundType.Defend] = 0x0140
+            }
+        };
+        attacker.AddEquippedItem(
+            ItemLayerType.TwoHanded,
+            new UOItemEntity
+            {
+                Id = (Serial)0x0300,
+                ItemId = 0x13B2,
+                MissSound = 0x0238,
+                WeaponSkill = UOSkillName.Archery
+            }
+        );
+
+        await handler.HandleAsync(new(attacker.Id, defender.Id, attacker.MapId, attacker.Location, attacker, defender));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(eventBus.Events, Has.Count.EqualTo(2));
+                Assert.That(((MobilePlaySoundEvent)eventBus.Events[0]).SoundModel, Is.EqualTo((ushort)0x0238));
+                Assert.That(((MobilePlaySoundEvent)eventBus.Events[1]).SoundModel, Is.EqualTo((ushort)0x0140));
+            }
+        );
+    }
 }

--- a/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using Moongate.Network.Client;
 using Moongate.Network.Packets.Incoming.Login;
+using Moongate.Network.Packets.Outgoing.Login;
 using Moongate.Network.Spans;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Handlers;
@@ -299,6 +300,7 @@ public class LoginHandlerTests
     public async Task HandlePacketAsync_WhenSelectingCharacterAfterGameLogin_ShouldReuseCachedCharacterList()
     {
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sender = new GameLoopTestOutboundPacketSender();
         var accountService = new LoginHandlerTestAccountService();
         var characterService = new LoginHandlerTestCharacterService
         {
@@ -319,7 +321,8 @@ public class LoginHandlerTests
             characterService,
             new NetworkServiceTestGameEventBusService(),
             new(),
-            new FakeGameNetworkSessionService()
+            new FakeGameNetworkSessionService(),
+            sender
         );
 
         using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
@@ -352,6 +355,44 @@ public class LoginHandlerTests
         Assert.That(characterService.GetCharactersForAccountCalls, Is.EqualTo(1));
     }
 
+    [Test]
+    public async Task HandlePacketAsync_WhenServerSelectPacketIsReceived_ShouldSendRedirectAndCloseClient()
+    {
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sender = new GameLoopTestOutboundPacketSender();
+        var handler = new LoginHandler(
+            queue,
+            new LoginHandlerTestAccountService(),
+            new LoginHandlerTestCharacterService(),
+            new NetworkServiceTestGameEventBusService(),
+            new(),
+            new FakeGameNetworkSessionService(),
+            sender
+        );
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client));
+        var packet = new ServerSelectPacket
+        {
+            SelectedServerIndex = 0
+        };
+        var disconnected = false;
+        client.OnDisconnected += (_, _) => disconnected = true;
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(disconnected, Is.True);
+                Assert.That(sender.SentPackets, Has.Count.EqualTo(1));
+                Assert.That(sender.SentPackets[0].Packet, Is.TypeOf<ServerRedirectPacket>());
+                Assert.That(queue.CurrentQueueDepth, Is.EqualTo(0));
+            }
+        );
+    }
+
     private static byte[] BuildClientVersionPayload(string version, bool includeNullTerminator)
     {
         var writer = new SpanWriter(64, true);
@@ -378,6 +419,7 @@ public class LoginHandlerTests
             new LoginHandlerTestCharacterService(),
             new NetworkServiceTestGameEventBusService(),
             new(),
-            new FakeGameNetworkSessionService()
+            new FakeGameNetworkSessionService(),
+            new GameLoopTestOutboundPacketSender()
         );
 }

--- a/tests/Moongate.Tests/Server/Services/Entities/ItemFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Entities/ItemFactoryServiceTests.cs
@@ -424,7 +424,9 @@ public class ItemFactoryServiceTests
             BaseRange = 1,
             MaxRange = 10,
             Ammo = 0x0F3F,
-            AmmoFx = 0x1BFE
+            AmmoFx = 0x1BFE,
+            HitSound = 0x0234,
+            MissSound = 0x0238
         };
         template.WeaponSkill = UOSkillName.Archery;
         templateService.Upsert(template);
@@ -439,6 +441,8 @@ public class ItemFactoryServiceTests
                 Assert.That(item.WeaponSkill, Is.EqualTo(UOSkillName.Archery));
                 Assert.That(item.AmmoItemId, Is.EqualTo(0x0F3F));
                 Assert.That(item.AmmoEffectId, Is.EqualTo(0x1BFE));
+                Assert.That(item.HitSound, Is.EqualTo(0x0234));
+                Assert.That(item.MissSound, Is.EqualTo(0x0238));
                 Assert.That(item.CombatStats, Is.Not.Null);
                 Assert.That(item.CombatStats!.RangeMin, Is.EqualTo(1));
                 Assert.That(item.CombatStats.RangeMax, Is.EqualTo(10));


### PR DESCRIPTION
## Summary
- resolve combat hit and miss sounds from equipped weapons before mobile fallbacks
- publish a transient blood splash effect on successful combat hits and keep defender sounds mobile-owned
- extend weapon item templates and sync tooling with `hitSound` and `missSound` values imported from ModernUO

## Notes
- this branch also carries the pending local `fix: align enhanced client shard redirect flow` commit that existed on `develop` locally but not yet on `origin/develop`

Closes #144

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ItemTemplateLoaderTests|FullyQualifiedName~ItemFactoryServiceTests|FullyQualifiedName~CombatHitSoundHandlerTests|FullyQualifiedName~CombatMissSoundHandlerTests|FullyQualifiedName~CombatStartedSoundHandlerTests|FullyQualifiedName~CombatBloodEffectHandlerTests"`
- [x] `python3 -m unittest scripts.tests.test_sync_modernuo_shields_weapons`
- [x] `dotnet build src/Moongate.Server/Moongate.Server.csproj`
