### PR TITLE
refactor: split mobile module responsibilities

### DIFF
--- a/src/Moongate.Server/Modules/MobileCombatModule.cs
+++ b/src/Moongate.Server/Modules/MobileCombatModule.cs
@@ -1,0 +1,179 @@
+using Moongate.Server.Data.Interaction;
+using Moongate.Server.Data.Internal.Interaction;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Modules;
+
+internal sealed class MobileCombatModule
+{
+    private readonly IMobileService? _mobileService;
+    private readonly IGameNetworkSessionService _gameNetworkSessionService;
+    private readonly ISpatialWorldService? _spatialWorldService;
+    private readonly IOutgoingPacketQueue? _outgoingPacketQueue;
+    private readonly ISkillGainService? _skillGainService;
+    private readonly Func<double> _skillCheckRollProvider;
+
+    public MobileCombatModule(
+        IMobileService? mobileService,
+        IGameNetworkSessionService gameNetworkSessionService,
+        ISpatialWorldService? spatialWorldService,
+        IOutgoingPacketQueue? outgoingPacketQueue,
+        ISkillGainService? skillGainService,
+        Func<double>? skillCheckRollProvider = null
+    )
+    {
+        _mobileService = mobileService;
+        _gameNetworkSessionService = gameNetworkSessionService;
+        _spatialWorldService = spatialWorldService;
+        _outgoingPacketQueue = outgoingPacketQueue;
+        _skillGainService = skillGainService;
+        _skillCheckRollProvider = skillCheckRollProvider ?? Random.Shared.NextDouble;
+    }
+
+    public bool CheckSkill(UOMobileEntity mobile, string skillName, double minSkill, double maxSkill, uint targetId = 0)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        if (_skillGainService is null || !TryResolveSkillName(skillName, out var resolvedSkill))
+        {
+            return false;
+        }
+
+        var skill = mobile.GetSkill(resolvedSkill);
+
+        if (skill is null)
+        {
+            return false;
+        }
+
+        var currentValue = skill.Value / 10.0;
+
+        if (currentValue < minSkill)
+        {
+            return false;
+        }
+
+        if (currentValue >= maxSkill || minSkill >= maxSkill)
+        {
+            return true;
+        }
+
+        var successChance = Math.Clamp((currentValue - minSkill) / (maxSkill - minSkill), 0.0, 1.0);
+        var wasSuccessful = successChance >= _skillCheckRollProvider();
+        _ = _skillGainService.TryGain(
+            mobile,
+            resolvedSkill,
+            successChance,
+            wasSuccessful,
+            new SkillGainContext(mobile.Location, targetId == 0 ? null : (Serial)targetId)
+        );
+
+        return wasSuccessful;
+    }
+
+    public bool Dismount(Serial riderId)
+    {
+        if (riderId == Serial.Zero || _mobileService is null)
+        {
+            return false;
+        }
+
+        return _mobileService.DismountAsync(riderId).GetAwaiter().GetResult();
+    }
+
+    public void RefreshMountedSession(Serial riderId, Serial mountId, bool isMounted)
+    {
+        if (!_gameNetworkSessionService.TryGetByCharacterId(riderId, out var session) || session.Character is null)
+        {
+            return;
+        }
+
+        var rider = ResolveRuntimeMobile(riderId) ??
+                    _mobileService?.GetAsync(riderId).GetAwaiter().GetResult() ??
+                    session.Character;
+        var mount = mountId == Serial.Zero
+                        ? null
+                        : ResolveRuntimeMobile(mountId) ??
+                          _mobileService?.GetAsync(mountId).GetAwaiter().GetResult();
+
+        if (_outgoingPacketQueue is null)
+        {
+            return;
+        }
+
+        MountedSelfRefreshHelper.Refresh(session, _outgoingPacketQueue, rider, mount, isMounted);
+    }
+
+    public bool TryMount(Serial riderId, Serial mountId, UOMobileEntity? rider, UOMobileEntity? mount)
+    {
+        if (riderId == Serial.Zero || mountId == Serial.Zero || _mobileService is null)
+        {
+            return false;
+        }
+
+        if (rider is not null)
+        {
+            _mobileService.CreateOrUpdateAsync(rider).GetAwaiter().GetResult();
+        }
+
+        if (mount is not null)
+        {
+            _mobileService.CreateOrUpdateAsync(mount).GetAwaiter().GetResult();
+        }
+
+        return _mobileService.TryMountAsync(riderId, mountId).GetAwaiter().GetResult();
+    }
+
+    private UOMobileEntity? ResolveRuntimeMobile(Serial mobileId)
+    {
+        if (_spatialWorldService is null)
+        {
+            return null;
+        }
+
+        foreach (var sector in _spatialWorldService.GetActiveSectors())
+        {
+            var runtimeMobile = sector.GetEntity<UOMobileEntity>(mobileId);
+
+            if (runtimeMobile is not null)
+            {
+                return runtimeMobile;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryResolveSkillName(string skillName, out UOSkillName resolvedSkill)
+    {
+        resolvedSkill = default;
+
+        if (string.IsNullOrWhiteSpace(skillName))
+        {
+            return false;
+        }
+
+        var normalized = new string(skillName.Where(char.IsLetterOrDigit).ToArray());
+
+        foreach (var candidate in Enum.GetValues<UOSkillName>())
+        {
+            var candidateName = new string(candidate.ToString().Where(char.IsLetterOrDigit).ToArray());
+
+            if (string.Equals(candidateName, normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                resolvedSkill = candidate;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Moongate.Server/Modules/MobileInventoryModule.cs
+++ b/src/Moongate.Server/Modules/MobileInventoryModule.cs
@@ -1,0 +1,205 @@
+using Moongate.Server.Interfaces.Items;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Modules;
+
+internal sealed class MobileInventoryModule
+{
+    private readonly IItemService? _itemService;
+
+    public MobileInventoryModule(IItemService? itemService)
+    {
+        _itemService = itemService;
+    }
+
+    public UOItemEntity? AddItemToBackpack(UOMobileEntity mobile, string itemTemplateId, int amount = 1)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        if (_itemService is null || string.IsNullOrWhiteSpace(itemTemplateId) || amount <= 0)
+        {
+            return null;
+        }
+
+        var backpackId = ResolveBackpackId(mobile);
+
+        if (backpackId == Serial.Zero)
+        {
+            return null;
+        }
+
+        var item = _itemService.SpawnFromTemplateAsync(itemTemplateId.Trim()).GetAwaiter().GetResult();
+
+        if (amount > 1)
+        {
+            if (!item.IsStackable)
+            {
+                return null;
+            }
+
+            item.Amount = amount;
+            _itemService.UpsertItemAsync(item).GetAwaiter().GetResult();
+        }
+
+        var moved = _itemService.MoveItemToContainerAsync(item.Id, backpackId, new(1, 1)).GetAwaiter().GetResult();
+
+        return moved ? item : null;
+    }
+
+    public bool ConsumeItem(UOMobileEntity mobile, int itemId, int amount = 1)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        if (_itemService is null || itemId <= 0 || amount <= 0)
+        {
+            return false;
+        }
+
+        var sources = GetConsumableSources(mobile).ToList();
+
+        if (CountMatchingItems(sources, itemId) < amount)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < amount; i++)
+        {
+            if (!TryConsumeFromSources(sources, itemId))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int CountMatchingItems(IEnumerable<UOItemEntity> containers, int itemId)
+        => containers.Sum(container => CountMatchingItems(container, itemId));
+
+    private static int CountMatchingItems(UOItemEntity container, int itemId)
+    {
+        var count = 0;
+
+        foreach (var child in container.Items)
+        {
+            if (child.ItemId == itemId)
+            {
+                count += Math.Max(0, child.Amount);
+            }
+
+            if (child.Items.Count > 0)
+            {
+                count += CountMatchingItems(child, itemId);
+            }
+        }
+
+        return count;
+    }
+
+    private static IEnumerable<UOItemEntity> GetConsumableSources(UOMobileEntity mobile)
+    {
+        var quiver = mobile.GetEquippedItemsRuntime().FirstOrDefault(static item => item.IsQuiver);
+
+        if (quiver is not null)
+        {
+            yield return quiver;
+        }
+
+        var backpack = TryResolveBackpack(mobile);
+
+        if (backpack is not null)
+        {
+            yield return backpack;
+        }
+    }
+
+    private static Serial ResolveBackpackId(UOMobileEntity mobile)
+    {
+        if (mobile.BackpackId != Serial.Zero)
+        {
+            return mobile.BackpackId;
+        }
+
+        return mobile.EquippedItemIds.TryGetValue(ItemLayerType.Backpack, out var equippedBackpackId)
+                   ? equippedBackpackId
+                   : Serial.Zero;
+    }
+
+    private static UOItemEntity? TryResolveBackpack(UOMobileEntity mobile)
+    {
+        var backpackId = ResolveBackpackId(mobile);
+
+        return mobile.GetEquippedItemsRuntime()
+                     .FirstOrDefault(item => item.Id == backpackId || item.EquippedLayer == ItemLayerType.Backpack);
+    }
+
+    private bool TryConsumeFromSources(IEnumerable<UOItemEntity> sources, int itemId)
+    {
+        foreach (var source in sources)
+        {
+            if (!TryConsumeItemRecursive(source, itemId, out var changedStack, out var deletedStack))
+            {
+                continue;
+            }
+
+            if (changedStack is not null)
+            {
+                _itemService!.UpsertItemAsync(changedStack).GetAwaiter().GetResult();
+            }
+
+            if (deletedStack is not null)
+            {
+                _ = _itemService!.DeleteItemAsync(deletedStack.Id).GetAwaiter().GetResult();
+            }
+
+            _itemService!.UpsertItemAsync(source).GetAwaiter().GetResult();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryConsumeItemRecursive(
+        UOItemEntity container,
+        int itemId,
+        out UOItemEntity? changedStack,
+        out UOItemEntity? deletedStack
+    )
+    {
+        changedStack = null;
+        deletedStack = null;
+
+        for (var index = container.Items.Count - 1; index >= 0; index--)
+        {
+            var child = container.Items[index];
+
+            if (child.ItemId == itemId)
+            {
+                child.Amount--;
+
+                if (child.Amount <= 0)
+                {
+                    container.RemoveItem(child.Id);
+                    deletedStack = child;
+                }
+                else
+                {
+                    changedStack = child;
+                }
+
+                return true;
+            }
+
+            if (TryConsumeItemRecursive(child, itemId, out changedStack, out deletedStack))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Moongate.Server/Modules/MobileModule.cs
+++ b/src/Moongate.Server/Modules/MobileModule.cs
@@ -48,7 +48,9 @@ public sealed class MobileModule
     private readonly IItemService? _itemService;
     private readonly ISkillGainService? _skillGainService;
     private readonly IMobileTemplateService? _mobileTemplateService;
-    private readonly Func<double> _skillCheckRollProvider;
+    private readonly MobileCombatModule _combatModule;
+    private readonly MobileInventoryModule _inventoryModule;
+    private readonly MobileMovementModule _movementModule;
 
     public MobileModule(
         ICharacterService characterService,
@@ -80,7 +82,24 @@ public sealed class MobileModule
         _itemService = itemService;
         _skillGainService = skillGainService;
         _mobileTemplateService = mobileTemplateService;
-        _skillCheckRollProvider = skillCheckRollProvider ?? Random.Shared.NextDouble;
+        _movementModule = new(
+            speechService,
+            gameNetworkSessionService,
+            spatialWorldService,
+            movementValidationService,
+            pathfindingService,
+            gameEventBusService,
+            backgroundJobService
+        );
+        _combatModule = new(
+            mobileService,
+            gameNetworkSessionService,
+            spatialWorldService,
+            outgoingPacketQueue,
+            skillGainService,
+            skillCheckRollProvider
+        );
+        _inventoryModule = new(itemService);
     }
 
     [ScriptFunction("dismount", "Attempts to dismount the rider from the current mount.")]
@@ -91,11 +110,11 @@ public sealed class MobileModule
             return false;
         }
 
-        var dismounted = _mobileService.DismountAsync((Serial)riderId).GetAwaiter().GetResult();
+        var dismounted = _combatModule.Dismount((Serial)riderId);
 
         if (dismounted)
         {
-            RefreshMountedSession((Serial)riderId, Serial.Zero, false);
+            _combatModule.RefreshMountedSession((Serial)riderId, Serial.Zero, false);
         }
 
         return dismounted;
@@ -163,56 +182,20 @@ public sealed class MobileModule
             return false;
         }
 
-        var proxy = CreateLuaMobileProxy(mobile);
-
-        return proxy is not null && proxy.Teleport(mapId, x, y, z);
+        return _movementModule.Teleport(mobile, mapId, x, y, z);
     }
 
     [ScriptFunction("check_skill", "Checks a skill against a min/max range and applies gain rules.")]
     public bool CheckSkill(uint characterId, string skillName, double minSkill, double maxSkill, uint targetId = 0)
     {
-        if (_skillGainService is null)
-        {
-            return false;
-        }
-
         var mobile = ResolveMobile((Serial)characterId);
 
-        if (mobile is null || !TryResolveSkillName(skillName, out var resolvedSkill))
+        if (mobile is null)
         {
             return false;
         }
 
-        var skill = mobile.GetSkill(resolvedSkill);
-
-        if (skill is null)
-        {
-            return false;
-        }
-
-        var currentValue = skill.Value / 10.0;
-
-        if (currentValue < minSkill)
-        {
-            return false;
-        }
-
-        if (currentValue >= maxSkill || minSkill >= maxSkill)
-        {
-            return true;
-        }
-
-        var successChance = Math.Clamp((currentValue - minSkill) / (maxSkill - minSkill), 0.0, 1.0);
-        var wasSuccessful = successChance >= _skillCheckRollProvider();
-        _ = _skillGainService.TryGain(
-            mobile,
-            resolvedSkill,
-            successChance,
-            wasSuccessful,
-            new SkillGainContext(mobile.Location, targetId == 0 ? null : (Serial)targetId)
-        );
-
-        return wasSuccessful;
+        return _combatModule.CheckSkill(mobile, skillName, minSkill, maxSkill, targetId);
     }
 
     [ScriptFunction("consume_item", "Consumes a matching item id from equipped quivers first, then backpack.")]
@@ -230,22 +213,7 @@ public sealed class MobileModule
             return false;
         }
 
-        var sources = GetConsumableSources(mobile);
-
-        if (CountMatchingItems(sources, itemId) < amount)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < amount; i++)
-        {
-            if (!TryConsumeFromSources(sources, itemId))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return _inventoryModule.ConsumeItem(mobile, itemId, amount);
     }
 
     [ScriptFunction("add_item_to_backpack", "Spawns an item template and places it in the target backpack.")]
@@ -263,29 +231,7 @@ public sealed class MobileModule
             return null;
         }
 
-        var backpackId = ResolveBackpackId(mobile);
-
-        if (backpackId == Serial.Zero)
-        {
-            return null;
-        }
-
-        var item = _itemService.SpawnFromTemplateAsync(itemTemplateId.Trim()).GetAwaiter().GetResult();
-
-        if (amount > 1)
-        {
-            if (!item.IsStackable)
-            {
-                return null;
-            }
-
-            item.Amount = amount;
-            _itemService.UpsertItemAsync(item).GetAwaiter().GetResult();
-        }
-
-        var moved = _itemService.MoveItemToContainerAsync(item.Id, backpackId, new(1, 1)).GetAwaiter().GetResult();
-
-        return moved ? CreateLuaItemProxy(item) : null;
+        return CreateLuaItemProxy(_inventoryModule.AddItemToBackpack(mobile, itemTemplateId, amount));
     }
 
     [ScriptFunction("spawn", "Spawns a mobile template at world position { x, y, z, map_id }.")]
@@ -360,47 +306,14 @@ public sealed class MobileModule
         var mount = TryResolveRuntimeMobile(mountSerial) ??
                     _mobileService.GetAsync(mountSerial).GetAwaiter().GetResult();
 
-        if (rider is not null)
-        {
-            _mobileService.CreateOrUpdateAsync(rider).GetAwaiter().GetResult();
-        }
-
-        if (mount is not null)
-        {
-            _mobileService.CreateOrUpdateAsync(mount).GetAwaiter().GetResult();
-        }
-
-        var mounted = _mobileService.TryMountAsync(riderSerial, mountSerial).GetAwaiter().GetResult();
+        var mounted = _combatModule.TryMount(riderSerial, mountSerial, rider, mount);
 
         if (mounted)
         {
-            RefreshMountedSession(riderSerial, mountSerial, true);
+            _combatModule.RefreshMountedSession(riderSerial, mountSerial, true);
         }
 
         return mounted;
-    }
-
-    private void RefreshMountedSession(Serial riderId, Serial mountId, bool isMounted)
-    {
-        if (!_gameNetworkSessionService.TryGetByCharacterId(riderId, out var session) || session.Character is null)
-        {
-            return;
-        }
-
-        var rider = TryResolveRuntimeMobile(riderId) ??
-                    _mobileService?.GetAsync(riderId).GetAwaiter().GetResult() ??
-                    session.Character;
-        var mount = mountId == Serial.Zero
-                        ? null
-                        : TryResolveRuntimeMobile(mountId) ??
-                          _mobileService?.GetAsync(mountId).GetAwaiter().GetResult();
-
-        if (_outgoingPacketQueue is null)
-        {
-            return;
-        }
-
-        MountedSelfRefreshHelper.Refresh(session, _outgoingPacketQueue, rider, mount, isMounted);
     }
 
     private static void RegisterLuaTypeIfNeeded()
@@ -522,58 +435,6 @@ public sealed class MobileModule
         );
     }
 
-    private static int CountMatchingItems(IEnumerable<UOItemEntity> containers, int itemId)
-        => containers.Sum(container => CountMatchingItems(container, itemId));
-
-    private static int CountMatchingItems(UOItemEntity container, int itemId)
-    {
-        var count = 0;
-
-        foreach (var child in container.Items)
-        {
-            if (child.ItemId == itemId)
-            {
-                count += Math.Max(0, child.Amount);
-            }
-
-            if (child.Items.Count > 0)
-            {
-                count += CountMatchingItems(child, itemId);
-            }
-        }
-
-        return count;
-    }
-
-    private IEnumerable<UOItemEntity> GetConsumableSources(UOMobileEntity mobile)
-    {
-        var quiver = mobile.GetEquippedItemsRuntime().FirstOrDefault(static item => item.IsQuiver);
-
-        if (quiver is not null)
-        {
-            yield return quiver;
-        }
-
-        var backpack = TryResolveBackpack(mobile);
-
-        if (backpack is not null)
-        {
-            yield return backpack;
-        }
-    }
-
-    private static Serial ResolveBackpackId(UOMobileEntity mobile)
-    {
-        if (mobile.BackpackId != Serial.Zero)
-        {
-            return mobile.BackpackId;
-        }
-
-        return mobile.EquippedItemIds.TryGetValue(ItemLayerType.Backpack, out var equippedBackpackId)
-                   ? equippedBackpackId
-                   : Serial.Zero;
-    }
-
     private UOMobileEntity? ResolveMobile(Serial mobileId)
     {
         if (mobileId == Serial.Zero)
@@ -606,71 +467,16 @@ public sealed class MobileModule
                              (item.WeaponSkill is not null || item.CombatStats is not null)
                  );
 
-    private bool TryConsumeFromSources(IEnumerable<UOItemEntity> sources, int itemId)
+    private static Serial ResolveBackpackId(UOMobileEntity mobile)
     {
-        foreach (var source in sources)
+        if (mobile.BackpackId != Serial.Zero)
         {
-            if (!TryConsumeItemRecursive(source, itemId, out var changedStack, out var deletedStack))
-            {
-                continue;
-            }
-
-            if (changedStack is not null)
-            {
-                _itemService!.UpsertItemAsync(changedStack).GetAwaiter().GetResult();
-            }
-
-            if (deletedStack is not null)
-            {
-                _ = _itemService!.DeleteItemAsync(deletedStack.Id).GetAwaiter().GetResult();
-            }
-
-            _itemService!.UpsertItemAsync(source).GetAwaiter().GetResult();
-
-            return true;
+            return mobile.BackpackId;
         }
 
-        return false;
-    }
-
-    private static bool TryConsumeItemRecursive(
-        UOItemEntity container,
-        int itemId,
-        out UOItemEntity? changedStack,
-        out UOItemEntity? deletedStack
-    )
-    {
-        changedStack = null;
-        deletedStack = null;
-
-        for (var index = container.Items.Count - 1; index >= 0; index--)
-        {
-            var child = container.Items[index];
-
-            if (child.ItemId == itemId)
-            {
-                child.Amount--;
-
-                if (child.Amount <= 0)
-                {
-                    container.RemoveItem(child.Id);
-                    deletedStack = child;
-                }
-                else
-                {
-                    changedStack = child;
-                }
-
-                return true;
-            }
-
-            if (TryConsumeItemRecursive(child, itemId, out changedStack, out deletedStack))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return mobile.EquippedItemIds.TryGetValue(ItemLayerType.Backpack, out var equippedBackpackId)
+                   ? equippedBackpackId
+                   : Serial.Zero;
     }
 
     private static bool TryResolveSkillName(string skillName, out UOSkillName resolvedSkill)

--- a/src/Moongate.Server/Modules/MobileMovementModule.cs
+++ b/src/Moongate.Server/Modules/MobileMovementModule.cs
@@ -1,0 +1,58 @@
+using Moongate.Server.Data.Internal.Entities;
+using Moongate.Server.Interfaces.Services.EvenLoop;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Movement;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Interfaces.Services.Speech;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Server.Modules;
+
+internal sealed class MobileMovementModule
+{
+    private readonly ISpeechService _speechService;
+    private readonly IGameNetworkSessionService _gameNetworkSessionService;
+    private readonly ISpatialWorldService? _spatialWorldService;
+    private readonly IMovementValidationService? _movementValidationService;
+    private readonly IPathfindingService? _pathfindingService;
+    private readonly IGameEventBusService? _gameEventBusService;
+    private readonly IBackgroundJobService? _backgroundJobService;
+
+    public MobileMovementModule(
+        ISpeechService speechService,
+        IGameNetworkSessionService gameNetworkSessionService,
+        ISpatialWorldService? spatialWorldService = null,
+        IMovementValidationService? movementValidationService = null,
+        IPathfindingService? pathfindingService = null,
+        IGameEventBusService? gameEventBusService = null,
+        IBackgroundJobService? backgroundJobService = null
+    )
+    {
+        _speechService = speechService;
+        _gameNetworkSessionService = gameNetworkSessionService;
+        _spatialWorldService = spatialWorldService;
+        _movementValidationService = movementValidationService;
+        _pathfindingService = pathfindingService;
+        _gameEventBusService = gameEventBusService;
+        _backgroundJobService = backgroundJobService;
+    }
+
+    public bool Teleport(UOMobileEntity mobile, int mapId, int x, int y, int z)
+    {
+        ArgumentNullException.ThrowIfNull(mobile);
+
+        var proxy = new LuaMobileProxy(
+            mobile,
+            _speechService,
+            _gameNetworkSessionService,
+            _spatialWorldService,
+            _movementValidationService,
+            _pathfindingService,
+            _gameEventBusService,
+            _backgroundJobService
+        );
+
+        return proxy.Teleport(mapId, x, y, z);
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/MobileCombatModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/MobileCombatModuleTests.cs
@@ -1,0 +1,153 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Modules;
+using Moongate.Server.Services.Interaction;
+using Moongate.Tests.Server.Modules.Support;
+using Moongate.Tests.Server.Services.Packets;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Types;
+using Stat = Moongate.UO.Data.Types.Stat;
+
+namespace Moongate.Tests.Server.Modules;
+
+public class MobileCombatModuleTests
+{
+    [SetUp]
+    public void SetUp()
+        => SkillInfo.Table =
+        [
+            new(
+                (int)UOSkillName.Archery,
+                "Archery",
+                0,
+                100,
+                0,
+                "Archer",
+                0,
+                0,
+                0,
+                1,
+                "Archery",
+                Stat.Dexterity,
+                Stat.Strength
+            )
+        ];
+
+    [Test]
+    public void CheckSkill_WhenSkillIsWithinRange_ShouldReturnSuccessAndApplyGain()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x211,
+            Name = "Archer",
+            IsPlayer = true,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        mobile.InitializeSkills();
+        mobile.SetSkill(UOSkillName.Archery, 500);
+
+        ISkillGainService skillGainService = new SkillGainService(() => 0.0);
+        var module = new MobileCombatModule(
+            mobileService: null,
+            gameNetworkSessionService: new FakeGameNetworkSessionService(),
+            spatialWorldService: new RegionDataLoaderTestSpatialWorldService(),
+            outgoingPacketQueue: null,
+            skillGainService: skillGainService,
+            skillCheckRollProvider: () => 0.0
+        );
+
+        var succeeded = module.CheckSkill(mobile, "archery", 0.0, 100.0, 0x999);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(succeeded, Is.True);
+                Assert.That(mobile.GetSkill(UOSkillName.Archery)!.Base, Is.EqualTo(501));
+            }
+        );
+    }
+
+    [Test]
+    public void Dismount_ShouldDelegateToMobileService()
+    {
+        var mobileService = new MobileModuleTestMobileService();
+        var module = new MobileCombatModule(
+            mobileService,
+            new FakeGameNetworkSessionService(),
+            new RegionDataLoaderTestSpatialWorldService(),
+            null,
+            null
+        );
+
+        var dismounted = module.Dismount((Serial)0x200);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(dismounted, Is.True);
+                Assert.That(mobileService.LastRiderId, Is.EqualTo((Serial)0x200));
+                Assert.That(mobileService.DismountCalls, Is.EqualTo(1));
+            }
+        );
+    }
+
+    [Test]
+    public void TryMount_ShouldPersistRuntimeRiderAndMountBeforeDelegating()
+    {
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var sessionService = new FakeGameNetworkSessionService();
+        var spatialService = new RegionDataLoaderTestSpatialWorldService();
+        var mobileService = new MobileModuleTestMobileService();
+        var outgoing = new BasePacketListenerTestOutgoingPacketQueue();
+        var rider = new UOMobileEntity
+        {
+            Id = (Serial)0x200,
+            Name = "Rider",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var mount = new UOMobileEntity
+        {
+            Id = (Serial)0x300,
+            Name = "Horse",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        mobileService.Register(rider);
+        mobileService.Register(mount);
+        spatialService.AddOrUpdateMobile(mount);
+        var session = new GameSession(new(client))
+        {
+            CharacterId = rider.Id,
+            Character = rider
+        };
+        sessionService.Add(session);
+        var module = new MobileCombatModule(
+            mobileService,
+            sessionService,
+            spatialService,
+            outgoing,
+            null
+        );
+
+        var mounted = module.TryMount(rider.Id, mount.Id, rider, mount);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(mounted, Is.True);
+                Assert.That(mobileService.CreateOrUpdateCalls, Is.EqualTo([(Serial)0x200, (Serial)0x300]));
+                Assert.That(mobileService.LastRiderId, Is.EqualTo((Serial)0x200));
+                Assert.That(mobileService.LastMountId, Is.EqualTo((Serial)0x300));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/MobileInventoryModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/MobileInventoryModuleTests.cs
@@ -1,0 +1,128 @@
+using Moongate.Server.Modules;
+using Moongate.Tests.Server.Modules.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Modules;
+
+public class MobileInventoryModuleTests
+{
+    [Test]
+    public void ConsumeItem_WhenMatchingItemExistsInQuiver_ShouldConsumeQuiverBeforeBackpack()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x214,
+            Name = "Ranger",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var backpack = new UOItemEntity
+        {
+            Id = (Serial)0x610,
+            Name = "Backpack",
+            ItemId = 0x0E75,
+            MapId = 1,
+            Location = mobile.Location
+        };
+        var quiver = new UOItemEntity
+        {
+            Id = (Serial)0x611,
+            Name = "Quiver",
+            ItemId = 0x1B02,
+            MapId = 1,
+            Location = mobile.Location,
+            IsQuiver = true
+        };
+        var quiverArrow = new UOItemEntity
+        {
+            Id = (Serial)0x612,
+            Name = "Arrow",
+            ItemId = 0x0F3F,
+            Amount = 3,
+            IsStackable = true,
+            MapId = 1,
+            Location = mobile.Location
+        };
+        var backpackArrow = new UOItemEntity
+        {
+            Id = (Serial)0x613,
+            Name = "Arrow",
+            ItemId = 0x0F3F,
+            Amount = 8,
+            IsStackable = true,
+            MapId = 1,
+            Location = mobile.Location
+        };
+        quiver.AddItem(quiverArrow, new(1, 1));
+        backpack.AddItem(backpackArrow, new(1, 1));
+        mobile.AddEquippedItem(ItemLayerType.Backpack, backpack);
+        mobile.AddEquippedItem(ItemLayerType.Cloak, quiver);
+        mobile.BackpackId = backpack.Id;
+
+        var itemService = new MobileModuleTestItemService();
+        var module = new MobileInventoryModule(itemService);
+
+        var consumed = module.ConsumeItem(mobile, 0x0F3F, 1);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(consumed, Is.True);
+                Assert.That(quiverArrow.Amount, Is.EqualTo(2));
+                Assert.That(backpackArrow.Amount, Is.EqualTo(8));
+            }
+        );
+    }
+
+    [Test]
+    public void AddItemToBackpack_WhenCharacterHasBackpack_ShouldSpawnAndMoveItem()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x215,
+            Name = "Gatherer",
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var backpack = new UOItemEntity
+        {
+            Id = (Serial)0x620,
+            Name = "Backpack",
+            ItemId = 0x0E75,
+            MapId = 1,
+            Location = mobile.Location
+        };
+        mobile.AddEquippedItem(ItemLayerType.Backpack, backpack);
+        mobile.BackpackId = backpack.Id;
+
+        var itemService = new MobileModuleTestItemService
+        {
+            SpawnedItem = new()
+            {
+                Id = (Serial)0x621,
+                Name = "Arrow",
+                ItemId = 0x0F3F,
+                Amount = 1,
+                IsStackable = true,
+                MapId = 1,
+                Location = Point3D.Zero
+            }
+        };
+        var module = new MobileInventoryModule(itemService);
+
+        var addedItem = module.AddItemToBackpack(mobile, "arrow", 5);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(addedItem, Is.Not.Null);
+                Assert.That(itemService.LastMoveItemId, Is.EqualTo((Serial)0x621));
+                Assert.That(itemService.LastContainerId, Is.EqualTo((Serial)0x620));
+                Assert.That(itemService.SpawnedItem!.Amount, Is.EqualTo(5));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/MobileMovementModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/MobileMovementModuleTests.cs
@@ -1,0 +1,40 @@
+using Moongate.Server.Modules;
+using Moongate.Tests.Server.Modules.Support;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Tests.Server.Modules;
+
+public class MobileMovementModuleTests
+{
+    [Test]
+    public void Teleport_WhenCharacterExists_ShouldUpdateMapAndLocation()
+    {
+        var mobile = new UOMobileEntity
+        {
+            Id = (Serial)0x220,
+            Name = "Traveler",
+            MapId = 1,
+            Location = new(100, 200, 5)
+        };
+        var module = new MobileMovementModule(
+            new MobileModuleTestSpeechService(),
+            new FakeGameNetworkSessionService(),
+            new RegionDataLoaderTestSpatialWorldService()
+        );
+
+        var teleported = module.Teleport(mobile, 0, 1496, 1628, 20);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(teleported, Is.True);
+                Assert.That(mobile.MapId, Is.EqualTo(0));
+                Assert.That(mobile.Location, Is.EqualTo(new Point3D(1496, 1628, 20)));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Modules/Support/MobileModuleTestDoubles.cs
+++ b/tests/Moongate.Tests/Server/Modules/Support/MobileModuleTestDoubles.cs
@@ -1,0 +1,379 @@
+using System.Net.Sockets;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.Speech;
+using Moongate.Network.Packets.Outgoing.Speech;
+using Moongate.Server.Data.Interaction;
+using Moongate.Server.Data.Items;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Characters;
+using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Speech;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Tests.Server.Modules.Support;
+
+internal sealed class MobileModuleTestSpeechService : ISpeechService
+{
+    public Task<int> BroadcastFromServerAsync(
+        string text,
+        short hue = 946,
+        short font = 3,
+        string language = "ENU"
+    )
+    {
+        _ = text;
+        _ = hue;
+        _ = font;
+        _ = language;
+
+        return Task.FromResult(0);
+    }
+
+    public Task HandleOpenChatWindowAsync(
+        GameSession session,
+        OpenChatWindowPacket packet,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _ = session;
+        _ = packet;
+        _ = cancellationToken;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<UnicodeSpeechMessagePacket?> ProcessIncomingSpeechAsync(
+        GameSession session,
+        UnicodeSpeechPacket speechPacket,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _ = session;
+        _ = speechPacket;
+        _ = cancellationToken;
+
+        return Task.FromResult<UnicodeSpeechMessagePacket?>(null);
+    }
+
+    public Task<bool> SendMessageFromServerAsync(
+        GameSession session,
+        string text,
+        short hue = 946,
+        short font = 3,
+        string language = "ENU"
+    )
+    {
+        _ = session;
+        _ = text;
+        _ = hue;
+        _ = font;
+        _ = language;
+
+        return Task.FromResult(true);
+    }
+
+    public Task<int> SpeakAsMobileAsync(
+        UOMobileEntity speaker,
+        string text,
+        int range = 12,
+        ChatMessageType messageType = ChatMessageType.Regular,
+        short hue = SpeechHues.Default,
+        short font = SpeechHues.DefaultFont,
+        string language = "ENU",
+        CancellationToken cancellationToken = default
+    )
+    {
+        _ = speaker;
+        _ = text;
+        _ = range;
+        _ = messageType;
+        _ = hue;
+        _ = font;
+        _ = language;
+        _ = cancellationToken;
+
+        return Task.FromResult(0);
+    }
+}
+
+internal sealed class MobileModuleTestCharacterService : ICharacterService
+{
+    public UOMobileEntity? CharacterToReturn { get; set; }
+
+    public Task<bool> AddCharacterToAccountAsync(Serial accountId, Serial characterId)
+    {
+        _ = accountId;
+        _ = characterId;
+
+        return Task.FromResult(true);
+    }
+
+    public Task ApplyStarterEquipmentHuesAsync(Serial characterId, short shirtHue, short pantsHue)
+    {
+        _ = characterId;
+        _ = shirtHue;
+        _ = pantsHue;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<Serial> CreateCharacterAsync(UOMobileEntity character)
+    {
+        _ = character;
+
+        return Task.FromResult((Serial)1u);
+    }
+
+    public Task<UOItemEntity?> GetBackpackWithItemsAsync(UOMobileEntity character)
+    {
+        _ = character;
+
+        return Task.FromResult<UOItemEntity?>(null);
+    }
+
+    public Task<UOItemEntity?> GetBankBoxWithItemsAsync(UOMobileEntity character)
+    {
+        _ = character;
+
+        return Task.FromResult<UOItemEntity?>(null);
+    }
+
+    public Task<UOMobileEntity?> GetCharacterAsync(Serial characterId)
+    {
+        _ = characterId;
+
+        return Task.FromResult(CharacterToReturn);
+    }
+
+    public Task<List<UOMobileEntity>> GetCharactersForAccountAsync(Serial accountId)
+    {
+        _ = accountId;
+
+        return Task.FromResult(new List<UOMobileEntity>());
+    }
+
+    public Task<bool> RemoveCharacterFromAccountAsync(Serial accountId, Serial characterId)
+    {
+        _ = accountId;
+        _ = characterId;
+
+        return Task.FromResult(true);
+    }
+}
+
+internal sealed class MobileModuleTestMobileService : IMobileService
+{
+    private readonly Dictionary<Serial, UOMobileEntity> _mobiles = new();
+    public List<Serial> CreateOrUpdateCalls { get; } = [];
+    public Serial LastRiderId { get; private set; } = Serial.Zero;
+    public Serial LastMountId { get; private set; } = Serial.Zero;
+    public int DismountCalls { get; private set; }
+    public string? LastSpawnTemplateId { get; private set; }
+    public Point3D LastSpawnLocation { get; private set; } = Point3D.Zero;
+    public int LastSpawnMapId { get; private set; }
+
+    public UOMobileEntity? SpawnedMobile
+    {
+        get => _spawnedMobile;
+        set
+        {
+            _spawnedMobile = value;
+
+            if (value is not null)
+            {
+                _mobiles[value.Id] = value;
+            }
+        }
+    }
+
+    private UOMobileEntity? _spawnedMobile;
+
+    public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+    {
+        CreateOrUpdateCalls.Add(mobile.Id);
+        _mobiles[mobile.Id] = mobile;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<bool> DismountAsync(Serial riderId, CancellationToken cancellationToken = default)
+    {
+        LastRiderId = riderId;
+        DismountCalls++;
+
+        if (_mobiles.TryGetValue(riderId, out var rider))
+        {
+            var mountId = rider.MountedMobileId;
+            rider.MountedMobileId = Serial.Zero;
+            rider.MountedDisplayItemId = 0;
+
+            if (mountId != Serial.Zero && _mobiles.TryGetValue(mountId, out var mount))
+            {
+                mount.RiderMobileId = Serial.Zero;
+            }
+        }
+
+        return Task.FromResult(true);
+    }
+
+    public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        => Task.FromResult(_mobiles.GetValueOrDefault(id));
+
+    public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+        int mapId,
+        int sectorX,
+        int sectorY,
+        CancellationToken cancellationToken = default
+    )
+        => Task.FromResult(new List<UOMobileEntity>());
+
+    public void Register(UOMobileEntity mobile)
+        => _mobiles[mobile.Id] = mobile;
+
+    public Task<UOMobileEntity> SpawnFromTemplateAsync(
+        string templateId,
+        Point3D location,
+        int mapId,
+        Serial? accountId = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        _ = accountId;
+        _ = cancellationToken;
+
+        LastSpawnTemplateId = templateId;
+        LastSpawnLocation = location;
+        LastSpawnMapId = mapId;
+
+        return Task.FromResult(
+            SpawnedMobile ??
+            new UOMobileEntity
+            {
+                Id = (Serial)0x400,
+                Name = "Horse",
+                MapId = mapId,
+                Location = location
+            }
+        );
+    }
+
+    public Task<bool> TryMountAsync(Serial riderId, Serial mountId, CancellationToken cancellationToken = default)
+    {
+        LastRiderId = riderId;
+        LastMountId = mountId;
+
+        if (_mobiles.TryGetValue(riderId, out var rider) && _mobiles.TryGetValue(mountId, out var mount))
+        {
+            rider.MountedMobileId = mountId;
+            mount.RiderMobileId = riderId;
+        }
+
+        return Task.FromResult(true);
+    }
+
+    public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+        string templateId,
+        Point3D location,
+        int mapId,
+        Serial? accountId = null,
+        CancellationToken cancellationToken = default
+    )
+        => Task.FromResult((false, (UOMobileEntity?)null));
+}
+
+internal sealed class MobileModuleTestItemService : IItemService
+{
+    public UOItemEntity? SpawnedItem { get; set; }
+    public UOItemEntity? LastUpsertedItem { get; private set; }
+    public Serial LastDeletedItemId { get; private set; } = Serial.Zero;
+    public Serial LastMoveItemId { get; private set; } = Serial.Zero;
+    public Serial LastContainerId { get; private set; } = Serial.Zero;
+    public Point2D LastContainerPosition { get; private set; } = Point2D.Zero;
+
+    public Task BulkUpsertItemsAsync(IReadOnlyList<UOItemEntity> items)
+        => Task.CompletedTask;
+
+    public UOItemEntity Clone(UOItemEntity item, bool generateNewSerial = true)
+        => item;
+
+    public Task<UOItemEntity?> CloneAsync(Serial itemId, bool generateNewSerial = true)
+        => Task.FromResult<UOItemEntity?>(null);
+
+    public Task<Serial> CreateItemAsync(UOItemEntity item)
+        => Task.FromResult(item.Id);
+
+    public Task<bool> DeleteItemAsync(Serial itemId)
+    {
+        LastDeletedItemId = itemId;
+
+        return Task.FromResult(true);
+    }
+
+    public Task<DropItemToGroundResult?> DropItemToGroundAsync(
+        Serial itemId,
+        Point3D location,
+        int mapId,
+        long sessionId = 0
+    )
+        => Task.FromResult<DropItemToGroundResult?>(null);
+
+    public Task<bool> EquipItemAsync(Serial itemId, Serial mobileId, ItemLayerType layer)
+        => Task.FromResult(true);
+
+    public Task<List<UOItemEntity>> GetGroundItemsInSectorAsync(int mapId, int sectorX, int sectorY)
+        => Task.FromResult(new List<UOItemEntity>());
+
+    public Task<UOItemEntity?> GetItemAsync(Serial itemId)
+        => Task.FromResult(SpawnedItem?.Id == itemId ? SpawnedItem : null);
+
+    public Task<List<UOItemEntity>> GetItemsInContainerAsync(Serial containerId)
+        => Task.FromResult(new List<UOItemEntity>());
+
+    public Task<bool> MoveItemToContainerAsync(Serial itemId, Serial containerId, Point2D position, long sessionId = 0)
+    {
+        LastMoveItemId = itemId;
+        LastContainerId = containerId;
+        LastContainerPosition = position;
+
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> MoveItemToWorldAsync(Serial itemId, Point3D location, int mapId, long sessionId = 0)
+        => Task.FromResult(true);
+
+    public Task<UOItemEntity> SpawnFromTemplateAsync(string itemTemplateId)
+        => Task.FromResult(
+            SpawnedItem ??=
+                new UOItemEntity
+                {
+                    Id = (Serial)0x800,
+                    Name = itemTemplateId,
+                    ItemId = 0x0F3F,
+                    Amount = 1,
+                    IsStackable = true,
+                    MapId = 0,
+                    Location = Point3D.Zero
+                }
+        );
+
+    public Task<(bool Found, UOItemEntity? Item)> TryToGetItemAsync(Serial itemId)
+        => Task.FromResult((SpawnedItem?.Id == itemId, SpawnedItem));
+
+    public Task UpsertItemAsync(UOItemEntity item)
+    {
+        LastUpsertedItem = item;
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpsertItemsAsync(params UOItemEntity[] items)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- extract `MobileMovementModule`, `MobileCombatModule`, and `MobileInventoryModule` from `MobileModule`
- keep the Lua `mobile.*` facade stable, including `spawn` and `search_templates` used by the GM menu
- add targeted collaborator tests plus shared test doubles for the refactor

## Test Plan
- [x] `dotnet build src/Moongate.Server/Moongate.Server.csproj`
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~MobileModuleTests|FullyQualifiedName~MobileMovementModuleTests|FullyQualifiedName~MobileCombatModuleTests|FullyQualifiedName~MobileInventoryModuleTests|FullyQualifiedName~GmMenuLuaRuntimeTests|FullyQualifiedName~TargetModuleTests"`
- [x] `git diff --check`

Refs #170