### PR TITLE
fix: preserve enhanced client metadata across shard redirect

### DIFF
--- a/src/Moongate.Server/Data/Session/GameLoginHandoff.cs
+++ b/src/Moongate.Server/Data/Session/GameLoginHandoff.cs
@@ -1,0 +1,37 @@
+using Moongate.UO.Data.Version;
+
+namespace Moongate.Server.Data.Session;
+
+/// <summary>
+/// Carries client handshake metadata across the login-server to game-server reconnect.
+/// </summary>
+public sealed class GameLoginHandoff
+{
+    public GameLoginHandoff(uint sessionKey, ClientType clientType, ClientVersion? clientVersion, long createdAtUnixTimeMs)
+    {
+        SessionKey = sessionKey;
+        ClientType = clientType;
+        ClientVersion = clientVersion;
+        CreatedAtUnixTimeMs = createdAtUnixTimeMs;
+    }
+
+    /// <summary>
+    /// Gets the redirect session key used by the reconnecting client.
+    /// </summary>
+    public uint SessionKey { get; }
+
+    /// <summary>
+    /// Gets the resolved client type observed on the login socket.
+    /// </summary>
+    public ClientType ClientType { get; }
+
+    /// <summary>
+    /// Gets the negotiated client version observed on the login socket, when available.
+    /// </summary>
+    public ClientVersion? ClientVersion { get; }
+
+    /// <summary>
+    /// Gets the creation timestamp in Unix milliseconds.
+    /// </summary>
+    public long CreatedAtUnixTimeMs { get; }
+}

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapCoreServicesExtension.cs
@@ -88,6 +88,7 @@ public static class AddBootstrapCoreServicesExtension
         container.Register<IOutboundPacketSender, OutboundPacketSender>(Reuse.Singleton);
         container.Register<IPacketDispatchService, PacketDispatchService>(Reuse.Singleton);
         container.Register<IGameNetworkSessionService, GameNetworkSessionService>(Reuse.Singleton);
+        container.Register<IGameLoginHandoffService, GameLoginHandoffService>(Reuse.Singleton);
         container.Register<ISpatialWorldService, SpatialWorldService>(Reuse.Singleton);
         container.Register<ISpeechService, SpeechService>(Reuse.Singleton);
         container.Register<IChatSystemService, ChatSystemService>(Reuse.Singleton);

--- a/src/Moongate.Server/Handlers/LoginHandler.cs
+++ b/src/Moongate.Server/Handlers/LoginHandler.cs
@@ -44,6 +44,7 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
     private readonly ICharacterService _characterService;
     private readonly IGameEventBusService _gameEventBusService;
 
+    private readonly IGameLoginHandoffService _gameLoginHandoffService;
     private readonly IGameNetworkSessionService _gameNetworkSessionService;
     private readonly IOutboundPacketSender _outboundPacketSender;
 
@@ -55,6 +56,7 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         ICharacterService characterService,
         IGameEventBusService gameEventBusService,
         MoongateConfig serverConfig,
+        IGameLoginHandoffService gameLoginHandoffService,
         IGameNetworkSessionService gameNetworkSessionService,
         IOutboundPacketSender outboundPacketSender
     ) : base(outgoingPacketQueue)
@@ -63,6 +65,7 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
         _characterService = characterService;
         _gameEventBusService = gameEventBusService;
         _serverConfig = serverConfig;
+        _gameLoginHandoffService = gameLoginHandoffService;
         _gameNetworkSessionService = gameNetworkSessionService;
         _outboundPacketSender = outboundPacketSender;
     }
@@ -238,6 +241,25 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
             gameLoginPacket.AccountName
         );
 
+        if (_gameLoginHandoffService.TryConsume(gameLoginPacket.SessionKey, out var handoff))
+        {
+            session.NetworkSession.SetClientType(handoff.ClientType);
+
+            if (handoff.ClientVersion is not null)
+            {
+                session.SetClientVersion(handoff.ClientVersion);
+                session.NetworkSession.SetClientVersion(handoff.ClientVersion);
+            }
+
+            _logger.Debug(
+                "Applied game login handoff for session {SessionId}: session key 0x{SessionKey:X8}, client type {ClientType}, version {ClientVersion}",
+                session.SessionId,
+                gameLoginPacket.SessionKey,
+                handoff.ClientType,
+                handoff.ClientVersion?.SourceString ?? "<none>"
+            );
+        }
+
         var account = await _accountService.LoginAsync(gameLoginPacket.AccountName, gameLoginPacket.Password);
 
         if (account == null)
@@ -324,6 +346,11 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
             };
 
             session.NetworkSession.SetSeed((uint)sessionKey);
+            _gameLoginHandoffService.Store(
+                connectToServer.SessionKey,
+                session.NetworkSession.ClientType,
+                session.NetworkSession.ClientVersion
+            );
 
             _logger.Debug(
                 "Received ServerSelectPacket from session {SessionId} with shard index {ShardIndex}; redirecting to {IPAddress}:{Port} with session key 0x{SessionKey:X8}",

--- a/src/Moongate.Server/Interfaces/Services/Sessions/IGameLoginHandoffService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Sessions/IGameLoginHandoffService.cs
@@ -1,0 +1,26 @@
+using Moongate.Server.Data.Session;
+using Moongate.UO.Data.Version;
+
+namespace Moongate.Server.Interfaces.Services.Sessions;
+
+/// <summary>
+/// Stores one-shot client handshake metadata across the login-server to game-server redirect.
+/// </summary>
+public interface IGameLoginHandoffService
+{
+    /// <summary>
+    /// Stores client metadata for a redirect session key.
+    /// </summary>
+    /// <param name="sessionKey">Redirect session key.</param>
+    /// <param name="clientType">Resolved client type from the login socket.</param>
+    /// <param name="clientVersion">Negotiated client version from the login socket, when known.</param>
+    void Store(uint sessionKey, ClientType clientType, ClientVersion? clientVersion);
+
+    /// <summary>
+    /// Tries to consume a previously stored redirect handoff.
+    /// </summary>
+    /// <param name="sessionKey">Redirect session key.</param>
+    /// <param name="handoff">Resolved handoff metadata.</param>
+    /// <returns><c>true</c> when a matching handoff existed and was consumed.</returns>
+    bool TryConsume(uint sessionKey, out GameLoginHandoff handoff);
+}

--- a/src/Moongate.Server/Services/Sessions/GameLoginHandoffService.cs
+++ b/src/Moongate.Server/Services/Sessions/GameLoginHandoffService.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.UO.Data.Version;
+
+namespace Moongate.Server.Services.Sessions;
+
+public sealed class GameLoginHandoffService : IGameLoginHandoffService
+{
+    private const long TimeToLiveMs = 5 * 60 * 1000;
+
+    private readonly ConcurrentDictionary<uint, GameLoginHandoff> _handoffs = new();
+
+    public void Store(uint sessionKey, ClientType clientType, ClientVersion? clientVersion)
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        PruneExpired(now);
+
+        _handoffs[sessionKey] = new GameLoginHandoff(sessionKey, clientType, clientVersion, now);
+    }
+
+    public bool TryConsume(uint sessionKey, out GameLoginHandoff handoff)
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        PruneExpired(now);
+
+        if (_handoffs.TryRemove(sessionKey, out handoff!))
+        {
+            if (now - handoff.CreatedAtUnixTimeMs <= TimeToLiveMs)
+            {
+                return true;
+            }
+        }
+
+        handoff = null!;
+
+        return false;
+    }
+
+    private void PruneExpired(long nowUnixTimeMs)
+    {
+        foreach (var pair in _handoffs)
+        {
+            if (nowUnixTimeMs - pair.Value.CreatedAtUnixTimeMs > TimeToLiveMs)
+            {
+                _ = _handoffs.TryRemove(pair.Key, out _);
+            }
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
@@ -7,6 +7,7 @@ using Moongate.Server.Data.Session;
 using Moongate.Server.Handlers;
 using Moongate.Server.Interfaces.Characters;
 using Moongate.Server.Interfaces.Services.Accounting;
+using Moongate.Server.Services.Sessions;
 using Moongate.Tests.Server.Services.Spatial;
 using Moongate.Tests.Server.Support;
 using Moongate.UO.Data.Ids;
@@ -366,6 +367,7 @@ public class LoginHandlerTests
             characterService,
             new NetworkServiceTestGameEventBusService(),
             new(),
+            new GameLoginHandoffService(),
             new FakeGameNetworkSessionService(),
             sender
         );
@@ -411,6 +413,7 @@ public class LoginHandlerTests
             new LoginHandlerTestCharacterService(),
             new NetworkServiceTestGameEventBusService(),
             new(),
+            new GameLoginHandoffService(),
             new FakeGameNetworkSessionService(),
             sender
         );
@@ -434,6 +437,94 @@ public class LoginHandlerTests
                 Assert.That(sender.SentPackets, Has.Count.EqualTo(1));
                 Assert.That(sender.SentPackets[0].Packet, Is.TypeOf<ServerRedirectPacket>());
                 Assert.That(queue.CurrentQueueDepth, Is.EqualTo(0));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_WhenGameLoginFollowsEnhancedRedirect_ShouldPreserveEnhancedClientMetadata()
+    {
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sender = new GameLoopTestOutboundPacketSender();
+        var accountService = new LoginHandlerTestAccountService
+        {
+            NextLoginResult = new()
+            {
+                Id = (Serial)0x00000001,
+                Username = "admin",
+                PasswordHash = "x"
+            }
+        };
+        var characterService = new LoginHandlerTestCharacterService();
+        var sessionService = new FakeGameNetworkSessionService();
+        var handoffService = new GameLoginHandoffService();
+        var handler = new LoginHandler(
+            queue,
+            accountService,
+            characterService,
+            new NetworkServiceTestGameEventBusService(),
+            new(),
+            handoffService,
+            sessionService,
+            sender
+        );
+
+        using var loginClient = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var loginSession = new GameSession(new(loginClient));
+        sessionService.Add(loginSession);
+
+        var clientTypePacket = new ClientTypePacket();
+        Assert.That(
+            clientTypePacket.TryParse(
+                [
+                    0xE1,
+                    0x00,
+                    0x11,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x03,
+                    (byte)'6',
+                    (byte)'7',
+                    (byte)'.',
+                    (byte)'0',
+                    (byte)'.',
+                    (byte)'0',
+                    (byte)'.',
+                    (byte)'1',
+                    (byte)'1',
+                    (byte)'4'
+                ]
+            ),
+            Is.True
+        );
+
+        _ = await handler.HandlePacketAsync(loginSession, clientTypePacket);
+        _ = await handler.HandlePacketAsync(loginSession, new ServerSelectPacket { SelectedServerIndex = 0 });
+
+        var redirectPacket = sender.SentPackets.Select(static packet => packet.Packet).OfType<ServerRedirectPacket>().Single();
+
+        using var gameClient = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var gameSession = new GameSession(new(gameClient));
+        sessionService.Add(gameSession);
+
+        var handled = await handler.HandlePacketAsync(
+            gameSession,
+            new GameLoginPacket
+            {
+                SessionKey = redirectPacket.SessionKey,
+                AccountName = "admin",
+                Password = "password"
+            }
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(gameSession.NetworkSession.ClientType, Is.EqualTo(Moongate.UO.Data.Version.ClientType.SA));
+                Assert.That(gameSession.NetworkSession.IsEnhancedClient, Is.True);
+                Assert.That(gameSession.NetworkSession.ClientVersion?.SourceString, Is.EqualTo("67.0.0.114"));
             }
         );
     }
@@ -464,6 +555,7 @@ public class LoginHandlerTests
             new LoginHandlerTestCharacterService(),
             new NetworkServiceTestGameEventBusService(),
             new(),
+            new GameLoginHandoffService(),
             new FakeGameNetworkSessionService(),
             new GameLoopTestOutboundPacketSender()
         );


### PR DESCRIPTION
Closes #143

## Summary
- carry enhanced-client handshake metadata across the login-server to game-server reconnect
- reapply client type and client version on the game login socket before feature and character-list packets
- cover the redirect handoff with a regression test

## Verification
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~LoginHandlerTests|FullyQualifiedName~ClientTypePacketTests|FullyQualifiedName~ServerSelectPacketTests|FullyQualifiedName~CharactersStartingLocationsPacketTests|FullyQualifiedName~SupportFeaturesPacketTests"
- dotnet build src/Moongate.Server/Moongate.Server.csproj