### PR TITLE
fix: harden semantic-release github success handling

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -40,6 +40,12 @@
         "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "releasedLabels": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- disable `@semantic-release/github` success comments and released labels, which this repo does not use
- prevent release jobs from failing after publish because of broken historical issue references in PR bodies
- document the immediate root cause: PR `#127` previously contained `Closes #126`, but issue/PR `#126` does not exist in this repo

## Test Plan
- `gh pr view 127 --json body` and confirm `Closes #126` is no longer present
- `npx -y -p semantic-release -p @semantic-release/changelog -p @semantic-release/commit-analyzer -p @semantic-release/release-notes-generator -p @semantic-release/git -p @semantic-release/github -p @semantic-release/exec semantic-release --dry-run --debug`
