### PR TITLE
fix: align enhanced client shard selection handshake

### DIFF
--- a/src/Moongate.Network.Packets/Incoming/Login/ClientTypePacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/Login/ClientTypePacket.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using Moongate.Network.Packets.Attributes;
 using Moongate.Network.Packets.Base;
 using Moongate.Network.Packets.Types.Packets;
@@ -24,33 +25,68 @@ public class ClientTypePacket : BaseGameNetworkPacket
 
     protected override bool ParsePayload(ref SpanReader reader)
     {
-        if (reader.Remaining < 4)
+        if (reader.Remaining < 2)
         {
             return false;
         }
 
         var declaredLength = reader.ReadUInt16();
+        var payloadLength = declaredLength - 3;
 
-        if (declaredLength < 5)
+        if (declaredLength < 5 || payloadLength != reader.Remaining)
         {
             return false;
         }
 
-        if (reader.Remaining > 6)
-        {
-            AdvertisedClientType = reader.ReadUInt16();
-            VersionString = reader.Remaining == 0 ? string.Empty : reader.ReadAscii(reader.Remaining).TrimEnd('\0').Trim();
-        }
-        else
-        {
-            if (reader.Remaining < 6)
-            {
-                return false;
-            }
+        var payload = reader.ReadBytes(payloadLength);
+        var payloadReader = new SpanReader(payload);
 
-            _ = reader.ReadUInt16();
-            AdvertisedClientType = reader.ReadUInt32();
-            VersionString = string.Empty;
+        try
+        {
+            if (payloadLength == 4)
+            {
+                AdvertisedClientType = payloadReader.ReadUInt32();
+                VersionString = string.Empty;
+            }
+            else if (payloadLength >= 4)
+            {
+                var firstField = BinaryPrimitives.ReadUInt16BigEndian(payload);
+
+                if (payloadLength > 4)
+                {
+                    var secondField = BinaryPrimitives.ReadUInt16BigEndian(payload.AsSpan(2));
+
+                    if (secondField is 0x02 or 0x03)
+                    {
+                        _ = payloadReader.ReadUInt16();
+                        AdvertisedClientType = payloadReader.ReadUInt16();
+                        VersionString = payloadReader.ReadAscii(payloadLength - 4).TrimEnd('\0').Trim();
+                    }
+                    else if (firstField is 0x02 or 0x03)
+                    {
+                        AdvertisedClientType = payloadReader.ReadUInt16();
+                        VersionString = payloadReader.ReadAscii(payloadLength - 2).TrimEnd('\0').Trim();
+                    }
+                    else if (payloadLength == 6)
+                    {
+                        _ = payloadReader.ReadUInt16();
+                        AdvertisedClientType = payloadReader.ReadUInt32();
+                        VersionString = string.Empty;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            payloadReader.Dispose();
         }
 
         ResolvedClientType = AdvertisedClientType switch

--- a/src/Moongate.Network.Packets/Incoming/Login/ServerSelectPacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/Login/ServerSelectPacket.cs
@@ -19,7 +19,7 @@ public class ServerSelectPacket : BaseGameNetworkPacket
 
     protected override bool ParsePayload(ref SpanReader reader)
     {
-        SelectedServerIndex = reader.ReadInt16LE();
+        SelectedServerIndex = reader.ReadInt16();
 
         return true;
     }

--- a/tests/Moongate.Tests/Network/Packets/ClientTypePacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ClientTypePacketTests.cs
@@ -14,8 +14,8 @@ public class ClientTypePacketTests
         Assert.That(ok, Is.False);
     }
 
-    [TestCase(new byte[] { 0xE1, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 }, 0x02u),
-     TestCase(new byte[] { 0xE1, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03 }, 0x03u)]
+    [TestCase(new byte[] { 0xE1, 0x00, 0x09, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 }, 0x02u),
+     TestCase(new byte[] { 0xE1, 0x00, 0x09, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03 }, 0x03u)]
     public void TryParse_ShouldReadAdvertisedClientType(byte[] raw, uint advertisedClientType)
     {
         var packet = new ClientTypePacket();
@@ -61,6 +61,44 @@ public class ClientTypePacketTests
                 Assert.That(packet.AdvertisedClientType, Is.EqualTo(0x03u));
                 Assert.That(packet.ResolvedClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
                 Assert.That(packet.VersionString, Is.EqualTo("7.0.61.0"));
+            }
+        );
+    }
+
+    [Test]
+    public void TryParse_ShouldReadEnhancedClientTypeAndVersion_WhenPacketCarriesModernUoPayload()
+    {
+        var packet = new ClientTypePacket();
+
+        var ok = packet.TryParse(
+            [
+                0xE1,
+                0x00,
+                0x11,
+                0x00,
+                0x00,
+                0x00,
+                0x03,
+                (byte)'6',
+                (byte)'7',
+                (byte)'.',
+                (byte)'0',
+                (byte)'.',
+                (byte)'0',
+                (byte)'.',
+                (byte)'1',
+                (byte)'1',
+                (byte)'4'
+            ]
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(packet.AdvertisedClientType, Is.EqualTo(0x03u));
+                Assert.That(packet.ResolvedClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
+                Assert.That(packet.VersionString, Is.EqualTo("67.0.0.114"));
             }
         );
     }

--- a/tests/Moongate.Tests/Network/Packets/ServerSelectPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ServerSelectPacketTests.cs
@@ -1,0 +1,22 @@
+using Moongate.Network.Packets.Incoming.Login;
+
+namespace Moongate.Tests.Network.Packets;
+
+public class ServerSelectPacketTests
+{
+    [Test]
+    public void TryParse_ShouldReadServerIndexUsingBigEndianOrder()
+    {
+        var packet = new ServerSelectPacket();
+
+        var ok = packet.TryParse([0xA0, 0x00, 0x01]);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(packet.SelectedServerIndex, Is.EqualTo(1));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
@@ -171,7 +171,7 @@ public class LoginHandlerTests
         using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
         var session = new GameSession(new(client));
         var packet = new ClientTypePacket();
-        Assert.That(packet.TryParse([0xE1, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03]), Is.True);
+        Assert.That(packet.TryParse([0xE1, 0x00, 0x09, 0x00, 0x01, 0x00, 0x00, 0x00, 0x03]), Is.True);
 
         var handled = await handler.HandlePacketAsync(session, packet);
 
@@ -221,6 +221,51 @@ public class LoginHandlerTests
                 Assert.That(session.NetworkSession.ClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
                 Assert.That(session.NetworkSession.IsEnhancedClient, Is.True);
                 Assert.That(session.NetworkSession.ClientVersion?.SourceString, Is.EqualTo("7.0.61.0"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_WhenClientTypePacketCarriesModernUoVersionPayload_ShouldStoreEnhancedClientVersionInSession()
+    {
+        var handler = CreateHandler();
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client));
+        var packet = new ClientTypePacket();
+        Assert.That(
+            packet.TryParse(
+                [
+                    0xE1,
+                    0x00,
+                    0x11,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x03,
+                    (byte)'6',
+                    (byte)'7',
+                    (byte)'.',
+                    (byte)'0',
+                    (byte)'.',
+                    (byte)'0',
+                    (byte)'.',
+                    (byte)'1',
+                    (byte)'1',
+                    (byte)'4'
+                ]
+            ),
+            Is.True
+        );
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(session.NetworkSession.ClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
+                Assert.That(session.NetworkSession.IsEnhancedClient, Is.True);
+                Assert.That(session.NetworkSession.ClientVersion?.SourceString, Is.EqualTo("67.0.0.114"));
             }
         );
     }


### PR DESCRIPTION
## Summary
- parse the ModernUO-style long `0xE1` client type packet so EC sessions keep the advertised client version and type
- keep compatibility with the compact `0xE1` payload shape already used in Moongate tests
- parse `0xA0` shard selections using protocol-correct big-endian order

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ClientTypePacketTests|FullyQualifiedName~LoginHandlerTests|FullyQualifiedName~ServerSelectPacketTests|FullyQualifiedName~CharactersStartingLocationsPacketTests|FullyQualifiedName~SupportFeaturesPacketTests"`
- [x] `dotnet build src/Moongate.Server/Moongate.Server.csproj`

Closes #143