### PR TITLE
fix: prevent path traversal in email template and Lua script loaders

### DIFF
--- a/src/Moongate.Email/Services/ScribanEmailTemplateService.cs
+++ b/src/Moongate.Email/Services/ScribanEmailTemplateService.cs
@@ -96,19 +96,42 @@ public sealed class ScribanEmailTemplateService : BaseMoongateService, IEmailTem
 
     private string ResolveTemplatePath(string templateId, string locale, string suffix)
     {
-        if (string.IsNullOrWhiteSpace(templateId))
+        if (string.IsNullOrWhiteSpace(templateId) ||
+            templateId.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            templateId.Contains(".."))
         {
-            throw new ArgumentException("Template id is required.", nameof(templateId));
+            throw new ArgumentException("Invalid template id.", nameof(templateId));
         }
 
-        var localePath = Path.Combine(_options.TemplatesRootPath, templateId, $"{locale}.{suffix}");
+        if (string.IsNullOrWhiteSpace(locale) ||
+            locale.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            locale = _options.FallbackLocale;
+        }
+
+        var canonicalRoot = Path.GetFullPath(_options.TemplatesRootPath)
+                                .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+        var localePath = Path.GetFullPath(Path.Combine(_options.TemplatesRootPath, templateId, $"{locale}.{suffix}"));
+
+        if (!localePath.StartsWith(canonicalRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new UnauthorizedAccessException("Resolved template path is outside the configured root.");
+        }
 
         if (File.Exists(localePath))
         {
             return localePath;
         }
 
-        var fallbackPath = Path.Combine(_options.TemplatesRootPath, templateId, $"{_options.FallbackLocale}.{suffix}");
+        var fallbackPath = Path.GetFullPath(
+            Path.Combine(_options.TemplatesRootPath, templateId, $"{_options.FallbackLocale}.{suffix}")
+        );
+
+        if (!fallbackPath.StartsWith(canonicalRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new UnauthorizedAccessException("Resolved template path is outside the configured root.");
+        }
 
         if (File.Exists(fallbackPath))
         {

--- a/src/Moongate.Scripting/Loaders/LuaScriptLoader.cs
+++ b/src/Moongate.Scripting/Loaders/LuaScriptLoader.cs
@@ -104,11 +104,25 @@ public class LuaScriptLoader : ScriptLoaderBase
             return pluginPath;
         }
 
+        var canonicalRoot = Path.GetFullPath(_scriptsDirectory)
+                                .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
         // Try each module path pattern
         foreach (var pattern in ModulePaths)
         {
             var fileName = pattern.Replace("?", moduleName);
-            var fullPath = Path.Combine(_scriptsDirectory, fileName);
+            var fullPath = Path.GetFullPath(Path.Combine(_scriptsDirectory, fileName));
+
+            if (!fullPath.StartsWith(canonicalRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.Warning(
+                    "Rejected path traversal attempt for module '{ModuleName}': {FullPath}",
+                    moduleName,
+                    fullPath
+                );
+
+                continue;
+            }
 
             if (File.Exists(fullPath))
             {
@@ -119,7 +133,18 @@ public class LuaScriptLoader : ScriptLoaderBase
         }
 
         // If no pattern matched, try the direct path
-        var directPath = Path.Combine(_scriptsDirectory, moduleName);
+        var directPath = Path.GetFullPath(Path.Combine(_scriptsDirectory, moduleName));
+
+        if (!directPath.StartsWith(canonicalRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.Warning(
+                "Rejected path traversal attempt for module '{ModuleName}': {DirectPath}",
+                moduleName,
+                directPath
+            );
+
+            return null;
+        }
 
         if (File.Exists(directPath))
         {
@@ -157,10 +182,24 @@ public class LuaScriptLoader : ScriptLoaderBase
             return null;
         }
 
+        var canonicalPluginRoot = Path.GetFullPath(pluginRoot)
+                                      .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
         foreach (var pattern in ModulePaths)
         {
             var fileName = pattern.Replace("?", relativeModulePath);
-            var fullPath = Path.Combine(pluginRoot, fileName);
+            var fullPath = Path.GetFullPath(Path.Combine(pluginRoot, fileName));
+
+            if (!fullPath.StartsWith(canonicalPluginRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.Warning(
+                    "Rejected path traversal attempt for plugin module '{ModuleName}': {FullPath}",
+                    moduleName,
+                    fullPath
+                );
+
+                continue;
+            }
 
             if (File.Exists(fullPath))
             {
@@ -174,7 +213,18 @@ public class LuaScriptLoader : ScriptLoaderBase
             }
         }
 
-        var directPath = Path.Combine(pluginRoot, relativeModulePath);
+        var directPath = Path.GetFullPath(Path.Combine(pluginRoot, relativeModulePath));
+
+        if (!directPath.StartsWith(canonicalPluginRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.Warning(
+                "Rejected path traversal attempt for plugin module '{ModuleName}': {DirectPath}",
+                moduleName,
+                directPath
+            );
+
+            return null;
+        }
 
         if (File.Exists(directPath))
         {


### PR DESCRIPTION
## Summary

Fixes two path traversal vulnerabilities where unsanitized caller-controlled
input could escape the configured root directory via `../` segments.

## Changes

### `Moongate.Email` — ScribanEmailTemplateService
- Validate `templateId` and `locale` against `Path.GetInvalidFileNameChars()`
  and reject `..` segments before constructing template file paths.
- Assert the fully-resolved path starts with the canonical `TemplatesRootPath`
  root; throw `UnauthorizedAccessException` if the boundary is violated.

### `Moongate.Scripting` — LuaScriptLoader
- Canonicalise all resolved module paths with `Path.GetFullPath` and verify
  they remain within `_scriptsDirectory` before returning them.
- Apply the same boundary check in `ResolvePluginModulePath` to prevent
  cross-plugin and host-escape traversal via `require()`.

## Security

Both issues were path traversal (CWE-22). An attacker or malicious Lua script
that controlled the template id or module name could have read arbitrary files
accessible to the server process.