### PR TITLE
fix: correct enhanced client server list ip order

### DIFF
--- a/src/Moongate.UO.Data/Data/GameServerEntry.cs
+++ b/src/Moongate.UO.Data/Data/GameServerEntry.cs
@@ -21,7 +21,7 @@ public class GameServerEntry
         writer.WriteAscii(ServerName, 32);
         writer.Write((byte)0);
         writer.Write((byte)0);
-        writer.Write(IpAddress.ToRawAddress());
+        writer.WriteLE(IpAddress.ToRawAddress());
 
         return writer.ToArray().AsMemory();
     }

--- a/tests/Moongate.Tests/Network/Packets/ServerListPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ServerListPacketTests.cs
@@ -52,4 +52,32 @@ public class ServerListPacketTests
             }
         );
     }
+
+    [Test]
+    public void Write_WithSingleShard_ShouldSerializeIpAddressInNetworkByteOrder()
+    {
+        var packet = new ServerListPacket(
+            new GameServerEntry
+            {
+                Index = 0,
+                ServerName = "Moongate Shard",
+                IpAddress = IPAddress.Parse("192.168.0.206")
+            }
+        );
+
+        var writer = new SpanWriter(128, true);
+        packet.Write(ref writer);
+        var data = writer.ToArray();
+        writer.Dispose();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(data[^4], Is.EqualTo(0xC0));
+                Assert.That(data[^3], Is.EqualTo(0xA8));
+                Assert.That(data[^2], Is.EqualTo(0x00));
+                Assert.That(data[^1], Is.EqualTo(0xCE));
+            }
+        );
+    }
 }


### PR DESCRIPTION
Closes #143

## Summary
- fix shard address serialization in server list packets
- send the shard IPv4 bytes in the order expected by UO clients
- add a regression test for explicit server list packet IP byte order

## Verification
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ServerListPacketTests"
- dotnet build src/Moongate.Server/Moongate.Server.csproj