### PR TITLE
fix: exclude template payload from docfx metadata

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -10,6 +10,7 @@
           "exclude": [
             "**/bin/**",
             "**/obj/**",
+            "**/content/**",
             "**/*.Tests.csproj",
             "**/Moongate.Server.Metrics.Generators.csproj",
             "**/Moongate.Network.Packets.Generators.csproj",

--- a/src/Moongate.Templates/Moongate.Templates.csproj
+++ b/src/Moongate.Templates/Moongate.Templates.csproj
@@ -49,6 +49,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
         <IsPackable>true</IsPackable>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <NoDefaultExcludes>true</NoDefaultExcludes>


### PR DESCRIPTION
## Summary
- exclude `src/Moongate.Templates/content/**` from DocFX metadata project discovery
- disable default compile items in `Moongate.Templates` so template payload source files are not compiled
- keep docs CI from restoring placeholder package versions from `PluginTemplate.csproj`

## Test Plan
- `dotnet build src/Moongate.Templates/Moongate.Templates.csproj -c Release`
- `cd docs && DOTNET_ROOT=/Users/squid/.dotnet DOTNET_ROOT_ARM64=/Users/squid/.dotnet docfx docfx.json --logLevel Warning`
