### PR TITLE
fix: restore ModernUO server list address encoding

### DIFF
--- a/src/Moongate.UO.Data/Data/GameServerEntry.cs
+++ b/src/Moongate.UO.Data/Data/GameServerEntry.cs
@@ -21,7 +21,7 @@ public class GameServerEntry
         writer.WriteAscii(ServerName, 32);
         writer.Write((byte)0);
         writer.Write((byte)0);
-        writer.WriteLE(IpAddress.ToRawAddress());
+        writer.Write(IpAddress.ToRawAddress());
 
         return writer.ToArray().AsMemory();
     }

--- a/tests/Moongate.Tests/Network/Packets/ServerListPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/ServerListPacketTests.cs
@@ -54,7 +54,7 @@ public class ServerListPacketTests
     }
 
     [Test]
-    public void Write_WithSingleShard_ShouldSerializeIpAddressInNetworkByteOrder()
+    public void Write_WithSingleShard_ShouldSerializeIpAddressLikeModernUoServerList()
     {
         var packet = new ServerListPacket(
             new GameServerEntry
@@ -73,10 +73,10 @@ public class ServerListPacketTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(data[^4], Is.EqualTo(0xC0));
-                Assert.That(data[^3], Is.EqualTo(0xA8));
-                Assert.That(data[^2], Is.EqualTo(0x00));
-                Assert.That(data[^1], Is.EqualTo(0xCE));
+                Assert.That(data[^4], Is.EqualTo(0xCE));
+                Assert.That(data[^3], Is.EqualTo(0x00));
+                Assert.That(data[^2], Is.EqualTo(0xA8));
+                Assert.That(data[^1], Is.EqualTo(0xC0));
             }
         );
     }


### PR DESCRIPTION
Related to #143

## Summary
- revert the server-list IP byte-order regression introduced in #153
- serialize shard addresses in A8 exactly like ModernUO
- keep the EC shard-selection investigation open until the original issue is fully resolved

## Verification
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ServerListPacketTests"
- dotnet build src/Moongate.Server/Moongate.Server.csproj