### PR TITLE
fix: polish gm menu spawning workflow

### DIFF
--- a/docs/articles/getting-started/quickstart.md
+++ b/docs/articles/getting-started/quickstart.md
@@ -67,6 +67,7 @@ Built-in default commands currently include:
 - `orion` (in-game only, minimum `Regular`, requests target cursor and spawns Orion on selected tile)
 - `teleport` / `tp` (in-game only, minimum `GameMaster`, usage: `.teleport <mapId> <x> <y> <z>`)
 - `add_item_backpack` / `.add_item_backpack` (in-game only, minimum `GameMaster`, usage: `.add_item_backpack <templateId> [amount]`)
+- `gm` / `.gm` (in-game only, minimum `GameMaster`, opens the GM sidebar menu with Add and Travel tools)
 
 Command source and authorization rules:
 

--- a/docs/articles/operations/console-commands.md
+++ b/docs/articles/operations/console-commands.md
@@ -120,6 +120,19 @@ Spawns an item from a template and places it in the player backpack. Supports au
 
 Resolves the backpack either from `BackpackId` or from the equipped `Backpack` layer item. Context: InGame only. Access: GameMaster.
 
+#### `gm`
+
+Opens the in-game GM sidebar menu. The menu currently exposes:
+
+- `Add`: free-search item/NPC templates, item tile-art preview, quantity input, `Add To Backpack`, `Target Ground`, and repeat `Brush`
+- `Travel`: embedded curated teleport browser grouped by map and category
+
+```
+.gm
+```
+
+Context: InGame only. Access: GameMaster.
+
 #### `add_item`
 
 Spawns a hardcoded "brick" test item and adds it to the player backpack at position (1,1). Primarily a development/test command.

--- a/moongate_data/scripts/gumps/gm_menu.lua
+++ b/moongate_data/scripts/gumps/gm_menu.lua
@@ -1,0 +1,18 @@
+local c = require("gumps.gm_menu.constants")
+local controller = require("gumps.gm_menu.controller")
+
+local gm_menu = {}
+
+function gm_menu.open(session_id, character_id)
+  local layout, sender_serial = controller.build_layout(
+    session_id,
+    character_id,
+    function(target_session, target_character)
+      gm_menu.open(target_session, target_character)
+    end
+  )
+
+  return gump.send_layout(session_id, layout, sender_serial, c.GUMP_ID, c.GUMP_X, c.GUMP_Y)
+end
+
+return gm_menu

--- a/moongate_data/scripts/gumps/gm_menu/constants.lua
+++ b/moongate_data/scripts/gumps/gm_menu/constants.lua
@@ -1,0 +1,18 @@
+local constants = {}
+
+constants.GUMP_ID = 0xB930
+constants.GUMP_X = 60
+constants.GUMP_Y = 40
+constants.GUMP_WIDTH = 560
+constants.GUMP_HEIGHT = 420
+constants.SIDEBAR_WIDTH = 150
+
+constants.TITLE_HUE = 1152
+constants.LABEL_HUE = 0
+constants.ACCENT_HUE = 1153
+constants.MUTED_HUE = 1102
+
+constants.BUTTON_TAB_ADD = 100
+constants.BUTTON_TAB_TRAVEL = 101
+
+return constants

--- a/moongate_data/scripts/gumps/gm_menu/constants.lua
+++ b/moongate_data/scripts/gumps/gm_menu/constants.lua
@@ -3,8 +3,8 @@ local constants = {}
 constants.GUMP_ID = 0xB930
 constants.GUMP_X = 60
 constants.GUMP_Y = 40
-constants.GUMP_WIDTH = 560
-constants.GUMP_HEIGHT = 420
+constants.GUMP_WIDTH = 720
+constants.GUMP_HEIGHT = 460
 constants.SIDEBAR_WIDTH = 150
 
 constants.TITLE_HUE = 1152
@@ -12,7 +12,28 @@ constants.LABEL_HUE = 0
 constants.ACCENT_HUE = 1153
 constants.MUTED_HUE = 1102
 
-constants.BUTTON_TAB_ADD = 100
-constants.BUTTON_TAB_TRAVEL = 101
+constants.BUTTON_TAB_ADD = 10
+constants.BUTTON_TAB_TRAVEL = 11
+
+constants.TEXT_ENTRY_SEARCH = 1
+constants.TEXT_ENTRY_QUANTITY = 2
+
+constants.BUTTON_FILTER_ITEMS = 100
+constants.BUTTON_FILTER_NPCS = 101
+constants.BUTTON_SEARCH = 102
+constants.BUTTON_PREV_PAGE = 103
+constants.BUTTON_NEXT_PAGE = 104
+
+constants.BUTTON_RESULT_BASE = 200
+constants.RESULT_ROWS = 10
+
+constants.BUTTON_TARGET_GROUND = 300
+constants.BUTTON_ADD_TO_BACKPACK = 301
+constants.BUTTON_BRUSH = 302
+constants.BUTTON_STOP_BRUSH = 303
+
+constants.PAGE_SIZE = 10
+constants.MAX_ITEM_QUANTITY = 100
+constants.MAX_NPC_QUANTITY = 20
 
 return constants

--- a/moongate_data/scripts/gumps/gm_menu/constants.lua
+++ b/moongate_data/scripts/gumps/gm_menu/constants.lua
@@ -4,11 +4,11 @@ constants.GUMP_ID = 0xB930
 constants.GUMP_X = 60
 constants.GUMP_Y = 40
 constants.GUMP_WIDTH = 720
-constants.GUMP_HEIGHT = 460
+constants.GUMP_HEIGHT = 500
 constants.SIDEBAR_WIDTH = 150
 
 constants.TITLE_HUE = 1152
-constants.LABEL_HUE = 0
+constants.LABEL_HUE = 33
 constants.ACCENT_HUE = 1153
 constants.MUTED_HUE = 1102
 
@@ -25,14 +25,14 @@ constants.BUTTON_PREV_PAGE = 103
 constants.BUTTON_NEXT_PAGE = 104
 
 constants.BUTTON_RESULT_BASE = 200
-constants.RESULT_ROWS = 10
+constants.RESULT_ROWS = 7
 
 constants.BUTTON_TARGET_GROUND = 300
 constants.BUTTON_ADD_TO_BACKPACK = 301
 constants.BUTTON_BRUSH = 302
 constants.BUTTON_STOP_BRUSH = 303
 
-constants.PAGE_SIZE = 10
+constants.PAGE_SIZE = 7
 constants.MAX_ITEM_QUANTITY = 100
 constants.MAX_NPC_QUANTITY = 20
 

--- a/moongate_data/scripts/gumps/gm_menu/controller.lua
+++ b/moongate_data/scripts/gumps/gm_menu/controller.lua
@@ -17,18 +17,26 @@ function controller.build_layout(session_id, character_id, reopen_callback)
 
   ui.add_frame(layout_ui)
   ui.add_sidebar(layout_ui, current_state)
-  render.add_content(layout_ui, current_state)
+  local section_handler = render.add_content(layout, session_id, character_id, current_state, reopen_callback)
 
   layout.handlers.on_click = function(ctx)
     local button_id = tonumber(ctx.button_id) or 0
 
     if button_id == c.BUTTON_TAB_TRAVEL then
       state.set_active_tab(ctx.session_id, "travel")
-    else
-      state.set_active_tab(ctx.session_id, "add")
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
     end
 
-    reopen_callback(ctx.session_id, ctx.character_id)
+    if button_id == c.BUTTON_TAB_ADD then
+      state.set_active_tab(ctx.session_id, "add")
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if section_handler ~= nil then
+      section_handler(ctx)
+    end
   end
 
   return layout, sender_serial

--- a/moongate_data/scripts/gumps/gm_menu/controller.lua
+++ b/moongate_data/scripts/gumps/gm_menu/controller.lua
@@ -1,0 +1,37 @@
+local c = require("gumps.gm_menu.constants")
+local state = require("gumps.gm_menu.state")
+local ui = require("gumps.gm_menu.ui")
+local render = require("gumps.gm_menu.render")
+
+local controller = {}
+
+function controller.build_layout(session_id, character_id, reopen_callback)
+  local sender_serial = tonumber(character_id) or 0
+  if sender_serial <= 0 then
+    sender_serial = tonumber(session_id) or 1
+  end
+
+  local current_state = state.get(session_id)
+  local layout = { ui = {}, handlers = {} }
+  local layout_ui = layout.ui
+
+  ui.add_frame(layout_ui)
+  ui.add_sidebar(layout_ui, current_state)
+  render.add_content(layout_ui, current_state)
+
+  layout.handlers.on_click = function(ctx)
+    local button_id = tonumber(ctx.button_id) or 0
+
+    if button_id == c.BUTTON_TAB_TRAVEL then
+      state.set_active_tab(ctx.session_id, "travel")
+    else
+      state.set_active_tab(ctx.session_id, "add")
+    end
+
+    reopen_callback(ctx.session_id, ctx.character_id)
+  end
+
+  return layout, sender_serial
+end
+
+return controller

--- a/moongate_data/scripts/gumps/gm_menu/render.lua
+++ b/moongate_data/scripts/gumps/gm_menu/render.lua
@@ -1,0 +1,15 @@
+local add_section = require("gumps.gm_menu.sections.add")
+local travel_section = require("gumps.gm_menu.sections.travel")
+
+local render = {}
+
+function render.add_content(layout_ui, current_state)
+  if current_state.active_tab == "travel" then
+    travel_section.add_content(layout_ui)
+    return
+  end
+
+  add_section.add_content(layout_ui)
+end
+
+return render

--- a/moongate_data/scripts/gumps/gm_menu/render.lua
+++ b/moongate_data/scripts/gumps/gm_menu/render.lua
@@ -3,13 +3,12 @@ local travel_section = require("gumps.gm_menu.sections.travel")
 
 local render = {}
 
-function render.add_content(layout_ui, current_state)
+function render.add_content(layout, session_id, character_id, current_state, reopen_callback)
   if current_state.active_tab == "travel" then
-    travel_section.add_content(layout_ui)
-    return
+    return travel_section.add_content(layout, session_id, character_id, reopen_callback)
   end
 
-  add_section.add_content(layout_ui)
+  return add_section.add_content(layout, session_id, character_id, current_state, reopen_callback)
 end
 
 return render

--- a/moongate_data/scripts/gumps/gm_menu/sections/add.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/add.lua
@@ -1,0 +1,28 @@
+local c = require("gumps.gm_menu.constants")
+local ui = require("gumps.gm_menu.ui")
+
+local add_section = {}
+
+function add_section.add_content(layout_ui)
+  ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Search Items and NPCs" })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 196,
+    y = 88,
+    width = 324,
+    height = 20,
+    hue = c.MUTED_HUE,
+    text = "Use the sidebar to switch tools. Search and spawn controls are next."
+  })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 196,
+    y = 122,
+    width = 324,
+    height = 20,
+    hue = c.LABEL_HUE,
+    text = "Items and NPC templates will appear here."
+  })
+end
+
+return add_section

--- a/moongate_data/scripts/gumps/gm_menu/sections/add.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/add.lua
@@ -168,6 +168,11 @@ end
 
 local function request_spawn_target(session_id, character_id, selection, quantity, reopen_callback)
   return target.request_location(session_id, function(target_ctx)
+    if target_ctx.cancelled then
+      reopen_callback(session_id, character_id)
+      return
+    end
+
     spawn_selection(
       selection,
       {
@@ -194,6 +199,12 @@ request_brush_target = function(session_id, character_id, nonce, reopen_callback
     local latest_state = gm_state.get(session_id)
     local latest_add_state = ensure_add_state(latest_state)
     local latest_brush = latest_add_state.brush
+
+    if target_ctx.cancelled then
+      clear_brush(latest_add_state, session_id)
+      reopen_callback(session_id, character_id)
+      return
+    end
 
     if latest_brush == nil or not latest_brush.active or latest_brush.nonce ~= nonce or latest_brush.template_id == nil then
       return
@@ -257,8 +268,7 @@ local function render_filter_buttons(layout_ui, add_state)
 end
 
 local function render_results(layout_ui, add_state, results)
-  ui.push(layout_ui, { type = "image_tiled", x = 196, y = 150, width = 260, height = 250, gump_id = 2624 })
-  ui.push(layout_ui, { type = "alpha_region", x = 196, y = 150, width = 260, height = 250 })
+  ui.push(layout_ui, { type = "image_tiled", x = 196, y = 150, width = 260, height = 286, gump_id = 2624 })
   ui.push(layout_ui, { type = "label", x = 208, y = 160, hue = c.TITLE_HUE, text = "Results" })
 
   local row_y = 188
@@ -312,8 +322,7 @@ end
 local function render_preview(layout_ui, add_state)
   local selected = add_state.selected
 
-  ui.push(layout_ui, { type = "image_tiled", x = 470, y = 150, width = 224, height = 250, gump_id = 2624 })
-  ui.push(layout_ui, { type = "alpha_region", x = 470, y = 150, width = 224, height = 250 })
+  ui.push(layout_ui, { type = "image_tiled", x = 470, y = 150, width = 224, height = 286, gump_id = 2624 })
   ui.push(layout_ui, { type = "label", x = 482, y = 160, hue = c.TITLE_HUE, text = "Preview" })
 
   if selected == nil then
@@ -383,7 +392,7 @@ local function render_actions(layout_ui, add_state)
     y = 112,
     width = 190,
     height = 20,
-    hue = 0,
+    hue = c.LABEL_HUE,
     entry_id = c.TEXT_ENTRY_SEARCH,
     text = add_state.query or "",
     size = 60
@@ -398,40 +407,40 @@ local function render_actions(layout_ui, add_state)
     y = 112,
     width = 48,
     height = 20,
-    hue = 0,
+    hue = c.LABEL_HUE,
     entry_id = c.TEXT_ENTRY_QUANTITY,
     text = tostring(add_state.quantity or 1),
     size = 3
   })
 
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_PREV_PAGE, x = 196, y = 410, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 226, y = 412, hue = c.LABEL_HUE, text = "Prev" })
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_NEXT_PAGE, x = 290, y = 410, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 320, y = 412, hue = c.LABEL_HUE, text = "Next" })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_PREV_PAGE, x = 196, y = 446, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 226, y = 448, hue = c.LABEL_HUE, text = "Prev" })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_NEXT_PAGE, x = 290, y = 446, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 320, y = 448, hue = c.LABEL_HUE, text = "Next" })
 
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_TARGET_GROUND, x = 470, y = 410, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 500, y = 412, hue = c.LABEL_HUE, text = "Target Ground" })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_TARGET_GROUND, x = 470, y = 446, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 500, y = 448, hue = c.LABEL_HUE, text = "Target Ground" })
 
   if add_state.selected ~= nil and add_state.selected.kind == "item" then
-    ui.push(layout_ui, { type = "button", id = c.BUTTON_ADD_TO_BACKPACK, x = 470, y = 382, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-    ui.push(layout_ui, { type = "label", x = 500, y = 384, hue = c.LABEL_HUE, text = "Add To Backpack" })
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_ADD_TO_BACKPACK, x = 470, y = 418, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "label", x = 500, y = 420, hue = c.LABEL_HUE, text = "Add To Backpack" })
   end
 
   if add_state.brush.active then
-    ui.push(layout_ui, { type = "button", id = c.BUTTON_STOP_BRUSH, x = 610, y = 410, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
-    ui.push(layout_ui, { type = "label", x = 640, y = 412, hue = c.ACCENT_HUE, text = "Stop Brush" })
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_STOP_BRUSH, x = 610, y = 446, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+    ui.push(layout_ui, { type = "label", x = 640, y = 448, hue = c.ACCENT_HUE, text = "Stop Brush" })
     ui.push(layout_ui, {
       type = "label_cropped",
       x = 470,
-      y = 356,
+      y = 392,
       width = 204,
       height = 20,
       hue = c.ACCENT_HUE,
       text = "Brush Active: " .. tostring(add_state.brush.display_name or add_state.brush.template_id or "")
     })
   else
-    ui.push(layout_ui, { type = "button", id = c.BUTTON_BRUSH, x = 610, y = 410, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-    ui.push(layout_ui, { type = "label", x = 640, y = 412, hue = c.LABEL_HUE, text = "Brush" })
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_BRUSH, x = 610, y = 446, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "label", x = 640, y = 448, hue = c.LABEL_HUE, text = "Brush" })
   end
 end
 
@@ -440,8 +449,7 @@ function add_section.add_content(layout, session_id, character_id, current_state
   local add_state = ensure_add_state(current_state)
   local results = load_results(add_state)
 
-  ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 392, gump_id = 2624 })
-  ui.push(layout_ui, { type = "alpha_region", x = 188, y = 48, width = 520, height = 392 })
+  ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 428, gump_id = 2624 })
   ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Search Items and NPCs" })
   ui.push(layout_ui, {
     type = "label_cropped",

--- a/moongate_data/scripts/gumps/gm_menu/sections/add.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/add.lua
@@ -1,28 +1,557 @@
 local c = require("gumps.gm_menu.constants")
 local ui = require("gumps.gm_menu.ui")
+local gm_state = require("gumps.gm_menu.state")
 
 local add_section = {}
 
-function add_section.add_content(layout_ui)
+local function create_default_add_state()
+  return {
+    filter = "items",
+    query = "",
+    page = 1,
+    quantity = 1,
+    selected = nil,
+    brush = {
+      active = false,
+      kind = nil,
+      template_id = nil,
+      display_name = nil,
+      item_id = 0,
+      quantity = 1,
+      cursor_id = 0,
+      nonce = 0
+    }
+  }
+end
+
+local function ensure_add_state(current_state)
+  if current_state.add == nil then
+    current_state.add = create_default_add_state()
+  end
+
+  if current_state.add.brush == nil then
+    current_state.add.brush = create_default_add_state().brush
+  end
+
+  return current_state.add
+end
+
+local function get_entry_text(text_entries, entry_id, fallback)
+  if text_entries == nil then
+    return fallback
+  end
+
+  local value = text_entries[entry_id]
+  if value == nil then
+    return fallback
+  end
+
+  return tostring(value)
+end
+
+local function get_kind(add_state)
+  if add_state.filter == "npcs" then
+    return "npc"
+  end
+
+  return "item"
+end
+
+local function get_quantity_limit(kind)
+  if kind == "npc" then
+    return c.MAX_NPC_QUANTITY
+  end
+
+  return c.MAX_ITEM_QUANTITY
+end
+
+local function clamp_quantity(raw_value, kind)
+  local parsed = tonumber(raw_value) or 1
+  local whole = math.floor(parsed)
+
+  if whole < 1 then
+    whole = 1
+  end
+
+  local max_quantity = get_quantity_limit(kind)
+  if whole > max_quantity then
+    whole = max_quantity
+  end
+
+  return whole
+end
+
+local function sync_inputs(add_state, text_entries)
+  add_state.query = get_entry_text(text_entries, c.TEXT_ENTRY_SEARCH, add_state.query or "")
+  add_state.quantity = clamp_quantity(get_entry_text(text_entries, c.TEXT_ENTRY_QUANTITY, add_state.quantity or 1), get_kind(add_state))
+end
+
+local function normalize_results(raw_results, kind)
+  local results = {}
+
+  for index = 1, c.RESULT_ROWS do
+    local entry = raw_results[index]
+    if entry == nil then
+      break
+    end
+
+    results[#results + 1] = {
+      kind = kind,
+      template_id = tostring(entry.template_id or ""),
+      display_name = tostring(entry.display_name or entry.template_id or ""),
+      item_id = tonumber(entry.item_id) or 0
+    }
+  end
+
+  return results
+end
+
+local function load_results(add_state)
+  local kind = get_kind(add_state)
+  local query = add_state.query or ""
+  local page = tonumber(add_state.page) or 1
+  local raw_results
+
+  if kind == "item" then
+    raw_results = item.search_templates(query, page, c.PAGE_SIZE)
+  else
+    raw_results = mobile.search_templates(query, page, c.PAGE_SIZE)
+  end
+
+  return normalize_results(raw_results, kind)
+end
+
+local function format_item_id(item_id)
+  return string.format("0x%04X", tonumber(item_id) or 0)
+end
+
+local function clear_selection(add_state)
+  add_state.selected = nil
+end
+
+local function clear_brush(add_state, session_id)
+  local brush = add_state.brush
+
+  if brush ~= nil and brush.active and (tonumber(brush.cursor_id) or 0) > 0 then
+    target.cancel(session_id, brush.cursor_id)
+  end
+
+  add_state.brush = {
+    active = false,
+    kind = nil,
+    template_id = nil,
+    display_name = nil,
+    item_id = 0,
+    quantity = add_state.quantity or 1,
+    cursor_id = 0,
+    nonce = (brush ~= nil and tonumber(brush.nonce) or 0) + 1
+  }
+end
+
+local function spawn_selection(selection, location, quantity)
+  if selection == nil or location == nil then
+    return false
+  end
+
+  if selection.kind == "item" then
+    return item.spawn(selection.template_id, location, quantity) ~= nil
+  end
+
+  for i = 1, quantity do
+    if mobile.spawn(selection.template_id, location) == nil then
+      return false
+    end
+  end
+
+  return true
+end
+
+local function request_spawn_target(session_id, character_id, selection, quantity, reopen_callback)
+  return target.request_location(session_id, function(target_ctx)
+    spawn_selection(
+      selection,
+      {
+        x = target_ctx.x,
+        y = target_ctx.y,
+        z = target_ctx.z,
+        map_id = target_ctx.map_id
+      },
+      quantity
+    )
+
+    reopen_callback(session_id, character_id)
+  end)
+end
+
+local request_brush_target
+
+request_brush_target = function(session_id, character_id, nonce, reopen_callback)
+  local current_state = gm_state.get(session_id)
+  local add_state = ensure_add_state(current_state)
+  local brush = add_state.brush
+
+  brush.cursor_id = target.request_location(session_id, function(target_ctx)
+    local latest_state = gm_state.get(session_id)
+    local latest_add_state = ensure_add_state(latest_state)
+    local latest_brush = latest_add_state.brush
+
+    if latest_brush == nil or not latest_brush.active or latest_brush.nonce ~= nonce or latest_brush.template_id == nil then
+      return
+    end
+
+    spawn_selection(
+      {
+        kind = latest_brush.kind,
+        template_id = latest_brush.template_id,
+        display_name = latest_brush.display_name,
+        item_id = latest_brush.item_id or 0
+      },
+      {
+        x = target_ctx.x,
+        y = target_ctx.y,
+        z = target_ctx.z,
+        map_id = target_ctx.map_id
+      },
+      latest_brush.quantity or 1
+    )
+
+    reopen_callback(session_id, character_id)
+
+    local refreshed_state = gm_state.get(session_id)
+    local refreshed_add_state = ensure_add_state(refreshed_state)
+    local refreshed_brush = refreshed_add_state.brush
+
+    if refreshed_brush ~= nil and refreshed_brush.active and refreshed_brush.nonce == nonce then
+      request_brush_target(session_id, character_id, nonce, reopen_callback)
+    end
+  end)
+
+  return brush.cursor_id
+end
+
+local function activate_brush(add_state, selection, quantity)
+  local brush = add_state.brush
+  local next_nonce = (tonumber(brush.nonce) or 0) + 1
+
+  brush.active = true
+  brush.kind = selection.kind
+  brush.template_id = selection.template_id
+  brush.display_name = selection.display_name
+  brush.item_id = selection.item_id or 0
+  brush.quantity = quantity
+  brush.cursor_id = 0
+  brush.nonce = next_nonce
+
+  return next_nonce
+end
+
+local function render_filter_buttons(layout_ui, add_state)
+  local items_hue = add_state.filter == "items" and c.ACCENT_HUE or c.LABEL_HUE
+  local npcs_hue = add_state.filter == "npcs" and c.ACCENT_HUE or c.LABEL_HUE
+
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_FILTER_ITEMS, x = 196, y = 86, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 226, y = 88, hue = items_hue, text = "Items" })
+
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_FILTER_NPCS, x = 300, y = 86, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 330, y = 88, hue = npcs_hue, text = "NPCs" })
+end
+
+local function render_results(layout_ui, add_state, results)
+  ui.push(layout_ui, { type = "image_tiled", x = 196, y = 150, width = 260, height = 250, gump_id = 2624 })
+  ui.push(layout_ui, { type = "alpha_region", x = 196, y = 150, width = 260, height = 250 })
+  ui.push(layout_ui, { type = "label", x = 208, y = 160, hue = c.TITLE_HUE, text = "Results" })
+
+  local row_y = 188
+
+  for index, result in ipairs(results) do
+    local button_id = c.BUTTON_RESULT_BASE + index - 1
+    local is_selected = add_state.selected ~= nil and add_state.selected.kind == result.kind and add_state.selected.template_id == result.template_id
+    local display_hue = is_selected and c.ACCENT_HUE or c.LABEL_HUE
+    local meta_text = result.template_id
+
+    if result.kind == "item" and result.item_id > 0 then
+      meta_text = result.template_id .. " • " .. format_item_id(result.item_id)
+    end
+
+    ui.push(layout_ui, { type = "button", id = button_id, x = 206, y = row_y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 236,
+      y = row_y,
+      width = 208,
+      height = 18,
+      hue = display_hue,
+      text = result.display_name
+    })
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 236,
+      y = row_y + 14,
+      width = 208,
+      height = 18,
+      hue = c.MUTED_HUE,
+      text = meta_text
+    })
+
+    row_y = row_y + 34
+  end
+
+  if #results == 0 then
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 208,
+      y = 192,
+      width = 228,
+      height = 20,
+      hue = c.MUTED_HUE,
+      text = "No results. Try another query."
+    })
+  end
+end
+
+local function render_preview(layout_ui, add_state)
+  local selected = add_state.selected
+
+  ui.push(layout_ui, { type = "image_tiled", x = 470, y = 150, width = 224, height = 250, gump_id = 2624 })
+  ui.push(layout_ui, { type = "alpha_region", x = 470, y = 150, width = 224, height = 250 })
+  ui.push(layout_ui, { type = "label", x = 482, y = 160, hue = c.TITLE_HUE, text = "Preview" })
+
+  if selected == nil then
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 482,
+      y = 190,
+      width = 188,
+      height = 40,
+      hue = c.MUTED_HUE,
+      text = "Select an item or NPC template to inspect and spawn."
+    })
+    return
+  end
+
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 482,
+    y = 190,
+    width = 188,
+    height = 20,
+    hue = c.ACCENT_HUE,
+    text = selected.display_name
+  })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 482,
+    y = 212,
+    width = 188,
+    height = 20,
+    hue = c.LABEL_HUE,
+    text = "Template: " .. selected.template_id
+  })
+
+  if selected.kind == "item" then
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 482,
+      y = 234,
+      width = 188,
+      height = 20,
+      hue = c.LABEL_HUE,
+      text = "Item ID: " .. format_item_id(selected.item_id)
+    })
+
+    if selected.item_id > 0 then
+      ui.push(layout_ui, { type = "item", x = 552, y = 272, item_id = selected.item_id })
+    end
+  else
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 482,
+      y = 234,
+      width = 188,
+      height = 40,
+      hue = c.MUTED_HUE,
+      text = "NPC preview uses a placeholder in this first version."
+    })
+  end
+end
+
+local function render_actions(layout_ui, add_state)
+  ui.push(layout_ui, { type = "label", x = 196, y = 116, hue = c.LABEL_HUE, text = "Search" })
+  ui.push(layout_ui, {
+    type = "text_entry_limited",
+    x = 248,
+    y = 112,
+    width = 190,
+    height = 20,
+    hue = 0,
+    entry_id = c.TEXT_ENTRY_SEARCH,
+    text = add_state.query or "",
+    size = 60
+  })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_SEARCH, x = 448, y = 112, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 478, y = 114, hue = c.LABEL_HUE, text = "Search" })
+
+  ui.push(layout_ui, { type = "label", x = 560, y = 116, hue = c.LABEL_HUE, text = "Qty" })
+  ui.push(layout_ui, {
+    type = "text_entry_limited",
+    x = 592,
+    y = 112,
+    width = 48,
+    height = 20,
+    hue = 0,
+    entry_id = c.TEXT_ENTRY_QUANTITY,
+    text = tostring(add_state.quantity or 1),
+    size = 3
+  })
+
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_PREV_PAGE, x = 196, y = 410, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 226, y = 412, hue = c.LABEL_HUE, text = "Prev" })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_NEXT_PAGE, x = 290, y = 410, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 320, y = 412, hue = c.LABEL_HUE, text = "Next" })
+
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_TARGET_GROUND, x = 470, y = 410, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 500, y = 412, hue = c.LABEL_HUE, text = "Target Ground" })
+
+  if add_state.selected ~= nil and add_state.selected.kind == "item" then
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_ADD_TO_BACKPACK, x = 470, y = 382, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "label", x = 500, y = 384, hue = c.LABEL_HUE, text = "Add To Backpack" })
+  end
+
+  if add_state.brush.active then
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_STOP_BRUSH, x = 610, y = 410, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+    ui.push(layout_ui, { type = "label", x = 640, y = 412, hue = c.ACCENT_HUE, text = "Stop Brush" })
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 470,
+      y = 356,
+      width = 204,
+      height = 20,
+      hue = c.ACCENT_HUE,
+      text = "Brush Active: " .. tostring(add_state.brush.display_name or add_state.brush.template_id or "")
+    })
+  else
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_BRUSH, x = 610, y = 410, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "label", x = 640, y = 412, hue = c.LABEL_HUE, text = "Brush" })
+  end
+end
+
+function add_section.add_content(layout, session_id, character_id, current_state, reopen_callback)
+  local layout_ui = layout.ui
+  local add_state = ensure_add_state(current_state)
+  local results = load_results(add_state)
+
+  ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 392, gump_id = 2624 })
+  ui.push(layout_ui, { type = "alpha_region", x = 188, y = 48, width = 520, height = 392 })
   ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Search Items and NPCs" })
   ui.push(layout_ui, {
     type = "label_cropped",
     x = 196,
-    y = 88,
-    width = 324,
-    height = 20,
+    y = 72,
+    width = 480,
+    height = 18,
     hue = c.MUTED_HUE,
-    text = "Use the sidebar to switch tools. Search and spawn controls are next."
+    text = "Free search with preview, backpack add, ground target and brush."
   })
-  ui.push(layout_ui, {
-    type = "label_cropped",
-    x = 196,
-    y = 122,
-    width = 324,
-    height = 20,
-    hue = c.LABEL_HUE,
-    text = "Items and NPC templates will appear here."
-  })
+
+  render_filter_buttons(layout_ui, add_state)
+  render_actions(layout_ui, add_state)
+  render_results(layout_ui, add_state, results)
+  render_preview(layout_ui, add_state)
+
+  _ = session_id
+  _ = character_id
+
+  return function(ctx)
+    local button_id = tonumber(ctx.button_id) or 0
+    local state_for_session = gm_state.get(ctx.session_id)
+    local current_add_state = ensure_add_state(state_for_session)
+    local target_character_id = tonumber(ctx.character_id) or 0
+
+    sync_inputs(current_add_state, ctx.text_entries)
+
+    if button_id == c.BUTTON_FILTER_ITEMS then
+      current_add_state.filter = "items"
+      current_add_state.page = 1
+      clear_selection(current_add_state)
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_FILTER_NPCS then
+      current_add_state.filter = "npcs"
+      current_add_state.page = 1
+      clear_selection(current_add_state)
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_SEARCH then
+      current_add_state.page = 1
+      clear_selection(current_add_state)
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_PREV_PAGE then
+      current_add_state.page = math.max(1, (tonumber(current_add_state.page) or 1) - 1)
+      clear_selection(current_add_state)
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_NEXT_PAGE then
+      current_add_state.page = (tonumber(current_add_state.page) or 1) + 1
+      clear_selection(current_add_state)
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id >= c.BUTTON_RESULT_BASE and button_id < c.BUTTON_RESULT_BASE + c.RESULT_ROWS then
+      local row = button_id - c.BUTTON_RESULT_BASE + 1
+      local current_results = load_results(current_add_state)
+      current_add_state.selected = current_results[row]
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_ADD_TO_BACKPACK then
+      if current_add_state.selected ~= nil and current_add_state.selected.kind == "item" and target_character_id > 0 then
+        mobile.add_item_to_backpack(target_character_id, current_add_state.selected.template_id, current_add_state.quantity or 1)
+      end
+
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_TARGET_GROUND then
+      if current_add_state.selected ~= nil and target_character_id > 0 then
+        request_spawn_target(
+          ctx.session_id,
+          target_character_id,
+          current_add_state.selected,
+          current_add_state.quantity or 1,
+          reopen_callback
+        )
+      end
+
+      return
+    end
+
+    if button_id == c.BUTTON_BRUSH then
+      if current_add_state.selected ~= nil and target_character_id > 0 then
+        local nonce = activate_brush(current_add_state, current_add_state.selected, current_add_state.quantity or 1)
+        request_brush_target(ctx.session_id, target_character_id, nonce, reopen_callback)
+      end
+
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_STOP_BRUSH then
+      clear_brush(current_add_state, ctx.session_id)
+      reopen_callback(ctx.session_id, ctx.character_id)
+    end
+  end
 end
 
 return add_section

--- a/moongate_data/scripts/gumps/gm_menu/sections/travel.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/travel.lua
@@ -11,6 +11,7 @@ function travel_section.add_content(layout, session_id, character_id, reopen_cal
       origin_x = 188,
       origin_y = 20,
       show_outer_frame = false,
+      use_alpha_regions = false,
       title = "Travel Browser"
     }
   )

--- a/moongate_data/scripts/gumps/gm_menu/sections/travel.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/travel.lua
@@ -1,19 +1,25 @@
-local c = require("gumps.gm_menu.constants")
-local ui = require("gumps.gm_menu.ui")
+local teleports_controller = require("gumps.teleports.controller")
 
 local travel_section = {}
 
-function travel_section.add_content(layout_ui)
-  ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Travel" })
-  ui.push(layout_ui, {
-    type = "label_cropped",
-    x = 196,
-    y = 88,
-    width = 324,
-    height = 20,
-    hue = c.MUTED_HUE,
-    text = "Curated travel destinations will appear here."
-  })
+function travel_section.add_content(layout, session_id, character_id, reopen_callback)
+  local embedded_layout = teleports_controller.build_layout(
+    session_id,
+    character_id,
+    reopen_callback,
+    {
+      origin_x = 188,
+      origin_y = 20,
+      show_outer_frame = false,
+      title = "Travel Browser"
+    }
+  )
+
+  for _, entry in ipairs(embedded_layout.ui) do
+    layout.ui[#layout.ui + 1] = entry
+  end
+
+  return embedded_layout.handlers.on_click
 end
 
 return travel_section

--- a/moongate_data/scripts/gumps/gm_menu/sections/travel.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/travel.lua
@@ -1,0 +1,19 @@
+local c = require("gumps.gm_menu.constants")
+local ui = require("gumps.gm_menu.ui")
+
+local travel_section = {}
+
+function travel_section.add_content(layout_ui)
+  ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Travel" })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 196,
+    y = 88,
+    width = 324,
+    height = 20,
+    hue = c.MUTED_HUE,
+    text = "Curated travel destinations will appear here."
+  })
+end
+
+return travel_section

--- a/moongate_data/scripts/gumps/gm_menu/state.lua
+++ b/moongate_data/scripts/gumps/gm_menu/state.lua
@@ -1,0 +1,48 @@
+local state = {}
+
+local session_state = {}
+
+local function create_default_state()
+  return {
+    active_tab = "add"
+  }
+end
+
+function state.clear(session_id)
+  local key = tonumber(session_id) or 0
+
+  if key > 0 then
+    session_state[key] = nil
+  end
+end
+
+function state.get(session_id)
+  local key = tonumber(session_id) or 0
+
+  if key <= 0 then
+    return create_default_state()
+  end
+
+  local current = session_state[key]
+
+  if current == nil then
+    current = create_default_state()
+    session_state[key] = current
+  end
+
+  return current
+end
+
+function state.set_active_tab(session_id, active_tab)
+  local current = state.get(session_id)
+
+  if active_tab == "travel" then
+    current.active_tab = "travel"
+  else
+    current.active_tab = "add"
+  end
+
+  return current
+end
+
+return state

--- a/moongate_data/scripts/gumps/gm_menu/state.lua
+++ b/moongate_data/scripts/gumps/gm_menu/state.lua
@@ -2,9 +2,30 @@ local state = {}
 
 local session_state = {}
 
+local function create_default_add_state()
+  return {
+    filter = "items",
+    query = "",
+    page = 1,
+    quantity = 1,
+    selected = nil,
+    brush = {
+      active = false,
+      kind = nil,
+      template_id = nil,
+      display_name = nil,
+      item_id = 0,
+      quantity = 1,
+      cursor_id = 0,
+      nonce = 0
+    }
+  }
+end
+
 local function create_default_state()
   return {
-    active_tab = "add"
+    active_tab = "add",
+    add = create_default_add_state()
   }
 end
 

--- a/moongate_data/scripts/gumps/gm_menu/ui.lua
+++ b/moongate_data/scripts/gumps/gm_menu/ui.lua
@@ -1,0 +1,44 @@
+local c = require("gumps.gm_menu.constants")
+
+local ui = {}
+
+local function push(layout_ui, entry)
+  layout_ui[#layout_ui + 1] = entry
+end
+
+ui.push = push
+
+function ui.add_frame(layout_ui)
+  push(layout_ui, { type = "background", x = 0, y = 0, gump_id = 5054, width = c.GUMP_WIDTH, height = c.GUMP_HEIGHT })
+  push(layout_ui, { type = "alpha_region", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = c.GUMP_HEIGHT - 24 })
+  push(layout_ui, { type = "image_tiled", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = 24, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = 24 })
+  push(layout_ui, { type = "label", x = 24, y = 16, hue = c.TITLE_HUE, text = "GM Menu" })
+
+  push(layout_ui, { type = "image_tiled", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = 344, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = 344 })
+
+  push(layout_ui, { type = "image_tiled", x = 180, y = 48, width = 360, height = 344, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = 180, y = 48, width = 360, height = 344 })
+end
+
+function ui.add_sidebar(layout_ui, current_state)
+  local add_hue = c.LABEL_HUE
+  local travel_hue = c.LABEL_HUE
+
+  if current_state.active_tab == "add" then
+    add_hue = c.ACCENT_HUE
+  else
+    travel_hue = c.ACCENT_HUE
+  end
+
+  push(layout_ui, { type = "label", x = 32, y = 62, hue = c.TITLE_HUE, text = "Tools" })
+
+  push(layout_ui, { type = "button", id = c.BUTTON_TAB_ADD, x = 32, y = 94, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = 64, y = 96, hue = add_hue, text = "Add" })
+
+  push(layout_ui, { type = "button", id = c.BUTTON_TAB_TRAVEL, x = 32, y = 126, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = 64, y = 128, hue = travel_hue, text = "Travel" })
+end
+
+return ui

--- a/moongate_data/scripts/gumps/gm_menu/ui.lua
+++ b/moongate_data/scripts/gumps/gm_menu/ui.lua
@@ -15,11 +15,8 @@ function ui.add_frame(layout_ui)
   push(layout_ui, { type = "alpha_region", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = 24 })
   push(layout_ui, { type = "label", x = 24, y = 16, hue = c.TITLE_HUE, text = "GM Menu" })
 
-  push(layout_ui, { type = "image_tiled", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = 344, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = 344 })
-
-  push(layout_ui, { type = "image_tiled", x = 180, y = 48, width = 360, height = 344, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 180, y = 48, width = 360, height = 344 })
+  push(layout_ui, { type = "image_tiled", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = c.GUMP_HEIGHT - 68, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = c.GUMP_HEIGHT - 68 })
 end
 
 function ui.add_sidebar(layout_ui, current_state)

--- a/moongate_data/scripts/gumps/gm_menu/ui.lua
+++ b/moongate_data/scripts/gumps/gm_menu/ui.lua
@@ -10,13 +10,10 @@ ui.push = push
 
 function ui.add_frame(layout_ui)
   push(layout_ui, { type = "background", x = 0, y = 0, gump_id = 5054, width = c.GUMP_WIDTH, height = c.GUMP_HEIGHT })
-  push(layout_ui, { type = "alpha_region", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = c.GUMP_HEIGHT - 24 })
   push(layout_ui, { type = "image_tiled", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = 24, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 12, y = 12, width = c.GUMP_WIDTH - 24, height = 24 })
   push(layout_ui, { type = "label", x = 24, y = 16, hue = c.TITLE_HUE, text = "GM Menu" })
 
   push(layout_ui, { type = "image_tiled", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = c.GUMP_HEIGHT - 68, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 20, y = 48, width = c.SIDEBAR_WIDTH, height = c.GUMP_HEIGHT - 68 })
 end
 
 function ui.add_sidebar(layout_ui, current_state)

--- a/moongate_data/scripts/gumps/teleports/actions.lua
+++ b/moongate_data/scripts/gumps/teleports/actions.lua
@@ -3,8 +3,13 @@ local c = require("gumps.teleports.constants")
 local actions = {}
 
 local function info(msg)
-  if log ~= nil and log.info ~= nil then
+  if type(log) == "table" and log.info ~= nil then
     log.info(msg)
+    return
+  end
+
+  if type(log) == "function" then
+    log(msg)
   end
 end
 
@@ -49,9 +54,9 @@ function actions.apply_button_action(state, button_id, character)
   elseif button_id == c.BUTTON_REFRESH then
     state.page = 1
   elseif button_id == c.BUTTON_GO then
-    if state.selected ~= nil and character ~= nil then
-      local m = mobile.get(character)
-      if m ~= nil then
+    local character_id = tonumber(character) or 0
+    if state.selected ~= nil and character_id > 0 then
+      if mobile.teleport(character_id, state.selected.map_id, state.selected.x, state.selected.y, state.selected.z) then
         info(
           "teleports go map="
             .. tostring(state.selected.map_id)
@@ -62,7 +67,6 @@ function actions.apply_button_action(state, button_id, character)
             .. " z="
             .. tostring(state.selected.z)
         )
-        m:teleport(state.selected.map_id, state.selected.x, state.selected.y, state.selected.z)
       end
     end
   end

--- a/moongate_data/scripts/gumps/teleports/controller.lua
+++ b/moongate_data/scripts/gumps/teleports/controller.lua
@@ -7,7 +7,7 @@ local actions = require("gumps.teleports.actions")
 
 local controller = {}
 
-function controller.build_layout(session_id, character_id, reopen_callback)
+function controller.build_layout(session_id, character_id, reopen_callback, options)
   local sender_serial = tonumber(character_id) or 0
   if sender_serial <= 0 then
     sender_serial = tonumber(session_id) or 1
@@ -16,25 +16,26 @@ function controller.build_layout(session_id, character_id, reopen_callback)
   local state = s.get(session_id)
   local all_locations = d.load_locations()
   local maps = d.distinct_maps(all_locations)
+  local view = ui.create_view(options)
 
   local layout = { ui = {}, handlers = {} }
   local layout_ui = layout.ui
 
-  ui.add_frame(layout_ui)
+  ui.add_frame(layout_ui, view)
 
   if #maps == 0 then
-    ui.push(layout_ui, { type = "label", x = 24, y = 54, hue = c.LABEL_HUE, text = "No locations loaded." })
+    ui.push(layout_ui, { type = "label", x = (view.origin_x or 0) + 24, y = (view.origin_y or 0) + 54, hue = c.LABEL_HUE, text = "No locations loaded." })
     return layout, sender_serial
   end
 
   render.ensure_valid_map(state, maps)
 
   if state.view == "map" then
-    render.map_step(layout_ui, state, maps)
+    render.map_step(layout_ui, state, maps, view)
   elseif state.view == "category" then
-    render.category_step(layout_ui, state, all_locations)
+    render.category_step(layout_ui, state, all_locations, view)
   else
-    render.location_step(layout_ui, state, all_locations)
+    render.location_step(layout_ui, state, all_locations, view)
   end
 
   layout.handlers.on_click = function(ctx)

--- a/moongate_data/scripts/gumps/teleports/render.lua
+++ b/moongate_data/scripts/gumps/teleports/render.lua
@@ -4,6 +4,18 @@ local ui = require("gumps.teleports.ui")
 
 local render = {}
 
+local function resolve_origin(view)
+  local ox = 0
+  local oy = 0
+
+  if view ~= nil then
+    ox = tonumber(view.origin_x) or 0
+    oy = tonumber(view.origin_y) or 0
+  end
+
+  return ox, oy
+end
+
 function render.ensure_valid_map(state, maps)
   if state.map_id == nil then
     state.map_id = maps[1].map_id
@@ -26,7 +38,8 @@ function render.ensure_valid_map(state, maps)
   end
 end
 
-function render.map_step(layout_ui, state, maps)
+function render.map_step(layout_ui, state, maps, view)
+  local ox, oy = resolve_origin(view)
   local total_pages
   state.page, total_pages = d.clamp_page(state.page, #maps, c.MAP_ROWS)
 
@@ -34,19 +47,19 @@ function render.map_step(layout_ui, state, maps)
   local end_idx = math.min(#maps, start_idx + c.MAP_ROWS - 1)
   state.visible_maps = {}
 
-  ui.push(layout_ui, { type = "label", x = 24, y = 48, hue = c.TITLE_HUE, text = "Step 1/3 - Select map" })
+  ui.push(layout_ui, { type = "label", x = ox + 24, y = oy + 48, hue = c.TITLE_HUE, text = "Step 1/3 - Select map" })
 
   local row = 1
-  local y = 72
+  local y = oy + 72
   for i = start_idx, end_idx do
     local map_entry = maps[i]
     state.visible_maps[row] = map_entry
     local prefix = (map_entry.map_id == state.map_id) and "* " or "  "
 
-    ui.push(layout_ui, { type = "button", id = c.BUTTON_MAP_BASE + row, x = 22, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_MAP_BASE + row, x = ox + 22, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
     ui.push(layout_ui, {
       type = "label_cropped",
-      x = 50,
+      x = ox + 50,
       y = y + 2,
       width = 430,
       height = 20,
@@ -58,12 +71,13 @@ function render.map_step(layout_ui, state, maps)
     row = row + 1
   end
 
-  ui.add_page_nav(layout_ui, state.page, total_pages)
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_TO_CATEGORY, x = 420, y = 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 450, y = 364, hue = c.LABEL_HUE, text = "Next" })
+  ui.add_page_nav(layout_ui, state.page, total_pages, view)
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_TO_CATEGORY, x = ox + 420, y = oy + 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = ox + 450, y = oy + 364, hue = c.LABEL_HUE, text = "Next" })
 end
 
-function render.category_step(layout_ui, state, all_locations)
+function render.category_step(layout_ui, state, all_locations, view)
+  local ox, oy = resolve_origin(view)
   local categories = d.categories_for_map(all_locations, state.map_id)
 
   if #categories == 0 then
@@ -79,20 +93,20 @@ function render.category_step(layout_ui, state, all_locations)
   local end_idx = math.min(#categories, start_idx + c.CATEGORY_ROWS - 1)
   state.visible_categories = {}
 
-  ui.push(layout_ui, { type = "label", x = 24, y = 48, hue = c.TITLE_HUE, text = "Step 2/3 - Select category" })
-  ui.push(layout_ui, { type = "label", x = 24, y = 64, hue = c.LABEL_HUE, text = "Map: " .. tostring(state.map_id) })
+  ui.push(layout_ui, { type = "label", x = ox + 24, y = oy + 48, hue = c.TITLE_HUE, text = "Step 2/3 - Select category" })
+  ui.push(layout_ui, { type = "label", x = ox + 24, y = oy + 64, hue = c.LABEL_HUE, text = "Map: " .. tostring(state.map_id) })
 
   local row = 1
-  local y = 86
+  local y = oy + 86
   for i = start_idx, end_idx do
     local category = categories[i]
     state.visible_categories[row] = category
     local prefix = (category == state.category) and "* " or "  "
 
-    ui.push(layout_ui, { type = "button", id = c.BUTTON_CATEGORY_BASE + row, x = 22, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_CATEGORY_BASE + row, x = ox + 22, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
     ui.push(layout_ui, {
       type = "label_cropped",
-      x = 50,
+      x = ox + 50,
       y = y + 2,
       width = 430,
       height = 20,
@@ -104,15 +118,16 @@ function render.category_step(layout_ui, state, all_locations)
     row = row + 1
   end
 
-  ui.add_page_nav(layout_ui, state.page, total_pages)
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_BACK_TO_MAP, x = 330, y = 362, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 360, y = 364, hue = c.LABEL_HUE, text = "Back" })
+  ui.add_page_nav(layout_ui, state.page, total_pages, view)
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_BACK_TO_MAP, x = ox + 330, y = oy + 362, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = ox + 360, y = oy + 364, hue = c.LABEL_HUE, text = "Back" })
 
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_TO_LOCATION, x = 420, y = 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 450, y = 364, hue = c.LABEL_HUE, text = "Next" })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_TO_LOCATION, x = ox + 420, y = oy + 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = ox + 450, y = oy + 364, hue = c.LABEL_HUE, text = "Next" })
 end
 
-function render.location_step(layout_ui, state, all_locations)
+function render.location_step(layout_ui, state, all_locations, view)
+  local ox, oy = resolve_origin(view)
   local categories = d.categories_for_map(all_locations, state.map_id)
 
   if #categories == 0 then
@@ -135,11 +150,11 @@ function render.location_step(layout_ui, state, all_locations)
   local end_idx = math.min(#locations, start_idx + c.LOCATION_ROWS - 1)
   state.visible_locations = {}
 
-  ui.push(layout_ui, { type = "label", x = 24, y = 48, hue = c.TITLE_HUE, text = "Step 3/3 - Select location" })
+  ui.push(layout_ui, { type = "label", x = ox + 24, y = oy + 48, hue = c.TITLE_HUE, text = "Step 3/3 - Select location" })
   ui.push(layout_ui, {
     type = "label_cropped",
-    x = 24,
-    y = 64,
+    x = ox + 24,
+    y = oy + 64,
     width = 460,
     height = 20,
     hue = c.LABEL_HUE,
@@ -147,16 +162,16 @@ function render.location_step(layout_ui, state, all_locations)
   })
 
   local row = 1
-  local y = 86
+  local y = oy + 86
   for i = start_idx, end_idx do
     local location_entry = locations[i]
     state.visible_locations[row] = location_entry
     local prefix = d.selected_equals(state.selected, location_entry) and "* " or "  "
 
-    ui.push(layout_ui, { type = "button", id = c.BUTTON_LOCATION_BASE + row, x = 22, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, { type = "button", id = c.BUTTON_LOCATION_BASE + row, x = ox + 22, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
     ui.push(layout_ui, {
       type = "label_cropped",
-      x = 50,
+      x = ox + 50,
       y = y + 2,
       width = 430,
       height = 20,
@@ -168,18 +183,18 @@ function render.location_step(layout_ui, state, all_locations)
     row = row + 1
   end
 
-  ui.add_page_nav(layout_ui, state.page, total_pages)
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_BACK_TO_CATEGORY, x = 300, y = 362, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 330, y = 364, hue = c.LABEL_HUE, text = "Back" })
+  ui.add_page_nav(layout_ui, state.page, total_pages, view)
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_BACK_TO_CATEGORY, x = ox + 300, y = oy + 362, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = ox + 330, y = oy + 364, hue = c.LABEL_HUE, text = "Back" })
 
-  ui.push(layout_ui, { type = "button", id = c.BUTTON_GO, x = 420, y = 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  ui.push(layout_ui, { type = "label", x = 450, y = 364, hue = c.LABEL_HUE, text = "Go" })
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_GO, x = ox + 420, y = oy + 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = ox + 450, y = oy + 364, hue = c.LABEL_HUE, text = "Go" })
 
   if state.selected ~= nil then
     ui.push(layout_ui, {
       type = "label_cropped",
-      x = 150,
-      y = 364,
+      x = ox + 150,
+      y = oy + 364,
       width = 140,
       height = 20,
       hue = c.LABEL_HUE,

--- a/moongate_data/scripts/gumps/teleports/ui.lua
+++ b/moongate_data/scripts/gumps/teleports/ui.lua
@@ -8,28 +8,50 @@ end
 
 ui.push = push
 
-function ui.add_frame(layout_ui)
-  push(layout_ui, { type = "background", x = 0, y = 0, gump_id = 5054, width = c.GUMP_WIDTH, height = c.GUMP_HEIGHT })
-  push(layout_ui, { type = "alpha_region", x = 10, y = 10, width = 500, height = 400 })
+function ui.create_view(options)
+  local resolved = options or {}
 
-  push(layout_ui, { type = "image_tiled", x = 10, y = 10, width = 500, height = 22, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 10, y = 10, width = 500, height = 22 })
-  push(layout_ui, { type = "label", x = 20, y = 14, hue = c.TITLE_HUE, text = "Teleport Browser" })
-
-  push(layout_ui, { type = "button", id = c.BUTTON_REFRESH, x = 420, y = 12, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  push(layout_ui, { type = "label", x = 450, y = 14, hue = c.LABEL_HUE, text = "Refresh" })
-
-  push(layout_ui, { type = "image_tiled", x = 10, y = 40, width = 500, height = 300, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 10, y = 40, width = 500, height = 300 })
-
-  push(layout_ui, { type = "image_tiled", x = 10, y = 350, width = 500, height = 60, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = 10, y = 350, width = 500, height = 60 })
+  return {
+    origin_x = tonumber(resolved.origin_x) or 0,
+    origin_y = tonumber(resolved.origin_y) or 0,
+    show_outer_frame = resolved.show_outer_frame ~= false,
+    show_refresh = resolved.show_refresh ~= false,
+    title = tostring(resolved.title or "Teleport Browser")
+  }
 end
 
-function ui.add_page_nav(layout_ui, page, pages)
-  push(layout_ui, { type = "button", id = c.BUTTON_PREV_PAGE, x = 20, y = 362, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
-  push(layout_ui, { type = "button", id = c.BUTTON_NEXT_PAGE, x = 60, y = 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  push(layout_ui, { type = "label", x = 95, y = 364, hue = c.LABEL_HUE, text = "Page " .. tostring(page) .. "/" .. tostring(pages) })
+function ui.add_frame(layout_ui, view)
+  local ox = view.origin_x or 0
+  local oy = view.origin_y or 0
+
+  if view.show_outer_frame then
+    push(layout_ui, { type = "background", x = ox, y = oy, gump_id = 5054, width = c.GUMP_WIDTH, height = c.GUMP_HEIGHT })
+    push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 10, width = 500, height = 400 })
+  end
+
+  push(layout_ui, { type = "image_tiled", x = ox + 10, y = oy + 10, width = 500, height = 22, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 10, width = 500, height = 22 })
+  push(layout_ui, { type = "label", x = ox + 20, y = oy + 14, hue = c.TITLE_HUE, text = view.title })
+
+  if view.show_refresh then
+    push(layout_ui, { type = "button", id = c.BUTTON_REFRESH, x = ox + 420, y = oy + 12, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    push(layout_ui, { type = "label", x = ox + 450, y = oy + 14, hue = c.LABEL_HUE, text = "Refresh" })
+  end
+
+  push(layout_ui, { type = "image_tiled", x = ox + 10, y = oy + 40, width = 500, height = 300, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 40, width = 500, height = 300 })
+
+  push(layout_ui, { type = "image_tiled", x = ox + 10, y = oy + 350, width = 500, height = 60, gump_id = 2624 })
+  push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 350, width = 500, height = 60 })
+end
+
+function ui.add_page_nav(layout_ui, page, pages, view)
+  local ox = view.origin_x or 0
+  local oy = view.origin_y or 0
+
+  push(layout_ui, { type = "button", id = c.BUTTON_PREV_PAGE, x = ox + 20, y = oy + 362, normal_id = 4014, pressed_id = 4016, onclick = "on_click" })
+  push(layout_ui, { type = "button", id = c.BUTTON_NEXT_PAGE, x = ox + 60, y = oy + 362, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = ox + 95, y = oy + 364, hue = c.LABEL_HUE, text = "Page " .. tostring(page) .. "/" .. tostring(pages) })
 end
 
 return ui

--- a/moongate_data/scripts/gumps/teleports/ui.lua
+++ b/moongate_data/scripts/gumps/teleports/ui.lua
@@ -16,6 +16,7 @@ function ui.create_view(options)
     origin_y = tonumber(resolved.origin_y) or 0,
     show_outer_frame = resolved.show_outer_frame ~= false,
     show_refresh = resolved.show_refresh ~= false,
+    use_alpha_regions = resolved.use_alpha_regions ~= false,
     title = tostring(resolved.title or "Teleport Browser")
   }
 end
@@ -23,14 +24,19 @@ end
 function ui.add_frame(layout_ui, view)
   local ox = view.origin_x or 0
   local oy = view.origin_y or 0
+  local use_alpha_regions = view.use_alpha_regions ~= false
 
   if view.show_outer_frame then
     push(layout_ui, { type = "background", x = ox, y = oy, gump_id = 5054, width = c.GUMP_WIDTH, height = c.GUMP_HEIGHT })
-    push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 10, width = 500, height = 400 })
+    if use_alpha_regions then
+      push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 10, width = 500, height = 400 })
+    end
   end
 
   push(layout_ui, { type = "image_tiled", x = ox + 10, y = oy + 10, width = 500, height = 22, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 10, width = 500, height = 22 })
+  if use_alpha_regions then
+    push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 10, width = 500, height = 22 })
+  end
   push(layout_ui, { type = "label", x = ox + 20, y = oy + 14, hue = c.TITLE_HUE, text = view.title })
 
   if view.show_refresh then
@@ -39,10 +45,14 @@ function ui.add_frame(layout_ui, view)
   end
 
   push(layout_ui, { type = "image_tiled", x = ox + 10, y = oy + 40, width = 500, height = 300, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 40, width = 500, height = 300 })
+  if use_alpha_regions then
+    push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 40, width = 500, height = 300 })
+  end
 
   push(layout_ui, { type = "image_tiled", x = ox + 10, y = oy + 350, width = 500, height = 60, gump_id = 2624 })
-  push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 350, width = 500, height = 60 })
+  if use_alpha_regions then
+    push(layout_ui, { type = "alpha_region", x = ox + 10, y = oy + 350, width = 500, height = 60 })
+  end
 end
 
 function ui.add_page_nav(layout_ui, page, pages, view)

--- a/moongate_data/scripts/interaction/gm_menu.lua
+++ b/moongate_data/scripts/interaction/gm_menu.lua
@@ -1,0 +1,9 @@
+local gm_menu = require("gumps.gm_menu")
+
+function on_gm_menu_request(session_id, character_id)
+  if session_id == nil or character_id == nil then
+    return false
+  end
+
+  return gm_menu.open(session_id, character_id)
+end

--- a/moongate_data/scripts/interaction/init.lua
+++ b/moongate_data/scripts/interaction/init.lua
@@ -1,1 +1,2 @@
 require("interaction.help")
+require("interaction.gm_menu")

--- a/src/Moongate.Server/Commands/Player/GmCommand.cs
+++ b/src/Moongate.Server/Commands/Player/GmCommand.cs
@@ -1,0 +1,43 @@
+using Moongate.Scripting.Interfaces;
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Internal.Commands;
+using Moongate.Server.Interfaces.Services.Console;
+using Moongate.Server.Types.Commands;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Commands.Player;
+
+[RegisterConsoleCommand(
+    "gm|.gm",
+    "Open the GM menu. Usage: .gm",
+    CommandSourceType.InGame,
+    AccountType.GameMaster
+)]
+public sealed class GmCommand : ICommandExecutor
+{
+    private readonly IScriptEngineService _scriptEngineService;
+
+    public GmCommand(IScriptEngineService scriptEngineService)
+    {
+        _scriptEngineService = scriptEngineService;
+    }
+
+    public Task ExecuteCommandAsync(CommandSystemContext context)
+    {
+        if (context.Arguments.Length != 0)
+        {
+            context.Print("Usage: .gm");
+
+            return Task.CompletedTask;
+        }
+
+        if (!context.CharacterId.IsValid)
+        {
+            return Task.CompletedTask;
+        }
+
+        _scriptEngineService.CallFunction("on_gm_menu_request", context.SessionId, (uint)context.CharacterId);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Moongate.Server/Data/Internal/Templates/LuaItemTemplateSearchResult.cs
+++ b/src/Moongate.Server/Data/Internal/Templates/LuaItemTemplateSearchResult.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Server.Data.Internal.Templates;
+
+internal sealed class LuaItemTemplateSearchResult
+{
+    public LuaItemTemplateSearchResult(string templateId, string displayName, int itemId)
+    {
+        TemplateId = templateId;
+        DisplayName = displayName;
+        ItemId = itemId;
+    }
+
+    public string TemplateId { get; }
+
+    public string DisplayName { get; }
+
+    public int ItemId { get; }
+}

--- a/src/Moongate.Server/Data/Internal/Templates/LuaMobileTemplateSearchResult.cs
+++ b/src/Moongate.Server/Data/Internal/Templates/LuaMobileTemplateSearchResult.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Server.Data.Internal.Templates;
+
+internal sealed class LuaMobileTemplateSearchResult
+{
+    public LuaMobileTemplateSearchResult(string templateId, string displayName)
+    {
+        TemplateId = templateId;
+        DisplayName = displayName;
+    }
+
+    public string TemplateId { get; }
+
+    public string DisplayName { get; }
+}

--- a/src/Moongate.Server/Modules/ItemModule.cs
+++ b/src/Moongate.Server/Modules/ItemModule.cs
@@ -82,6 +82,7 @@ public sealed class ItemModule
         }
 
         var resolved = _itemService.GetItemAsync(item.Id).GetAwaiter().GetResult() ?? item;
+        _spatialWorldService?.AddOrUpdateItem(resolved, mapId);
 
         return new(resolved, _itemService, _spatialWorldService, _speechService);
     }

--- a/src/Moongate.Server/Modules/ItemModule.cs
+++ b/src/Moongate.Server/Modules/ItemModule.cs
@@ -1,11 +1,15 @@
+using System.Globalization;
 using Moongate.Scripting.Attributes.Scripts;
 using Moongate.Scripting.Descriptors;
 using Moongate.Server.Data.Internal.Entities;
+using Moongate.Server.Data.Internal.Templates;
 using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Interfaces.Services.Speech;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Interfaces.Templates;
+using Moongate.UO.Data.Templates.Items;
 using MoonSharp.Interpreter;
 
 namespace Moongate.Server.Modules;
@@ -17,20 +21,24 @@ namespace Moongate.Server.Modules;
 /// </summary>
 public sealed class ItemModule
 {
+    private const int MaxTemplateSearchPageSize = 50;
     private static bool _isLuaItemProxyTypeRegistered;
     private readonly IItemService _itemService;
     private readonly ISpatialWorldService? _spatialWorldService;
     private readonly ISpeechService? _speechService;
+    private readonly IItemTemplateService? _itemTemplateService;
 
     public ItemModule(
         IItemService itemService,
         ISpatialWorldService? spatialWorldService = null,
-        ISpeechService? speechService = null
+        ISpeechService? speechService = null,
+        IItemTemplateService? itemTemplateService = null
     )
     {
         _itemService = itemService;
         _spatialWorldService = spatialWorldService;
         _speechService = speechService;
+        _itemTemplateService = itemTemplateService;
     }
 
     [ScriptFunction("get", "Gets an item reference by item id, or nil when not found.")]
@@ -76,6 +84,37 @@ public sealed class ItemModule
         var resolved = _itemService.GetItemAsync(item.Id).GetAwaiter().GetResult() ?? item;
 
         return new(resolved, _itemService, _spatialWorldService, _speechService);
+    }
+
+    [ScriptFunction("search_templates", "Searches item templates for GM tools and returns paged results.")]
+    public Table SearchTemplates(string query, int page = 1, int pageSize = 20)
+    {
+        var results = new Table(null);
+
+        if (_itemTemplateService is null)
+        {
+            return results;
+        }
+
+        var normalizedQuery = query?.Trim() ?? string.Empty;
+        var normalizedPage = Math.Max(1, page);
+        var normalizedPageSize = Math.Clamp(pageSize, 1, MaxTemplateSearchPageSize);
+        var matches = SearchTemplateDefinitions(_itemTemplateService.GetAll(), normalizedQuery);
+        var paged = matches.Skip((normalizedPage - 1) * normalizedPageSize).Take(normalizedPageSize);
+        var index = 1;
+
+        foreach (var match in paged)
+        {
+            var entry = new Table(null)
+            {
+                ["template_id"] = match.TemplateId,
+                ["display_name"] = match.DisplayName,
+                ["item_id"] = match.ItemId
+            };
+            results[index++] = entry;
+        }
+
+        return results;
     }
 
     private static void RegisterLuaTypeIfNeeded()
@@ -132,4 +171,74 @@ public sealed class ItemModule
 
         return true;
     }
+
+    private static IReadOnlyList<LuaItemTemplateSearchResult> SearchTemplateDefinitions(
+        IReadOnlyList<ItemTemplateDefinition> templates,
+        string query
+    )
+    {
+        var orderedTemplates = templates.OrderBy(static template => template.Id, StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return orderedTemplates.Select(MapSearchResult).ToList();
+        }
+
+        var prefixMatches = new List<LuaItemTemplateSearchResult>();
+        var substringMatches = new List<LuaItemTemplateSearchResult>();
+
+        foreach (var template in orderedTemplates)
+        {
+            var displayName = ResolveDisplayName(template);
+            var matchesPrefix = template.Id.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
+                                displayName.StartsWith(query, StringComparison.OrdinalIgnoreCase);
+
+            if (matchesPrefix)
+            {
+                prefixMatches.Add(MapSearchResult(template));
+
+                continue;
+            }
+
+            if (template.Id.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                displayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+            {
+                substringMatches.Add(MapSearchResult(template));
+            }
+        }
+
+        return [..prefixMatches, ..substringMatches];
+    }
+
+    private static LuaItemTemplateSearchResult MapSearchResult(ItemTemplateDefinition template)
+        => new(template.Id, ResolveDisplayName(template), ParseItemId(template.ItemId));
+
+    private static int ParseItemId(string itemIdText)
+    {
+        if (string.IsNullOrWhiteSpace(itemIdText))
+        {
+            return 0;
+        }
+
+        var value = itemIdText.Trim();
+
+        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return int.TryParse(
+                value.AsSpan(2),
+                NumberStyles.AllowHexSpecifier,
+                CultureInfo.InvariantCulture,
+                out var itemId
+            )
+                       ? itemId
+                       : 0;
+        }
+
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedItemId)
+                   ? parsedItemId
+                   : 0;
+    }
+
+    private static string ResolveDisplayName(ItemTemplateDefinition template)
+        => string.IsNullOrWhiteSpace(template.Name) ? template.Id : template.Name.Trim();
 }

--- a/src/Moongate.Server/Modules/MobileModule.cs
+++ b/src/Moongate.Server/Modules/MobileModule.cs
@@ -3,6 +3,7 @@ using Moongate.Scripting.Descriptors;
 using Moongate.Server.Data.Interaction;
 using Moongate.Server.Data.Internal.Entities;
 using Moongate.Server.Data.Internal.Interaction;
+using Moongate.Server.Data.Internal.Templates;
 using Moongate.Server.Interfaces.Characters;
 using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Services.Entities;
@@ -16,7 +17,9 @@ using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Interfaces.Services.Speech;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Interfaces.Templates;
 using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Templates.Mobiles;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
 
@@ -29,6 +32,7 @@ namespace Moongate.Server.Modules;
 /// </summary>
 public sealed class MobileModule
 {
+    private const int MaxTemplateSearchPageSize = 50;
     private static bool _isLuaMobileProxyTypeRegistered;
     private static bool _isLuaItemProxyTypeRegistered;
     private readonly ICharacterService _characterService;
@@ -43,6 +47,7 @@ public sealed class MobileModule
     private readonly IOutgoingPacketQueue? _outgoingPacketQueue;
     private readonly IItemService? _itemService;
     private readonly ISkillGainService? _skillGainService;
+    private readonly IMobileTemplateService? _mobileTemplateService;
     private readonly Func<double> _skillCheckRollProvider;
 
     public MobileModule(
@@ -58,6 +63,7 @@ public sealed class MobileModule
         IOutgoingPacketQueue? outgoingPacketQueue = null,
         IItemService? itemService = null,
         ISkillGainService? skillGainService = null,
+        IMobileTemplateService? mobileTemplateService = null,
         Func<double>? skillCheckRollProvider = null
     )
     {
@@ -73,6 +79,7 @@ public sealed class MobileModule
         _outgoingPacketQueue = outgoingPacketQueue;
         _itemService = itemService;
         _skillGainService = skillGainService;
+        _mobileTemplateService = mobileTemplateService;
         _skillCheckRollProvider = skillCheckRollProvider ?? Random.Shared.NextDouble;
     }
 
@@ -293,6 +300,36 @@ public sealed class MobileModule
         );
     }
 
+    [ScriptFunction("search_templates", "Searches mobile templates for GM tools and returns paged results.")]
+    public Table SearchTemplates(string query, int page = 1, int pageSize = 20)
+    {
+        var results = new Table(null);
+
+        if (_mobileTemplateService is null)
+        {
+            return results;
+        }
+
+        var normalizedQuery = query?.Trim() ?? string.Empty;
+        var normalizedPage = Math.Max(1, page);
+        var normalizedPageSize = Math.Clamp(pageSize, 1, MaxTemplateSearchPageSize);
+        var matches = SearchTemplateDefinitions(_mobileTemplateService.GetAll(), normalizedQuery);
+        var paged = matches.Skip((normalizedPage - 1) * normalizedPageSize).Take(normalizedPageSize);
+        var index = 1;
+
+        foreach (var match in paged)
+        {
+            var entry = new Table(null)
+            {
+                ["template_id"] = match.TemplateId,
+                ["display_name"] = match.DisplayName
+            };
+            results[index++] = entry;
+        }
+
+        return results;
+    }
+
     [ScriptFunction("try_mount", "Attempts to mount the rider on the target mount creature.")]
     public bool TryMount(uint riderId, uint mountId)
     {
@@ -376,6 +413,54 @@ public sealed class MobileModule
         UserData.RegisterType(type, new GenericUserDataDescriptor(type));
         _isLuaItemProxyTypeRegistered = true;
     }
+
+    private static string ResolveDisplayName(MobileTemplateDefinition template)
+        => !string.IsNullOrWhiteSpace(template.Name)
+               ? template.Name.Trim()
+               : !string.IsNullOrWhiteSpace(template.Title)
+                   ? template.Title.Trim()
+                   : template.Id;
+
+    private static IReadOnlyList<LuaMobileTemplateSearchResult> SearchTemplateDefinitions(
+        IReadOnlyList<MobileTemplateDefinition> templates,
+        string query
+    )
+    {
+        var orderedTemplates = templates.OrderBy(static template => template.Id, StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return orderedTemplates.Select(MapSearchResult).ToList();
+        }
+
+        var prefixMatches = new List<LuaMobileTemplateSearchResult>();
+        var substringMatches = new List<LuaMobileTemplateSearchResult>();
+
+        foreach (var template in orderedTemplates)
+        {
+            var displayName = ResolveDisplayName(template);
+            var matchesPrefix = template.Id.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
+                                displayName.StartsWith(query, StringComparison.OrdinalIgnoreCase);
+
+            if (matchesPrefix)
+            {
+                prefixMatches.Add(MapSearchResult(template));
+
+                continue;
+            }
+
+            if (template.Id.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                displayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+            {
+                substringMatches.Add(MapSearchResult(template));
+            }
+        }
+
+        return [..prefixMatches, ..substringMatches];
+    }
+
+    private static LuaMobileTemplateSearchResult MapSearchResult(MobileTemplateDefinition template)
+        => new(template.Id, ResolveDisplayName(template));
 
     private UOMobileEntity? ResolveRiderForMount(Serial riderId)
     {

--- a/src/Moongate.Server/Modules/MobileModule.cs
+++ b/src/Moongate.Server/Modules/MobileModule.cs
@@ -153,6 +153,21 @@ public sealed class MobileModule
         return CreateLuaItemProxy(TryResolveWeapon(mobile));
     }
 
+    [ScriptFunction("teleport", "Teleports a character id to the provided map and world coordinates.")]
+    public bool Teleport(uint characterId, int mapId, int x, int y, int z)
+    {
+        var mobile = ResolveMobile((Serial)characterId);
+
+        if (mobile is null)
+        {
+            return false;
+        }
+
+        var proxy = CreateLuaMobileProxy(mobile);
+
+        return proxy is not null && proxy.Teleport(mapId, x, y, z);
+    }
+
     [ScriptFunction("check_skill", "Checks a skill against a min/max range and applies gain rules.")]
     public bool CheckSkill(uint characterId, string skillName, double minSkill, double maxSkill, uint targetId = 0)
     {

--- a/src/Moongate.Server/Modules/MobileModule.cs
+++ b/src/Moongate.Server/Modules/MobileModule.cs
@@ -302,6 +302,7 @@ public sealed class MobileModule
         var mobile = _mobileService.SpawnFromTemplateAsync(mobileTemplateId.Trim(), location, mapId)
                                    .GetAwaiter()
                                    .GetResult();
+        _spatialWorldService?.AddOrUpdateMobile(mobile);
 
         return new(
             mobile,

--- a/src/Moongate.Server/Modules/TargetModule.cs
+++ b/src/Moongate.Server/Modules/TargetModule.cs
@@ -70,7 +70,8 @@ public sealed class TargetModule
             ["x"] = callback.Packet.Location.X,
             ["y"] = callback.Packet.Location.Y,
             ["z"] = callback.Packet.Location.Z,
-            ["cursor_id"] = (uint)callback.Packet.CursorId
+            ["cursor_id"] = (uint)callback.Packet.CursorId,
+            ["cancelled"] = callback.Packet.CursorType == TargetCursorType.CancelCurrentTargeting
         };
 
         if (_gameNetworkSessionService.TryGet(sessionId, out var session) && session.Character is not null)

--- a/src/Moongate.Server/Modules/TargetModule.cs
+++ b/src/Moongate.Server/Modules/TargetModule.cs
@@ -1,0 +1,88 @@
+using Moongate.Network.Packets.Types.Targeting;
+using Moongate.Scripting.Attributes.Scripts;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.UO.Data.Ids;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Server.Modules;
+
+[ScriptModule("target", "Provides target cursor request helpers for Lua scripts.")]
+public sealed class TargetModule
+{
+    private readonly IPlayerTargetService _playerTargetService;
+    private readonly IGameNetworkSessionService _gameNetworkSessionService;
+
+    public TargetModule(
+        IPlayerTargetService playerTargetService,
+        IGameNetworkSessionService gameNetworkSessionService
+    )
+    {
+        _playerTargetService = playerTargetService;
+        _gameNetworkSessionService = gameNetworkSessionService;
+    }
+
+    [ScriptFunction("cancel", "Cancels a pending target cursor by cursor id.")]
+    public bool Cancel(long sessionId, uint cursorId)
+    {
+        if (sessionId <= 0 || cursorId == 0)
+        {
+            return false;
+        }
+
+        _playerTargetService.SendCancelTargetCursorAsync(sessionId, (Serial)cursorId).GetAwaiter().GetResult();
+
+        return true;
+    }
+
+    [ScriptFunction("request_location", "Requests a location target cursor and dispatches the result to a Lua closure.")]
+    public uint RequestLocation(long sessionId, Closure handler, int cursorType = (int)TargetCursorType.Neutral)
+    {
+        if (sessionId <= 0 || handler is null)
+        {
+            return 0;
+        }
+
+        var requestedCursorType = (TargetCursorType)cursorType;
+        var cursorId = _playerTargetService.SendTargetCursorAsync(
+                                               sessionId,
+                                               callback => InvokeHandler(handler, sessionId, callback),
+                                               TargetCursorSelectionType.SelectLocation,
+                                               requestedCursorType
+                                           )
+                                           .GetAwaiter()
+                                           .GetResult();
+
+        return (uint)cursorId;
+    }
+
+    private void InvokeHandler(Closure handler, long sessionId, Data.Internal.Cursors.PendingCursorCallback callback)
+    {
+        var script = handler.OwnerScript;
+
+        if (script is null)
+        {
+            return;
+        }
+
+        var payload = new Table(script)
+        {
+            ["x"] = callback.Packet.Location.X,
+            ["y"] = callback.Packet.Location.Y,
+            ["z"] = callback.Packet.Location.Z,
+            ["cursor_id"] = (uint)callback.Packet.CursorId
+        };
+
+        if (_gameNetworkSessionService.TryGet(sessionId, out var session) && session.Character is not null)
+        {
+            payload["map_id"] = session.Character.MapId;
+            payload["character_id"] = (uint)session.Character.Id;
+        }
+        else
+        {
+            payload["map_id"] = 0;
+        }
+
+        script.Call(handler, payload);
+    }
+}

--- a/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
@@ -1,29 +1,942 @@
+using System.Buffers.Binary;
 using System.Net.Sockets;
+using System.Text;
 using DryIoc;
 using Moongate.Core.Data.Directories;
 using Moongate.Core.Types;
 using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.Speech;
+using Moongate.Network.Packets.Incoming.Targeting;
+using Moongate.Network.Packets.Incoming.UI;
+using Moongate.Network.Packets.Outgoing.Speech;
 using Moongate.Network.Packets.Outgoing.UI;
+using Moongate.Network.Packets.Types.Targeting;
 using Moongate.Scripting.Services;
+using Moongate.Server.Data.Internal.Cursors;
+using Moongate.Server.Data.Items;
 using Moongate.Server.Data.Session;
+using Moongate.Server.Data.World;
+using Moongate.Server.Interfaces.Characters;
+using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Interaction;
 using Moongate.Server.Interfaces.Services.Packets;
 using Moongate.Server.Interfaces.Services.Scripting;
 using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Speech;
+using Moongate.Server.Interfaces.Services.World;
 using Moongate.Server.Modules;
 using Moongate.Server.Services.Scripting;
 using Moongate.Tests.Server.Services.Spatial;
 using Moongate.Tests.Server.Support;
 using Moongate.Tests.TestSupport;
+using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Interfaces.Templates;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Templates.Items;
+using Moongate.UO.Data.Templates.Mobiles;
+using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
 
 namespace Moongate.Tests.Scripting;
 
 public sealed class GmMenuLuaRuntimeTests
 {
+    private sealed class GmMenuLuaRuntimeCharacterService : ICharacterService
+    {
+        public UOMobileEntity? Character { get; set; }
+
+        public Task<bool> AddCharacterToAccountAsync(Serial accountId, Serial characterId)
+        {
+            _ = accountId;
+            _ = characterId;
+
+            return Task.FromResult(true);
+        }
+
+        public Task ApplyStarterEquipmentHuesAsync(Serial characterId, short shirtHue, short pantsHue)
+        {
+            _ = characterId;
+            _ = shirtHue;
+            _ = pantsHue;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<Serial> CreateCharacterAsync(UOMobileEntity character)
+        {
+            Character = character;
+
+            return Task.FromResult(character.Id);
+        }
+
+        public Task<UOItemEntity?> GetBackpackWithItemsAsync(UOMobileEntity character)
+        {
+            _ = character;
+
+            return Task.FromResult<UOItemEntity?>(null);
+        }
+
+        public Task<UOItemEntity?> GetBankBoxWithItemsAsync(UOMobileEntity character)
+        {
+            _ = character;
+
+            return Task.FromResult<UOItemEntity?>(null);
+        }
+
+        public Task<UOMobileEntity?> GetCharacterAsync(Serial characterId)
+            => Task.FromResult(Character?.Id == characterId ? Character : null);
+
+        public Task<List<UOMobileEntity>> GetCharactersForAccountAsync(Serial accountId)
+        {
+            _ = accountId;
+
+            return Task.FromResult(new List<UOMobileEntity>());
+        }
+
+        public Task<bool> RemoveCharacterFromAccountAsync(Serial accountId, Serial characterId)
+        {
+            _ = accountId;
+            _ = characterId;
+
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class GmMenuLuaRuntimeLocationCatalogService : ILocationCatalogService
+    {
+        public IReadOnlyList<WorldLocationEntry> Locations { get; set; } = [];
+
+        public IReadOnlyList<WorldLocationEntry> GetAllLocations()
+            => Locations;
+
+        public void SetLocations(IReadOnlyList<WorldLocationEntry> locations)
+            => Locations = locations;
+    }
+
+    private sealed class GmMenuLuaRuntimeSpeechService : ISpeechService
+    {
+        public Task<int> BroadcastFromServerAsync(
+            string text,
+            short hue = 946,
+            short font = 3,
+            string language = "ENU"
+        )
+        {
+            _ = text;
+            _ = hue;
+            _ = font;
+            _ = language;
+
+            return Task.FromResult(0);
+        }
+
+        public Task HandleOpenChatWindowAsync(
+            GameSession session,
+            OpenChatWindowPacket packet,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = session;
+            _ = packet;
+            _ = cancellationToken;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<UnicodeSpeechMessagePacket?> ProcessIncomingSpeechAsync(
+            GameSession session,
+            UnicodeSpeechPacket speechPacket,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = session;
+            _ = speechPacket;
+            _ = cancellationToken;
+
+            return Task.FromResult<UnicodeSpeechMessagePacket?>(null);
+        }
+
+        public Task<bool> SendMessageFromServerAsync(
+            GameSession session,
+            string text,
+            short hue = 946,
+            short font = 3,
+            string language = "ENU"
+        )
+        {
+            _ = session;
+            _ = text;
+            _ = hue;
+            _ = font;
+            _ = language;
+
+            return Task.FromResult(true);
+        }
+
+        public Task<int> SpeakAsMobileAsync(
+            UOMobileEntity speaker,
+            string text,
+            int range = 12,
+            ChatMessageType messageType = ChatMessageType.Regular,
+            short hue = SpeechHues.Default,
+            short font = SpeechHues.DefaultFont,
+            string language = "ENU",
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = speaker;
+            _ = text;
+            _ = range;
+            _ = messageType;
+            _ = hue;
+            _ = font;
+            _ = language;
+            _ = cancellationToken;
+
+            return Task.FromResult(0);
+        }
+    }
+
+    private sealed class GmMenuLuaRuntimeItemTemplateService : IItemTemplateService
+    {
+        private readonly Dictionary<string, ItemTemplateDefinition> _templates = new(StringComparer.OrdinalIgnoreCase);
+
+        public int Count => _templates.Count;
+
+        public void Clear()
+            => _templates.Clear();
+
+        public IReadOnlyList<ItemTemplateDefinition> GetAll()
+            => _templates.Values.ToList();
+
+        public bool TryGet(string id, out ItemTemplateDefinition? definition)
+            => _templates.TryGetValue(id, out definition);
+
+        public void Upsert(ItemTemplateDefinition definition)
+            => _templates[definition.Id] = definition;
+
+        public void UpsertRange(IEnumerable<ItemTemplateDefinition> templates)
+        {
+            foreach (var template in templates)
+            {
+                Upsert(template);
+            }
+        }
+    }
+
+    private sealed class GmMenuLuaRuntimeMobileTemplateService : IMobileTemplateService
+    {
+        private readonly Dictionary<string, MobileTemplateDefinition> _templates = new(StringComparer.OrdinalIgnoreCase);
+
+        public int Count => _templates.Count;
+
+        public void Clear()
+            => _templates.Clear();
+
+        public IReadOnlyList<MobileTemplateDefinition> GetAll()
+            => _templates.Values.ToList();
+
+        public bool TryGet(string id, out MobileTemplateDefinition? definition)
+            => _templates.TryGetValue(id, out definition);
+
+        public void Upsert(MobileTemplateDefinition definition)
+            => _templates[definition.Id] = definition;
+
+        public void UpsertRange(IEnumerable<MobileTemplateDefinition> definitions)
+        {
+            foreach (var definition in definitions)
+            {
+                Upsert(definition);
+            }
+        }
+    }
+
+    private sealed class GmMenuLuaRuntimeItemService : IItemService
+    {
+        private readonly Dictionary<Serial, UOItemEntity> _items = new();
+        private uint _nextSerial = 0x40002000u;
+
+        public string? LastSpawnTemplateId { get; private set; }
+
+        public UOItemEntity? LastSpawnedItem { get; private set; }
+
+        public Serial LastMoveItemId { get; private set; } = Serial.Zero;
+
+        public Serial LastContainerId { get; private set; } = Serial.Zero;
+
+        public Point2D LastContainerPosition { get; private set; } = Point2D.Zero;
+
+        public Point3D LastWorldLocation { get; private set; } = Point3D.Zero;
+
+        public int LastWorldMapId { get; private set; }
+
+        public UOItemEntity? LastUpsertedItem { get; private set; }
+
+        public void Register(UOItemEntity item)
+            => _items[item.Id] = item;
+
+        public Task BulkUpsertItemsAsync(IReadOnlyList<UOItemEntity> items)
+        {
+            foreach (var item in items)
+            {
+                _items[item.Id] = item;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public UOItemEntity Clone(UOItemEntity item, bool generateNewSerial = true)
+            => item;
+
+        public Task<UOItemEntity?> CloneAsync(Serial itemId, bool generateNewSerial = true)
+            => Task.FromResult(_items.GetValueOrDefault(itemId));
+
+        public Task<Serial> CreateItemAsync(UOItemEntity item)
+        {
+            _items[item.Id] = item;
+
+            return Task.FromResult(item.Id);
+        }
+
+        public Task<bool> DeleteItemAsync(Serial itemId)
+        {
+            _items.Remove(itemId);
+
+            return Task.FromResult(true);
+        }
+
+        public Task<DropItemToGroundResult?> DropItemToGroundAsync(
+            Serial itemId,
+            Point3D location,
+            int mapId,
+            long sessionId = 0
+        )
+            => Task.FromResult<DropItemToGroundResult?>(null);
+
+        public Task<bool> EquipItemAsync(Serial itemId, Serial mobileId, ItemLayerType layer)
+        {
+            _ = itemId;
+            _ = mobileId;
+            _ = layer;
+
+            return Task.FromResult(true);
+        }
+
+        public Task<List<UOItemEntity>> GetGroundItemsInSectorAsync(int mapId, int sectorX, int sectorY)
+            => Task.FromResult(new List<UOItemEntity>());
+
+        public Task<UOItemEntity?> GetItemAsync(Serial itemId)
+            => Task.FromResult(_items.GetValueOrDefault(itemId));
+
+        public Task<List<UOItemEntity>> GetItemsInContainerAsync(Serial containerId)
+            => Task.FromResult(_items.Values.Where(item => item.ParentContainerId == containerId).ToList());
+
+        public Task<bool> MoveItemToContainerAsync(
+            Serial itemId,
+            Serial containerId,
+            Point2D position,
+            long sessionId = 0
+        )
+        {
+            LastMoveItemId = itemId;
+            LastContainerId = containerId;
+            LastContainerPosition = position;
+
+            if (_items.TryGetValue(itemId, out var item))
+            {
+                item.ParentContainerId = containerId;
+                item.ContainerPosition = position;
+            }
+
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> MoveItemToWorldAsync(Serial itemId, Point3D location, int mapId, long sessionId = 0)
+        {
+            LastMoveItemId = itemId;
+            LastWorldLocation = location;
+            LastWorldMapId = mapId;
+
+            if (_items.TryGetValue(itemId, out var item))
+            {
+                item.ParentContainerId = Serial.Zero;
+                item.Location = location;
+                item.MapId = mapId;
+            }
+
+            return Task.FromResult(true);
+        }
+
+        public Task<UOItemEntity> SpawnFromTemplateAsync(string itemTemplateId)
+        {
+            LastSpawnTemplateId = itemTemplateId;
+            var item = new UOItemEntity
+            {
+                Id = (Serial)_nextSerial++,
+                Name = itemTemplateId,
+                ItemId = itemTemplateId.Equals("gold_coin", StringComparison.OrdinalIgnoreCase) ? 0x0EED : 0x1BFB,
+                Amount = 1,
+                IsStackable = true,
+                MapId = 0,
+                Location = Point3D.Zero
+            };
+            _items[item.Id] = item;
+            LastSpawnedItem = item;
+
+            return Task.FromResult(item);
+        }
+
+        public Task<(bool Found, UOItemEntity? Item)> TryToGetItemAsync(Serial itemId)
+            => Task.FromResult((_items.TryGetValue(itemId, out var item), item));
+
+        public Task UpsertItemAsync(UOItemEntity item)
+        {
+            _items[item.Id] = item;
+            LastUpsertedItem = item;
+
+            return Task.CompletedTask;
+        }
+
+        public Task UpsertItemsAsync(params UOItemEntity[] items)
+        {
+            foreach (var item in items)
+            {
+                _items[item.Id] = item;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class GmMenuLuaRuntimeMobileService : IMobileService
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = new();
+        private uint _nextSerial = 0x50002000u;
+
+        public List<(string TemplateId, Point3D Location, int MapId)> SpawnCalls { get; } = [];
+
+        public void Register(UOMobileEntity mobile)
+            => _mobiles[mobile.Id] = mobile;
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _mobiles[mobile.Id] = mobile;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _mobiles.Remove(id);
+
+            return Task.FromResult(true);
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+            => Task.FromResult(_mobiles.GetValueOrDefault(id));
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult(new List<UOMobileEntity>());
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var mobile = new UOMobileEntity
+            {
+                Id = (Serial)_nextSerial++,
+                Name = templateId,
+                MapId = mapId,
+                Location = location
+            };
+            _mobiles[mobile.Id] = mobile;
+            SpawnCalls.Add((templateId, location, mapId));
+
+            return Task.FromResult(mobile);
+        }
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var mobile = new UOMobileEntity
+            {
+                Id = (Serial)_nextSerial++,
+                Name = templateId,
+                MapId = mapId,
+                Location = location
+            };
+            _mobiles[mobile.Id] = mobile;
+            SpawnCalls.Add((templateId, location, mapId));
+
+            return Task.FromResult((true, (UOMobileEntity?)mobile));
+        }
+    }
+
+    private sealed class GmMenuLuaRuntimePlayerTargetService : IPlayerTargetService
+    {
+        public long LastSessionId { get; private set; }
+
+        public TargetCursorSelectionType LastSelectionType { get; private set; }
+
+        public TargetCursorType LastCursorType { get; private set; }
+
+        public Action<PendingCursorCallback>? LastCallback { get; private set; }
+
+        public int RequestCount { get; private set; }
+
+        public Serial LastCursorId { get; private set; } = Serial.Zero;
+
+        public long LastCancelSessionId { get; private set; }
+
+        public Serial LastCancelCursorId { get; private set; } = Serial.Zero;
+
+        private uint _nextCursorId = 0x40001000u;
+
+        public Task SendCancelTargetCursorAsync(long sessionId, Serial cursorId)
+        {
+            LastCancelSessionId = sessionId;
+            LastCancelCursorId = cursorId;
+
+            return Task.CompletedTask;
+        }
+
+        public void ResolveLocation(int x, int y, int z)
+        {
+            LastCallback?.Invoke(
+                new(
+                    new TargetCursorCommandsPacket
+                    {
+                        CursorTarget = TargetCursorSelectionType.SelectLocation,
+                        CursorId = LastCursorId,
+                        CursorType = LastCursorType,
+                        Location = new Point3D(x, y, z)
+                    }
+                )
+            );
+        }
+
+        public Task<Serial> SendTargetCursorAsync(
+            long sessionId,
+            Action<PendingCursorCallback> callback,
+            TargetCursorSelectionType selectionType = TargetCursorSelectionType.SelectLocation,
+            TargetCursorType cursorType = TargetCursorType.Neutral
+        )
+        {
+            LastSessionId = sessionId;
+            LastSelectionType = selectionType;
+            LastCursorType = cursorType;
+            LastCallback = callback;
+            RequestCount++;
+            LastCursorId = (Serial)_nextCursorId++;
+
+            return Task.FromResult(LastCursorId);
+        }
+
+        public Task StartAsync()
+            => Task.CompletedTask;
+
+        public Task StopAsync()
+            => Task.CompletedTask;
+    }
+
+    private sealed class GmMenuRuntimeContext : IDisposable
+    {
+        public GmMenuRuntimeContext(
+            TempDirectory tempDirectory,
+            LuaScriptEngineService service,
+            BasePacketListenerTestOutgoingPacketQueue queue,
+            FakeGameNetworkSessionService sessionService,
+            GumpScriptDispatcherService gumpDispatcher,
+            GmMenuLuaRuntimeItemService itemService,
+            GmMenuLuaRuntimeMobileService mobileService,
+            GmMenuLuaRuntimePlayerTargetService targetService,
+            GameSession session,
+            MoongateTCPClient client
+        )
+        {
+            TempDirectory = tempDirectory;
+            Service = service;
+            Queue = queue;
+            SessionService = sessionService;
+            GumpDispatcher = gumpDispatcher;
+            ItemService = itemService;
+            MobileService = mobileService;
+            TargetService = targetService;
+            Session = session;
+            Client = client;
+        }
+
+        public TempDirectory TempDirectory { get; }
+
+        public LuaScriptEngineService Service { get; }
+
+        public BasePacketListenerTestOutgoingPacketQueue Queue { get; }
+
+        public FakeGameNetworkSessionService SessionService { get; }
+
+        public GumpScriptDispatcherService GumpDispatcher { get; }
+
+        public GmMenuLuaRuntimeItemService ItemService { get; }
+
+        public GmMenuLuaRuntimeMobileService MobileService { get; }
+
+        public GmMenuLuaRuntimePlayerTargetService TargetService { get; }
+
+        public GameSession Session { get; }
+
+        public MoongateTCPClient Client { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            TempDirectory.Dispose();
+        }
+    }
+
     [Test]
     public async Task StartAsync_WithGmMenuScripts_ShouldOpenCompressedMenuGumpWithAddDefaultTab()
     {
-        using var temp = new TempDirectory();
+        using var context = await CreateRuntimeContextAsync();
+
+        var result = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Data, Is.EqualTo(true));
+                Assert.That(context.Queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.SessionId, Is.EqualTo(context.Session.SessionId));
+                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+                var gump = (CompressedGumpPacket)outbound.Packet;
+                Assert.That(gump.GumpId, Is.EqualTo(0xB930u));
+                Assert.That(gump.Layout, Does.Contain("{ resizepic 0 0 5054"));
+                Assert.That(gump.TextLines, Does.Contain("GM Menu"));
+                Assert.That(gump.TextLines, Does.Contain("Add"));
+                Assert.That(gump.TextLines, Does.Contain("Travel"));
+                Assert.That(gump.TextLines, Does.Contain("Search Items and NPCs"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenSearchingItem_ShouldSelectPreviewAndAddToBackpack()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            102,
+            new Dictionary<ushort, string>
+            {
+                [1] = "gold",
+                [2] = "25"
+            }
+        );
+
+        Assert.That(context.Queue.TryDequeue(out var searchOutbound), Is.True);
+        Assert.That(searchOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var searchGump = (CompressedGumpPacket)searchOutbound.Packet;
+        Assert.That(searchGump.TextLines, Has.Some.Contains("Gold Coin"));
+
+        DispatchButton(
+            context,
+            0xB930,
+            200,
+            new Dictionary<ushort, string>
+            {
+                [1] = "gold",
+                [2] = "25"
+            }
+        );
+
+        Assert.That(context.Queue.TryDequeue(out var selectionOutbound), Is.True);
+        Assert.That(selectionOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var selectionGump = (CompressedGumpPacket)selectionOutbound.Packet;
+        Assert.That(selectionGump.TextLines, Has.Some.Contains("Template: gold_coin"));
+        Assert.That(selectionGump.TextLines, Has.Some.Contains("Item ID: 0x0EED"));
+
+        DispatchButton(
+            context,
+            0xB930,
+            301,
+            new Dictionary<ushort, string>
+            {
+                [1] = "gold",
+                [2] = "25"
+            }
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.ItemService.LastSpawnTemplateId, Is.EqualTo("gold_coin"));
+                Assert.That(context.ItemService.LastContainerId, Is.EqualTo(context.Session.Character!.BackpackId));
+                Assert.That(context.ItemService.LastUpsertedItem, Is.Not.Null);
+                Assert.That(context.ItemService.LastUpsertedItem!.Amount, Is.EqualTo(25));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenTargetingGroundForItem_ShouldSpawnAtSelectedLocation()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            102,
+            new Dictionary<ushort, string>
+            {
+                [1] = "gold",
+                [2] = "10"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            200,
+            new Dictionary<ushort, string>
+            {
+                [1] = "gold",
+                [2] = "10"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            300,
+            new Dictionary<ushort, string>
+            {
+                [1] = "gold",
+                [2] = "10"
+            }
+        );
+
+        Assert.That(context.TargetService.RequestCount, Is.EqualTo(1));
+        context.TargetService.ResolveLocation(111, 222, 7);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.ItemService.LastSpawnTemplateId, Is.EqualTo("gold_coin"));
+                Assert.That(context.ItemService.LastWorldLocation, Is.EqualTo(new Point3D(111, 222, 7)));
+                Assert.That(context.ItemService.LastWorldMapId, Is.EqualTo(1));
+                Assert.That(context.ItemService.LastUpsertedItem, Is.Not.Null);
+                Assert.That(context.ItemService.LastUpsertedItem!.Amount, Is.EqualTo(10));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenUsingNpcBrush_ShouldRespawnTargetCursorUntilStopped()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            101,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            102,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out var searchOutbound), Is.True);
+        Assert.That(searchOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var searchGump = (CompressedGumpPacket)searchOutbound.Packet;
+        Assert.That(searchGump.TextLines, Has.Some.Contains("Zombie"));
+
+        DispatchButton(
+            context,
+            0xB930,
+            200,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            302,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+
+        Assert.That(context.TargetService.RequestCount, Is.EqualTo(1));
+        Assert.That(context.Queue.TryDequeue(out var brushOutbound), Is.True);
+        Assert.That(brushOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var brushGump = (CompressedGumpPacket)brushOutbound.Packet;
+        Assert.That(brushGump.TextLines, Has.Some.Contains("Brush Active: Zombie"));
+
+        context.TargetService.ResolveLocation(333, 444, 0);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.MobileService.SpawnCalls.Count, Is.EqualTo(2));
+                Assert.That(context.MobileService.SpawnCalls[0], Is.EqualTo(("zombie", new Point3D(333, 444, 0), 1)));
+                Assert.That(context.MobileService.SpawnCalls[1], Is.EqualTo(("zombie", new Point3D(333, 444, 0), 1)));
+                Assert.That(context.TargetService.RequestCount, Is.EqualTo(2));
+            }
+        );
+
+        DispatchButton(
+            context,
+            0xB930,
+            303,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+
+        Assert.That(context.TargetService.LastCancelCursorId, Is.Not.EqualTo(Serial.Zero));
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenSwitchingToTravel_ShouldRenderTeleportBrowserAndTeleport()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        var travelPacket = new GumpMenuSelectionPacket();
+        Assert.That(
+            travelPacket.TryParse(BuildGumpResponsePacket((uint)context.Session.CharacterId, 0xB930, 11)),
+            Is.True
+        );
+        Assert.That(context.GumpDispatcher.TryDispatch(context.Session, travelPacket), Is.True);
+        Assert.That(context.Queue.TryDequeue(out var travelOutbound), Is.True);
+        Assert.That(travelOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var travelGump = (CompressedGumpPacket)travelOutbound.Packet;
+        Assert.That(travelGump.TextLines, Does.Contain("Step 1/3 - Select map"));
+        Assert.That(travelGump.TextLines, Has.Some.Contains("Felucca"));
+
+        DispatchButton(context, 0xB930, 101);
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+        DispatchButton(context, 0xB930, 20);
+
+        Assert.That(context.Queue.TryDequeue(out var categoryOutbound), Is.True);
+        Assert.That(categoryOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var categoryGump = (CompressedGumpPacket)categoryOutbound.Packet;
+        Assert.That(categoryGump.TextLines, Does.Contain("Step 2/3 - Select category"));
+        Assert.That(categoryGump.TextLines, Has.Some.Contains("Towns"));
+
+        DispatchButton(context, 0xB930, 201);
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+        DispatchButton(context, 0xB930, 21);
+
+        Assert.That(context.Queue.TryDequeue(out var locationOutbound), Is.True);
+        Assert.That(locationOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var locationGump = (CompressedGumpPacket)locationOutbound.Packet;
+        Assert.That(locationGump.TextLines, Does.Contain("Step 3/3 - Select location"));
+        Assert.That(locationGump.TextLines, Has.Some.Contains("Britain Bank"));
+
+        DispatchButton(context, 0xB930, 301);
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+        DispatchButton(context, 0xB930, 15);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.Session.Character, Is.Not.Null);
+                Assert.That(context.Session.Character!.MapId, Is.EqualTo(0));
+                Assert.That(context.Session.Character.Location, Is.EqualTo(new Point3D(1496, 1628, 20)));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithTeleportScripts_ShouldStillOpenStandaloneTeleportBrowser()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        var result = context.Service.ExecuteFunction(
+            $"(function() local teleports = require(\"gumps.teleports\") return teleports.open({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Data, Is.EqualTo(true));
+        Assert.That(context.Queue.TryDequeue(out var outbound), Is.True);
+        Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var gump = (CompressedGumpPacket)outbound.Packet;
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(gump.GumpId, Is.EqualTo(0xB61Fu));
+                Assert.That(gump.Layout, Does.Contain("{ resizepic 0 0 5054 520 420 }"));
+                Assert.That(gump.TextLines, Does.Contain("Teleport Browser"));
+            }
+        );
+    }
+
+    private static async Task<GmMenuRuntimeContext> CreateRuntimeContextAsync()
+    {
+        var temp = new TempDirectory();
         var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
         var scriptsDir = dirs[DirectoryType.Scripts];
         var luarcDir = temp.Path;
@@ -31,6 +944,7 @@ public sealed class GmMenuLuaRuntimeTests
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "gm_menu"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "gm_menu", "sections"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "teleports"));
         Directory.CreateDirectory(luarcDir);
 
         var repoRoot =
@@ -44,6 +958,14 @@ public sealed class GmMenuLuaRuntimeTests
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/render.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/add.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/travel.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/constants.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/controller.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/render.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/ui.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/state.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/actions.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/teleports/data.lua");
 
         await File.WriteAllTextAsync(
             Path.Combine(scriptsDir, "init.lua"),
@@ -52,21 +974,89 @@ public sealed class GmMenuLuaRuntimeTests
 
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
         var sessionService = new FakeGameNetworkSessionService();
-        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var gumpDispatcher = new GumpScriptDispatcherService();
+        var characterService = new GmMenuLuaRuntimeCharacterService();
+        var speechService = new GmMenuLuaRuntimeSpeechService();
+        var itemTemplateService = new GmMenuLuaRuntimeItemTemplateService();
+        itemTemplateService.Upsert(
+            new ItemTemplateDefinition
+            {
+                Id = "gold_coin",
+                Name = "Gold Coin",
+                ItemId = "0x0EED",
+                IsMovable = true,
+                Weight = 0.1m,
+                ScriptId = string.Empty
+            }
+        );
+        var mobileTemplateService = new GmMenuLuaRuntimeMobileTemplateService();
+        mobileTemplateService.Upsert(
+            new MobileTemplateDefinition
+            {
+                Id = "zombie",
+                Name = "Zombie",
+                Body = 3
+            }
+        );
+        var itemService = new GmMenuLuaRuntimeItemService();
+        var mobileService = new GmMenuLuaRuntimeMobileService();
+        var targetService = new GmMenuLuaRuntimePlayerTargetService();
+        var locationCatalogService = new GmMenuLuaRuntimeLocationCatalogService
+        {
+            Locations =
+            [
+                new(0, "Felucca", "Towns", "Britain Bank", new(1496, 1628, 20))
+            ]
+        };
+        var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
         var session = new GameSession(new(client))
         {
-            CharacterId = (Serial)0x00000044u
+            CharacterId = (Serial)0x00000044u,
+            Character = new UOMobileEntity
+            {
+                Id = (Serial)0x00000044u,
+                Name = "GM",
+                MapId = 1,
+                Location = new(100, 100, 0)
+            }
         };
+        var backpack = new UOItemEntity
+        {
+            Id = (Serial)0x00007000u,
+            Name = "Backpack",
+            ItemId = 0x0E75,
+            MapId = 1,
+            Location = session.Character!.Location
+        };
+        session.Character.AddEquippedItem(ItemLayerType.Backpack, backpack);
+        session.Character.BackpackId = backpack.Id;
+        characterService.Character = session.Character;
+        itemService.Register(backpack);
+        mobileService.Register(session.Character);
         sessionService.Add(session);
 
         var container = new Container();
         container.RegisterInstance<IOutgoingPacketQueue>(queue);
         container.RegisterInstance<IGameNetworkSessionService>(sessionService);
-        container.RegisterInstance<IGumpScriptDispatcherService>(new GumpScriptDispatcherService());
+        container.RegisterInstance<IGumpScriptDispatcherService>(gumpDispatcher);
+        container.RegisterInstance<ICharacterService>(characterService);
+        container.RegisterInstance<ISpeechService>(speechService);
+        container.RegisterInstance<IItemTemplateService>(itemTemplateService);
+        container.RegisterInstance<IMobileTemplateService>(mobileTemplateService);
+        container.RegisterInstance<IItemService>(itemService);
+        container.RegisterInstance<IMobileService>(mobileService);
+        container.RegisterInstance<IPlayerTargetService>(targetService);
+        container.RegisterInstance<ILocationCatalogService>(locationCatalogService);
 
         var service = new LuaScriptEngineService(
             dirs,
-            [new(typeof(GumpModule))],
+            [
+                new(typeof(GumpModule)),
+                new(typeof(ItemModule)),
+                new(typeof(MobileModule)),
+                new(typeof(TargetModule)),
+                new(typeof(LocationModule))
+            ],
             container,
             new(luarcDir, scriptsDir, "0.1.0"),
             []
@@ -74,27 +1064,43 @@ public sealed class GmMenuLuaRuntimeTests
 
         await service.StartAsync();
 
-        var result = service.ExecuteFunction(
-            $"(function() return on_gm_menu_request({session.SessionId}, {(uint)session.CharacterId}) end)()"
-        );
+        return new(temp, service, queue, sessionService, gumpDispatcher, itemService, mobileService, targetService, session, client);
+    }
 
-        Assert.Multiple(
-            () =>
-            {
-                Assert.That(result.Success, Is.True);
-                Assert.That(result.Data, Is.EqualTo(true));
-                Assert.That(queue.TryDequeue(out var outbound), Is.True);
-                Assert.That(outbound.SessionId, Is.EqualTo(session.SessionId));
-                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
-                var gump = (CompressedGumpPacket)outbound.Packet;
-                Assert.That(gump.GumpId, Is.EqualTo(0xB930u));
-                Assert.That(gump.Layout, Does.Contain("{ resizepic 0 0 5054 560 420 }"));
-                Assert.That(gump.TextLines, Does.Contain("GM Menu"));
-                Assert.That(gump.TextLines, Does.Contain("Add"));
-                Assert.That(gump.TextLines, Does.Contain("Travel"));
-                Assert.That(gump.TextLines, Does.Contain("Search Items and NPCs"));
-            }
-        );
+    private static byte[] BuildGumpResponsePacket(
+        uint serial,
+        uint gumpId,
+        uint buttonId,
+        IReadOnlyDictionary<ushort, string>? textEntries = null
+    )
+    {
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms, Encoding.UTF8, true);
+
+        bw.Write((byte)0xB1);
+        bw.Write((ushort)0);
+        WriteUInt32BE(bw, serial);
+        WriteUInt32BE(bw, gumpId);
+        WriteUInt32BE(bw, buttonId);
+        WriteInt32BE(bw, 0);
+
+        var entries = textEntries ?? new Dictionary<ushort, string>();
+        WriteInt32BE(bw, entries.Count);
+
+        foreach (var (id, text) in entries)
+        {
+            var value = text ?? string.Empty;
+            var textBytes = Encoding.BigEndianUnicode.GetBytes(value);
+            WriteUInt16BE(bw, id);
+            WriteUInt16BE(bw, (ushort)value.Length);
+            bw.Write(textBytes);
+        }
+
+        bw.Flush();
+        var bytes = ms.ToArray();
+        BinaryPrimitives.WriteUInt16BigEndian(bytes.AsSpan(1, 2), (ushort)bytes.Length);
+
+        return bytes;
     }
 
     private static void CopyScript(string repoRoot, string scriptsDir, string relativePath)
@@ -110,4 +1116,28 @@ public sealed class GmMenuLuaRuntimeTests
 
         File.Copy(sourcePath, destinationPath);
     }
+
+    private static void DispatchButton(
+        GmMenuRuntimeContext context,
+        uint gumpId,
+        uint buttonId,
+        IReadOnlyDictionary<ushort, string>? textEntries = null
+    )
+    {
+        var packet = new GumpMenuSelectionPacket();
+        Assert.That(
+            packet.TryParse(BuildGumpResponsePacket((uint)context.Session.CharacterId, gumpId, buttonId, textEntries)),
+            Is.True
+        );
+        Assert.That(context.GumpDispatcher.TryDispatch(context.Session, packet), Is.True);
+    }
+
+    private static void WriteInt32BE(BinaryWriter writer, int value)
+        => writer.Write(BinaryPrimitives.ReverseEndianness(value));
+
+    private static void WriteUInt16BE(BinaryWriter writer, ushort value)
+        => writer.Write(BinaryPrimitives.ReverseEndianness(value));
+
+    private static void WriteUInt32BE(BinaryWriter writer, uint value)
+        => writer.Write(BinaryPrimitives.ReverseEndianness(value));
 }

--- a/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
@@ -8,6 +8,7 @@ using Moongate.Network.Client;
 using Moongate.Network.Packets.Incoming.Speech;
 using Moongate.Network.Packets.Incoming.Targeting;
 using Moongate.Network.Packets.Incoming.UI;
+using Moongate.Network.Packets.Interfaces;
 using Moongate.Network.Packets.Outgoing.Speech;
 using Moongate.Network.Packets.Outgoing.UI;
 using Moongate.Network.Packets.Types.Targeting;
@@ -23,6 +24,7 @@ using Moongate.Server.Interfaces.Services.Interaction;
 using Moongate.Server.Interfaces.Services.Packets;
 using Moongate.Server.Interfaces.Services.Scripting;
 using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Interfaces.Services.Speech;
 using Moongate.Server.Interfaces.Services.World;
 using Moongate.Server.Modules;
@@ -33,6 +35,8 @@ using Moongate.Tests.TestSupport;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Interfaces.Templates;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
 using Moongate.UO.Data.Persistence.Entities;
 using Moongate.UO.Data.Templates.Items;
 using Moongate.UO.Data.Templates.Mobiles;
@@ -113,6 +117,142 @@ public sealed class GmMenuLuaRuntimeTests
 
         public void SetLocations(IReadOnlyList<WorldLocationEntry> locations)
             => Locations = locations;
+    }
+
+    private sealed class GmMenuLuaRuntimeSpatialWorldService : ISpatialWorldService
+    {
+        public List<UOMobileEntity> AddedOrUpdatedMobiles { get; } = [];
+
+        public void AddOrUpdateItem(UOItemEntity item, int mapId)
+        {
+            _ = item;
+            _ = mapId;
+        }
+
+        public void AddOrUpdateMobile(UOMobileEntity mobile)
+            => AddedOrUpdatedMobiles.Add(mobile);
+
+        public void AddRegion(JsonRegion region)
+            => _ = region;
+
+        public Task<int> BroadcastToPlayersAsync(
+            IGameNetworkPacket packet,
+            int mapId,
+            Point3D location,
+            int? range = null,
+            long? excludeSessionId = null
+        )
+        {
+            _ = packet;
+            _ = mapId;
+            _ = location;
+            _ = range;
+            _ = excludeSessionId;
+
+            return Task.FromResult(0);
+        }
+
+        public List<MapSector> GetActiveSectors()
+            => [];
+
+        public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
+        {
+            _ = mapId;
+            _ = centerSectorX;
+            _ = centerSectorY;
+            _ = radius;
+
+            return [];
+        }
+
+        public int GetMusic(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return 0;
+        }
+
+        public List<UOItemEntity> GetNearbyItems(Point3D location, int range, int mapId)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return [];
+        }
+
+        public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return [];
+        }
+
+        public List<GameSession> GetPlayersInRange(Point3D location, int range, int mapId, GameSession? excludeSession = null)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+            _ = excludeSession;
+
+            return [];
+        }
+
+        public List<UOMobileEntity> GetPlayersInSector(int mapId, int sectorX, int sectorY)
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+
+            return [];
+        }
+
+        public JsonRegion? GetRegionById(int regionId)
+        {
+            _ = regionId;
+
+            return null;
+        }
+
+        public MapSector? GetSectorByLocation(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return null;
+        }
+
+        public SectorSystemStats GetStats()
+            => new();
+
+        public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation)
+        {
+            _ = item;
+            _ = mapId;
+            _ = oldLocation;
+            _ = newLocation;
+        }
+
+        public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation)
+        {
+            _ = mobile;
+            _ = oldLocation;
+            _ = newLocation;
+        }
+
+        public void RemoveEntity(Serial serial)
+            => _ = serial;
+
+        public JsonRegion? ResolveRegion(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return null;
+        }
     }
 
     private sealed class GmMenuLuaRuntimeSpeechService : ISpeechService
@@ -531,6 +671,21 @@ public sealed class GmMenuLuaRuntimeTests
             );
         }
 
+        public void ResolveCancel()
+        {
+            LastCallback?.Invoke(
+                new(
+                    new TargetCursorCommandsPacket
+                    {
+                        CursorTarget = TargetCursorSelectionType.SelectLocation,
+                        CursorId = LastCursorId,
+                        CursorType = TargetCursorType.CancelCurrentTargeting,
+                        Location = Point3D.Zero
+                    }
+                )
+            );
+        }
+
         public Task<Serial> SendTargetCursorAsync(
             long sessionId,
             Action<PendingCursorCallback> callback,
@@ -563,8 +718,10 @@ public sealed class GmMenuLuaRuntimeTests
             BasePacketListenerTestOutgoingPacketQueue queue,
             FakeGameNetworkSessionService sessionService,
             GumpScriptDispatcherService gumpDispatcher,
+            GmMenuLuaRuntimeItemTemplateService itemTemplateService,
             GmMenuLuaRuntimeItemService itemService,
             GmMenuLuaRuntimeMobileService mobileService,
+            GmMenuLuaRuntimeSpatialWorldService spatialWorldService,
             GmMenuLuaRuntimePlayerTargetService targetService,
             GameSession session,
             MoongateTCPClient client
@@ -575,8 +732,10 @@ public sealed class GmMenuLuaRuntimeTests
             Queue = queue;
             SessionService = sessionService;
             GumpDispatcher = gumpDispatcher;
+            ItemTemplateService = itemTemplateService;
             ItemService = itemService;
             MobileService = mobileService;
+            SpatialWorldService = spatialWorldService;
             TargetService = targetService;
             Session = session;
             Client = client;
@@ -592,9 +751,13 @@ public sealed class GmMenuLuaRuntimeTests
 
         public GumpScriptDispatcherService GumpDispatcher { get; }
 
+        public GmMenuLuaRuntimeItemTemplateService ItemTemplateService { get; }
+
         public GmMenuLuaRuntimeItemService ItemService { get; }
 
         public GmMenuLuaRuntimeMobileService MobileService { get; }
+
+        public GmMenuLuaRuntimeSpatialWorldService SpatialWorldService { get; }
 
         public GmMenuLuaRuntimePlayerTargetService TargetService { get; }
 
@@ -629,10 +792,62 @@ public sealed class GmMenuLuaRuntimeTests
                 var gump = (CompressedGumpPacket)outbound.Packet;
                 Assert.That(gump.GumpId, Is.EqualTo(0xB930u));
                 Assert.That(gump.Layout, Does.Contain("{ resizepic 0 0 5054"));
+                Assert.That(gump.Layout, Does.Not.Contain("{ checkertrans"));
+                Assert.That(gump.Layout, Does.Not.Contain("{ text 64 128 0 "));
+                Assert.That(gump.Layout, Does.Not.Contain("{ text 478 114 0 "));
+                Assert.That(gump.Layout, Does.Not.Contain("{ textentrylimited 248 112 190 20 0 "));
                 Assert.That(gump.TextLines, Does.Contain("GM Menu"));
                 Assert.That(gump.TextLines, Does.Contain("Add"));
                 Assert.That(gump.TextLines, Does.Contain("Travel"));
                 Assert.That(gump.TextLines, Does.Contain("Search Items and NPCs"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenSearchingManyItems_ShouldRenderCompactResultPage()
+    {
+        using var context = await CreateRuntimeContextAsync();
+        context.ItemTemplateService.UpsertRange(
+            Enumerable.Range(1, 8).Select(
+                static index => new ItemTemplateDefinition
+                {
+                    Id = $"test_item_{index:00}",
+                    Name = $"Test Item {index:00}",
+                    ItemId = "0x0EED",
+                    IsMovable = true,
+                    Weight = 1.0m,
+                    ScriptId = string.Empty
+                }
+            )
+        );
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            102,
+            new Dictionary<ushort, string>
+            {
+                [1] = "Test Item",
+                [2] = "1"
+            }
+        );
+
+        Assert.That(context.Queue.TryDequeue(out var searchOutbound), Is.True);
+        Assert.That(searchOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var searchGump = (CompressedGumpPacket)searchOutbound.Packet;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(searchGump.TextLines, Has.Some.Contains("Test Item 01"));
+                Assert.That(searchGump.TextLines, Has.Some.Contains("Test Item 07"));
+                Assert.That(searchGump.TextLines, Has.None.Contains("Test Item 08"));
             }
         );
     }
@@ -855,6 +1070,153 @@ public sealed class GmMenuLuaRuntimeTests
     }
 
     [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenBrushTargetIsCancelled_ShouldStopBrushWithoutReRequestingCursor()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            101,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            102,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            200,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            302,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "2"
+            }
+        );
+
+        Assert.That(context.TargetService.RequestCount, Is.EqualTo(1));
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        context.TargetService.ResolveCancel();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.MobileService.SpawnCalls, Is.Empty);
+                Assert.That(context.TargetService.RequestCount, Is.EqualTo(1));
+                Assert.That(context.Queue.TryDequeue(out var cancelOutbound), Is.True);
+                Assert.That(cancelOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+                var cancelGump = (CompressedGumpPacket)cancelOutbound.Packet;
+                Assert.That(cancelGump.TextLines, Has.None.Contains("Brush Active: Zombie"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenTargetingGroundForNpc_ShouldAddSpawnedMobileToSpatialWorld()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            101,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "1"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            102,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "1"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            200,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "1"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            300,
+            new Dictionary<ushort, string>
+            {
+                [1] = "zombie",
+                [2] = "1"
+            }
+        );
+
+        Assert.That(context.TargetService.RequestCount, Is.EqualTo(1));
+        context.TargetService.ResolveLocation(150, 250, 0);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.MobileService.SpawnCalls.Count, Is.EqualTo(1));
+                Assert.That(context.SpatialWorldService.AddedOrUpdatedMobiles.Count, Is.EqualTo(1));
+                Assert.That(context.SpatialWorldService.AddedOrUpdatedMobiles[0].Name, Is.EqualTo("zombie"));
+                Assert.That(context.SpatialWorldService.AddedOrUpdatedMobiles[0].Location, Is.EqualTo(new Point3D(150, 250, 0)));
+                Assert.That(context.SpatialWorldService.AddedOrUpdatedMobiles[0].MapId, Is.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
     public async Task StartAsync_WithGmMenuScripts_WhenSwitchingToTravel_ShouldRenderTeleportBrowserAndTeleport()
     {
         using var context = await CreateRuntimeContextAsync();
@@ -873,6 +1235,7 @@ public sealed class GmMenuLuaRuntimeTests
         Assert.That(context.Queue.TryDequeue(out var travelOutbound), Is.True);
         Assert.That(travelOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
         var travelGump = (CompressedGumpPacket)travelOutbound.Packet;
+        Assert.That(travelGump.Layout, Does.Not.Contain("{ checkertrans"));
         Assert.That(travelGump.TextLines, Does.Contain("Step 1/3 - Select map"));
         Assert.That(travelGump.TextLines, Has.Some.Contains("Felucca"));
 
@@ -1000,6 +1363,7 @@ public sealed class GmMenuLuaRuntimeTests
         );
         var itemService = new GmMenuLuaRuntimeItemService();
         var mobileService = new GmMenuLuaRuntimeMobileService();
+        var spatialWorldService = new GmMenuLuaRuntimeSpatialWorldService();
         var targetService = new GmMenuLuaRuntimePlayerTargetService();
         var locationCatalogService = new GmMenuLuaRuntimeLocationCatalogService
         {
@@ -1045,6 +1409,7 @@ public sealed class GmMenuLuaRuntimeTests
         container.RegisterInstance<IMobileTemplateService>(mobileTemplateService);
         container.RegisterInstance<IItemService>(itemService);
         container.RegisterInstance<IMobileService>(mobileService);
+        container.RegisterInstance<ISpatialWorldService>(spatialWorldService);
         container.RegisterInstance<IPlayerTargetService>(targetService);
         container.RegisterInstance<ILocationCatalogService>(locationCatalogService);
 
@@ -1064,7 +1429,20 @@ public sealed class GmMenuLuaRuntimeTests
 
         await service.StartAsync();
 
-        return new(temp, service, queue, sessionService, gumpDispatcher, itemService, mobileService, targetService, session, client);
+        return new(
+            temp,
+            service,
+            queue,
+            sessionService,
+            gumpDispatcher,
+            itemTemplateService,
+            itemService,
+            mobileService,
+            spatialWorldService,
+            targetService,
+            session,
+            client
+        );
     }
 
     private static byte[] BuildGumpResponsePacket(

--- a/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
@@ -1,0 +1,113 @@
+using System.Net.Sockets;
+using DryIoc;
+using Moongate.Core.Data.Directories;
+using Moongate.Core.Types;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Outgoing.UI;
+using Moongate.Scripting.Services;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Scripting;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Modules;
+using Moongate.Server.Services.Scripting;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
+using Moongate.Tests.TestSupport;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Scripting;
+
+public sealed class GmMenuLuaRuntimeTests
+{
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_ShouldOpenCompressedMenuGumpWithAddDefaultTab()
+    {
+        using var temp = new TempDirectory();
+        var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDir = dirs[DirectoryType.Scripts];
+        var luarcDir = temp.Path;
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "interaction"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "gm_menu"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "gm_menu", "sections"));
+        Directory.CreateDirectory(luarcDir);
+
+        var repoRoot =
+            Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+        CopyScript(repoRoot, scriptsDir, "interaction/gm_menu.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/constants.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/state.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/ui.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/controller.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/render.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/add.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/travel.lua");
+
+        await File.WriteAllTextAsync(
+            Path.Combine(scriptsDir, "init.lua"),
+            "require(\"interaction.gm_menu\")\n"
+        );
+
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00000044u
+        };
+        sessionService.Add(session);
+
+        var container = new Container();
+        container.RegisterInstance<IOutgoingPacketQueue>(queue);
+        container.RegisterInstance<IGameNetworkSessionService>(sessionService);
+        container.RegisterInstance<IGumpScriptDispatcherService>(new GumpScriptDispatcherService());
+
+        var service = new LuaScriptEngineService(
+            dirs,
+            [new(typeof(GumpModule))],
+            container,
+            new(luarcDir, scriptsDir, "0.1.0"),
+            []
+        );
+
+        await service.StartAsync();
+
+        var result = service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({session.SessionId}, {(uint)session.CharacterId}) end)()"
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Data, Is.EqualTo(true));
+                Assert.That(queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.SessionId, Is.EqualTo(session.SessionId));
+                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+                var gump = (CompressedGumpPacket)outbound.Packet;
+                Assert.That(gump.GumpId, Is.EqualTo(0xB930u));
+                Assert.That(gump.Layout, Does.Contain("{ resizepic 0 0 5054 560 420 }"));
+                Assert.That(gump.TextLines, Does.Contain("GM Menu"));
+                Assert.That(gump.TextLines, Does.Contain("Add"));
+                Assert.That(gump.TextLines, Does.Contain("Travel"));
+                Assert.That(gump.TextLines, Does.Contain("Search Items and NPCs"));
+            }
+        );
+    }
+
+    private static void CopyScript(string repoRoot, string scriptsDir, string relativePath)
+    {
+        var sourcePath = Path.Combine(repoRoot, "moongate_data", "scripts", relativePath);
+        var destinationPath = Path.Combine(scriptsDir, relativePath);
+        var destinationDirectory = Path.GetDirectoryName(destinationPath);
+
+        if (!string.IsNullOrWhiteSpace(destinationDirectory))
+        {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        File.Copy(sourcePath, destinationPath);
+    }
+}

--- a/tests/Moongate.Tests/Server/Commands/Player/GmCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/Player/GmCommandTests.cs
@@ -1,0 +1,84 @@
+using Moongate.Server.Commands.Player;
+using Moongate.Server.Data.Internal.Commands;
+using Moongate.Server.Types.Commands;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Ids;
+
+namespace Moongate.Tests.Server.Commands.Player;
+
+public sealed class GmCommandTests
+{
+    [Test]
+    public async Task ExecuteCommandAsync_WhenArgumentsAreInvalid_ShouldPrintUsageAndSkipScriptCallback()
+    {
+        var scriptEngine = new GameEventScriptBridgeTestScriptEngineService();
+        var command = new GmCommand(scriptEngine);
+        var output = new List<string>();
+        var context = new CommandSystemContext(
+            "gm extra",
+            ["extra"],
+            CommandSourceType.InGame,
+            7,
+            (message, _) => output.Add(message),
+            (Serial)0x00001234u
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(output, Has.Count.EqualTo(1));
+                Assert.That(output[0], Is.EqualTo("Usage: .gm"));
+                Assert.That(scriptEngine.LastCallbackName, Is.Null);
+                Assert.That(scriptEngine.LastCallbackArgs, Is.Null);
+            }
+        );
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenCharacterIsMissing_ShouldNotCallScriptCallback()
+    {
+        var scriptEngine = new GameEventScriptBridgeTestScriptEngineService();
+        var command = new GmCommand(scriptEngine);
+        var context = new CommandSystemContext(
+            "gm",
+            [],
+            CommandSourceType.InGame,
+            7,
+            static (_, _) => { }
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.That(scriptEngine.LastCallbackName, Is.Null);
+        Assert.That(scriptEngine.LastCallbackArgs, Is.Null);
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenCommandIsValid_ShouldCallLuaGmMenuFunctionWithSessionAndCharacter()
+    {
+        var scriptEngine = new GameEventScriptBridgeTestScriptEngineService();
+        var command = new GmCommand(scriptEngine);
+        var context = new CommandSystemContext(
+            "gm",
+            [],
+            CommandSourceType.InGame,
+            7,
+            static (_, _) => { },
+            (Serial)0x00001234u
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(scriptEngine.LastCallbackName, Is.EqualTo("on_gm_menu_request"));
+                Assert.That(scriptEngine.LastCallbackArgs, Has.Length.EqualTo(2));
+                Assert.That(scriptEngine.LastCallbackArgs![0], Is.EqualTo(7L));
+                Assert.That(scriptEngine.LastCallbackArgs[1], Is.EqualTo((uint)0x00001234u));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/ItemModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/ItemModuleTests.cs
@@ -1,12 +1,16 @@
 using Moongate.Server.Data.Items;
 using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Spatial;
 using Moongate.Server.Modules;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
 using Moongate.UO.Data.Persistence.Entities;
 using Moongate.UO.Data.Services.Templates;
 using Moongate.UO.Data.Templates.Items;
 using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
 using MoonSharp.Interpreter;
 
 namespace Moongate.Tests.Server.Modules;
@@ -159,6 +163,144 @@ public class ItemModuleTests
         }
     }
 
+    private sealed class ItemModuleTestSpatialWorldService : ISpatialWorldService
+    {
+        public List<(UOItemEntity Item, int MapId)> AddedOrUpdatedItems { get; } = [];
+
+        public void AddOrUpdateItem(UOItemEntity item, int mapId)
+            => AddedOrUpdatedItems.Add((item, mapId));
+
+        public void AddOrUpdateMobile(UOMobileEntity mobile)
+            => _ = mobile;
+
+        public void AddRegion(JsonRegion region)
+            => _ = region;
+
+        public Task<int> BroadcastToPlayersAsync(
+            Moongate.Network.Packets.Interfaces.IGameNetworkPacket packet,
+            int mapId,
+            Point3D location,
+            int? range = null,
+            long? excludeSessionId = null
+        )
+        {
+            _ = packet;
+            _ = mapId;
+            _ = location;
+            _ = range;
+            _ = excludeSessionId;
+
+            return Task.FromResult(0);
+        }
+
+        public List<MapSector> GetActiveSectors()
+            => [];
+
+        public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
+        {
+            _ = mapId;
+            _ = centerSectorX;
+            _ = centerSectorY;
+            _ = radius;
+
+            return [];
+        }
+
+        public int GetMusic(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return 0;
+        }
+
+        public List<UOItemEntity> GetNearbyItems(Point3D location, int range, int mapId)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return [];
+        }
+
+        public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return [];
+        }
+
+        public List<Moongate.Server.Data.Session.GameSession> GetPlayersInRange(
+            Point3D location,
+            int range,
+            int mapId,
+            Moongate.Server.Data.Session.GameSession? excludeSession = null
+        )
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+            _ = excludeSession;
+
+            return [];
+        }
+
+        public List<UOMobileEntity> GetPlayersInSector(int mapId, int sectorX, int sectorY)
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+
+            return [];
+        }
+
+        public JsonRegion? GetRegionById(int regionId)
+        {
+            _ = regionId;
+
+            return null;
+        }
+
+        public MapSector? GetSectorByLocation(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return null;
+        }
+
+        public SectorSystemStats GetStats()
+            => new();
+
+        public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation)
+        {
+            _ = item;
+            _ = mapId;
+            _ = oldLocation;
+            _ = newLocation;
+        }
+
+        public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation)
+        {
+            _ = mobile;
+            _ = oldLocation;
+            _ = newLocation;
+        }
+
+        public void RemoveEntity(Serial serial)
+            => _ = serial;
+
+        public JsonRegion? ResolveRegion(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return null;
+        }
+    }
+
     [Test]
     public void Get_WhenItemDoesNotExist_ShouldReturnNull()
     {
@@ -288,6 +430,27 @@ public class ItemModuleTests
                 Assert.That(itemService.LastMoveMapId, Is.EqualTo(1));
                 Assert.That(itemService.LastUpsertedItem, Is.Not.Null);
                 Assert.That(itemService.LastUpsertedItem!.Amount, Is.EqualTo(25));
+            }
+        );
+    }
+
+    [Test]
+    public void Spawn_WhenValidInput_ShouldAddItemToSpatialWorld()
+    {
+        var itemService = new ItemModuleTestItemService();
+        var spatialWorldService = new ItemModuleTestSpatialWorldService();
+        var module = new ItemModule(itemService, spatialWorldService);
+        var position = CreatePositionTable(120, 210, 0, 1);
+
+        var result = module.Spawn("gold", position);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(spatialWorldService.AddedOrUpdatedItems.Count, Is.EqualTo(1));
+                Assert.That(spatialWorldService.AddedOrUpdatedItems[0].Item.Id, Is.EqualTo((Serial)1u));
+                Assert.That(spatialWorldService.AddedOrUpdatedItems[0].MapId, Is.EqualTo(1));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Modules/ItemModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/ItemModuleTests.cs
@@ -4,6 +4,8 @@ using Moongate.Server.Modules;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Services.Templates;
+using Moongate.UO.Data.Templates.Items;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
 
@@ -289,6 +291,115 @@ public class ItemModuleTests
             }
         );
     }
+
+    [Test]
+    public void SearchTemplates_WhenQueryMatchesTemplateIdPrefix_ShouldReturnStableItemMetadata()
+    {
+        var itemService = new ItemModuleTestItemService();
+        var templateService = new ItemTemplateService();
+        templateService.UpsertRange(
+        [
+            CreateTemplate("arrow", "Arrow", "0x0F3F"),
+            CreateTemplate("arrow_bundle", "Arrow Bundle", "0x1BFB"),
+            CreateTemplate("bone_armor", "Bone Armor", "0x144F")
+        ]
+        );
+        var module = new ItemModule(itemService, itemTemplateService: templateService);
+
+        var results = module.SearchTemplates("arr");
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(results.Length, Is.EqualTo(2));
+                AssertResult(results, 1, "arrow", "Arrow", 0x0F3F);
+                AssertResult(results, 2, "arrow_bundle", "Arrow Bundle", 0x1BFB);
+            }
+        );
+    }
+
+    [Test]
+    public void SearchTemplates_WhenQueryMatchesDisplayNameSubstring_ShouldReturnSubstringMatches()
+    {
+        var itemService = new ItemModuleTestItemService();
+        var templateService = new ItemTemplateService();
+        templateService.UpsertRange(
+        [
+            CreateTemplate("ceremonial_dagger", "Ceremonial Blade", "0x0F52"),
+            CreateTemplate("training_sword", "Training Blade", "0x13B9"),
+            CreateTemplate("war_mace", "War Mace", "0x1407")
+        ]
+        );
+        var module = new ItemModule(itemService, itemTemplateService: templateService);
+
+        var results = module.SearchTemplates("blade");
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(results.Length, Is.EqualTo(2));
+                AssertResult(results, 1, "ceremonial_dagger", "Ceremonial Blade", 0x0F52);
+                AssertResult(results, 2, "training_sword", "Training Blade", 0x13B9);
+            }
+        );
+    }
+
+    [Test]
+    public void SearchTemplates_WhenPageSizeExceedsMax_ShouldClampResultCount()
+    {
+        var itemService = new ItemModuleTestItemService();
+        var templateService = new ItemTemplateService();
+
+        for (var index = 1; index <= 60; index++)
+        {
+            templateService.Upsert(
+                CreateTemplate(
+                    $"search_item_{index:00}",
+                    $"Search Item {index:00}",
+                    "0x0EED"
+                )
+            );
+        }
+
+        var module = new ItemModule(itemService, itemTemplateService: templateService);
+
+        var results = module.SearchTemplates("search_item", pageSize: 999);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(results.Length, Is.EqualTo(50));
+                AssertResult(results, 1, "search_item_01", "Search Item 01", 0x0EED);
+                AssertResult(results, 50, "search_item_50", "Search Item 50", 0x0EED);
+            }
+        );
+    }
+
+    private static void AssertResult(Table results, int index, string templateId, string displayName, int itemId)
+    {
+        var entry = results.Get(index).Table;
+
+        Assert.That(entry, Is.Not.Null);
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(entry!.Get("template_id").String, Is.EqualTo(templateId));
+                Assert.That(entry.Get("display_name").String, Is.EqualTo(displayName));
+                Assert.That((int)entry.Get("item_id").Number, Is.EqualTo(itemId));
+            }
+        );
+    }
+
+    private static ItemTemplateDefinition CreateTemplate(string id, string name, string itemId)
+        => new()
+        {
+            Id = id,
+            Name = name,
+            Category = "Test",
+            Description = name,
+            ItemId = itemId,
+            ScriptId = string.Empty
+        };
 
     private static Table CreatePositionTable(int x, int y, int z, int mapId)
     {

--- a/tests/Moongate.Tests/Server/Modules/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/MobileModuleTests.cs
@@ -17,7 +17,9 @@ using Moongate.Tests.Server.Support;
 using Moongate.UO.Data.Geometry;
 using Moongate.UO.Data.Ids;
 using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Services.Templates;
 using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Templates.Mobiles;
 using Moongate.UO.Data.Types;
 using Moongate.UO.Data.Utils;
 using MoonSharp.Interpreter;
@@ -1013,4 +1015,119 @@ public class MobileModuleTests
             }
         );
     }
+
+    [Test]
+    public void SearchTemplates_WhenQueryMatchesTemplateIdPrefix_ShouldReturnStableMobileMetadata()
+    {
+        var templateService = new MobileTemplateService();
+        templateService.UpsertRange(
+        [
+            CreateTemplate("zombie_archer", "Zombie Archer"),
+            CreateTemplate("zombie_warrior", "Zombie Warrior"),
+            CreateTemplate("town_guard", "Town Guard")
+        ]
+        );
+        var module = new MobileModule(
+            new MobileModuleTestCharacterService(),
+            new MobileModuleTestSpeechService(),
+            new FakeGameNetworkSessionService(),
+            new RegionDataLoaderTestSpatialWorldService(),
+            mobileTemplateService: templateService
+        );
+
+        var results = module.SearchTemplates("zom");
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(results.Length, Is.EqualTo(2));
+                AssertResult(results, 1, "zombie_archer", "Zombie Archer");
+                AssertResult(results, 2, "zombie_warrior", "Zombie Warrior");
+            }
+        );
+    }
+
+    [Test]
+    public void SearchTemplates_WhenQueryMatchesDisplayNameSubstring_ShouldReturnSubstringMatches()
+    {
+        var templateService = new MobileTemplateService();
+        templateService.UpsertRange(
+        [
+            CreateTemplate("docks_escort", "Docks Escort"),
+            CreateTemplate("harbor_mage", "Harbor Spellbinder"),
+            CreateTemplate("forest_wolf", "Forest Wolf")
+        ]
+        );
+        var module = new MobileModule(
+            new MobileModuleTestCharacterService(),
+            new MobileModuleTestSpeechService(),
+            new FakeGameNetworkSessionService(),
+            new RegionDataLoaderTestSpatialWorldService(),
+            mobileTemplateService: templateService
+        );
+
+        var results = module.SearchTemplates("spell");
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(results.Length, Is.EqualTo(1));
+                AssertResult(results, 1, "harbor_mage", "Harbor Spellbinder");
+            }
+        );
+    }
+
+    [Test]
+    public void SearchTemplates_WhenPageSizeExceedsMax_ShouldClampResultCount()
+    {
+        var templateService = new MobileTemplateService();
+
+        for (var index = 1; index <= 60; index++)
+        {
+            templateService.Upsert(CreateTemplate($"search_mobile_{index:00}", $"Search Mobile {index:00}"));
+        }
+
+        var module = new MobileModule(
+            new MobileModuleTestCharacterService(),
+            new MobileModuleTestSpeechService(),
+            new FakeGameNetworkSessionService(),
+            new RegionDataLoaderTestSpatialWorldService(),
+            mobileTemplateService: templateService
+        );
+
+        var results = module.SearchTemplates("search_mobile", pageSize: 999);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(results.Length, Is.EqualTo(50));
+                AssertResult(results, 1, "search_mobile_01", "Search Mobile 01");
+                AssertResult(results, 50, "search_mobile_50", "Search Mobile 50");
+            }
+        );
+    }
+
+    private static void AssertResult(Table results, int index, string templateId, string displayName)
+    {
+        var entry = results.Get(index).Table;
+
+        Assert.That(entry, Is.Not.Null);
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(entry!.Get("template_id").String, Is.EqualTo(templateId));
+                Assert.That(entry.Get("display_name").String, Is.EqualTo(displayName));
+            }
+        );
+    }
+
+    private static MobileTemplateDefinition CreateTemplate(string id, string name)
+        => new()
+        {
+            Id = id,
+            Name = name,
+            Category = "Test",
+            Description = name,
+            Title = string.Empty
+        };
 }

--- a/tests/Moongate.Tests/Server/Modules/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/MobileModuleTests.cs
@@ -524,6 +524,39 @@ public class MobileModuleTests
     }
 
     [Test]
+    public void Teleport_WhenCharacterExists_ShouldUpdateMapAndLocation()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x220,
+            Name = "Traveler",
+            MapId = 1,
+            Location = new(100, 200, 5)
+        };
+        var characterService = new MobileModuleTestCharacterService
+        {
+            CharacterToReturn = mobile
+        };
+        var module = new MobileModule(
+            characterService,
+            new MobileModuleTestSpeechService(),
+            new FakeGameNetworkSessionService(),
+            new RegionDataLoaderTestSpatialWorldService()
+        );
+
+        var teleported = module.Teleport(0x220, 0, 1496, 1628, 20);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(teleported, Is.True);
+                Assert.That(mobile.MapId, Is.EqualTo(0));
+                Assert.That(mobile.Location, Is.EqualTo(new Point3D(1496, 1628, 20)));
+            }
+        );
+    }
+
+    [Test]
     public void Get_WhenCharacterIsMounted_ShouldExposeMountedState()
     {
         var characterService = new MobileModuleTestCharacterService

--- a/tests/Moongate.Tests/Server/Modules/TargetModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/TargetModuleTests.cs
@@ -1,0 +1,157 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.Targeting;
+using Moongate.Network.Packets.Types.Targeting;
+using Moongate.Server.Data.Internal.Cursors;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Modules;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Tests.Server.Modules;
+
+public sealed class TargetModuleTests
+{
+    private sealed class TargetModuleTestPlayerTargetService : IPlayerTargetService
+    {
+        public long LastSessionId { get; private set; }
+
+        public TargetCursorSelectionType LastSelectionType { get; private set; }
+
+        public TargetCursorType LastCursorType { get; private set; }
+
+        public Action<PendingCursorCallback>? LastCallback { get; private set; }
+
+        public Serial NextCursorId { get; set; } = (Serial)0x40001001u;
+
+        public long LastCancelSessionId { get; private set; }
+
+        public Serial LastCancelCursorId { get; private set; }
+
+        public Task SendCancelTargetCursorAsync(long sessionId, Serial cursorId)
+        {
+            LastCancelSessionId = sessionId;
+            LastCancelCursorId = cursorId;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<Serial> SendTargetCursorAsync(
+            long sessionId,
+            Action<PendingCursorCallback> callback,
+            TargetCursorSelectionType selectionType = TargetCursorSelectionType.SelectLocation,
+            TargetCursorType cursorType = TargetCursorType.Neutral
+        )
+        {
+            LastSessionId = sessionId;
+            LastSelectionType = selectionType;
+            LastCursorType = cursorType;
+            LastCallback = callback;
+
+            return Task.FromResult(NextCursorId);
+        }
+
+        public Task StartAsync()
+            => Task.CompletedTask;
+
+        public Task StopAsync()
+            => Task.CompletedTask;
+    }
+
+    [Test]
+    public void Cancel_ShouldForwardToPlayerTargetService()
+    {
+        var targetService = new TargetModuleTestPlayerTargetService();
+        var sessionService = new FakeGameNetworkSessionService();
+        var module = new TargetModule(targetService, sessionService);
+
+        var canceled = module.Cancel(11, (uint)0x4000100Au);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(canceled, Is.True);
+                Assert.That(targetService.LastCancelSessionId, Is.EqualTo(11));
+                Assert.That(targetService.LastCancelCursorId, Is.EqualTo((Serial)0x4000100Au));
+            }
+        );
+    }
+
+    [Test]
+    public void RequestLocation_ShouldForwardToPlayerTargetServiceAndReturnCursorId()
+    {
+        var targetService = new TargetModuleTestPlayerTargetService
+        {
+            NextCursorId = (Serial)0x4000100Bu
+        };
+        var sessionService = new FakeGameNetworkSessionService();
+        var module = new TargetModule(targetService, sessionService);
+        var callback = new Script().DoString("return function(_) end").Function;
+
+        var cursorId = module.RequestLocation(11, callback, (int)TargetCursorType.Helpful);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(cursorId, Is.EqualTo((uint)0x4000100Bu));
+                Assert.That(targetService.LastSessionId, Is.EqualTo(11));
+                Assert.That(targetService.LastSelectionType, Is.EqualTo(TargetCursorSelectionType.SelectLocation));
+                Assert.That(targetService.LastCursorType, Is.EqualTo(TargetCursorType.Helpful));
+                Assert.That(targetService.LastCallback, Is.Not.Null);
+            }
+        );
+    }
+
+    [Test]
+    public void RequestLocation_CallbackShouldExecuteLuaClosureWithLocationPayload()
+    {
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00001111u,
+            Character = new UOMobileEntity
+            {
+                Id = (Serial)0x00001111u,
+                MapId = 4,
+                Location = new(25, 35, 0)
+            }
+        };
+        var targetService = new TargetModuleTestPlayerTargetService();
+        var sessionService = new FakeGameNetworkSessionService();
+        sessionService.Add(session);
+        var module = new TargetModule(targetService, sessionService);
+        var script = new Script();
+        script.DoString("called = false; result_x = 0; result_y = 0; result_z = 0; result_map_id = 0");
+        var callback = script.DoString(
+            "return function(ctx) called = true; result_x = ctx.x; result_y = ctx.y; result_z = ctx.z; result_map_id = ctx.map_id end"
+        ).Function;
+
+        _ = module.RequestLocation(session.SessionId, callback);
+        targetService.LastCallback!.Invoke(
+            new(
+                new TargetCursorCommandsPacket
+                {
+                    CursorTarget = TargetCursorSelectionType.SelectLocation,
+                    CursorId = (Serial)0x4000100Cu,
+                    CursorType = TargetCursorType.Neutral,
+                    Location = new Point3D(111, 222, 7)
+                }
+            )
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(script.Globals.Get("called").Boolean, Is.True);
+                Assert.That(script.Globals.Get("result_x").Number, Is.EqualTo(111));
+                Assert.That(script.Globals.Get("result_y").Number, Is.EqualTo(222));
+                Assert.That(script.Globals.Get("result_z").Number, Is.EqualTo(7));
+                Assert.That(script.Globals.Get("result_map_id").Number, Is.EqualTo(4));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/TargetModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/TargetModuleTests.cs
@@ -154,4 +154,51 @@ public sealed class TargetModuleTests
             }
         );
     }
+
+    [Test]
+    public void RequestLocation_CallbackShouldExposeCancelledFlagWhenClientCancelsTargeting()
+    {
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00001111u,
+            Character = new UOMobileEntity
+            {
+                Id = (Serial)0x00001111u,
+                MapId = 4,
+                Location = new(25, 35, 0)
+            }
+        };
+        var targetService = new TargetModuleTestPlayerTargetService();
+        var sessionService = new FakeGameNetworkSessionService();
+        sessionService.Add(session);
+        var module = new TargetModule(targetService, sessionService);
+        var script = new Script();
+        script.DoString("called = false; cancelled = false; result_cursor_id = 0");
+        var callback = script.DoString(
+            "return function(ctx) called = true; cancelled = ctx.cancelled; result_cursor_id = ctx.cursor_id end"
+        ).Function;
+
+        _ = module.RequestLocation(session.SessionId, callback);
+        targetService.LastCallback!.Invoke(
+            new(
+                new TargetCursorCommandsPacket
+                {
+                    CursorTarget = TargetCursorSelectionType.SelectLocation,
+                    CursorId = (Serial)0x4000100Du,
+                    CursorType = TargetCursorType.CancelCurrentTargeting,
+                    Location = Point3D.Zero
+                }
+            )
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(script.Globals.Get("called").Boolean, Is.True);
+                Assert.That(script.Globals.Get("cancelled").Boolean, Is.True);
+                Assert.That(script.Globals.Get("result_cursor_id").Number, Is.EqualTo(0x4000100Du));
+            }
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- reduce GM menu transparency, improve text contrast, and tighten result paging in the add browser
- stop brush loops on target cancel and expose cancel state to Lua target callbacks
- refresh the spatial world immediately for GM item and NPC target-ground spawns

## Test Plan
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~ItemModuleTests.Spawn_WhenValidInput_ShouldAddItemToSpatialWorld|FullyQualifiedName~ItemModuleTests.Spawn_WhenValidInput_ShouldSpawnAndReturnLuaItemProxy|FullyQualifiedName~GmMenuLuaRuntimeTests|FullyQualifiedName~TargetModuleTests"
- git diff --check

Refs #167