### PR TITLE
feat: add reusable base loot packs

### DIFF
--- a/moongate_data/templates/loot/creatures.json
+++ b/moongate_data/templates/loot/creatures.json
@@ -1653,5 +1653,204 @@
         "amount": 1
       }
     ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.low_scrolls",
+    "name": "Low Scrolls",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "clumsy_scroll",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.med_scrolls",
+    "name": "Med Scrolls",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "arch_cure_scroll",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.high_scrolls",
+    "name": "High Scrolls",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "summon_air_elemental_scroll",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.gems",
+    "name": "Gems",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "amber",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.potions",
+    "name": "Potions",
+    "category": "loot",
+    "description": "",
+    "mode": "weighted",
+    "rolls": 1,
+    "entries": [
+      {
+        "itemTemplateId": "agility_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "strength_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "refresh_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "lesser_cure_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "lesser_heal_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "lesser_poison_potion",
+        "weight": 1,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.poor",
+    "name": "Poor Pack",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 10,
+        "amountMax": 30
+      },
+      {
+        "itemTemplateId": "bone",
+        "chance": 0.25,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.meager",
+    "name": "Meager Pack",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 20,
+        "amountMax": 50
+      },
+      {
+        "itemTemplateId": "left_arm",
+        "chance": 0.1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "right_arm",
+        "chance": 0.1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "torso",
+        "chance": 0.1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "bone",
+        "chance": 0.7,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "pack.average",
+    "name": "Average Pack",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 50,
+        "amountMax": 100
+      },
+      {
+        "itemTemplateId": "amber",
+        "chance": 1.0,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "arch_cure_scroll",
+        "chance": 0.35,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "agility_potion",
+        "chance": 0.25,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "strength_potion",
+        "chance": 0.25,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "refresh_potion",
+        "chance": 0.25,
+        "amount": 1
+      }
+    ]
   }
 ]

--- a/tests/Moongate.Tests/Server/FileLoaders/LootTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/LootTemplateLoaderTests.cs
@@ -40,6 +40,61 @@ public sealed class LootTemplateLoaderTests
     }
 
     [Test]
+    public async Task LoadAsync_WhenRepositoryContainsBasePackTables_ShouldLoadThemWithExpectedModes()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var dataRoot = Path.Combine(repositoryRoot, "moongate_data");
+        var directoriesConfig = new DirectoriesConfig(dataRoot, DirectoryType.Templates);
+        var lootTemplateService = new LootTemplateService();
+        var loader = new LootTemplateLoader(directoriesConfig, lootTemplateService);
+
+        await loader.LoadAsync();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(lootTemplateService.TryGet("pack.low_scrolls", out var lowScrolls), Is.True);
+                Assert.That(lowScrolls, Is.Not.Null);
+                Assert.That(lowScrolls!.Mode, Is.EqualTo(LootTemplateMode.Additive));
+                Assert.That(lowScrolls.Entries[0].ItemTemplateId, Is.EqualTo("clumsy_scroll"));
+
+                Assert.That(lootTemplateService.TryGet("pack.med_scrolls", out var medScrolls), Is.True);
+                Assert.That(medScrolls, Is.Not.Null);
+                Assert.That(medScrolls!.Entries[0].ItemTemplateId, Is.EqualTo("arch_cure_scroll"));
+
+                Assert.That(lootTemplateService.TryGet("pack.high_scrolls", out var highScrolls), Is.True);
+                Assert.That(highScrolls, Is.Not.Null);
+                Assert.That(highScrolls!.Entries[0].ItemTemplateId, Is.EqualTo("summon_air_elemental_scroll"));
+
+                Assert.That(lootTemplateService.TryGet("pack.gems", out var gems), Is.True);
+                Assert.That(gems, Is.Not.Null);
+                Assert.That(gems!.Entries[0].ItemTemplateId, Is.EqualTo("amber"));
+
+                Assert.That(lootTemplateService.TryGet("pack.potions", out var potions), Is.True);
+                Assert.That(potions, Is.Not.Null);
+                Assert.That(potions!.Mode, Is.EqualTo(LootTemplateMode.Weighted));
+                Assert.That(potions.Rolls, Is.EqualTo(1));
+                Assert.That(potions.Entries, Has.Count.EqualTo(6));
+
+                Assert.That(lootTemplateService.TryGet("pack.poor", out var poor), Is.True);
+                Assert.That(poor, Is.Not.Null);
+                Assert.That(poor!.Mode, Is.EqualTo(LootTemplateMode.Additive));
+                Assert.That(poor.Entries.Any(entry => entry.ItemTemplateId == "gold"), Is.True);
+
+                Assert.That(lootTemplateService.TryGet("pack.meager", out var meager), Is.True);
+                Assert.That(meager, Is.Not.Null);
+                Assert.That(meager!.Mode, Is.EqualTo(LootTemplateMode.Additive));
+                Assert.That(meager.Entries.Any(entry => entry.ItemTemplateId == "left_arm"), Is.True);
+
+                Assert.That(lootTemplateService.TryGet("pack.average", out var average), Is.True);
+                Assert.That(average, Is.Not.Null);
+                Assert.That(average!.Mode, Is.EqualTo(LootTemplateMode.Additive));
+                Assert.That(average.Entries.Any(entry => entry.ItemTemplateId == "amber"), Is.True);
+            }
+        );
+    }
+
+    [Test]
     public async Task LoadAsync_WhenTemplateDefinesAdditiveMode_ShouldLoadChanceAndAmountRange()
     {
         using var tempDirectory = new TempDirectory();


### PR DESCRIPTION
## Summary
- add reusable low-tier loot pack tables for scrolls, gems, potions, and creature loot
- keep the current loot runtime unchanged by expressing the packs in the existing JSON format
- add repository loader coverage for the new pack definitions

## Test Plan
- [x] dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~LootTemplateLoaderTests|FullyQualifiedName~TemplateValidationLoaderTests"

Closes #147