### PR TITLE
refactor: unify training dummy flippable template

### DIFF
--- a/moongate_data/templates/items/training_items.json
+++ b/moongate_data/templates/items/training_items.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "item",
-    "id": "training_dummy_east",
+    "id": "training_dummy",
     "name": "Training Dummy",
     "category": "Training Items",
     "description": "Practice target for melee weapon training.",
@@ -14,26 +14,32 @@
     "tags": [
       "modernuo",
       "training",
-      "melee"
+      "melee",
+      "flippable"
+    ],
+    "flippableItemIds": [
+      "0x1074",
+      "0x1070"
     ]
   },
   {
     "type": "item",
+    "base_item": "training_dummy",
+    "id": "training_dummy_east",
+    "itemId": "0x1074",
+    "name": "Training Dummy",
+    "category": "Training Items",
+    "description": "Practice target for melee weapon training."
+  },
+  {
+    "type": "item",
+    "base_item": "training_dummy",
     "id": "training_dummy_south",
     "name": "Training Dummy",
     "category": "Training Items",
     "description": "Practice target for melee weapon training.",
     "itemId": "0x1070",
-    "hue": "0",
-    "goldValue": "0",
-    "weight": 0,
-    "scriptId": "items.training_dummy",
-    "isMovable": false,
-    "tags": [
-      "modernuo",
-      "training",
-      "melee"
-    ]
+    "scriptId": "items.training_dummy"
   },
   {
     "type": "item",

--- a/tests/Moongate.Tests/Server/FileLoaders/ItemTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/ItemTemplateLoaderTests.cs
@@ -1156,6 +1156,72 @@ public class ItemTemplateLoaderTests
     }
 
     [Test]
+    public async Task LoadAsync_WhenRootTrainingItemsTemplateContainsTrainingDummy_ShouldExposeFlippableBaseAndAliases()
+    {
+        using var tempDirectory = new TempDirectory();
+        var directoriesConfig = new DirectoriesConfig(
+            tempDirectory.Path,
+            DirectoryType.Data,
+            DirectoryType.Templates,
+            DirectoryType.Scripts,
+            DirectoryType.Save,
+            DirectoryType.Logs,
+            DirectoryType.Cache
+        );
+
+        var targetItemsDirectory = Path.Combine(directoriesConfig[DirectoryType.Templates], "items");
+        Directory.CreateDirectory(targetItemsDirectory);
+        File.Copy(
+            Path.GetFullPath(
+                Path.Combine(
+                    TestContext.CurrentContext.TestDirectory,
+                    "..",
+                    "..",
+                    "..",
+                    "..",
+                    "..",
+                    "moongate_data",
+                    "templates",
+                    "items",
+                    "training_items.json"
+                )
+            ),
+            Path.Combine(targetItemsDirectory, "training_items.json"),
+            true
+        );
+
+        var itemTemplateService = new ItemTemplateService();
+        var loader = new ItemTemplateLoader(directoriesConfig, itemTemplateService);
+
+        await loader.LoadAsync();
+
+        Assert.That(itemTemplateService.TryGet("training_dummy", out var baseTemplate), Is.True);
+        Assert.That(itemTemplateService.TryGet("training_dummy_east", out var eastTemplate), Is.True);
+        Assert.That(itemTemplateService.TryGet("training_dummy_south", out var southTemplate), Is.True);
+        Assert.That(baseTemplate, Is.Not.Null);
+        Assert.That(eastTemplate, Is.Not.Null);
+        Assert.That(southTemplate, Is.Not.Null);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(baseTemplate!.ItemId, Is.EqualTo("0x1074"));
+                Assert.That(baseTemplate.ScriptId, Is.EqualTo("items.training_dummy"));
+                Assert.That(baseTemplate.Tags, Does.Contain("flippable"));
+                Assert.That(baseTemplate.FlippableItemIds, Is.EqualTo(new[] { "0x1074", "0x1070" }));
+
+                Assert.That(eastTemplate!.ItemId, Is.EqualTo("0x1074"));
+                Assert.That(eastTemplate.ScriptId, Is.EqualTo("items.training_dummy"));
+                Assert.That(eastTemplate.FlippableItemIds, Is.EqualTo(new[] { "0x1074", "0x1070" }));
+
+                Assert.That(southTemplate!.ItemId, Is.EqualTo("0x1070"));
+                Assert.That(southTemplate.ScriptId, Is.EqualTo("items.training_dummy"));
+                Assert.That(southTemplate.FlippableItemIds, Is.EqualTo(new[] { "0x1074", "0x1070" }));
+            }
+        );
+    }
+
+    [Test]
     public async Task LoadAsync_WhenRootMapsTemplateContainsTreasureMap_ShouldExposeDerivedTemplate()
     {
         using var tempDirectory = new TempDirectory();


### PR DESCRIPTION
## Summary
- promote `training_dummy` to the canonical flippable template
- keep `training_dummy_east` and `training_dummy_south` as compatibility aliases via `base_item`
- add loader coverage for the base template and both aliases

## Test Plan
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ItemTemplateLoaderTests"`

Refs #165