### PR TITLE
fix: restore enhanced client shard select flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ Server port: `2593`
 UDP ping port: `12000`
 HTTP/UI API port: `8088`
 
-On multi-homed hosts or VM/lab setups, set `game.serverListingAddress` in `moongate.json` so shard redirects advertise the
-reachable server IP instead of relying on socket auto-detection.
-
 Transport encryption:
 
 - Moongate supports both plain and encrypted UO clients.

--- a/src/Moongate.Network.Packets/Incoming/System/SpyOnClientPacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/System/SpyOnClientPacket.cs
@@ -5,7 +5,7 @@ using Moongate.Network.Spans;
 
 namespace Moongate.Network.Packets.Incoming.System;
 
-[PacketHandler(0xD9, PacketSizing.Variable, Description = "Spy On Client")]
+[PacketHandler(0xD9, PacketSizing.Fixed, Length = 0x10C, Description = "Spy On Client")]
 
 /// <summary>
 /// Represents SpyOnClientPacket.
@@ -71,18 +71,6 @@ public class SpyOnClientPacket : BaseGameNetworkPacket
 
     protected override bool ParsePayload(ref SpanReader reader)
     {
-        if (reader.Remaining < 3)
-        {
-            return false;
-        }
-
-        var declaredLength = reader.ReadUInt16();
-
-        if (declaredLength != reader.Length)
-        {
-            return false;
-        }
-
         ClientInfoVersion = reader.ReadByte();
         InstanceId = reader.ReadUInt32();
         OsMajor = reader.ReadUInt32();
@@ -107,9 +95,9 @@ public class SpyOnClientPacket : BaseGameNetworkPacket
         ClientsRunning = reader.ReadByte();
         ClientsInstalled = reader.ReadByte();
         PartialInstalled = reader.ReadByte();
-        UnknownFlag = reader.ReadByte();
         LanguageCode = reader.ReadLittleUniSafe(4).TrimEnd();
         UnknownEnding = reader.ReadAsciiSafe(64).TrimEnd();
+        UnknownFlag = 0;
 
         return true;
     }

--- a/src/Moongate.Server/Data/Config/MoongateGameConfig.cs
+++ b/src/Moongate.Server/Data/Config/MoongateGameConfig.cs
@@ -9,8 +9,6 @@ public class MoongateGameConfig
 {
     public string ShardName { get; set; } = "Moongate Shard";
 
-    public string? ServerListingAddress { get; set; }
-
     public bool PingServerEnabled { get; set; } = true;
 
     public int PingServerPort { get; set; } = 12000;

--- a/src/Moongate.Server/Handlers/LoginHandler.cs
+++ b/src/Moongate.Server/Handlers/LoginHandler.cs
@@ -391,22 +391,6 @@ public class LoginHandler : BasePacketListener, IGameEventListener<PlayerCharact
 
     private IPAddress ResolveShardAddress(GameSession session)
     {
-        var configuredAddress = _serverConfig.Game.ServerListingAddress;
-
-        if (!string.IsNullOrWhiteSpace(configuredAddress))
-        {
-            if (IPAddress.TryParse(configuredAddress, out var configuredIp))
-            {
-                return configuredIp;
-            }
-
-            _logger.Warning(
-                "Configured server listing address '{ServerListingAddress}' is invalid. Falling back to detected local IP for session {SessionId}.",
-                configuredAddress,
-                session.SessionId
-            );
-        }
-
         var rawAddress = session.NetworkSession.LocalIpAddress;
 
         if (!string.IsNullOrWhiteSpace(rawAddress) && IPAddress.TryParse(rawAddress, out var resolved))

--- a/tests/Moongate.Tests/Network/Packets/SpyOnClientPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/SpyOnClientPacketTests.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Binary;
 using Moongate.Network.Packets.Incoming.System;
 using Moongate.Network.Spans;
 
@@ -54,8 +53,7 @@ public sealed class SpyOnClientPacketTests
     {
         var packet = new SpyOnClientPacket();
         var payload = BuildPacketPayload();
-
-        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(1, 2), 0xFFFF);
+        payload[0] = 0xD8;
         var parsed = packet.TryParse(payload);
 
         Assert.That(parsed, Is.False);
@@ -66,7 +64,6 @@ public sealed class SpyOnClientPacketTests
         var writer = new SpanWriter(300, true);
 
         writer.Write((byte)0xD9);
-        writer.Write((ushort)0); // placeholder length
         writer.Write((byte)0x02);
         writer.Write(0x11223344u);
         writer.Write(10u);
@@ -91,12 +88,10 @@ public sealed class SpyOnClientPacketTests
         writer.Write((byte)1);
         writer.Write((byte)1);
         writer.Write((byte)0);
-        writer.Write((byte)0);
         writer.WriteLittleUni("ENU", 4);
         writer.WriteAscii("tail", 64);
 
         var payload = writer.ToArray();
-        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(1, 2), (ushort)payload.Length);
         writer.Dispose();
 
         return payload;

--- a/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/LoginHandlerTests.cs
@@ -3,7 +3,6 @@ using Moongate.Network.Client;
 using Moongate.Network.Packets.Incoming.Login;
 using Moongate.Network.Packets.Outgoing.Login;
 using Moongate.Network.Spans;
-using Moongate.Server.Data.Config;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Handlers;
 using Moongate.Server.Interfaces.Characters;
@@ -530,93 +529,6 @@ public class LoginHandlerTests
         );
     }
 
-    [Test]
-    public async Task HandlePacketAsync_WhenAccountLoginSucceedsWithConfiguredServerListingAddress_ShouldAdvertiseConfiguredShardIp()
-    {
-        var queue = new BasePacketListenerTestOutgoingPacketQueue();
-        var accountService = new LoginHandlerTestAccountService
-        {
-            NextLoginResult = new()
-            {
-                Id = (Serial)0x00000001,
-                Username = "admin",
-                PasswordHash = "x"
-            }
-        };
-        var handler = CreateHandler(
-            queue: queue,
-            accountService: accountService,
-            config: new MoongateConfig
-            {
-                Game =
-                {
-                    ServerListingAddress = "192.168.0.153"
-                }
-            }
-        );
-
-        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
-        var session = new GameSession(new(client));
-
-        var handled = await handler.HandlePacketAsync(
-            session,
-            new AccountLoginPacket
-            {
-                Account = "admin",
-                Password = "password"
-            }
-        );
-
-        Assert.Multiple(
-            () =>
-            {
-                Assert.That(handled, Is.True);
-                Assert.That(queue.TryDequeue(out var outgoingPacket), Is.True);
-                Assert.That(outgoingPacket.Packet, Is.TypeOf<ServerListPacket>());
-                var serverListPacket = (ServerListPacket)outgoingPacket.Packet;
-                Assert.That(serverListPacket.Shards.Single().IpAddress.ToString(), Is.EqualTo("192.168.0.153"));
-            }
-        );
-    }
-
-    [Test]
-    public async Task HandlePacketAsync_WhenServerSelectSucceedsWithConfiguredServerListingAddress_ShouldRedirectToConfiguredShardIp()
-    {
-        var sender = new GameLoopTestOutboundPacketSender();
-        var handler = CreateHandler(
-            sender: sender,
-            config: new MoongateConfig
-            {
-                Game =
-                {
-                    ServerListingAddress = "192.168.0.153"
-                }
-            }
-        );
-
-        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
-        var session = new GameSession(new(client));
-
-        var handled = await handler.HandlePacketAsync(
-            session,
-            new ServerSelectPacket
-            {
-                SelectedServerIndex = 0
-            }
-        );
-
-        Assert.Multiple(
-            () =>
-            {
-                Assert.That(handled, Is.True);
-                Assert.That(sender.SentPackets, Has.Count.EqualTo(1));
-                Assert.That(sender.SentPackets[0].Packet, Is.TypeOf<ServerRedirectPacket>());
-                var redirectPacket = (ServerRedirectPacket)sender.SentPackets[0].Packet;
-                Assert.That(redirectPacket.IPAddress.ToString(), Is.EqualTo("192.168.0.153"));
-            }
-        );
-    }
-
     private static byte[] BuildClientVersionPayload(string version, bool includeNullTerminator)
     {
         var writer = new SpanWriter(64, true);
@@ -636,22 +548,15 @@ public class LoginHandlerTests
         return data;
     }
 
-    private static LoginHandler CreateHandler(
-        BasePacketListenerTestOutgoingPacketQueue? queue = null,
-        LoginHandlerTestAccountService? accountService = null,
-        LoginHandlerTestCharacterService? characterService = null,
-        MoongateConfig? config = null,
-        FakeGameNetworkSessionService? sessionService = null,
-        GameLoopTestOutboundPacketSender? sender = null
-    )
+    private static LoginHandler CreateHandler()
         => new(
-            queue ?? new BasePacketListenerTestOutgoingPacketQueue(),
-            accountService ?? new LoginHandlerTestAccountService(),
-            characterService ?? new LoginHandlerTestCharacterService(),
+            new BasePacketListenerTestOutgoingPacketQueue(),
+            new LoginHandlerTestAccountService(),
+            new LoginHandlerTestCharacterService(),
             new NetworkServiceTestGameEventBusService(),
-            config ?? new(),
+            new(),
             new GameLoginHandoffService(),
-            sessionService ?? new FakeGameNetworkSessionService(),
-            sender ?? new GameLoopTestOutboundPacketSender()
+            new FakeGameNetworkSessionService(),
+            new GameLoopTestOutboundPacketSender()
         );
 }

--- a/tests/Moongate.Tests/Server/Handlers/PlayerHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/PlayerHandlerTests.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Binary;
 using System.Net.Sockets;
 using Moongate.Network.Client;
 using Moongate.Network.Packets.Incoming.System;
@@ -46,7 +45,6 @@ public sealed class PlayerHandlerTests
         var writer = new SpanWriter(300, true);
 
         writer.Write((byte)0xD9);
-        writer.Write((ushort)0); // placeholder length
         writer.Write((byte)0x02);
         writer.Write(0x11223344u);
         writer.Write(10u);
@@ -71,12 +69,10 @@ public sealed class PlayerHandlerTests
         writer.Write((byte)1);
         writer.Write((byte)1);
         writer.Write((byte)0);
-        writer.Write((byte)0);
         writer.WriteLittleUni("ENU", 4);
         writer.WriteAscii("tail", 64);
 
         var payload = writer.ToArray();
-        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(1, 2), (ushort)payload.Length);
         writer.Dispose();
 
         return payload;

--- a/tests/Moongate.Tests/Server/Services/Network/NetworkServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Network/NetworkServiceTests.cs
@@ -8,6 +8,8 @@ using Moongate.Network.Encryption;
 using Moongate.Network.Events;
 using Moongate.Network.Packets.Incoming.Login;
 using Moongate.Network.Packets.Incoming.Speech;
+using Moongate.Network.Packets.Incoming.System;
+using Moongate.Network.Spans;
 using Moongate.Network.Types.Encryption;
 using Moongate.Server.Data.Events.Connections;
 using Moongate.Server.Data.Internal.Network;
@@ -438,6 +440,49 @@ public class NetworkServiceTests
     }
 
     [Test]
+    public void OnClientData_WhenHardwareInfoPacketPrecedesServerSelect_ShouldParseBothPackets()
+    {
+        var messageBus = new NetworkServiceTestMessageBusService();
+        var eventBus = new NetworkServiceTestGameEventBusService();
+        var sessions = new GameNetworkSessionService();
+        using var service = new NetworkService(
+            messageBus,
+            eventBus,
+            new PacketDispatchService(),
+            sessions,
+            new()
+            {
+                RootDirectory = Path.GetTempPath(),
+                LogLevel = LogLevelType.Debug,
+                LogPacketData = false
+            }
+        );
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        InvokeOnClientData(service, client, BuildLoginSeedPacket(0x12345678, 67, 0, 114, 0));
+        Assert.That(service.TryDequeueParsedPacket(out var loginSeedPacket), Is.True);
+        Assert.That(loginSeedPacket.Packet, Is.TypeOf<LoginSeedPacket>());
+
+        InvokeOnClientData(service, client, BuildHardwareInfoPacket());
+        InvokeOnClientData(service, client, [0xA0, 0x00, 0x00]);
+
+        var hasHardwarePacket = service.TryDequeueParsedPacket(out var hardwarePacket);
+        var hasServerSelectPacket = service.TryDequeueParsedPacket(out var serverSelectPacket);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(hasHardwarePacket, Is.True);
+                Assert.That(hasServerSelectPacket, Is.True);
+                Assert.That(hardwarePacket.PacketId, Is.EqualTo(0xD9));
+                Assert.That(hardwarePacket.Packet, Is.TypeOf<SpyOnClientPacket>());
+                Assert.That(serverSelectPacket.PacketId, Is.EqualTo(0xA0));
+                Assert.That(serverSelectPacket.Packet, Is.TypeOf<ServerSelectPacket>());
+            }
+        );
+    }
+
+    [Test]
     public void OnClientData_WhenReconnectSeedIsZero_ShouldDiscardAndWaitForNewHandshakeData()
     {
         var messageBus = new NetworkServiceTestMessageBusService();
@@ -739,6 +784,44 @@ public class NetworkServiceTests
         WriteInt32BigEndian(payload, 9, minor);
         WriteInt32BigEndian(payload, 13, revision);
         WriteInt32BigEndian(payload, 17, patch);
+
+        return payload;
+    }
+
+    private static byte[] BuildHardwareInfoPacket()
+    {
+        var writer = new SpanWriter(300, true);
+
+        writer.Write((byte)0xD9);
+        writer.Write((byte)0x02);
+        writer.Write(0x45AFB128u);
+        writer.Write(6u);
+        writer.Write(2u);
+        writer.Write(9200u);
+        writer.Write((byte)1);
+        writer.Write(15u);
+        writer.Write(4u);
+        writer.Write(3160u);
+        writer.Write((byte)4);
+        writer.Write(3416u);
+        writer.Write(1368u);
+        writer.Write(1365u);
+        writer.Write(32u);
+        writer.Write((ushort)9);
+        writer.Write((ushort)0);
+        writer.WriteLittleUni("Parallels Display Adapter (WDDM)", 64);
+        writer.Write(0u);
+        writer.Write(0u);
+        writer.Write(0u);
+        writer.Write((byte)0);
+        writer.Write((byte)0);
+        writer.Write((byte)0);
+        writer.Write((byte)0);
+        writer.WriteLittleUni("ENU", 4);
+        writer.WriteAscii(string.Empty, 64);
+
+        var payload = writer.ToArray();
+        writer.Dispose();
 
         return payload;
     }


### PR DESCRIPTION
## Summary
- revert the temporary configured shard redirect override from #155
- parse EC hardware info packet 0xD9 using the fixed ModernUO layout so it no longer blocks shard selection
- add regression coverage for the 0xD9 -> 0xA0 handshake path

## Verification
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~SpyOnClientPacketTests|FullyQualifiedName~PlayerHandlerTests|FullyQualifiedName~NetworkServiceTests|FullyQualifiedName~LoginHandlerTests"

Closes #143