### PR TITLE
feat: implement player character profile packet flow

### DIFF
--- a/docs/articles/networking/packet-reference/0xB8.md
+++ b/docs/articles/networking/packet-reference/0xB8.md
@@ -13,6 +13,7 @@ Do not edit manually. Re-run the generator instead.
 ## Moongate Packet Classes
 
 - `RequestCharProfilePacket` (Incoming, Variable, length `-1`) from `src/Moongate.Network.Packets/Incoming/Player/RequestCharProfilePacket.cs`
+- `DisplayCharacterProfilePacket` (Outgoing, Variable, length `-1`) from `src/Moongate.Network.Packets/Outgoing/Entity/DisplayCharacterProfilePacket.cs`
 
 ## Current Moongate Behavior
 

--- a/docs/articles/networking/packet-reference/index.md
+++ b/docs/articles/networking/packet-reference/index.md
@@ -160,7 +160,7 @@ Generated packet pages: `201`
 | `0xB5` | Open Chat Window | `implemented` | Client | 64 bytes | OpenChatWindowPacket | [0xB5.md](0xB5.md) |
 | `0xB6` | Send Help/Tip Request | `implemented` | Client | 9 Bytes | SendHelpTipRequestPacket | [0xB6.md](0xB6.md) |
 | `0xB7` | Help/Tip Data | `placeholder` | Server | Variable | None | [0xB7.md](0xB7.md) |
-| `0xB8` | Request/Char Profile | `implemented` | Both | Variable | RequestCharProfilePacket | [0xB8.md](0xB8.md) |
+| `0xB8` | Request/Char Profile | `implemented` | Both | Variable | RequestCharProfilePacket, DisplayCharacterProfilePacket | [0xB8.md](0xB8.md) |
 | `0xB9` | Enable locked client features | `implemented` | Server | 3/5 Bytes | SupportFeaturesPacket | [0xB9.md](0xB9.md) |
 | `0xBA` | Quest Arrow | `placeholder` | Server | 6 or 10 Bytes | None | [0xBA.md](0xBA.md) |
 | `0xBB` | Ultima Messenger | `placeholder` | Both | 9 Bytes | None | [0xBB.md](0xBB.md) |

--- a/docs/articles/networking/pol-packet-coverage.md
+++ b/docs/articles/networking/pol-packet-coverage.md
@@ -112,7 +112,7 @@ It is meant for gap analysis against the POL packet catalog, not just for docume
 | `0xA7` | Request tip / notice window | C -> S | `?Packet=0xA7` | `RequestTipNoticeWindowPacket` | `parse-only` | Tip flow missing |
 | `0xB3` | Chat text | C -> S | `?Packet=0xB3` | `ChatTextPacket` | `handler` | ModernUO-style conference chat action dispatch via `IChatSystemService` |
 | `0xB6` | Help / tip request | C -> S | `?Packet=0xB6` | `SendHelpTipRequestPacket` | `parse-only` | Tip flow missing |
-| `0xB8` | Character profile request | C -> S | `?Packet=0xB8` | `RequestCharProfilePacket` | `parse-only` | Profile flow missing |
+| `0xB8` | Character profile request | C -> S | `?Packet=0xB8` | `RequestCharProfilePacket` | `handler` | `CharacterProfileHandler` | Player-only profile display and self-edit flow with lock and account-age footer |
 | `0xBE` | Assist version | C -> S | `?Packet=0xBE` | `AssistVersionPacket` | `parse-only` | No behavior attached |
 | `0xC2` | Unicode text entry | C -> S | `?Packet=0xC2` | `UnicodeTextEntryPacket` | `parse-only` | Text entry flow missing |
 | `0xD0` | Configuration file | C -> S | `?Packet=0xD0` | `ConfigurationFilePacket` | `parse-only` | No behavior attached |

--- a/src/Moongate.Network.Packets/Incoming/Player/RequestCharProfilePacket.cs
+++ b/src/Moongate.Network.Packets/Incoming/Player/RequestCharProfilePacket.cs
@@ -2,6 +2,7 @@ using Moongate.Network.Packets.Attributes;
 using Moongate.Network.Packets.Base;
 using Moongate.Network.Packets.Types.Packets;
 using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
 
 namespace Moongate.Network.Packets.Incoming.Player;
 
@@ -12,9 +13,68 @@ namespace Moongate.Network.Packets.Incoming.Player;
 /// </summary>
 public class RequestCharProfilePacket : BaseGameNetworkPacket
 {
+    private const int MaximumProfileCharacters = 511;
+
+    public byte Mode { get; private set; }
+
+    public Serial TargetId { get; private set; }
+
+    public ushort? CommandType { get; private set; }
+
+    public ushort? CharacterCount { get; private set; }
+
+    public string? ProfileText { get; private set; }
+
     public RequestCharProfilePacket()
         : base(0xB8) { }
 
     protected override bool ParsePayload(ref SpanReader reader)
-        => true;
+    {
+        if (reader.Remaining < 7)
+        {
+            return false;
+        }
+
+        var declaredLength = reader.ReadUInt16();
+
+        if (declaredLength != reader.Length || reader.Remaining < 5)
+        {
+            return false;
+        }
+
+        Mode = reader.ReadByte();
+        TargetId = (Serial)reader.ReadUInt32();
+        CommandType = null;
+        CharacterCount = null;
+        ProfileText = null;
+
+        if (Mode == 0x00)
+        {
+            return reader.Remaining == 0;
+        }
+
+        if (Mode != 0x01 || reader.Remaining < 4)
+        {
+            return false;
+        }
+
+        CommandType = reader.ReadUInt16();
+        CharacterCount = reader.ReadUInt16();
+
+        if (CharacterCount.Value > MaximumProfileCharacters)
+        {
+            return false;
+        }
+
+        var requiredBytes = CharacterCount.Value * 2;
+
+        if (reader.Remaining != requiredBytes)
+        {
+            return false;
+        }
+
+        ProfileText = CharacterCount.Value == 0 ? string.Empty : reader.ReadBigUni(CharacterCount.Value);
+
+        return reader.Remaining == 0;
+    }
 }

--- a/src/Moongate.Network.Packets/Outgoing/Entity/DisplayCharacterProfilePacket.cs
+++ b/src/Moongate.Network.Packets/Outgoing/Entity/DisplayCharacterProfilePacket.cs
@@ -1,0 +1,42 @@
+using Moongate.Network.Packets.Base;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Network.Packets.Outgoing.Entity;
+
+public sealed class DisplayCharacterProfilePacket : BaseGameNetworkPacket
+{
+    public Serial TargetId { get; set; }
+
+    public string Header { get; set; } = string.Empty;
+
+    public string Footer { get; set; } = string.Empty;
+
+    public string Body { get; set; } = string.Empty;
+
+    public DisplayCharacterProfilePacket()
+        : base(0xB8, -1) { }
+
+    public DisplayCharacterProfilePacket(Serial targetId, string? header, string? footer, string? body)
+        : this()
+    {
+        TargetId = targetId;
+        Header = header ?? string.Empty;
+        Footer = footer ?? string.Empty;
+        Body = body ?? string.Empty;
+    }
+
+    public override void Write(ref SpanWriter writer)
+    {
+        writer.Write(OpCode);
+        writer.Write((ushort)0);
+        writer.Write((uint)TargetId);
+        writer.WriteAsciiNull(Header);
+        writer.WriteBigUniNull(Footer);
+        writer.WriteBigUniNull(Body);
+        writer.WritePacketLength();
+    }
+
+    protected override bool ParsePayload(ref SpanReader reader)
+        => throw new NotSupportedException();
+}

--- a/src/Moongate.Server/Data/Internal/Interaction/CharacterProfileHelper.cs
+++ b/src/Moongate.Server/Data/Internal/Interaction/CharacterProfileHelper.cs
@@ -1,0 +1,176 @@
+using Moongate.Server.Data.Internal.Scripting;
+using Moongate.Server.Data.Session;
+using Moongate.UO.Data.Data.Reputation;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Server.Data.Internal.Interaction;
+
+internal static class CharacterProfileHelper
+{
+    public static string BuildFooter(GameSession session, UOMobileEntity requester, UOMobileEntity target, UOAccountEntity? account)
+    {
+        var isSelf = requester.Id == target.Id;
+
+        if (IsLocked(target))
+        {
+            if (isSelf)
+            {
+                return "Your profile has been locked.";
+            }
+
+            return session.AccountType >= AccountType.GameMaster ? "This profile has been locked." : string.Empty;
+        }
+
+        if (!isSelf || account is null)
+        {
+            return string.Empty;
+        }
+
+        return FormatAccountAge(DateTime.UtcNow - account.CreatedUtc);
+    }
+
+    public static string BuildHeader(UOMobileEntity requester, UOMobileEntity target)
+    {
+        var configuration = ReputationTitleRuntime.Current;
+        var parts = new List<string>(4);
+
+        if (ShouldIncludeReputationTitle(requester, target))
+        {
+            var reputationTitle = GetReputationTitle(target.Fame, target.Karma, configuration);
+
+            if (!string.IsNullOrWhiteSpace(reputationTitle))
+            {
+                parts.Add(reputationTitle);
+            }
+        }
+
+        if (target.Fame >= 10000)
+        {
+            parts.Add(target.Gender == GenderType.Female ? configuration.Honorifics.Female : configuration.Honorifics.Male);
+        }
+
+        if (!string.IsNullOrWhiteSpace(target.Name))
+        {
+            parts.Add(target.Name);
+        }
+
+        if (!string.IsNullOrWhiteSpace(target.Title))
+        {
+            parts.Add(target.Title);
+        }
+
+        return string.Join(' ', parts);
+    }
+
+    public static string GetBody(UOMobileEntity mobile)
+        => mobile.TryGetCustomString(MobileCustomParamKeys.Profile.Body, out var body) && !string.IsNullOrEmpty(body)
+            ? body
+            : string.Empty;
+
+    public static Serial GetDisplaySerial(UOMobileEntity requester, UOMobileEntity target)
+        => requester.Id == target.Id && IsLocked(target) ? Serial.Zero : target.Id;
+
+    public static bool IsLocked(UOMobileEntity mobile)
+        => mobile.TryGetCustomBoolean(MobileCustomParamKeys.Profile.Locked, out var locked) && locked;
+
+    public static string SanitizeBody(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var buffer = new char[normalized.Length];
+
+        for (var i = 0; i < normalized.Length; i++)
+        {
+            var chr = normalized[i];
+            buffer[i] = chr == '\n' || chr == '\t' || !char.IsControl(chr) ? chr : ' ';
+        }
+
+        return new string(buffer);
+    }
+
+    public static void SetBody(UOMobileEntity mobile, string? body)
+        => mobile.SetCustomString(MobileCustomParamKeys.Profile.Body, SanitizeBody(body));
+
+    public static void SetLocked(UOMobileEntity mobile, bool locked)
+        => mobile.SetCustomBoolean(MobileCustomParamKeys.Profile.Locked, locked);
+
+    private static string FormatAccountAge(TimeSpan age)
+    {
+        if (TryFormatAge(age.TotalDays, "This account is {0} day{1} old.", out var formatted))
+        {
+            return formatted;
+        }
+
+        if (TryFormatAge(age.TotalHours, "This account is {0} hour{1} old.", out formatted))
+        {
+            return formatted;
+        }
+
+        if (TryFormatAge(age.TotalMinutes, "This account is {0} minute{1} old.", out formatted))
+        {
+            return formatted;
+        }
+
+        return TryFormatAge(age.TotalSeconds, "This account is {0} second{1} old.", out formatted)
+            ? formatted
+            : string.Empty;
+    }
+
+    private static string GetReputationTitle(
+        int fame,
+        int karma,
+        ReputationTitleConfiguration configuration
+    )
+    {
+        var fameEntry = configuration.FameBuckets[^1];
+
+        foreach (var candidate in configuration.FameBuckets)
+        {
+            fameEntry = candidate;
+
+            if (fame <= candidate.MaxFame)
+            {
+                break;
+            }
+        }
+
+        var karmaEntry = fameEntry.KarmaBuckets[^1];
+
+        foreach (var candidate in fameEntry.KarmaBuckets)
+        {
+            karmaEntry = candidate;
+
+            if (karma <= candidate.MaxKarma)
+            {
+                break;
+            }
+        }
+
+        return karmaEntry.Title;
+    }
+
+    private static bool ShouldIncludeReputationTitle(UOMobileEntity requester, UOMobileEntity target)
+        => requester.Id == target.Id || target.Fame >= 5000;
+
+    private static bool TryFormatAge(double value, string format, out string result)
+    {
+        if (value >= 1.0)
+        {
+            var amount = (int)value;
+            result = string.Format(format, amount, amount != 1 ? "s" : "");
+
+            return true;
+        }
+
+        result = string.Empty;
+
+        return false;
+    }
+}

--- a/src/Moongate.Server/Data/Internal/Scripting/MobileCustomParamKeys.Profile.cs
+++ b/src/Moongate.Server/Data/Internal/Scripting/MobileCustomParamKeys.Profile.cs
@@ -1,0 +1,10 @@
+namespace Moongate.Server.Data.Internal.Scripting;
+
+public static partial class MobileCustomParamKeys
+{
+    public static class Profile
+    {
+        public const string Body = "profile_body";
+        public const string Locked = "profile_locked";
+    }
+}

--- a/src/Moongate.Server/Data/Internal/Scripting/MobileCustomParamKeys.cs
+++ b/src/Moongate.Server/Data/Internal/Scripting/MobileCustomParamKeys.cs
@@ -1,6 +1,6 @@
 namespace Moongate.Server.Data.Internal.Scripting;
 
-public static class MobileCustomParamKeys
+public static partial class MobileCustomParamKeys
 {
     public static class Loot
     {

--- a/src/Moongate.Server/Handlers/CharacterProfileHandler.cs
+++ b/src/Moongate.Server/Handlers/CharacterProfileHandler.cs
@@ -1,0 +1,122 @@
+using Moongate.Network.Packets.Data.Packets;
+using Moongate.Network.Packets.Incoming.Player;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Network.Packets.Outgoing.Speech;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Internal.Interaction;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Accounting;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Listeners.Base;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Server.Handlers;
+
+[RegisterPacketHandler(PacketDefinition.RequestCharProfilePacket)]
+public sealed class CharacterProfileHandler : BasePacketListener
+{
+    private const int DisplayRange = 12;
+    private const string LockedProfileMessage = "Your profile is locked. You may not change it.";
+
+    private readonly IAccountService _accountService;
+    private readonly IMobileService _mobileService;
+
+    public CharacterProfileHandler(
+        IOutgoingPacketQueue outgoingPacketQueue,
+        IAccountService accountService,
+        IMobileService mobileService
+    )
+        : base(outgoingPacketQueue)
+    {
+        _accountService = accountService;
+        _mobileService = mobileService;
+    }
+
+    protected override async Task<bool> HandleCoreAsync(GameSession session, IGameNetworkPacket packet)
+    {
+        if (packet is not RequestCharProfilePacket requestPacket || session.Character is null)
+        {
+            return true;
+        }
+
+        var target = await ResolveTargetAsync(session, requestPacket.TargetId);
+
+        if (target is null || !target.IsPlayer)
+        {
+            return true;
+        }
+
+        return requestPacket.Mode switch
+        {
+            0x00 => await HandleDisplayRequestAsync(session, target),
+            0x01 => await HandleUpdateRequestAsync(session, target, requestPacket.ProfileText),
+            _ => true
+        };
+    }
+
+    private async Task<bool> HandleDisplayRequestAsync(GameSession session, UOMobileEntity target)
+    {
+        var requester = session.Character!;
+
+        if (!CanDisplayProfile(requester, target))
+        {
+            return true;
+        }
+
+        var header = CharacterProfileHelper.BuildHeader(requester, target);
+        var body = CharacterProfileHelper.GetBody(target);
+        var account = requester.Id == target.Id ? await _accountService.GetAccountAsync(session.AccountId) : null;
+        var footer = CharacterProfileHelper.BuildFooter(session, requester, target, account);
+        var serial = CharacterProfileHelper.GetDisplaySerial(requester, target);
+
+        Enqueue(session, new DisplayCharacterProfilePacket(serial, header, footer, body));
+
+        return true;
+    }
+
+    private async Task<bool> HandleUpdateRequestAsync(GameSession session, UOMobileEntity target, string? profileText)
+    {
+        _ = target;
+
+        var requester = session.Character!;
+
+        if (CharacterProfileHelper.IsLocked(requester))
+        {
+            Enqueue(session, SpeechMessageFactory.CreateSystem(LockedProfileMessage));
+
+            return true;
+        }
+
+        CharacterProfileHelper.SetBody(requester, profileText);
+        await _mobileService.CreateOrUpdateAsync(requester);
+
+        return true;
+    }
+
+    private async Task<UOMobileEntity?> ResolveTargetAsync(GameSession session, Moongate.UO.Data.Ids.Serial targetId)
+    {
+        if (session.Character is not null && session.Character.Id == targetId)
+        {
+            return session.Character;
+        }
+
+        return await _mobileService.GetAsync(targetId);
+    }
+
+    private static bool CanDisplayProfile(UOMobileEntity requester, UOMobileEntity target)
+    {
+        if (requester.MapId != target.MapId)
+        {
+            return false;
+        }
+
+        if (!requester.Location.InRange(target.Location, DisplayRange))
+        {
+            return false;
+        }
+
+        return requester.Id == target.Id || !target.IsHidden;
+    }
+}

--- a/tests/Moongate.Tests/Network/Packets/DisplayCharacterProfilePacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/DisplayCharacterProfilePacketTests.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Network.Packets;
+
+public sealed class DisplayCharacterProfilePacketTests
+{
+    [Test]
+    public void Write_ShouldEmitModernUoCompatibleProfilePayload()
+    {
+        var packet = new DisplayCharacterProfilePacket(
+            (Serial)0x00000001u,
+            "Lord Marcus",
+            "This account is 2 days old.",
+            "Hello"
+        );
+        var writer = new SpanWriter(256, true);
+        packet.Write(ref writer);
+        var bytes = writer.ToArray();
+        writer.Dispose();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(bytes[0], Is.EqualTo(0xB8));
+                Assert.That((bytes[1] << 8) | bytes[2], Is.EqualTo(bytes.Length));
+                Assert.That(ToUInt32(bytes, 3), Is.EqualTo(0x00000001u));
+                Assert.That(ReadAsciiNull(bytes, 7), Is.EqualTo("Lord Marcus"));
+
+                var footerOffset = 7 + "Lord Marcus".Length + 1;
+                var footer = ReadBigEndianUnicodeNull(bytes, footerOffset, out var bodyOffset);
+
+                Assert.That(footer, Is.EqualTo("This account is 2 days old."));
+                Assert.That(ReadBigEndianUnicodeNull(bytes, bodyOffset, out _), Is.EqualTo("Hello"));
+            }
+        );
+    }
+
+    [Test]
+    public void Write_WhenStringsAreNull_ShouldEmitEmptyNullTerminatedFields()
+    {
+        var packet = new DisplayCharacterProfilePacket((Serial)0x00000002u, null, null, null);
+        var writer = new SpanWriter(128, true);
+        packet.Write(ref writer);
+        var bytes = writer.ToArray();
+        writer.Dispose();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(bytes[0], Is.EqualTo(0xB8));
+                Assert.That((bytes[1] << 8) | bytes[2], Is.EqualTo(bytes.Length));
+                Assert.That(ToUInt32(bytes, 3), Is.EqualTo(0x00000002u));
+                Assert.That(bytes[7], Is.EqualTo(0x00));
+                Assert.That(bytes[8], Is.EqualTo(0x00));
+                Assert.That(bytes[9], Is.EqualTo(0x00));
+                Assert.That(bytes[10], Is.EqualTo(0x00));
+                Assert.That(bytes[11], Is.EqualTo(0x00));
+            }
+        );
+    }
+
+    private static string ReadAsciiNull(byte[] bytes, int offset)
+    {
+        var end = offset;
+
+        while (end < bytes.Length && bytes[end] != 0x00)
+        {
+            end++;
+        }
+
+        return Encoding.ASCII.GetString(bytes, offset, end - offset);
+    }
+
+    private static string ReadBigEndianUnicodeNull(byte[] bytes, int offset, out int nextOffset)
+    {
+        var end = offset;
+
+        while (end + 1 < bytes.Length)
+        {
+            if (bytes[end] == 0x00 && bytes[end + 1] == 0x00)
+            {
+                break;
+            }
+
+            end += 2;
+        }
+
+        var value = end == offset
+                        ? string.Empty
+                        : Encoding.BigEndianUnicode.GetString(bytes, offset, end - offset);
+
+        nextOffset = end + 2;
+
+        return value;
+    }
+
+    private static uint ToUInt32(byte[] bytes, int offset)
+        => (uint)((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]);
+}

--- a/tests/Moongate.Tests/Network/Packets/RequestCharProfilePacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/RequestCharProfilePacketTests.cs
@@ -1,0 +1,105 @@
+using Moongate.Network.Packets.Incoming.Player;
+using Moongate.Network.Spans;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Network.Packets;
+
+public sealed class RequestCharProfilePacketTests
+{
+    [Test]
+    public void TryParse_WhenDisplayRequest_ShouldReadModeAndTarget()
+    {
+        var bytes = BuildDisplayRequest((uint)0x00000042);
+        var packet = new RequestCharProfilePacket();
+
+        var ok = packet.TryParse(bytes);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(packet.Mode, Is.EqualTo(0x00));
+                Assert.That(packet.TargetId, Is.EqualTo((Serial)0x00000042u));
+                Assert.That(packet.CommandType, Is.Null);
+                Assert.That(packet.CharacterCount, Is.Null);
+                Assert.That(packet.ProfileText, Is.Null);
+            }
+        );
+    }
+
+    [Test]
+    public void TryParse_WhenUpdateRequest_ShouldReadAllFields()
+    {
+        var bytes = BuildUpdateRequest(
+            (uint)0x00000044,
+            0x0001,
+            "Hello world"
+        );
+        var packet = new RequestCharProfilePacket();
+
+        var ok = packet.TryParse(bytes);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(packet.Mode, Is.EqualTo(0x01));
+                Assert.That(packet.TargetId, Is.EqualTo((Serial)0x00000044u));
+                Assert.That(packet.CommandType, Is.EqualTo((ushort)0x0001));
+                Assert.That(packet.CharacterCount, Is.EqualTo((ushort)11));
+                Assert.That(packet.ProfileText, Is.EqualTo("Hello world"));
+            }
+        );
+    }
+
+    [Test]
+    public void TryParse_WhenUpdateRequestExceedsModernUoLimit_ShouldFail()
+    {
+        var oversizedText = new string('a', 512);
+        var bytes = BuildUpdateRequest(
+            (uint)0x00000045,
+            0x0001,
+            oversizedText
+        );
+        var packet = new RequestCharProfilePacket();
+
+        var ok = packet.TryParse(bytes);
+
+        Assert.That(ok, Is.False);
+    }
+
+    private static byte[] BuildDisplayRequest(uint targetId)
+    {
+        var writer = new SpanWriter(32, true);
+        writer.Write((byte)0xB8);
+        writer.Write((ushort)0);
+        writer.Write((byte)0x00);
+        writer.Write(targetId);
+        writer.WritePacketLength();
+        var bytes = writer.ToArray();
+        writer.Dispose();
+
+        return bytes;
+    }
+
+    private static byte[] BuildUpdateRequest(
+        uint targetId,
+        ushort commandType,
+        string profileText
+    )
+    {
+        var writer = new SpanWriter(512, true);
+        writer.Write((byte)0xB8);
+        writer.Write((ushort)0);
+        writer.Write((byte)0x01);
+        writer.Write(targetId);
+        writer.Write(commandType);
+        writer.Write((ushort)profileText.Length);
+        writer.WriteBigUni(profileText);
+        writer.WritePacketLength();
+        var bytes = writer.ToArray();
+        writer.Dispose();
+
+        return bytes;
+    }
+}

--- a/tests/Moongate.Tests/Server/Handlers/CharacterProfileHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/CharacterProfileHandlerTests.cs
@@ -1,0 +1,555 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.Player;
+using Moongate.Network.Packets.Outgoing.Entity;
+using Moongate.Network.Packets.Outgoing.Speech;
+using Moongate.Network.Spans;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Handlers;
+using Moongate.Server.Interfaces.Services.Accounting;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Handlers;
+
+public sealed class CharacterProfileHandlerTests
+{
+    private sealed class TestAccountService : IAccountService
+    {
+        public Dictionary<Serial, UOAccountEntity> AccountsById { get; } = [];
+
+        public Task<bool> CheckAccountExistsAsync(string username)
+        {
+            _ = username;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<UOAccountEntity?> CreateAccountAsync(
+            string username,
+            string password,
+            string email = "",
+            AccountType accountType = AccountType.Regular
+        )
+        {
+            _ = username;
+            _ = password;
+            _ = email;
+            _ = accountType;
+
+            return Task.FromResult<UOAccountEntity?>(null);
+        }
+
+        public Task<bool> DeleteAccountAsync(Serial accountId)
+        {
+            _ = accountId;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<UOAccountEntity?> GetAccountAsync(Serial accountId)
+        {
+            AccountsById.TryGetValue(accountId, out var account);
+
+            return Task.FromResult(account);
+        }
+
+        public Task<IReadOnlyList<UOAccountEntity>> GetAccountsAsync(CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+
+            return Task.FromResult<IReadOnlyList<UOAccountEntity>>(AccountsById.Values.ToArray());
+        }
+
+        public Task<UOAccountEntity?> LoginAsync(string username, string password)
+        {
+            _ = username;
+            _ = password;
+
+            return Task.FromResult<UOAccountEntity?>(null);
+        }
+
+        public Task<UOAccountEntity?> UpdateAccountAsync(
+            Serial accountId,
+            string? username = null,
+            string? password = null,
+            string? email = null,
+            AccountType? accountType = null,
+            bool? isLocked = null,
+            bool clearRecoveryCode = false,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = accountId;
+            _ = username;
+            _ = password;
+            _ = email;
+            _ = accountType;
+            _ = isLocked;
+            _ = clearRecoveryCode;
+            _ = cancellationToken;
+
+            return Task.FromResult<UOAccountEntity?>(null);
+        }
+    }
+
+    private sealed class TestMobileService : IMobileService
+    {
+        public Dictionary<Serial, UOMobileEntity> MobilesById { get; } = [];
+
+        public UOMobileEntity? LastUpdatedMobile { get; private set; }
+
+        public int CreateOrUpdateCalls { get; private set; }
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            CreateOrUpdateCalls++;
+            LastUpdatedMobile = mobile;
+            MobilesById[mobile.Id] = mobile;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = id;
+            _ = cancellationToken;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> DismountAsync(Serial riderId, CancellationToken cancellationToken = default)
+        {
+            _ = riderId;
+            _ = cancellationToken;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            MobilesById.TryGetValue(id, out var mobile);
+
+            return Task.FromResult(mobile);
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+            _ = cancellationToken;
+
+            return Task.FromResult(new List<UOMobileEntity>());
+        }
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => throw new NotSupportedException();
+
+        public Task<bool> TryMountAsync(Serial riderId, Serial mountId, CancellationToken cancellationToken = default)
+        {
+            _ = riderId;
+            _ = mountId;
+            _ = cancellationToken;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult((false, (UOMobileEntity?)null));
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplaySelf_ShouldEnqueueProfileWithAccountAgeFooter()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Tommy", (Serial)0x500, new(100, 100, 0));
+        self.Fame = 10000;
+        self.Karma = 10000;
+        self.Title = "the brave";
+        self.Gender = GenderType.Male;
+        self.SetCustomString("profile_body", "Hello Britannia");
+        accounts.AccountsById[self.AccountId] = new()
+        {
+            Id = self.AccountId,
+            Username = "admin",
+            PasswordHash = "hash",
+            CreatedUtc = DateTime.UtcNow.AddDays(-3).AddMinutes(-5)
+        };
+
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var packet = ParseDisplayPacket(self.Id);
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.Packet, Is.TypeOf<DisplayCharacterProfilePacket>());
+
+                var displayPacket = (DisplayCharacterProfilePacket)outbound.Packet;
+                Assert.That(displayPacket.TargetId, Is.EqualTo(self.Id));
+                Assert.That(displayPacket.Header, Is.EqualTo("The Glorious Lord Tommy the brave"));
+                Assert.That(displayPacket.Body, Is.EqualTo("Hello Britannia"));
+                Assert.That(displayPacket.Footer, Is.EqualTo("This account is 3 days old."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplayOtherVisiblePlayer_ShouldEnqueueProfileWithoutSelfFooter()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Viewer", (Serial)0x500, new(100, 100, 0));
+        var target = CreatePlayer((Serial)0x101, "Target", (Serial)0x501, new(105, 100, 0));
+        target.Fame = 4000;
+        target.Karma = 1000;
+        target.Title = "the tailor";
+        target.SetCustomString("profile_body", "Target body");
+        mobiles.MobilesById[target.Id] = target;
+
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var packet = ParseDisplayPacket(target.Id);
+
+        var handled = await handler.HandlePacketAsync(session, packet);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.Packet, Is.TypeOf<DisplayCharacterProfilePacket>());
+
+                var displayPacket = (DisplayCharacterProfilePacket)outbound.Packet;
+                Assert.That(displayPacket.TargetId, Is.EqualTo(target.Id));
+                Assert.That(displayPacket.Header, Is.EqualTo("Target the tailor"));
+                Assert.That(displayPacket.Body, Is.EqualTo("Target body"));
+                Assert.That(displayPacket.Footer, Is.Empty);
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplayLockedSelf_ShouldUseSerialZero()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Tommy", (Serial)0x500, new(100, 100, 0));
+        self.SetCustomBoolean("profile_locked", true);
+        self.SetCustomString("profile_body", "Locked");
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseDisplayPacket(self.Id));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.TryDequeue(out var outbound), Is.True);
+                var displayPacket = (DisplayCharacterProfilePacket)outbound.Packet;
+                Assert.That(displayPacket.TargetId, Is.EqualTo(Serial.Zero));
+                Assert.That(displayPacket.Footer, Is.EqualTo("Your profile has been locked."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplayLockedOtherAsGameMaster_ShouldShowLockedFooter()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Viewer", (Serial)0x500, new(100, 100, 0));
+        var target = CreatePlayer((Serial)0x101, "Target", (Serial)0x501, new(101, 100, 0));
+        target.SetCustomBoolean("profile_locked", true);
+        mobiles.MobilesById[target.Id] = target;
+
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            AccountType = AccountType.GameMaster,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseDisplayPacket(target.Id));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.TryDequeue(out var outbound), Is.True);
+                var displayPacket = (DisplayCharacterProfilePacket)outbound.Packet;
+                Assert.That(displayPacket.TargetId, Is.EqualTo(target.Id));
+                Assert.That(displayPacket.Footer, Is.EqualTo("This profile has been locked."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplayOutOfRangeTarget_ShouldIgnoreRequest()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Viewer", (Serial)0x500, new(100, 100, 0));
+        var target = CreatePlayer((Serial)0x101, "Target", (Serial)0x501, new(130, 100, 0));
+        mobiles.MobilesById[target.Id] = target;
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseDisplayPacket(target.Id));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.CurrentQueueDepth, Is.EqualTo(0));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplayHiddenTarget_ShouldIgnoreRequest()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Viewer", (Serial)0x500, new(100, 100, 0));
+        var target = CreatePlayer((Serial)0x101, "Target", (Serial)0x501, new(101, 100, 0));
+        target.IsHidden = true;
+        mobiles.MobilesById[target.Id] = target;
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseDisplayPacket(target.Id));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.CurrentQueueDepth, Is.EqualTo(0));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_UpdateSelf_ShouldPersistSanitizedProfileBody()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Viewer", (Serial)0x500, new(100, 100, 0));
+        mobiles.MobilesById[self.Id] = self;
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseUpdatePacket(self.Id, "Hello\r\nBritannia\0"));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(self.TryGetCustomString("profile_body", out var body), Is.True);
+                Assert.That(body, Is.EqualTo("Hello\nBritannia"));
+                Assert.That(mobiles.CreateOrUpdateCalls, Is.EqualTo(1));
+                Assert.That(mobiles.LastUpdatedMobile, Is.SameAs(self));
+                Assert.That(outgoing.CurrentQueueDepth, Is.EqualTo(0));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_UpdateLockedSelf_ShouldRejectAndKeepBody()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Viewer", (Serial)0x500, new(100, 100, 0));
+        self.SetCustomString("profile_body", "Existing");
+        self.SetCustomBoolean("profile_locked", true);
+        mobiles.MobilesById[self.Id] = self;
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseUpdatePacket(self.Id, "New body"));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(self.TryGetCustomString("profile_body", out var body), Is.True);
+                Assert.That(body, Is.EqualTo("Existing"));
+                Assert.That(mobiles.CreateOrUpdateCalls, Is.EqualTo(0));
+                Assert.That(outgoing.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.Packet, Is.TypeOf<UnicodeSpeechMessagePacket>());
+                Assert.That(((UnicodeSpeechMessagePacket)outbound.Packet).Text, Is.EqualTo("Your profile is locked. You may not change it."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task HandlePacketAsync_DisplaySelfWithoutAccount_ShouldReturnEmptyFooter()
+    {
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var accounts = new TestAccountService();
+        var mobiles = new TestMobileService();
+        var handler = new CharacterProfileHandler(outgoing, accounts, mobiles);
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+
+        var self = CreatePlayer((Serial)0x100, "Tommy", (Serial)0x500, new(100, 100, 0));
+        var session = new GameSession(new(client))
+        {
+            AccountId = self.AccountId,
+            CharacterId = self.Id,
+            Character = self
+        };
+
+        var handled = await handler.HandlePacketAsync(session, ParseDisplayPacket(self.Id));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(handled, Is.True);
+                Assert.That(outgoing.TryDequeue(out var outbound), Is.True);
+                var displayPacket = (DisplayCharacterProfilePacket)outbound.Packet;
+                Assert.That(displayPacket.Footer, Is.Empty);
+            }
+        );
+    }
+
+    private static UOMobileEntity CreatePlayer(Serial id, string name, Serial accountId, Point3D location)
+        => new()
+        {
+            Id = id,
+            AccountId = accountId,
+            Name = name,
+            IsPlayer = true,
+            IsAlive = true,
+            MapId = 0,
+            Location = location,
+            Gender = GenderType.Male
+        };
+
+    private static RequestCharProfilePacket ParseDisplayPacket(Serial targetId)
+    {
+        var packet = new RequestCharProfilePacket();
+        var writer = new SpanWriter(8, true);
+        writer.Write((byte)0xB8);
+        writer.Write((ushort)8);
+        writer.Write((byte)0x00);
+        writer.Write(targetId.Value);
+
+        Assert.That(packet.TryParse(writer.ToArray()), Is.True);
+        writer.Dispose();
+
+        return packet;
+    }
+
+    private static RequestCharProfilePacket ParseUpdatePacket(Serial targetId, string profileText)
+    {
+        var packet = new RequestCharProfilePacket();
+        var writer = new SpanWriter(64 + (profileText.Length * 2), true);
+        var length = 1 + 2 + 1 + 4 + 2 + 2 + (profileText.Length * 2);
+
+        writer.Write((byte)0xB8);
+        writer.Write((ushort)length);
+        writer.Write((byte)0x01);
+        writer.Write(targetId.Value);
+        writer.Write((ushort)0x0001);
+        writer.Write((ushort)profileText.Length);
+        writer.WriteBigUni(profileText, profileText.Length);
+
+        Assert.That(packet.TryParse(writer.ToArray()), Is.True);
+        writer.Dispose();
+
+        return packet;
+    }
+}


### PR DESCRIPTION
## Summary
- add full player-only `0xB8` character profile request/update handling with a dedicated `CharacterProfileHandler`
- persist profile body and lock state via mobile custom properties and emit the ModernUO-style `DisplayCharacterProfilePacket`
- add packet/handler tests and update packet docs for `0xB8`

## Test Plan
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~RequestCharProfilePacketTests|FullyQualifiedName~DisplayCharacterProfilePacketTests|FullyQualifiedName~CharacterProfileHandlerTests"`
- `dotnet build src/Moongate.Server/Moongate.Server.csproj`

Closes #157