### PR TITLE
feat: add centralized hot reload for scripts and templates

### DIFF
--- a/docs/articles/architecture/overview.md
+++ b/docs/articles/architecture/overview.md
@@ -15,6 +15,7 @@ Moongate v2 is organized around a single game-loop thread with explicit queues b
 
 - `Moongate.Server`
   - Bootstrap, game loop, packet listeners/handlers, session services, file loaders.
+  - Includes `FileWatcherService`, which observes reloadable runtime files and marshals hot-reload work back to the game loop.
 - `Moongate.Network`
   - TCP client/server primitives, span-based readers/writers, transport middleware.
 - `Moongate.Network.Packets`
@@ -46,6 +47,7 @@ Moongate v2 is organized around a single game-loop thread with explicit queues b
 - Cross-thread handoff is explicit:
   - inbound: `IMessageBusService`
   - outbound: `IOutgoingPacketQueue`
+  - hot reload callbacks: `IBackgroundJobService.PostToGameLoop()`
 - `IGameEventBusService` is used for decoupled in-process event publication.
 
 ## Session Model

--- a/docs/articles/getting-started/configuration.md
+++ b/docs/articles/getting-started/configuration.md
@@ -148,7 +148,10 @@ Top-level shape:
 Current scripting runtime option:
 
 - `Scripting.EnableFileWatcher` (`bool`, default `true`)
-  - `true`: enables `FileSystemWatcher` on `scripts/**/*.lua` for live reload notifications
+  - `true`: enables the centralized runtime watcher for `scripts/**/*.lua`, `templates/**/*.json`, and `data/spawns/**/*.json`
+  - Lua files are invalidated by path and recompiled on next execution
+  - reloadable JSON files are reloaded one file at a time on the game loop thread
+  - manual single-file reload is also available with `reload_template <filePath>`
   - `false`: disables watcher creation entirely
 - `Scripting.LuaBrainMaxBrainsPerTick` (`int`, default `0`)
   - `<= 0`: no explicit per-tick cap

--- a/docs/articles/scripting/lua-plugins.md
+++ b/docs/articles/scripting/lua-plugins.md
@@ -119,4 +119,5 @@ Not supported in v1:
 
 ## Operational Note
 
-The core script file watcher still focuses on the scripting bootstrap flow. For now, treat plugins as part of the normal script reload cycle instead of expecting hot unload/reload per plugin.
+Lua plugins live under the same centralized script watcher as the core script tree. Changing a plugin Lua file invalidates
+that file's compiled chunk, but there is still no single-plugin unload lifecycle or dependency-aware plugin reload.

--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -11,6 +11,24 @@ The scripting system is built on **MoonSharp**, a lightweight Lua interpreter fo
 - Automatic `.luarc` generation for editor tooling
 - Callback system for game events
 - Lua plugin packaging under `plugins/`
+- File-path-based hot reload invalidation for Lua scripts
+
+## Hot Reload
+
+When `Scripting.EnableFileWatcher` is enabled, Moongate watches:
+
+- `scripts/**/*.lua`
+- `templates/**/*.json`
+- `data/spawns/**/*.json`
+
+Lua hot reload is lazy: when a watched `.lua` file changes, the compiled chunk for that file is invalidated and the next
+execution recompiles it. JSON template and spawn files are reloaded one file at a time through the registered file loader.
+
+For manual reload, use:
+
+```text
+reload_template <filePath>
+```
 
 ## Architecture
 

--- a/src/Moongate.Abstractions/Types/ServicePriority.cs
+++ b/src/Moongate.Abstractions/Types/ServicePriority.cs
@@ -18,6 +18,7 @@ public static class ServicePriority
     public const int GameEventScriptBridge = 140;
     public const int Network = 150;
     public const int ScriptEngine = 150;
+    public const int FileWatcher = 151;
     public const int EventListener = 200;
     public const int HttpServer = 200;
 }

--- a/src/Moongate.Scripting/Interfaces/IScriptEngineService.cs
+++ b/src/Moongate.Scripting/Interfaces/IScriptEngineService.cs
@@ -9,18 +9,6 @@ namespace Moongate.Scripting.Interfaces;
 public interface IScriptEngineService : IMoongateService
 {
     /// <summary>
-    /// Delegate for handling script file change events.
-    /// </summary>
-    /// <param name="filePath">The path to the changed file.</param>
-    /// <returns>True if the file change was handled successfully, false otherwise.</returns>
-    delegate bool LuaFileChangedHandler(string filePath);
-
-    /// <summary>
-    /// Event raised when a script file is modified.
-    /// </summary>
-    event LuaFileChangedHandler? FileChanged;
-
-    /// <summary>
     /// Event raised when a script error occurs
     /// </summary>
     event EventHandler<ScriptErrorInfo>? OnScriptError;
@@ -84,6 +72,12 @@ public interface IScriptEngineService : IMoongateService
     /// Clears the script cache
     /// </summary>
     void ClearScriptCache();
+
+    /// <summary>
+    /// Invalidates one cached script file so the next execution recompiles it.
+    /// </summary>
+    /// <param name="filePath">The script file path.</param>
+    void InvalidateScript(string filePath);
 
     /// <summary>
     /// Executes a previously registered callback function.

--- a/src/Moongate.Scripting/Internal/LuaScriptCache.cs
+++ b/src/Moongate.Scripting/Internal/LuaScriptCache.cs
@@ -11,7 +11,9 @@ namespace Moongate.Scripting.Internal;
 /// </summary>
 internal sealed class LuaScriptCache
 {
-    private readonly ConcurrentDictionary<string, DynValue> _compiledScripts = new();
+    private readonly ConcurrentDictionary<string, DynValue> _compiledScriptsByContentHash = new();
+    private readonly ConcurrentDictionary<string, (string ScriptHash, DynValue Chunk)> _compiledScriptsByFilePath =
+        new(StringComparer.OrdinalIgnoreCase);
 
     private int _cacheHits;
     private int _cacheMisses;
@@ -19,14 +21,33 @@ internal sealed class LuaScriptCache
     /// <summary>
     /// Returns a cached compiled chunk or compiles and stores it on miss.
     /// </summary>
-    public DynValue GetOrAddCompiledChunk(string script, Func<DynValue> compiler)
+    public DynValue GetOrAddCompiledChunk(string script, string? filePath, Func<DynValue> compiler)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(script);
         ArgumentNullException.ThrowIfNull(compiler);
 
         var scriptHash = GetScriptHash(script);
 
-        if (_compiledScripts.TryGetValue(scriptHash, out var compiledChunk))
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            var normalizedFilePath = NormalizePath(filePath);
+
+            if (_compiledScriptsByFilePath.TryGetValue(normalizedFilePath, out var cachedFileEntry)
+                && cachedFileEntry.ScriptHash == scriptHash)
+            {
+                Interlocked.Increment(ref _cacheHits);
+
+                return cachedFileEntry.Chunk;
+            }
+
+            Interlocked.Increment(ref _cacheMisses);
+            var compiledFileChunk = compiler();
+            _compiledScriptsByFilePath[normalizedFilePath] = (scriptHash, compiledFileChunk);
+
+            return compiledFileChunk;
+        }
+
+        if (_compiledScriptsByContentHash.TryGetValue(scriptHash, out var compiledChunk))
         {
             Interlocked.Increment(ref _cacheHits);
 
@@ -36,14 +57,24 @@ internal sealed class LuaScriptCache
         Interlocked.Increment(ref _cacheMisses);
         var compiled = compiler();
 
-        if (_compiledScripts.TryAdd(scriptHash, compiled))
+        if (_compiledScriptsByContentHash.TryAdd(scriptHash, compiled))
         {
             return compiled;
         }
 
         Interlocked.Increment(ref _cacheHits);
 
-        return _compiledScripts[scriptHash];
+        return _compiledScriptsByContentHash[scriptHash];
+    }
+
+    /// <summary>
+    /// Invalidates one cached compiled chunk for a script file.
+    /// </summary>
+    public bool Invalidate(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        return _compiledScriptsByFilePath.TryRemove(NormalizePath(filePath), out _);
     }
 
     /// <summary>
@@ -51,7 +82,8 @@ internal sealed class LuaScriptCache
     /// </summary>
     public void Clear()
     {
-        _compiledScripts.Clear();
+        _compiledScriptsByContentHash.Clear();
+        _compiledScriptsByFilePath.Clear();
         _cacheHits = 0;
         _cacheMisses = 0;
     }
@@ -64,7 +96,7 @@ internal sealed class LuaScriptCache
         {
             CacheHits = _cacheHits,
             CacheMisses = _cacheMisses,
-            TotalScriptsCached = _compiledScripts.Count
+            TotalScriptsCached = _compiledScriptsByContentHash.Count + _compiledScriptsByFilePath.Count
         };
 
     private static string GetScriptHash(string script)
@@ -73,4 +105,7 @@ internal sealed class LuaScriptCache
 
         return Convert.ToBase64String(hashBytes);
     }
+
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Scripting/Services/LuaScriptEngineService.cs
+++ b/src/Moongate.Scripting/Services/LuaScriptEngineService.cs
@@ -38,8 +38,6 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
 
     private readonly LuaEngineConfig _engineConfig;
 
-    public event IScriptEngineService.LuaFileChangedHandler? FileChanged;
-
     private const string OnReadyFunctionName = "on_ready";
 
     private const string OnEngineRunFunctionName = "on_initialize";
@@ -67,8 +65,6 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
     private bool _disposed;
     private bool _isInitialized;
     private Func<string, string> _nameResolver;
-
-    private FileSystemWatcher? _watcher;
 
     /// <summary>
     /// Initializes a new instance of the LuaScriptEngineService class.
@@ -312,6 +308,24 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
     {
         _scriptCache.Clear();
         _logger.Information("Script cache cleared");
+    }
+
+    /// <summary>
+    /// Invalidates one cached script file.
+    /// </summary>
+    /// <param name="filePath">The script file path.</param>
+    public void InvalidateScript(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        if (_scriptCache.Invalidate(filePath))
+        {
+            _logger.Debug("Script cache invalidated: {FilePath}", filePath);
+
+            return;
+        }
+
+        _logger.Debug("No cached script entry found to invalidate: {FilePath}", filePath);
     }
 
     /// <summary>
@@ -666,23 +680,6 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
             ExecuteBootFunction();
             _isInitialized = true;
             _logger.Information("Lua engine initialized successfully");
-
-            if (_engineConfig.EnableFileWatcher && _watcher == null)
-            {
-                _watcher = new(_engineConfig.ScriptsDirectory, "*.lua")
-                {
-                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
-                    IncludeSubdirectories = true,
-                    EnableRaisingEvents = true
-                };
-
-                _watcher.Changed += OnLuaFilesChanged;
-            }
-
-            if (!_engineConfig.EnableFileWatcher)
-            {
-                _logger.Information("Lua file watcher disabled by configuration.");
-            }
         }
         catch (Exception ex)
         {
@@ -694,13 +691,6 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
 
     public Task StopAsync()
     {
-        if (_watcher != null)
-        {
-            _watcher.EnableRaisingEvents = false;
-            _watcher.Dispose();
-            _watcher = null;
-        }
-
         _logger.Information("Lua engine stopped");
 
         return Task.CompletedTask;
@@ -874,6 +864,7 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
         {
             var compiledScriptChunk = _scriptCache.GetOrAddCompiledChunk(
                 script,
+                fileName,
                 () => LuaScript.LoadString(script, null, fileName ?? "runtime_chunk")
             );
 
@@ -1137,27 +1128,6 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
             _logger.Debug("User data type registered: {TypeName}", scriptUserData.UserType.Name);
 
             LuaDocumentationGenerator.AddClassToGenerate(scriptUserData.UserType);
-        }
-    }
-
-    private void OnLuaFilesChanged(object sender, FileSystemEventArgs e)
-    {
-        if (_initScripts.Contains(e.Name))
-        {
-            _logger.Information("Lua script file changed: {FileName}. Clearing script cache.", e.Name);
-
-            if (FileChanged != null)
-            {
-                ClearScriptCache();
-
-                if (FileChanged(e.FullPath))
-                {
-                    _logger.Information("File change handled successfully: {FileName}", e.Name);
-
-                    ExecuteBootstrap();
-                    ExecuteBootFunction();
-                }
-            }
         }
     }
 

--- a/src/Moongate.Server.Abstractions/Interfaces/Services/Files/IFileLoader.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Services/Files/IFileLoader.cs
@@ -9,4 +9,15 @@ public interface IFileLoader
     /// Loads the underlying data source.
     /// </summary>
     Task LoadAsync();
+
+    /// <summary>
+    /// Loads a single data file.
+    /// </summary>
+    /// <param name="filePath">The file path to load.</param>
+    Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        
+        return LoadAsync();
+    }
 }

--- a/src/Moongate.Server/Commands/ReloadTemplateCommand.cs
+++ b/src/Moongate.Server/Commands/ReloadTemplateCommand.cs
@@ -33,15 +33,24 @@ public sealed class ReloadTemplateCommand : ICommandExecutor
 
     public async Task ExecuteCommandAsync(CommandSystemContext context)
     {
-        if (context.Arguments.Length > 0)
+        if (context.Arguments.Length > 1)
         {
-            context.Print("Usage: reload_template");
+            context.Print("Usage: reload_template [filePath]");
 
             return;
         }
 
         try
         {
+            if (context.Arguments.Length == 1)
+            {
+                var filePath = context.Arguments[0];
+                await _fileLoaderService.LoadSingleAsync(filePath);
+                context.Print("Template reloaded successfully: {0}.", filePath);
+
+                return;
+            }
+
             await _fileLoaderService.ExecuteLoadersAsync();
             context.Print(
                 "Templates reloaded successfully. ItemTemplates={0}, MobileTemplates={1}.",
@@ -51,6 +60,13 @@ public sealed class ReloadTemplateCommand : ICommandExecutor
         }
         catch (Exception ex)
         {
+            if (context.Arguments.Length == 1)
+            {
+                context.PrintError("Failed to reload template {0}: {1}", context.Arguments[0], ex.Message);
+
+                return;
+            }
+
             context.PrintError("Failed to reload templates: {0}", ex.Message);
         }
     }

--- a/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtension.cs
+++ b/src/Moongate.Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtension.cs
@@ -87,6 +87,7 @@ public static class AddBootstrapHostedServicesExtension
         container.RegisterMoongateService<INetworkService, NetworkService>(ServicePriority.Network);
         container.RegisterMoongateService<IScriptEngineService, LuaScriptEngineService>(ServicePriority.ScriptEngine);
         container.RegisterMoongateService<ILuaBrainRunner, LuaBrainRunner>(ServicePriority.ScriptEngine);
+        container.RegisterMoongateService<IFileWatcherService, FileWatcherService>(ServicePriority.FileWatcher);
         container.RegisterMoongateService<IScheduledEventService, ScheduledEventService>(ServicePriority.EventListener);
         container.RegisterMoongateService<ISpawnService, SpawnService>(ServicePriority.EventListener);
 

--- a/src/Moongate.Server/FileLoaders/FactionTemplateLoader.cs
+++ b/src/Moongate.Server/FileLoaders/FactionTemplateLoader.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Moongate.Core.Data.Directories;
 using Moongate.Core.Json;
 using Moongate.Core.Types;
@@ -19,6 +20,7 @@ public sealed class FactionTemplateLoader : IFileLoader
     private readonly ILogger _logger = Log.ForContext<FactionTemplateLoader>();
     private readonly DirectoriesConfig _directoriesConfig;
     private readonly IFactionTemplateService _factionTemplateService;
+    private readonly Dictionary<string, string> _templateFileContents = new(StringComparer.OrdinalIgnoreCase);
 
     public FactionTemplateLoader(
         DirectoriesConfig directoriesConfig,
@@ -49,29 +51,16 @@ public sealed class FactionTemplateLoader : IFileLoader
             return Task.CompletedTask;
         }
 
-        _factionTemplateService.Clear();
-        var allFactionTemplates = new List<FactionDefinition>();
+        _templateFileContents.Clear();
 
         foreach (var templateFile in templateFiles)
         {
-            FactionDefinitionBase[] templates;
-
-            try
-            {
-                templates = JsonUtils.DeserializeFromFile<FactionDefinitionBase[]>(
-                    templateFile,
-                    MoongateUOTemplateJsonContext.Default
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to load faction template file {TemplateFile}", templateFile);
-
-                throw;
-            }
-
-            allFactionTemplates.AddRange(templates.OfType<FactionDefinition>());
+            _templateFileContents[NormalizePath(templateFile)] = File.ReadAllText(templateFile);
         }
+
+        var allFactionTemplates = RebuildTemplatesFromCache();
+
+        _factionTemplateService.Clear();
 
         _factionTemplateService.UpsertRange(allFactionTemplates);
 
@@ -83,4 +72,57 @@ public sealed class FactionTemplateLoader : IFileLoader
 
         return Task.CompletedTask;
     }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedPath = NormalizePath(filePath);
+        _templateFileContents[normalizedPath] = File.ReadAllText(normalizedPath);
+        var allFactionTemplates = RebuildTemplatesFromCache();
+
+        _factionTemplateService.Clear();
+        _factionTemplateService.UpsertRange(allFactionTemplates);
+
+        _logger.Information("Reloaded faction template file {TemplateFile}", normalizedPath);
+
+        return Task.CompletedTask;
+    }
+
+    private List<FactionDefinition> RebuildTemplatesFromCache()
+    {
+        var allFactionTemplates = new List<FactionDefinition>();
+
+        foreach (var (templateFile, json) in _templateFileContents.OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            FactionDefinitionBase[] templates;
+
+            try
+            {
+                templates = Deserialize<FactionDefinitionBase[]>(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to load faction template file {TemplateFile}", templateFile);
+
+                throw;
+            }
+
+            allFactionTemplates.AddRange(templates.OfType<FactionDefinition>());
+        }
+
+        return allFactionTemplates;
+    }
+
+    private static T Deserialize<T>(string json)
+    {
+        var result = JsonSerializer.Deserialize(json, MoongateUOTemplateJsonContext.Default.GetTypeInfo(typeof(T)));
+
+        return result is T typedResult
+                   ? typedResult
+                   : throw new JsonException($"Deserialization returned null for type {typeof(T).Name}");
+    }
+
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Server/FileLoaders/ItemTemplateLoader.cs
+++ b/src/Moongate.Server/FileLoaders/ItemTemplateLoader.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using Moongate.Core.Data.Directories;
-using Moongate.Core.Json;
 using Moongate.Core.Types;
 using Moongate.Server.Attributes;
 using Moongate.Server.Interfaces.Services.Files;
@@ -24,6 +24,7 @@ public sealed class ItemTemplateLoader : IFileLoader
     private static readonly ItemTemplateDefinition Defaults = new();
     private readonly DirectoriesConfig _directoriesConfig;
     private readonly IItemTemplateService _itemTemplateService;
+    private readonly Dictionary<string, string> _templateFileContents = new(StringComparer.OrdinalIgnoreCase);
 
     public ItemTemplateLoader(DirectoriesConfig directoriesConfig, IItemTemplateService itemTemplateService)
     {
@@ -51,32 +52,16 @@ public sealed class ItemTemplateLoader : IFileLoader
             return Task.CompletedTask;
         }
 
-        _itemTemplateService.Clear();
-        var allItemTemplates = new List<ItemTemplateDefinition>();
+        _templateFileContents.Clear();
 
         foreach (var templateFile in templateFiles)
         {
-            ItemTemplateDefinitionBase[] templates;
-
-            try
-            {
-                templates = JsonUtils.DeserializeFromFile<ItemTemplateDefinitionBase[]>(
-                    templateFile,
-                    MoongateUOTemplateJsonContext.Default
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to load item template file {TemplateFile}", templateFile);
-
-                throw;
-            }
-
-            var itemTemplates = templates.OfType<ItemTemplateDefinition>().ToList();
-            allItemTemplates.AddRange(itemTemplates);
+            _templateFileContents[NormalizePath(templateFile)] = File.ReadAllText(templateFile);
         }
 
-        ResolveBaseItems(allItemTemplates);
+        var allItemTemplates = RebuildTemplatesFromCache();
+
+        _itemTemplateService.Clear();
         _itemTemplateService.UpsertRange(allItemTemplates);
 
         _logger.Information(
@@ -84,6 +69,23 @@ public sealed class ItemTemplateLoader : IFileLoader
             allItemTemplates.Count,
             templateFiles.Length
         );
+
+        return Task.CompletedTask;
+    }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedPath = NormalizePath(filePath);
+        _templateFileContents[normalizedPath] = File.ReadAllText(normalizedPath);
+
+        var allItemTemplates = RebuildTemplatesFromCache();
+
+        _itemTemplateService.Clear();
+        _itemTemplateService.UpsertRange(allItemTemplates);
+
+        _logger.Information("Reloaded item template file {TemplateFile}", normalizedPath);
 
         return Task.CompletedTask;
     }
@@ -340,4 +342,43 @@ public sealed class ItemTemplateLoader : IFileLoader
 
         states[template.Id] = ResolveState.Done;
     }
+
+    private List<ItemTemplateDefinition> RebuildTemplatesFromCache()
+    {
+        var allItemTemplates = new List<ItemTemplateDefinition>();
+
+        foreach (var (templateFile, json) in _templateFileContents.OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            ItemTemplateDefinitionBase[] templates;
+
+            try
+            {
+                templates = Deserialize<ItemTemplateDefinitionBase[]>(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to load item template file {TemplateFile}", templateFile);
+
+                throw;
+            }
+
+            allItemTemplates.AddRange(templates.OfType<ItemTemplateDefinition>());
+        }
+
+        ResolveBaseItems(allItemTemplates);
+
+        return allItemTemplates;
+    }
+
+    private static T Deserialize<T>(string json)
+    {
+        var result = JsonSerializer.Deserialize(json, MoongateUOTemplateJsonContext.Default.GetTypeInfo(typeof(T)));
+
+        return result is T typedResult
+                   ? typedResult
+                   : throw new JsonException($"Deserialization returned null for type {typeof(T).Name}");
+    }
+
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Server/FileLoaders/LootTemplateLoader.cs
+++ b/src/Moongate.Server/FileLoaders/LootTemplateLoader.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Moongate.Core.Data.Directories;
 using Moongate.Core.Json;
 using Moongate.Core.Types;
@@ -19,6 +20,7 @@ public sealed class LootTemplateLoader : IFileLoader
     private readonly ILogger _logger = Log.ForContext<LootTemplateLoader>();
     private readonly DirectoriesConfig _directoriesConfig;
     private readonly ILootTemplateService _lootTemplateService;
+    private readonly Dictionary<string, string> _templateFileContents = new(StringComparer.OrdinalIgnoreCase);
 
     public LootTemplateLoader(
         DirectoriesConfig directoriesConfig,
@@ -49,29 +51,16 @@ public sealed class LootTemplateLoader : IFileLoader
             return Task.CompletedTask;
         }
 
-        _lootTemplateService.Clear();
-        var allLootTemplates = new List<LootTemplateDefinition>();
+        _templateFileContents.Clear();
 
         foreach (var templateFile in templateFiles)
         {
-            LootTemplateDefinitionBase[] templates;
-
-            try
-            {
-                templates = JsonUtils.DeserializeFromFile<LootTemplateDefinitionBase[]>(
-                    templateFile,
-                    MoongateUOTemplateJsonContext.Default
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to load loot template file {TemplateFile}", templateFile);
-
-                throw;
-            }
-
-            allLootTemplates.AddRange(templates.OfType<LootTemplateDefinition>());
+            _templateFileContents[NormalizePath(templateFile)] = File.ReadAllText(templateFile);
         }
+
+        var allLootTemplates = RebuildTemplatesFromCache();
+
+        _lootTemplateService.Clear();
 
         _lootTemplateService.UpsertRange(allLootTemplates);
 
@@ -83,4 +72,57 @@ public sealed class LootTemplateLoader : IFileLoader
 
         return Task.CompletedTask;
     }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedPath = NormalizePath(filePath);
+        _templateFileContents[normalizedPath] = File.ReadAllText(normalizedPath);
+        var allLootTemplates = RebuildTemplatesFromCache();
+
+        _lootTemplateService.Clear();
+        _lootTemplateService.UpsertRange(allLootTemplates);
+
+        _logger.Information("Reloaded loot template file {TemplateFile}", normalizedPath);
+
+        return Task.CompletedTask;
+    }
+
+    private List<LootTemplateDefinition> RebuildTemplatesFromCache()
+    {
+        var allLootTemplates = new List<LootTemplateDefinition>();
+
+        foreach (var (templateFile, json) in _templateFileContents.OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            LootTemplateDefinitionBase[] templates;
+
+            try
+            {
+                templates = Deserialize<LootTemplateDefinitionBase[]>(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to load loot template file {TemplateFile}", templateFile);
+
+                throw;
+            }
+
+            allLootTemplates.AddRange(templates.OfType<LootTemplateDefinition>());
+        }
+
+        return allLootTemplates;
+    }
+
+    private static T Deserialize<T>(string json)
+    {
+        var result = JsonSerializer.Deserialize(json, MoongateUOTemplateJsonContext.Default.GetTypeInfo(typeof(T)));
+
+        return result is T typedResult
+                   ? typedResult
+                   : throw new JsonException($"Deserialization returned null for type {typeof(T).Name}");
+    }
+
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Server/FileLoaders/MobileTemplateLoader.cs
+++ b/src/Moongate.Server/FileLoaders/MobileTemplateLoader.cs
@@ -1,5 +1,5 @@
+using System.Text.Json;
 using Moongate.Core.Data.Directories;
-using Moongate.Core.Json;
 using Moongate.Core.Types;
 using Moongate.Server.Attributes;
 using Moongate.Server.Interfaces.Services.Files;
@@ -28,6 +28,7 @@ public sealed class MobileTemplateLoader : IFileLoader
     private static readonly MobileTemplateDefinition Defaults = new();
     private readonly DirectoriesConfig _directoriesConfig;
     private readonly IMobileTemplateService _mobileTemplateService;
+    private readonly Dictionary<string, string> _templateFileContents = new(StringComparer.OrdinalIgnoreCase);
 
     public MobileTemplateLoader(DirectoriesConfig directoriesConfig, IMobileTemplateService mobileTemplateService)
     {
@@ -55,37 +56,16 @@ public sealed class MobileTemplateLoader : IFileLoader
             return Task.CompletedTask;
         }
 
-        _mobileTemplateService.Clear();
-        var allMobileTemplates = new List<MobileTemplateDefinition>();
+        _templateFileContents.Clear();
 
         foreach (var templateFile in templateFiles)
         {
-            MobileTemplateDefinitionBase[] templates;
-
-            try
-            {
-                templates = JsonUtils.DeserializeFromFile<MobileTemplateDefinitionBase[]>(
-                    templateFile,
-                    MoongateUOTemplateJsonContext.Default
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to load mobile template file {TemplateFile}", templateFile);
-
-                throw;
-            }
-
-            var mobileTemplates = templates.OfType<MobileTemplateDefinition>().ToList();
-
-            foreach (var mobileTemplate in mobileTemplates)
-            {
-                NormalizeTitleAndName(mobileTemplate);
-            }
-            allMobileTemplates.AddRange(mobileTemplates);
+            _templateFileContents[NormalizePath(templateFile)] = File.ReadAllText(templateFile);
         }
 
-        ResolveBaseMobiles(allMobileTemplates);
+        var allMobileTemplates = RebuildTemplatesFromCache();
+
+        _mobileTemplateService.Clear();
         _mobileTemplateService.UpsertRange(allMobileTemplates);
 
         _logger.Information(
@@ -93,6 +73,23 @@ public sealed class MobileTemplateLoader : IFileLoader
             allMobileTemplates.Count,
             templateFiles.Length
         );
+
+        return Task.CompletedTask;
+    }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedPath = NormalizePath(filePath);
+        _templateFileContents[normalizedPath] = File.ReadAllText(normalizedPath);
+
+        var allMobileTemplates = RebuildTemplatesFromCache();
+
+        _mobileTemplateService.Clear();
+        _mobileTemplateService.UpsertRange(allMobileTemplates);
+
+        _logger.Information("Reloaded mobile template file {TemplateFile}", normalizedPath);
 
         return Task.CompletedTask;
     }
@@ -375,4 +372,50 @@ public sealed class MobileTemplateLoader : IFileLoader
 
         states[template.Id] = ResolveState.Done;
     }
+
+    private List<MobileTemplateDefinition> RebuildTemplatesFromCache()
+    {
+        var allMobileTemplates = new List<MobileTemplateDefinition>();
+
+        foreach (var (templateFile, json) in _templateFileContents.OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            MobileTemplateDefinitionBase[] templates;
+
+            try
+            {
+                templates = Deserialize<MobileTemplateDefinitionBase[]>(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to load mobile template file {TemplateFile}", templateFile);
+
+                throw;
+            }
+
+            var mobileTemplates = templates.OfType<MobileTemplateDefinition>().ToList();
+
+            foreach (var mobileTemplate in mobileTemplates)
+            {
+                NormalizeTitleAndName(mobileTemplate);
+            }
+
+            allMobileTemplates.AddRange(mobileTemplates);
+        }
+
+        ResolveBaseMobiles(allMobileTemplates);
+
+        return allMobileTemplates;
+    }
+
+    private static T Deserialize<T>(string json)
+    {
+        var result = JsonSerializer.Deserialize(json, MoongateUOTemplateJsonContext.Default.GetTypeInfo(typeof(T)));
+
+        return result is T typedResult
+                   ? typedResult
+                   : throw new JsonException($"Deserialization returned null for type {typeof(T).Name}");
+    }
+
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Server/FileLoaders/SellProfileTemplateLoader.cs
+++ b/src/Moongate.Server/FileLoaders/SellProfileTemplateLoader.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Moongate.Core.Data.Directories;
 using Moongate.Core.Json;
 using Moongate.Core.Types;
@@ -19,6 +20,7 @@ public sealed class SellProfileTemplateLoader : IFileLoader
     private readonly ILogger _logger = Log.ForContext<SellProfileTemplateLoader>();
     private readonly DirectoriesConfig _directoriesConfig;
     private readonly ISellProfileTemplateService _sellProfileTemplateService;
+    private readonly Dictionary<string, string> _templateFileContents = new(StringComparer.OrdinalIgnoreCase);
 
     public SellProfileTemplateLoader(
         DirectoriesConfig directoriesConfig,
@@ -49,29 +51,14 @@ public sealed class SellProfileTemplateLoader : IFileLoader
             return Task.CompletedTask;
         }
 
-        _sellProfileTemplateService.Clear();
-        var allProfiles = new List<SellProfileTemplateDefinition>();
+        _templateFileContents.Clear();
 
         foreach (var templateFile in templateFiles)
         {
-            SellProfileTemplateDefinitionBase[] templates;
-
-            try
-            {
-                templates = JsonUtils.DeserializeFromFile<SellProfileTemplateDefinitionBase[]>(
-                    templateFile,
-                    MoongateUOTemplateJsonContext.Default
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Failed to load sell profile template file {TemplateFile}", templateFile);
-
-                throw;
-            }
-
-            allProfiles.AddRange(templates.OfType<SellProfileTemplateDefinition>());
+            _templateFileContents[NormalizePath(templateFile)] = File.ReadAllText(templateFile);
         }
+
+        var allProfiles = RebuildProfilesFromCache();
 
         _sellProfileTemplateService.UpsertRange(allProfiles);
 
@@ -83,4 +70,57 @@ public sealed class SellProfileTemplateLoader : IFileLoader
 
         return Task.CompletedTask;
     }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedPath = NormalizePath(filePath);
+        _templateFileContents[normalizedPath] = File.ReadAllText(normalizedPath);
+        var allProfiles = RebuildProfilesFromCache();
+
+        _sellProfileTemplateService.Clear();
+        _sellProfileTemplateService.UpsertRange(allProfiles);
+
+        _logger.Information("Reloaded sell profile template file {TemplateFile}", normalizedPath);
+
+        return Task.CompletedTask;
+    }
+
+    private List<SellProfileTemplateDefinition> RebuildProfilesFromCache()
+    {
+        var allProfiles = new List<SellProfileTemplateDefinition>();
+
+        foreach (var (templateFile, json) in _templateFileContents.OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            SellProfileTemplateDefinitionBase[] templates;
+
+            try
+            {
+                templates = Deserialize<SellProfileTemplateDefinitionBase[]>(json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to load sell profile template file {TemplateFile}", templateFile);
+
+                throw;
+            }
+
+            allProfiles.AddRange(templates.OfType<SellProfileTemplateDefinition>());
+        }
+
+        return allProfiles;
+    }
+
+    private static T Deserialize<T>(string json)
+    {
+        var result = JsonSerializer.Deserialize(json, MoongateUOTemplateJsonContext.Default.GetTypeInfo(typeof(T)));
+
+        return result is T typedResult
+                   ? typedResult
+                   : throw new JsonException($"Deserialization returned null for type {typeof(T).Name}");
+    }
+
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Server/FileLoaders/SpawnsDataLoader.cs
+++ b/src/Moongate.Server/FileLoaders/SpawnsDataLoader.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Moongate.Core.Data.Directories;
 using Moongate.Core.Json;
 using Moongate.Core.Types;
@@ -33,6 +34,7 @@ public class SpawnsDataLoader : IFileLoader
     private readonly DirectoriesConfig _directoriesConfig;
     private readonly ISpawnsDataService _spawnsDataService;
     private readonly ILogger _logger = Log.ForContext<SpawnsDataLoader>();
+    private readonly Dictionary<string, string> _spawnFileContents = new(StringComparer.OrdinalIgnoreCase);
 
     public SpawnsDataLoader(DirectoriesConfig directoriesConfig, ISpawnsDataService spawnsDataService)
     {
@@ -47,24 +49,109 @@ public class SpawnsDataLoader : IFileLoader
         if (!Directory.Exists(rootDirectory))
         {
             _logger.Warning("Spawns directory not found at {Path}.", rootDirectory);
+            _spawnFileContents.Clear();
             _spawnsDataService.SetEntries([]);
 
             return Task.CompletedTask;
         }
 
         var files = Directory.GetFiles(rootDirectory, "*.json", SearchOption.AllDirectories);
-        var entries = new List<SpawnDefinitionEntry>();
+        _spawnFileContents.Clear();
 
         foreach (var filePath in files)
+        {
+            _spawnFileContents[NormalizePath(filePath)] = File.ReadAllText(filePath);
+        }
+
+        var entries = RebuildEntriesFromCache(rootDirectory);
+
+        _spawnsDataService.SetEntries(entries);
+        _logger.Information("Loaded {Count} total spawn definitions from {Path}.", entries.Count, rootDirectory);
+
+        return Task.CompletedTask;
+    }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedPath = NormalizePath(filePath);
+        var rootDirectory = Path.Combine(_directoriesConfig[DirectoryType.Data], "spawns");
+
+        _spawnFileContents[normalizedPath] = File.ReadAllText(normalizedPath);
+
+        var entries = RebuildEntriesFromCache(rootDirectory);
+        _spawnsDataService.SetEntries(entries);
+
+        _logger.Information("Reloaded spawns file {Path}.", normalizedPath);
+
+        return Task.CompletedTask;
+    }
+
+    private static SpawnDefinitionKind ResolveKind(string? rawType)
+        => string.Equals(rawType, "ProximitySpawner", StringComparison.OrdinalIgnoreCase)
+               ? SpawnDefinitionKind.ProximitySpawner
+               : SpawnDefinitionKind.Spawner;
+
+    private static string ResolveSourceGroup(string rootDirectory, string filePath)
+    {
+        var directoryPath = Path.GetDirectoryName(filePath) ?? rootDirectory;
+        var relative = Path.GetRelativePath(rootDirectory, directoryPath);
+
+        return relative == "." ? string.Empty : relative.Replace('\\', '/');
+    }
+
+    private static bool TryParsePoint3D(int[] value, out Point3D location)
+    {
+        if (value.Length < 3)
+        {
+            location = Point3D.Zero;
+
+            return false;
+        }
+
+        location = new(value[0], value[1], value[2]);
+
+        return true;
+    }
+
+    private static bool TryResolveMap(
+        JsonSpawnDefinition spawn,
+        string sourceGroup,
+        out int mapId,
+        out string mapName
+    )
+    {
+        var resolvedMapName = spawn.Map.Trim();
+
+        if (resolvedMapName.Length == 0 && sourceGroup.Length > 0)
+        {
+            resolvedMapName = sourceGroup.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? string.Empty;
+        }
+
+        if (MapIdByName.TryGetValue(resolvedMapName, out mapId))
+        {
+            mapName = resolvedMapName;
+
+            return true;
+        }
+
+        mapName = resolvedMapName;
+
+        return false;
+    }
+
+    private List<SpawnDefinitionEntry> RebuildEntriesFromCache(string rootDirectory)
+    {
+        var entries = new List<SpawnDefinitionEntry>();
+
+        foreach (var (filePath, json) in _spawnFileContents.OrderBy(static entry => entry.Key, StringComparer.OrdinalIgnoreCase))
         {
             JsonSpawnDefinition[] spawns;
 
             try
             {
-                spawns = JsonUtils.DeserializeFromFile<JsonSpawnDefinition[]>(
-                    filePath,
-                    MoongateUOJsonSerializationContext.Default
-                );
+                spawns = Deserialize<JsonSpawnDefinition[]>(json);
             }
             catch (Exception ex)
             {
@@ -131,62 +218,18 @@ public class SpawnsDataLoader : IFileLoader
             _logger.Information("Loaded {Count} spawns from file {File}.", importedFromFile, sourceFile);
         }
 
-        _spawnsDataService.SetEntries(entries);
-        _logger.Information("Loaded {Count} total spawn definitions from {Path}.", entries.Count, rootDirectory);
-
-        return Task.CompletedTask;
+        return entries;
     }
 
-    private static SpawnDefinitionKind ResolveKind(string? rawType)
-        => string.Equals(rawType, "ProximitySpawner", StringComparison.OrdinalIgnoreCase)
-               ? SpawnDefinitionKind.ProximitySpawner
-               : SpawnDefinitionKind.Spawner;
-
-    private static string ResolveSourceGroup(string rootDirectory, string filePath)
+    private static T Deserialize<T>(string json)
     {
-        var directoryPath = Path.GetDirectoryName(filePath) ?? rootDirectory;
-        var relative = Path.GetRelativePath(rootDirectory, directoryPath);
+        var result = JsonSerializer.Deserialize(json, MoongateUOJsonSerializationContext.Default.GetTypeInfo(typeof(T)));
 
-        return relative == "." ? string.Empty : relative.Replace('\\', '/');
+        return result is T typedResult
+                   ? typedResult
+                   : throw new JsonException($"Deserialization returned null for type {typeof(T).Name}");
     }
 
-    private static bool TryParsePoint3D(int[] value, out Point3D location)
-    {
-        if (value.Length < 3)
-        {
-            location = Point3D.Zero;
-
-            return false;
-        }
-
-        location = new(value[0], value[1], value[2]);
-
-        return true;
-    }
-
-    private static bool TryResolveMap(
-        JsonSpawnDefinition spawn,
-        string sourceGroup,
-        out int mapId,
-        out string mapName
-    )
-    {
-        var resolvedMapName = spawn.Map.Trim();
-
-        if (resolvedMapName.Length == 0 && sourceGroup.Length > 0)
-        {
-            resolvedMapName = sourceGroup.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? string.Empty;
-        }
-
-        if (MapIdByName.TryGetValue(resolvedMapName, out mapId))
-        {
-            mapName = resolvedMapName;
-
-            return true;
-        }
-
-        mapName = resolvedMapName;
-
-        return false;
-    }
+    private static string NormalizePath(string filePath)
+        => Path.GetFullPath(filePath);
 }

--- a/src/Moongate.Server/Interfaces/Services/Files/IFileLoaderService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Files/IFileLoaderService.cs
@@ -23,4 +23,24 @@ public interface IFileLoaderService : IMoongateService
     /// Executes all registered file loaders in their registration order.
     /// </summary>
     Task ExecuteLoadersAsync();
+
+    /// <summary>
+    /// Loads a single file through the appropriate registered loader.
+    /// </summary>
+    /// <param name="filePath">The file path to load.</param>
+    Task LoadSingleAsync(string filePath);
+
+    /// <summary>
+    /// Loads a single file through the specified loader type.
+    /// </summary>
+    /// <typeparam name="T">The file loader type.</typeparam>
+    /// <param name="filePath">The file path to load.</param>
+    Task LoadSingleAsync<T>(string filePath) where T : IFileLoader;
+
+    /// <summary>
+    /// Loads a single file through the specified loader type.
+    /// </summary>
+    /// <param name="loaderType">The file loader type.</param>
+    /// <param name="filePath">The file path to load.</param>
+    Task LoadSingleAsync(Type loaderType, string filePath);
 }

--- a/src/Moongate.Server/Interfaces/Services/Files/IFileWatcherService.cs
+++ b/src/Moongate.Server/Interfaces/Services/Files/IFileWatcherService.cs
@@ -1,0 +1,8 @@
+using Moongate.Abstractions.Interfaces.Services.Base;
+
+namespace Moongate.Server.Interfaces.Services.Files;
+
+/// <summary>
+/// Watches runtime files and posts hot-reload work back to the game loop.
+/// </summary>
+public interface IFileWatcherService : IMoongateService;

--- a/src/Moongate.Server/Services/Files/FileLoaderService.cs
+++ b/src/Moongate.Server/Services/Files/FileLoaderService.cs
@@ -1,5 +1,9 @@
 using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 using DryIoc;
+using Moongate.Core.Data.Directories;
+using Moongate.Server.FileLoaders;
 using Moongate.Server.Interfaces.Services.Files;
 using Serilog;
 
@@ -11,14 +15,16 @@ namespace Moongate.Server.Services.Files;
 public class FileLoaderService : IFileLoaderService
 {
     private readonly List<IFileLoader> _fileLoaders = new();
+    private readonly DirectoriesConfig? _directoriesConfig;
 
     private readonly ILogger _logger = Log.ForContext<FileLoaderService>();
 
     private readonly IContainer _container;
 
-    public FileLoaderService(IContainer container)
+    public FileLoaderService(IContainer container, DirectoriesConfig? directoriesConfig = null)
     {
         _container = container;
+        _directoriesConfig = directoriesConfig;
     }
 
     public void AddFileLoader<T>() where T : IFileLoader
@@ -45,6 +51,35 @@ public class FileLoaderService : IFileLoaderService
 
         var fileLoader = (IFileLoader)_container.Resolve(loaderType);
         _fileLoaders.Add(fileLoader);
+    }
+
+    public Task LoadSingleAsync(string filePath)
+    {
+        var loaderType = ResolveLoaderTypeByFilePath(filePath);
+
+        if (loaderType is null)
+        {
+            throw new InvalidOperationException($"No file loader is registered for path '{filePath}'.");
+        }
+
+        return LoadSingleAsync(loaderType, filePath);
+    }
+
+    public Task LoadSingleAsync<T>(string filePath) where T : IFileLoader
+        => LoadSingleAsync(typeof(T), filePath);
+
+    public Task LoadSingleAsync(Type loaderType, string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(loaderType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        if (!typeof(IFileLoader).IsAssignableFrom(loaderType))
+        {
+            throw new InvalidOperationException($"Type '{loaderType.FullName}' does not implement IFileLoader.");
+        }
+
+        var loader = EnsureLoader(loaderType);
+        return loader.LoadSingleAsync(filePath);
     }
 
     public void Dispose()
@@ -80,4 +115,122 @@ public class FileLoaderService : IFileLoaderService
 
     public Task StopAsync()
         => Task.CompletedTask;
+
+    private IFileLoader EnsureLoader(Type loaderType)
+    {
+        foreach (var loader in _fileLoaders)
+        {
+            if (loader.GetType() == loaderType)
+            {
+                return loader;
+            }
+        }
+
+        AddFileLoader(loaderType);
+
+        foreach (var loader in _fileLoaders)
+        {
+            if (loader.GetType() == loaderType)
+            {
+                return loader;
+            }
+        }
+
+        throw new InvalidOperationException($"Unable to resolve loader '{loaderType.FullName}'.");
+    }
+
+    private Type? ResolveLoaderTypeByFilePath(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        if (!string.Equals(Path.GetExtension(filePath), ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var normalizedPath = NormalizePath(filePath);
+
+        if (IsUnderDirectory(normalizedPath, "templates", "items"))
+        {
+            return typeof(ItemTemplateLoader);
+        }
+
+        if (IsUnderDirectory(normalizedPath, "templates", "mobiles"))
+        {
+            return typeof(MobileTemplateLoader);
+        }
+
+        if (IsUnderDirectory(normalizedPath, "templates", "loot"))
+        {
+            return typeof(LootTemplateLoader);
+        }
+
+        if (IsUnderDirectory(normalizedPath, "templates", "factions"))
+        {
+            return typeof(FactionTemplateLoader);
+        }
+
+        if (IsUnderDirectory(normalizedPath, "templates", "sell_profiles"))
+        {
+            return typeof(SellProfileTemplateLoader);
+        }
+
+        if (IsUnderDirectory(normalizedPath, "data", "spawns"))
+        {
+            return typeof(SpawnsDataLoader);
+        }
+
+        return null;
+    }
+
+    private bool IsUnderDirectory(string normalizedPath, string rootDirectoryName, string childDirectoryName)
+    {
+        if (_directoriesConfig is not null)
+        {
+            var templatesDirectory = GetAbsoluteDirectory(_directoriesConfig[rootDirectoryName], childDirectoryName);
+
+            if (normalizedPath.StartsWith(templatesDirectory, StringComparison.OrdinalIgnoreCase)
+                && (normalizedPath.Length == templatesDirectory.Length
+                    || normalizedPath[templatesDirectory.Length] == '/'))
+            {
+                return true;
+            }
+        }
+
+        return HasFolderChain(normalizedPath, rootDirectoryName, childDirectoryName);
+    }
+
+    private static string GetAbsoluteDirectory(string rootDirectory, string childDirectoryName)
+    {
+        var directoryPath = Path.GetFullPath(Path.Combine(rootDirectory, childDirectoryName));
+        var normalized = NormalizePath(directoryPath);
+
+        return normalized.EndsWith('/') ? normalized : normalized + '/';
+    }
+
+    private static bool HasFolderChain(string normalizedPath, string first, string second)
+    {
+        var segments = normalizedPath.Split(
+            '/',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+        );
+
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (string.Equals(segments[i], first, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(segments[i + 1], second, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return Path.GetFullPath(path)
+                   .Replace(Path.DirectorySeparatorChar, '/')
+                   .Replace(Path.AltDirectorySeparatorChar, '/');
+    }
 }

--- a/src/Moongate.Server/Services/Files/FileWatcherService.cs
+++ b/src/Moongate.Server/Services/Files/FileWatcherService.cs
@@ -1,0 +1,176 @@
+using System.Collections.Concurrent;
+using Moongate.Core.Data.Directories;
+using Moongate.Core.Types;
+using Moongate.Scripting.Interfaces;
+using Moongate.Server.Data.Config;
+using Moongate.Server.Interfaces.Services.EvenLoop;
+using Moongate.Server.Interfaces.Services.Files;
+using Serilog;
+
+namespace Moongate.Server.Services.Files;
+
+/// <summary>
+/// Centralized watcher for Lua scripts and reloadable JSON runtime files.
+/// </summary>
+public sealed class FileWatcherService : IFileWatcherService
+{
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(300);
+
+    private readonly IBackgroundJobService _backgroundJobService;
+    private readonly ConcurrentDictionary<string, Timer> _debounceTimers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly DirectoriesConfig _directoriesConfig;
+    private readonly IFileLoaderService _fileLoaderService;
+    private readonly ILogger _logger = Log.ForContext<FileWatcherService>();
+    private readonly MoongateConfig _moongateConfig;
+    private readonly IScriptEngineService _scriptEngineService;
+    private readonly List<FileSystemWatcher> _watchers = [];
+
+    public FileWatcherService(
+        DirectoriesConfig directoriesConfig,
+        MoongateConfig moongateConfig,
+        IBackgroundJobService backgroundJobService,
+        IScriptEngineService scriptEngineService,
+        IFileLoaderService fileLoaderService
+    )
+    {
+        _directoriesConfig = directoriesConfig;
+        _moongateConfig = moongateConfig;
+        _backgroundJobService = backgroundJobService;
+        _scriptEngineService = scriptEngineService;
+        _fileLoaderService = fileLoaderService;
+    }
+
+    public Task StartAsync()
+    {
+        if (!_moongateConfig.Scripting.EnableFileWatcher)
+        {
+            _logger.Information("Runtime file watcher disabled by configuration.");
+
+            return Task.CompletedTask;
+        }
+
+        RegisterWatcher(_directoriesConfig[DirectoryType.Scripts], "*.lua");
+        RegisterWatcher(_directoriesConfig[DirectoryType.Templates], "*.json");
+        RegisterWatcher(Path.Combine(_directoriesConfig[DirectoryType.Data], "spawns"), "*.json");
+
+        _logger.Information("Runtime file watcher started. Watchers={WatcherCount}", _watchers.Count);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync()
+    {
+        foreach (var watcher in _watchers)
+        {
+            watcher.EnableRaisingEvents = false;
+            watcher.Dispose();
+        }
+
+        _watchers.Clear();
+
+        foreach (var (_, timer) in _debounceTimers)
+        {
+            timer.Dispose();
+        }
+
+        _debounceTimers.Clear();
+
+        _logger.Information("Runtime file watcher stopped.");
+
+        return Task.CompletedTask;
+    }
+
+    private void RegisterWatcher(string path, string filter)
+    {
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(path);
+        }
+
+        var watcher = new FileSystemWatcher(path, filter)
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime | NotifyFilters.Size,
+            IncludeSubdirectories = true,
+            EnableRaisingEvents = true
+        };
+
+        watcher.Changed += OnFileChanged;
+        watcher.Created += OnFileChanged;
+        watcher.Renamed += OnFileRenamed;
+        _watchers.Add(watcher);
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+        => ScheduleReload(e.FullPath);
+
+    private void OnFileRenamed(object sender, RenamedEventArgs e)
+        => ScheduleReload(e.FullPath);
+
+    private void ScheduleReload(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        var normalizedPath = Path.GetFullPath(filePath);
+        var timer = _debounceTimers.AddOrUpdate(
+            normalizedPath,
+            path => new Timer(OnDebounceTimerElapsed, path, DebounceDelay, Timeout.InfiniteTimeSpan),
+            (_, existingTimer) =>
+            {
+                existingTimer.Change(DebounceDelay, Timeout.InfiniteTimeSpan);
+
+                return existingTimer;
+            }
+        );
+
+        timer.Change(DebounceDelay, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnDebounceTimerElapsed(object? state)
+    {
+        if (state is not string filePath)
+        {
+            return;
+        }
+
+        if (_debounceTimers.TryRemove(filePath, out var timer))
+        {
+            timer.Dispose();
+        }
+
+        _backgroundJobService.PostToGameLoop(() => ProcessChangeOnGameLoop(filePath));
+    }
+
+    private void ProcessChangeOnGameLoop(string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                _logger.Debug("Skipping hot reload for deleted file {FilePath}", filePath);
+
+                return;
+            }
+
+            if (string.Equals(Path.GetExtension(filePath), ".lua", StringComparison.OrdinalIgnoreCase))
+            {
+                _scriptEngineService.InvalidateScript(filePath);
+                _logger.Information("[HotReload] Reloaded script: {FilePath}", filePath);
+
+                return;
+            }
+
+            if (string.Equals(Path.GetExtension(filePath), ".json", StringComparison.OrdinalIgnoreCase))
+            {
+                _fileLoaderService.LoadSingleAsync(filePath).GetAwaiter().GetResult();
+                _logger.Information("[HotReload] Reloaded data file: {FilePath}", filePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Hot reload failed for {FilePath}", filePath);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Scripting/LuaScriptEngineServiceTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaScriptEngineServiceTests.cs
@@ -646,6 +646,40 @@ public class LuaScriptEngineServiceTests
     }
 
     [Test]
+    public void InvalidateScript_WhenCalled_ShouldEvictOnlyRequestedScriptFromCache()
+    {
+        using var temp = new TempDirectory();
+        var service = CreateService(temp.Path);
+        var firstScriptPath = Path.Combine(temp.Path, "scripts", "first.lua");
+        var secondScriptPath = Path.Combine(temp.Path, "scripts", "second.lua");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(firstScriptPath)!);
+        File.WriteAllText(firstScriptPath, "FIRST_COUNTER = (FIRST_COUNTER or 0) + 1");
+        File.WriteAllText(secondScriptPath, "SECOND_COUNTER = (SECOND_COUNTER or 0) + 1");
+
+        service.ExecuteScriptFile(firstScriptPath);
+        service.ExecuteScriptFile(secondScriptPath);
+
+        var metricsAfterWarmup = service.GetExecutionMetrics();
+
+        service.InvalidateScript(firstScriptPath);
+        service.ExecuteScriptFile(firstScriptPath);
+        service.ExecuteScriptFile(secondScriptPath);
+
+        var metricsAfterInvalidate = service.GetExecutionMetrics();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(metricsAfterWarmup.TotalScriptsCached, Is.EqualTo(2));
+                Assert.That(metricsAfterInvalidate.TotalScriptsCached, Is.EqualTo(2));
+                Assert.That(metricsAfterInvalidate.CacheMisses, Is.EqualTo(metricsAfterWarmup.CacheMisses + 1));
+                Assert.That(metricsAfterInvalidate.CacheHits, Is.EqualTo(metricsAfterWarmup.CacheHits + 1));
+            }
+        );
+    }
+
+    [Test]
     public async Task StartAsync_WhenLuaPluginExists_ShouldLoadPluginEntryScript()
     {
         using var temp = new TempDirectory();

--- a/tests/Moongate.Tests/Server/Commands/ReloadTemplateCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/ReloadTemplateCommandTests.cs
@@ -13,8 +13,11 @@ public sealed class ReloadTemplateCommandTests
     private sealed class ReloadTemplateTestFileLoaderService : IFileLoaderService
     {
         public int ExecuteCalls { get; private set; }
+        public int LoadSingleCalls { get; private set; }
+        public string? LastSingleFilePath { get; private set; }
 
         public bool ThrowOnExecute { get; set; }
+        public bool ThrowOnLoadSingle { get; set; }
 
         public void AddFileLoader<T>() where T : IFileLoader { }
 
@@ -31,6 +34,29 @@ public sealed class ReloadTemplateCommandTests
             }
 
             return Task.CompletedTask;
+        }
+
+        public Task LoadSingleAsync(string filePath)
+        {
+            LoadSingleCalls++;
+            LastSingleFilePath = filePath;
+
+            if (ThrowOnLoadSingle)
+            {
+                throw new InvalidOperationException("single boom");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task LoadSingleAsync<T>(string filePath) where T : IFileLoader
+            => LoadSingleAsync(filePath);
+
+        public Task LoadSingleAsync(Type loaderType, string filePath)
+        {
+            _ = loaderType;
+
+            return LoadSingleAsync(filePath);
         }
 
         public Task StartAsync()
@@ -89,7 +115,7 @@ public sealed class ReloadTemplateCommandTests
     }
 
     [Test]
-    public async Task ExecuteCommandAsync_WhenArgumentsProvided_ShouldPrintUsage()
+    public async Task ExecuteCommandAsync_WhenMoreThanOneArgumentIsProvided_ShouldPrintUsage()
     {
         var command = new ReloadTemplateCommand(
             new ReloadTemplateTestFileLoaderService(),
@@ -98,8 +124,8 @@ public sealed class ReloadTemplateCommandTests
         );
         var output = new List<string>();
         var context = new CommandSystemContext(
-            "reload_template now",
-            ["now"],
+            "reload_template one two",
+            ["one", "two"],
             CommandSourceType.Console,
             0,
             (message, _) => output.Add(message)
@@ -107,7 +133,7 @@ public sealed class ReloadTemplateCommandTests
 
         await command.ExecuteCommandAsync(context);
 
-        Assert.That(output[^1], Is.EqualTo("Usage: reload_template"));
+        Assert.That(output[^1], Is.EqualTo("Usage: reload_template [filePath]"));
     }
 
     [Test]
@@ -161,5 +187,57 @@ public sealed class ReloadTemplateCommandTests
                 );
             }
         );
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenSingleFilePathIsProvided_ShouldReloadOnlyThatFile()
+    {
+        var fileLoaderService = new ReloadTemplateTestFileLoaderService();
+        var itemTemplateService = new ReloadTemplateTestItemTemplateService { Count = 123 };
+        var mobileTemplateService = new ReloadTemplateTestMobileTemplateService { Count = 45 };
+        var command = new ReloadTemplateCommand(fileLoaderService, itemTemplateService, mobileTemplateService);
+        var output = new List<string>();
+        var context = new CommandSystemContext(
+            "reload_template templates/items/weapon.json",
+            ["templates/items/weapon.json"],
+            CommandSourceType.Console,
+            0,
+            (message, _) => output.Add(message)
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(fileLoaderService.ExecuteCalls, Is.EqualTo(0));
+                Assert.That(fileLoaderService.LoadSingleCalls, Is.EqualTo(1));
+                Assert.That(fileLoaderService.LastSingleFilePath, Is.EqualTo("templates/items/weapon.json"));
+                Assert.That(output[^1], Is.EqualTo("Template reloaded successfully: templates/items/weapon.json."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_WhenSingleFileReloadFails_ShouldPrintError()
+    {
+        var fileLoaderService = new ReloadTemplateTestFileLoaderService { ThrowOnLoadSingle = true };
+        var command = new ReloadTemplateCommand(
+            fileLoaderService,
+            new ReloadTemplateTestItemTemplateService(),
+            new ReloadTemplateTestMobileTemplateService()
+        );
+        var output = new List<string>();
+        var context = new CommandSystemContext(
+            "reload_template templates/items/weapon.json",
+            ["templates/items/weapon.json"],
+            CommandSourceType.Console,
+            0,
+            (message, _) => output.Add(message)
+        );
+
+        await command.ExecuteCommandAsync(context);
+
+        Assert.That(output[^1], Is.EqualTo("Failed to reload template templates/items/weapon.json: single boom"));
     }
 }

--- a/tests/Moongate.Tests/Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtensionTests.cs
+++ b/tests/Moongate.Tests/Server/Extensions/Bootstrap/AddBootstrapHostedServicesExtensionTests.cs
@@ -2,7 +2,9 @@ using DryIoc;
 using Moongate.Abstractions.Data.Internal;
 using Moongate.Abstractions.Types;
 using Moongate.Server.Extensions.Bootstrap;
+using Moongate.Server.Interfaces.Services.Files;
 using Moongate.Server.Interfaces.Services.World;
+using Moongate.Server.Services.Files;
 using Moongate.Server.Services.World;
 
 namespace Moongate.Tests.Server.Extensions.Bootstrap;
@@ -27,6 +29,27 @@ public class AddBootstrapHostedServicesExtensionTests
                 Assert.That(registration.Priority, Is.EqualTo(ServicePriority.CorpseStartupCleanup));
                 Assert.That(registration.Priority, Is.GreaterThan(ServicePriority.Persistence));
                 Assert.That(registration.Priority, Is.LessThan(ServicePriority.FileLoader));
+            }
+        );
+    }
+
+    [Test]
+    public void AddBootstrapHostedServices_ShouldRegisterFileWatcherServiceAfterScriptEngine()
+    {
+        var container = new Container();
+
+        container.AddBootstrapHostedServices();
+
+        var registrations = container.Resolve<List<ServiceRegistrationObject>>();
+        var registration = registrations.SingleOrDefault(x => x.ServiceType == typeof(IFileWatcherService));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(registration, Is.Not.Null);
+                Assert.That(registration!.ImplementationType, Is.EqualTo(typeof(FileWatcherService)));
+                Assert.That(registration.Priority, Is.GreaterThan(ServicePriority.ScriptEngine));
+                Assert.That(registration.Priority, Is.LessThan(ServicePriority.EventListener));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/FileLoaders/SellProfileTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/SellProfileTemplateLoaderTests.cs
@@ -125,6 +125,100 @@ public class SellProfileTemplateLoaderTests
         );
     }
 
+    [Test]
+    public async Task LoadSingleAsync_WhenOtherFileWasRemoved_ShouldPreserveExistingProfiles()
+    {
+        using var tempDirectory = new TempDirectory();
+        var directoriesConfig = new DirectoriesConfig(
+            tempDirectory.Path,
+            DirectoryType.Data,
+            DirectoryType.Templates,
+            DirectoryType.Scripts,
+            DirectoryType.Save,
+            DirectoryType.Logs,
+            DirectoryType.Cache
+        );
+
+        var profilesDirectory = Path.Combine(directoriesConfig[DirectoryType.Templates], "sell_profiles");
+        Directory.CreateDirectory(profilesDirectory);
+
+        var blacksmithPath = Path.Combine(profilesDirectory, "blacksmith.json");
+        var healerPath = Path.Combine(profilesDirectory, "healer.json");
+
+        await File.WriteAllTextAsync(
+            blacksmithPath,
+            """
+            [
+              {
+                "type": "sell_profile",
+                "id": "vendor.blacksmith",
+                "name": "Blacksmith Vendor",
+                "category": "vendors",
+                "description": "Blacksmith profile",
+                "vendorItems": [
+                  { "itemTemplateId": "longsword", "price": 55, "maxStock": 20 }
+                ]
+              }
+            ]
+            """
+        );
+        await File.WriteAllTextAsync(
+            healerPath,
+            """
+            [
+              {
+                "type": "sell_profile",
+                "id": "vendor.healer",
+                "name": "Healer Vendor",
+                "category": "vendors",
+                "description": "Healer profile",
+                "vendorItems": [
+                  { "itemTemplateId": "bandage", "price": 5, "maxStock": 50 }
+                ]
+              }
+            ]
+            """
+        );
+
+        var service = new SellProfileTemplateService();
+        var loader = new SellProfileTemplateLoader(directoriesConfig, service);
+
+        await loader.LoadAsync();
+        File.Delete(healerPath);
+        await File.WriteAllTextAsync(
+            blacksmithPath,
+            """
+            [
+              {
+                "type": "sell_profile",
+                "id": "vendor.blacksmith",
+                "name": "Updated Blacksmith Vendor",
+                "category": "vendors",
+                "description": "Updated blacksmith profile",
+                "vendorItems": [
+                  { "itemTemplateId": "war_axe", "price": 80, "maxStock": 10 }
+                ]
+              }
+            ]
+            """
+        );
+
+        await loader.LoadSingleAsync(blacksmithPath);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(service.TryGet("vendor.blacksmith", out var blacksmith), Is.True);
+                Assert.That(blacksmith, Is.Not.Null);
+                Assert.That(blacksmith!.Name, Is.EqualTo("Updated Blacksmith Vendor"));
+                Assert.That(blacksmith.VendorItems[0].ItemTemplateId, Is.EqualTo("war_axe"));
+                Assert.That(service.TryGet("vendor.healer", out var healer), Is.True);
+                Assert.That(healer, Is.Not.Null);
+                Assert.That(service.Count, Is.EqualTo(2));
+            }
+        );
+    }
+
     private static string ResolveRepositoryRoot()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/Moongate.Tests/Server/Services/Scripting/ScheduledEventServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/ScheduledEventServiceTests.cs
@@ -76,6 +76,8 @@ public sealed class ScheduledEventServiceTests
         public void AddScriptModule(Type type) { }
         public void CallFunction(string functionName, params object[] args) { }
         public void ClearScriptCache() { }
+        public void InvalidateScript(string filePath)
+            => _ = filePath;
         public void ExecuteCallback(string name, params object[] args) { }
         public void ExecuteEngineReady() { }
 
@@ -113,10 +115,9 @@ public sealed class ScheduledEventServiceTests
         public bool UnregisterGlobal(string name)
             => true;
 
-    #pragma warning disable CS0067
-        public event IScriptEngineService.LuaFileChangedHandler? FileChanged;
+#pragma warning disable CS0067
         public event EventHandler<ScriptErrorInfo>? OnScriptError;
-    #pragma warning restore CS0067
+#pragma warning restore CS0067
     }
 
     private sealed class ScheduledEventServiceTestGameEventBusService : IGameEventBusService

--- a/tests/Moongate.Tests/Server/Support/GameEventScriptBridgeTestScriptEngineService.cs
+++ b/tests/Moongate.Tests/Server/Support/GameEventScriptBridgeTestScriptEngineService.cs
@@ -28,6 +28,9 @@ public sealed class GameEventScriptBridgeTestScriptEngineService : IScriptEngine
 
     public void ClearScriptCache() { }
 
+    public void InvalidateScript(string filePath)
+        => _ = filePath;
+
     public void ExecuteCallback(string name, params object[] args)
     {
         LastCallbackName = name;
@@ -65,7 +68,6 @@ public sealed class GameEventScriptBridgeTestScriptEngineService : IScriptEngine
         => true;
 
 #pragma warning disable CS0067
-    public event IScriptEngineService.LuaFileChangedHandler? FileChanged;
     public event EventHandler<ScriptErrorInfo>? OnScriptError;
 #pragma warning restore CS0067
 }

--- a/tests/Moongate.Tests/Server/Support/ItemScriptDispatcherTestScriptEngineService.cs
+++ b/tests/Moongate.Tests/Server/Support/ItemScriptDispatcherTestScriptEngineService.cs
@@ -36,6 +36,9 @@ public sealed class ItemScriptDispatcherTestScriptEngineService : IScriptEngineS
 
     public void ClearScriptCache() { }
 
+    public void InvalidateScript(string filePath)
+        => _ = filePath;
+
     public void ExecuteCallback(string name, params object[] args)
     {
         LastFunctionName = name;
@@ -77,7 +80,6 @@ public sealed class ItemScriptDispatcherTestScriptEngineService : IScriptEngineS
         => true;
 
 #pragma warning disable CS0067
-    public event IScriptEngineService.LuaFileChangedHandler? FileChanged;
     public event EventHandler<ScriptErrorInfo>? OnScriptError;
 #pragma warning restore CS0067
 }


### PR DESCRIPTION
## Summary
- add a centralized hot reload watcher for Lua scripts, JSON templates, and spawn data
- support single-file reload via `reload_template <filePath>` and rebuild loader state from cached file contents
- invalidate Lua compiled chunks by file path and document the runtime hot-reload flow

## Test Plan
- [x] dotnet test Moongate.slnx
- [x] cd docs && DOTNET_ROOT=/Users/squid/.dotnet DOTNET_ROOT_ARM64=/Users/squid/.dotnet docfx docfx.json --logLevel Warning

Closes #176