### PR TITLE
fix: import ModernUO loot packs and support items

### DIFF
--- a/moongate_data/templates/items/loot_support.json
+++ b/moongate_data/templates/items/loot_support.json
@@ -1,0 +1,69 @@
+[
+  {
+    "type": "item",
+    "id": "seed",
+    "name": "Seed",
+    "category": "Loot Support",
+    "description": "Imported support item for ModernUO loot conversion.",
+    "itemId": "0x0DCF",
+    "hue": "0",
+    "goldValue": "0",
+    "weight": 1.0,
+    "scriptId": "none",
+    "isMovable": true,
+    "tags": [
+      "modernuo",
+      "loot_support",
+      "seeds"
+    ]
+  },
+  {
+    "type": "item",
+    "id": "metal_chest",
+    "name": "Metal Chest",
+    "category": "Containers",
+    "description": "Imported support item for ModernUO loot conversion.",
+    "itemId": "0x09AB",
+    "hue": "0",
+    "goldValue": "0",
+    "weight": 2.0,
+    "scriptId": "none",
+    "isMovable": true,
+    "tags": [
+      "modernuo",
+      "containers",
+      "loot_support"
+    ],
+    "weightMax": 40000,
+    "maxItems": 125,
+    "containerLayoutId": "metal_chest",
+    "gumpId": "0x0048"
+  },
+  {
+    "type": "item",
+    "id": "gargoyles_pickaxe",
+    "name": "Gargoyle's Pickaxe",
+    "category": "Skill Items",
+    "description": "Imported support item for ModernUO loot conversion.",
+    "itemId": "0x0E85",
+    "hue": "0",
+    "goldValue": "0",
+    "weight": 11.0,
+    "scriptId": "none",
+    "isMovable": true,
+    "tags": [
+      "modernuo",
+      "skill items",
+      "loot_support",
+      "flippable"
+    ],
+    "flippableItemIds": [
+      "0x0E85",
+      "0x0E86"
+    ],
+    "lowDamage": 1,
+    "highDamage": 15,
+    "speed": 35,
+    "strength": 25
+  }
+]

--- a/moongate_data/templates/items/resources.json
+++ b/moongate_data/templates/items/resources.json
@@ -81,7 +81,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -115,7 +116,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -526,7 +528,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -543,7 +546,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -662,7 +666,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -696,7 +701,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -884,7 +890,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {
@@ -918,7 +925,8 @@
     "isMovable": true,
     "tags": [
       "modernuo",
-      "resources"
+      "resources",
+      "reagents"
     ]
   },
   {

--- a/moongate_data/templates/loot/creatures.json
+++ b/moongate_data/templates/loot/creatures.json
@@ -451,6 +451,31 @@
         "itemTemplateId": "amber",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "daemon_arms",
+        "chance": 1.0,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "daemon_chest",
+        "chance": 1.0,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "daemon_gloves",
+        "chance": 1.0,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "daemon_legs",
+        "chance": 1.0,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "daemon_helm",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   },
@@ -1650,205 +1675,6 @@
       {
         "itemTemplateId": "amber",
         "chance": 1.0,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.low_scrolls",
-    "name": "Low Scrolls",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "clumsy_scroll",
-        "chance": 1.0,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.med_scrolls",
-    "name": "Med Scrolls",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "arch_cure_scroll",
-        "chance": 1.0,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.high_scrolls",
-    "name": "High Scrolls",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "summon_air_elemental_scroll",
-        "chance": 1.0,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.gems",
-    "name": "Gems",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "amber",
-        "chance": 1.0,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.potions",
-    "name": "Potions",
-    "category": "loot",
-    "description": "",
-    "mode": "weighted",
-    "rolls": 1,
-    "entries": [
-      {
-        "itemTemplateId": "agility_potion",
-        "weight": 1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "strength_potion",
-        "weight": 1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "refresh_potion",
-        "weight": 1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "lesser_cure_potion",
-        "weight": 1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "lesser_heal_potion",
-        "weight": 1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "lesser_poison_potion",
-        "weight": 1,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.poor",
-    "name": "Poor Pack",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "gold",
-        "chance": 1.0,
-        "amountMin": 10,
-        "amountMax": 30
-      },
-      {
-        "itemTemplateId": "bone",
-        "chance": 0.25,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.meager",
-    "name": "Meager Pack",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "gold",
-        "chance": 1.0,
-        "amountMin": 20,
-        "amountMax": 50
-      },
-      {
-        "itemTemplateId": "left_arm",
-        "chance": 0.1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "right_arm",
-        "chance": 0.1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "torso",
-        "chance": 0.1,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "bone",
-        "chance": 0.7,
-        "amount": 1
-      }
-    ]
-  },
-  {
-    "type": "loot",
-    "id": "pack.average",
-    "name": "Average Pack",
-    "category": "loot",
-    "description": "",
-    "mode": "additive",
-    "entries": [
-      {
-        "itemTemplateId": "gold",
-        "chance": 1.0,
-        "amountMin": 50,
-        "amountMax": 100
-      },
-      {
-        "itemTemplateId": "amber",
-        "chance": 1.0,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "arch_cure_scroll",
-        "chance": 0.35,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "agility_potion",
-        "chance": 0.25,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "strength_potion",
-        "chance": 0.25,
-        "amount": 1
-      },
-      {
-        "itemTemplateId": "refresh_potion",
-        "chance": 0.25,
         "amount": 1
       }
     ]

--- a/moongate_data/templates/loot/creatures/creature_ant_lion.json
+++ b/moongate_data/templates/loot/creatures/creature_ant_lion.json
@@ -11,6 +11,11 @@
         "itemTemplateId": "bone",
         "chance": 1.0,
         "amount": 3
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_bake_kitsune.json
+++ b/moongate_data/templates/loot/creatures/creature_bake_kitsune.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.bake_kitsune",
+    "name": "BakeKitsune",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for BakeKitsune.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_bog_thing.json
+++ b/moongate_data/templates/loot/creatures/creature_bog_thing.json
@@ -28,7 +28,7 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_bone_magi.json
+++ b/moongate_data/templates/loot/creatures/creature_bone_magi.json
@@ -13,7 +13,7 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_cu_sidhe.json
+++ b/moongate_data/templates/loot/creatures/creature_cu_sidhe.json
@@ -8,11 +8,6 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "parrot_item",
-        "chance": 1.0,
-        "amount": 1
-      },
-      {
         "itemTemplateId": "gold",
         "chance": 1.0,
         "amount": 650

--- a/moongate_data/templates/loot/creatures/creature_deathwatch_beetle.json
+++ b/moongate_data/templates/loot/creatures/creature_deathwatch_beetle.json
@@ -36,6 +36,11 @@
         "itemTemplateId": "leather_chest",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_deep_sea_serpent.json
+++ b/moongate_data/templates/loot/creatures/creature_deep_sea_serpent.json
@@ -16,11 +16,6 @@
         "itemTemplateId": "black_pearl",
         "chance": 1.0,
         "amount": 4
-      },
-      {
-        "itemTemplateId": "special_fishing_net",
-        "chance": 1.0,
-        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_drake.json
+++ b/moongate_data/templates/loot/creatures/creature_drake.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_evil_mage.json
+++ b/moongate_data/templates/loot/creatures/creature_evil_mage.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 6
       }

--- a/moongate_data/templates/loot/creatures/creature_evil_mage_lord.json
+++ b/moongate_data/templates/loot/creatures/creature_evil_mage_lord.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 23
       }

--- a/moongate_data/templates/loot/creatures/creature_fan_dancer.json
+++ b/moongate_data/templates/loot/creatures/creature_fan_dancer.json
@@ -11,6 +11,11 @@
         "itemTemplateId": "origami_paper",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_hiryu.json
+++ b/moongate_data/templates/loot/creatures/creature_hiryu.json
@@ -1,16 +1,16 @@
 [
   {
     "type": "loot",
-    "id": "creature.yamandon",
-    "name": "Yamandon",
+    "id": "creature.hiryu",
+    "name": "Hiryu",
     "category": "loot",
-    "description": "Creature-specific loot for Yamandon.",
+    "description": "Creature-specific loot for Hiryu.",
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "eggs",
+        "itemTemplateId": "seed",
         "chance": 1.0,
-        "amount": 2
+        "amount": 1
       },
       {
         "itemTemplateId": "seed",

--- a/moongate_data/templates/loot/creatures/creature_ice_elemental.json
+++ b/moongate_data/templates/loot/creatures/creature_ice_elemental.json
@@ -13,7 +13,7 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_ilhenir.json
+++ b/moongate_data/templates/loot/creatures/creature_ilhenir.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "random_talisman",
+        "itemTag": "talismans",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_juka_mage.json
+++ b/moongate_data/templates/loot/creatures/creature_juka_mage.json
@@ -11,6 +11,11 @@
         "itemTemplateId": "arcane_gem",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_kappa.json
+++ b/moongate_data/templates/loot/creatures/creature_kappa.json
@@ -26,6 +26,11 @@
         "itemTemplateId": "axle",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_lady_of_the_snow.json
+++ b/moongate_data/templates/loot/creatures/creature_lady_of_the_snow.json
@@ -13,7 +13,12 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
+      },
+      {
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_lesser_hiryu.json
+++ b/moongate_data/templates/loot/creatures/creature_lesser_hiryu.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.lesser_hiryu",
+    "name": "LesserHiryu",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for LesserHiryu.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_master_jonath.json
+++ b/moongate_data/templates/loot/creatures/creature_master_jonath.json
@@ -8,17 +8,17 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 7
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 7
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 8
       }

--- a/moongate_data/templates/loot/creatures/creature_master_mikael.json
+++ b/moongate_data/templates/loot/creatures/creature_master_mikael.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_master_theophilus.json
+++ b/moongate_data/templates/loot/creatures/creature_master_theophilus.json
@@ -8,17 +8,17 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 7
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 7
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 8
       }

--- a/moongate_data/templates/loot/creatures/creature_ml_dryad.json
+++ b/moongate_data/templates/loot/creatures/creature_ml_dryad.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.ml_dryad",
+    "name": "MLDryad",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for MLDryad.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_mummy.json
+++ b/moongate_data/templates/loot/creatures/creature_mummy.json
@@ -16,6 +16,11 @@
         "itemTemplateId": "bandage",
         "chance": 1.0,
         "amount": 10
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_oni.json
+++ b/moongate_data/templates/loot/creatures/creature_oni.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.oni",
+    "name": "Oni",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for Oni.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_ophidian_mage.json
+++ b/moongate_data/templates/loot/creatures/creature_ophidian_mage.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 10
       }

--- a/moongate_data/templates/loot/creatures/creature_orc_captain.json
+++ b/moongate_data/templates/loot/creatures/creature_orc_captain.json
@@ -1,16 +1,16 @@
 [
   {
     "type": "loot",
-    "id": "creature.spectre",
-    "name": "Spectre",
+    "id": "creature.orc_captain",
+    "name": "OrcCaptain",
     "category": "loot",
-    "description": "Creature-specific loot for Spectre.",
+    "description": "Creature-specific loot for OrcCaptain.",
     "mode": "additive",
     "entries": [
       {
         "itemTag": "reagents",
         "chance": 1.0,
-        "amount": 10
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_orcish_lord.json
+++ b/moongate_data/templates/loot/creatures/creature_orcish_lord.json
@@ -16,6 +16,11 @@
         "itemTemplateId": "bola_ball",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTag": "reagents",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_orcish_mage.json
+++ b/moongate_data/templates/loot/creatures/creature_orcish_mage.json
@@ -13,7 +13,7 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 6
       }

--- a/moongate_data/templates/loot/creatures/creature_plague_beast.json
+++ b/moongate_data/templates/loot/creatures/creature_plague_beast.json
@@ -16,6 +16,11 @@
         "itemTemplateId": "metal_chest",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_ratman_mage.json
+++ b/moongate_data/templates/loot/creatures/creature_ratman_mage.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 6
       }

--- a/moongate_data/templates/loot/creatures/creature_rune_beetle.json
+++ b/moongate_data/templates/loot/creatures/creature_rune_beetle.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.malefic",
-    "name": "Malefic",
+    "id": "creature.rune_beetle",
+    "name": "RuneBeetle",
     "category": "loot",
-    "description": "Creature-specific loot for Malefic.",
+    "description": "Creature-specific loot for RuneBeetle.",
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "parrot_item",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_sea_serpent.json
+++ b/moongate_data/templates/loot/creatures/creature_sea_serpent.json
@@ -21,11 +21,6 @@
         "itemTemplateId": "raw_fish_steak",
         "chance": 1.0,
         "amount": 1
-      },
-      {
-        "itemTemplateId": "special_fishing_net",
-        "chance": 1.0,
-        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_serpentine_dragon.json
+++ b/moongate_data/templates/loot/creatures/creature_serpentine_dragon.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "loot",
+    "id": "creature.serpentine_dragon",
+    "name": "SerpentineDragon",
+    "category": "loot",
+    "description": "Creature-specific loot for SerpentineDragon.",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  }
+]

--- a/moongate_data/templates/loot/creatures/creature_shade.json
+++ b/moongate_data/templates/loot/creatures/creature_shade.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 10
       }

--- a/moongate_data/templates/loot/creatures/creature_skeletal_mage.json
+++ b/moongate_data/templates/loot/creatures/creature_skeletal_mage.json
@@ -13,7 +13,7 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_swamp_tentacle.json
+++ b/moongate_data/templates/loot/creatures/creature_swamp_tentacle.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_swoop.json
+++ b/moongate_data/templates/loot/creatures/creature_swoop.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 4
       }

--- a/moongate_data/templates/loot/creatures/creature_terathan_warrior.json
+++ b/moongate_data/templates/loot/creatures/creature_terathan_warrior.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "loot",
+    "id": "creature.terathan_warrior",
+    "name": "TerathanWarrior",
+    "category": "loot",
+    "description": "Creature-specific loot for TerathanWarrior.",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  }
+]

--- a/moongate_data/templates/loot/creatures/creature_titan.json
+++ b/moongate_data/templates/loot/creatures/creature_titan.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.titan",
+    "name": "Titan",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for Titan.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_tsuki_wolf.json
+++ b/moongate_data/templates/loot/creatures/creature_tsuki_wolf.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.tsuki_wolf",
+    "name": "TsukiWolf",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for TsukiWolf.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_whipping_vine.json
+++ b/moongate_data/templates/loot/creatures/creature_whipping_vine.json
@@ -18,7 +18,7 @@
         "amount": 1
       },
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 3
       }

--- a/moongate_data/templates/loot/creatures/creature_wisp.json
+++ b/moongate_data/templates/loot/creatures/creature_wisp.json
@@ -1,14 +1,14 @@
 [
   {
     "type": "loot",
-    "id": "creature.meraktus",
-    "name": "Meraktus",
+    "id": "creature.wisp",
+    "name": "Wisp",
     "category": "loot",
-    "description": "Creature-specific loot for Meraktus.",
+    "description": "Creature-specific loot for Wisp.",
     "mode": "additive",
     "entries": [
       {
-        "itemTag": "talismans",
+        "itemTemplateId": "seed",
         "chance": 1.0,
         "amount": 1
       }

--- a/moongate_data/templates/loot/creatures/creature_wraith.json
+++ b/moongate_data/templates/loot/creatures/creature_wraith.json
@@ -8,7 +8,7 @@
     "mode": "additive",
     "entries": [
       {
-        "itemTemplateId": "reagent",
+        "itemTag": "reagents",
         "chance": 1.0,
         "amount": 10
       }

--- a/moongate_data/templates/loot/creatures/creature_yomotsu_elder.json
+++ b/moongate_data/templates/loot/creatures/creature_yomotsu_elder.json
@@ -16,6 +16,11 @@
         "itemTemplateId": "executioners_axe",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_yomotsu_priest.json
+++ b/moongate_data/templates/loot/creatures/creature_yomotsu_priest.json
@@ -46,6 +46,11 @@
         "itemTemplateId": "thigh_boots",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/creatures/creature_yomotsu_warrior.json
+++ b/moongate_data/templates/loot/creatures/creature_yomotsu_warrior.json
@@ -46,6 +46,11 @@
         "itemTemplateId": "thigh_boots",
         "chance": 1.0,
         "amount": 1
+      },
+      {
+        "itemTemplateId": "seed",
+        "chance": 1.0,
+        "amount": 1
       }
     ]
   }

--- a/moongate_data/templates/loot/loot_packs.json
+++ b/moongate_data/templates/loot/loot_packs.json
@@ -1,0 +1,568 @@
+[
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_average",
+    "name": "AosAverage",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 55,
+        "amountMax": 100
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_filthy_rich",
+    "name": "AosFilthyRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 202,
+        "amountMax": 400
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_meager",
+    "name": "AosMeager",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 23,
+        "amountMax": 50
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_poor",
+    "name": "AosPoor",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 11,
+        "amountMax": 20
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_rich",
+    "name": "AosRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 160,
+        "amountMax": 250
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_super_boss",
+    "name": "AosSuperBoss",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 505,
+        "amountMax": 1000
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.aos_ultra_rich",
+    "name": "AosUltraRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 505,
+        "amountMax": 1000
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.average",
+    "name": "Average",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 108,
+        "amountMax": 180
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.filthy_rich",
+    "name": "FilthyRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 403,
+        "amountMax": 700
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.gems",
+    "name": "Gems",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "amber",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.high_scrolls",
+    "name": "HighScrolls",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "summon_air_elemental_scroll",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.low_scrolls",
+    "name": "LowScrolls",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "clumsy_scroll",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.meager",
+    "name": "Meager",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 44,
+        "amountMax": 80
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.med_scrolls",
+    "name": "MedScrolls",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "arch_cure_scroll",
+        "chance": 1.0,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.ml_rich",
+    "name": "MlRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 454,
+        "amountMax": 650
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_average",
+    "name": "OldAverage",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 60,
+        "amountMax": 150
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_filthy_rich",
+    "name": "OldFilthyRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 402,
+        "amountMax": 650
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_meager",
+    "name": "OldMeager",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 30,
+        "amountMax": 75
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_poor",
+    "name": "OldPoor",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 1,
+        "amountMax": 25
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_rich",
+    "name": "OldRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 260,
+        "amountMax": 350
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_super_boss",
+    "name": "OldSuperBoss",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 505,
+        "amountMax": 1000
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.old_ultra_rich",
+    "name": "OldUltraRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 505,
+        "amountMax": 1000
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.poor",
+    "name": "Poor",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 22,
+        "amountMax": 40
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.potions",
+    "name": "Potions",
+    "category": "loot",
+    "description": "",
+    "mode": "weighted",
+    "rolls": 1,
+    "noDropWeight": 0,
+    "entries": [
+      {
+        "itemTemplateId": "agility_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "strength_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "refresh_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "lesser_cure_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "lesser_heal_potion",
+        "weight": 1,
+        "amount": 1
+      },
+      {
+        "itemTemplateId": "lesser_poison_potion",
+        "weight": 1,
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.rich",
+    "name": "Rich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 240,
+        "amountMax": 375
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_average",
+    "name": "SeAverage",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 108,
+        "amountMax": 180
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_filthy_rich",
+    "name": "SeFilthyRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 403,
+        "amountMax": 700
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_meager",
+    "name": "SeMeager",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 44,
+        "amountMax": 80
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_poor",
+    "name": "SePoor",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 22,
+        "amountMax": 40
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_rich",
+    "name": "SeRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 240,
+        "amountMax": 375
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_super_boss",
+    "name": "SeSuperBoss",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 810,
+        "amountMax": 1800
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.se_ultra_rich",
+    "name": "SeUltraRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 606,
+        "amountMax": 1200
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.super_boss",
+    "name": "SuperBoss",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 810,
+        "amountMax": 1800
+      }
+    ]
+  },
+  {
+    "type": "loot",
+    "id": "loot_pack.ultra_rich",
+    "name": "UltraRich",
+    "category": "loot",
+    "description": "",
+    "mode": "additive",
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "chance": 1.0,
+        "amountMin": 606,
+        "amountMax": 1200
+      }
+    ]
+  }
+]

--- a/moongate_data/templates/mobiles/animals/mounts/hiryu_npc.json
+++ b/moongate_data/templates/mobiles/animals/mounts/hiryu_npc.json
@@ -33,7 +33,8 @@
       "loot_pack.gems",
       "loot_pack.gems",
       "loot_pack.gems",
-      "loot_pack.gems"
+      "loot_pack.gems",
+      "creature.hiryu"
     ],
     "resistances": {
       "physical": 62,

--- a/moongate_data/templates/mobiles/animals/mounts/lesser_hiryu_npc.json
+++ b/moongate_data/templates/mobiles/animals/mounts/lesser_hiryu_npc.json
@@ -32,7 +32,8 @@
       "loot_pack.gems",
       "loot_pack.gems",
       "loot_pack.gems",
-      "loot_pack.gems"
+      "loot_pack.gems",
+      "creature.lesser_hiryu"
     ],
     "resistances": {
       "physical": 57,

--- a/moongate_data/templates/mobiles/monsters/arachnid_melee/terathan_warrior_npc.json
+++ b/moongate_data/templates/mobiles/monsters/arachnid_melee/terathan_warrior_npc.json
@@ -27,7 +27,8 @@
       "Wrestling": 850
     },
     "lootTables": [
-      "loot_pack.average"
+      "loot_pack.average",
+      "creature.terathan_warrior"
     ],
     "sounds": {
       "Idle": 589,

--- a/moongate_data/templates/mobiles/monsters/humanoid_magic/titan_npc.json
+++ b/moongate_data/templates/mobiles/monsters/humanoid_magic/titan_npc.json
@@ -29,7 +29,8 @@
     "lootTables": [
       "loot_pack.filthy_rich",
       "loot_pack.average",
-      "loot_pack.med_scrolls"
+      "loot_pack.med_scrolls",
+      "creature.titan"
     ],
     "sounds": {
       "Idle": 609,

--- a/moongate_data/templates/mobiles/monsters/humanoid_melee/cursed_npc.json
+++ b/moongate_data/templates/mobiles/monsters/humanoid_melee/cursed_npc.json
@@ -27,8 +27,7 @@
       "Poisoning": 712
     },
     "lootTables": [
-      "loot_pack.meager",
-      "loot_pack.miscellaneous"
+      "loot_pack.meager"
     ],
     "sounds": {
       "Idle": 471,

--- a/moongate_data/templates/mobiles/monsters/humanoid_melee/orc_captain_npc.json
+++ b/moongate_data/templates/mobiles/monsters/humanoid_melee/orc_captain_npc.json
@@ -26,7 +26,8 @@
     },
     "lootTables": [
       "loot_pack.meager",
-      "loot_pack.meager"
+      "loot_pack.meager",
+      "creature.orc_captain"
     ],
     "sounds": {
       "Idle": 0,

--- a/moongate_data/templates/mobiles/monsters/lbr_jukas/chaos_dragoon_npc.json
+++ b/moongate_data/templates/mobiles/monsters/lbr_jukas/chaos_dragoon_npc.json
@@ -28,8 +28,7 @@
       "Tactics": 825
     },
     "lootTables": [
-      "loot_pack.rich",
-      "loot_pack.gems"
+      "loot_pack.rich"
     ],
     "resistances": {
       "physical": 31,

--- a/moongate_data/templates/mobiles/monsters/misc_magic/wisp_npc.json
+++ b/moongate_data/templates/mobiles/monsters/misc_magic/wisp_npc.json
@@ -21,7 +21,8 @@
     "brain": "mage_combat",
     "lootTables": [
       "loot_pack.rich",
-      "loot_pack.average"
+      "loot_pack.average",
+      "creature.wisp"
     ],
     "sounds": {
       "Idle": 466,

--- a/moongate_data/templates/mobiles/monsters/ml_humanoid_magic/ml_dryad_npc.json
+++ b/moongate_data/templates/mobiles/monsters/ml_humanoid_magic/ml_dryad_npc.json
@@ -28,7 +28,8 @@
       "Wrestling": 750
     },
     "lootTables": [
-      "loot_pack.ml_rich"
+      "loot_pack.ml_rich",
+      "creature.ml_dryad"
     ],
     "sounds": {
       "Idle": 0,

--- a/moongate_data/templates/mobiles/monsters/ml_prism_of_light/crystal_lattice_seeker_npc.json
+++ b/moongate_data/templates/mobiles/monsters/ml_prism_of_light/crystal_lattice_seeker_npc.json
@@ -32,7 +32,6 @@
       "loot_pack.filthy_rich",
       "loot_pack.filthy_rich",
       "loot_pack.filthy_rich",
-      "loot_pack.parrot",
       "loot_pack.gems"
     ],
     "resistances": {

--- a/moongate_data/templates/mobiles/monsters/ml_prism_of_light/crystal_vortex_npc.json
+++ b/moongate_data/templates/mobiles/monsters/ml_prism_of_light/crystal_vortex_npc.json
@@ -21,8 +21,7 @@
     "brain": "melee_combat",
     "lootTables": [
       "loot_pack.filthy_rich",
-      "loot_pack.filthy_rich",
-      "loot_pack.parrot"
+      "loot_pack.filthy_rich"
     ],
     "sounds": {
       "Idle": 0,

--- a/moongate_data/templates/mobiles/monsters/ml_prism_of_light/unfrozen_mummy_npc.json
+++ b/moongate_data/templates/mobiles/monsters/ml_prism_of_light/unfrozen_mummy_npc.json
@@ -25,8 +25,7 @@
     },
     "lootTables": [
       "loot_pack.ultra_rich",
-      "loot_pack.ultra_rich",
-      "loot_pack.parrot"
+      "loot_pack.ultra_rich"
     ],
     "sounds": {
       "Idle": 0,

--- a/moongate_data/templates/mobiles/monsters/ml_twisted_weald/malefic_npc.json
+++ b/moongate_data/templates/mobiles/monsters/ml_twisted_weald/malefic_npc.json
@@ -30,8 +30,7 @@
     "lootTables": [
       "loot_pack.ultra_rich",
       "loot_pack.ultra_rich",
-      "loot_pack.ultra_rich",
-      "creature.malefic"
+      "loot_pack.ultra_rich"
     ],
     "resistances": {
       "physical": 65,

--- a/moongate_data/templates/mobiles/monsters/reptile_magic/serpentine_dragon_npc.json
+++ b/moongate_data/templates/mobiles/monsters/reptile_magic/serpentine_dragon_npc.json
@@ -29,7 +29,8 @@
       "loot_pack.filthy_rich",
       "loot_pack.filthy_rich",
       "loot_pack.gems",
-      "loot_pack.gems"
+      "loot_pack.gems",
+      "creature.serpentine_dragon"
     ],
     "sounds": {
       "Idle": 362,

--- a/moongate_data/templates/mobiles/monsters/se/bake_kitsune_npc.json
+++ b/moongate_data/templates/mobiles/monsters/se/bake_kitsune_npc.json
@@ -30,7 +30,8 @@
       "loot_pack.filthy_rich",
       "loot_pack.rich",
       "loot_pack.med_scrolls",
-      "loot_pack.med_scrolls"
+      "loot_pack.med_scrolls",
+      "creature.bake_kitsune"
     ],
     "resistances": {
       "physical": 50,

--- a/moongate_data/templates/mobiles/monsters/se/oni_npc.json
+++ b/moongate_data/templates/mobiles/monsters/se/oni_npc.json
@@ -29,7 +29,8 @@
     "lootTables": [
       "loot_pack.filthy_rich",
       "loot_pack.filthy_rich",
-      "loot_pack.filthy_rich"
+      "loot_pack.filthy_rich",
+      "creature.oni"
     ],
     "resistances": {
       "physical": 72,

--- a/moongate_data/templates/mobiles/monsters/se/rune_beetle_npc.json
+++ b/moongate_data/templates/mobiles/monsters/se/rune_beetle_npc.json
@@ -30,7 +30,8 @@
     "lootTables": [
       "loot_pack.filthy_rich",
       "loot_pack.filthy_rich",
-      "loot_pack.med_scrolls"
+      "loot_pack.med_scrolls",
+      "creature.rune_beetle"
     ],
     "resistances": {
       "physical": 52,

--- a/moongate_data/templates/mobiles/monsters/se/tsuki_wolf_npc.json
+++ b/moongate_data/templates/mobiles/monsters/se/tsuki_wolf_npc.json
@@ -27,7 +27,8 @@
     },
     "lootTables": [
       "loot_pack.average",
-      "loot_pack.rich"
+      "loot_pack.rich",
+      "creature.tsuki_wolf"
     ],
     "resistances": {
       "physical": 50,

--- a/scripts/generate_loot_templates.py
+++ b/scripts/generate_loot_templates.py
@@ -11,6 +11,7 @@ from typing import Dict, Iterable, List, Sequence
 try:
     from scripts.modernuo_loot_tooling import (
         build_loot_id,
+        ensure_loot_support_items,
         build_output_paths,
         extract_balanced_block,
         load_item_template_index,
@@ -18,11 +19,13 @@ try:
         parse_dice_range,
         resolve_item_reference,
         split_top_level_arguments,
+        strip_comments,
         write_json_array,
     )
 except ModuleNotFoundError:  # pragma: no cover - direct CLI execution
     from modernuo_loot_tooling import (
         build_loot_id,
+        ensure_loot_support_items,
         build_output_paths,
         extract_balanced_block,
         load_item_template_index,
@@ -30,6 +33,7 @@ except ModuleNotFoundError:  # pragma: no cover - direct CLI execution
         parse_dice_range,
         resolve_item_reference,
         split_top_level_arguments,
+        strip_comments,
         write_json_array,
     )
 
@@ -41,6 +45,15 @@ CREATURE_CLASS_PATTERN = re.compile(r"public partial class\s+(\w+)\s*:\s*BaseCre
 GENERATE_LOOT_PATTERN = re.compile(r"public override void GenerateLoot\(\)\s*\{", re.MULTILINE)
 FILLABLE_CONTENT_PATTERN = re.compile(
     r"private static readonly FillableContent\s+(\w+)\s*=\s*new\(",
+    re.MULTILINE,
+)
+PACK_ITEM_CONSTRUCTOR_PATTERN = re.compile(r"PackItem\s*\(\s*new\s+(\w+)\s*\(\s*(\d+)?\s*\)\s*\);", re.MULTILINE)
+PACK_ITEM_SEED_FACTORY_PATTERN = re.compile(
+    r"PackItem\s*\(\s*Seed\.(?:RandomPeculiarSeed|RandomBonsaiSeed)\s*\([^)]*\)\s*\);",
+    re.MULTILINE,
+)
+PACK_ITEM_RANDOM_REAGENT_PATTERN = re.compile(
+    r"PackItem\s*\(\s*Loot\.Random(?:Possible|Necromancy)?Reagent\s*\(\s*\)\s*\);",
     re.MULTILINE,
 )
 
@@ -76,6 +89,7 @@ def try_resolve_reference(
 
 
 def parse_loot_pack_arrays(text: str) -> Dict[str, List[Dict[str, object]]]:
+    text = strip_comments(text)
     arrays: Dict[str, List[Dict[str, object]]] = {}
 
     for match in LOOTPACK_ARRAY_PATTERN.finditer(text):
@@ -91,6 +105,7 @@ def parse_loot_pack_arrays(text: str) -> Dict[str, List[Dict[str, object]]]:
 
 
 def parse_type_arrays(text: str) -> Dict[str, List[str]]:
+    text = strip_comments(text)
     arrays: Dict[str, List[str]] = {}
 
     for match in TYPE_ARRAY_PATTERN.finditer(text):
@@ -102,6 +117,7 @@ def parse_type_arrays(text: str) -> Dict[str, List[str]]:
 
 
 def parse_loot_packs(text: str) -> Dict[str, List[Dict[str, object]]]:
+    text = strip_comments(text)
     packs: Dict[str, List[Dict[str, object]]] = {}
 
     for match in LOOTPACK_PATTERN.finditer(text):
@@ -136,6 +152,7 @@ def parse_loot_packs(text: str) -> Dict[str, List[Dict[str, object]]]:
 
 
 def parse_loot_pack_aliases(text: str, pack_names: Sequence[str]) -> Dict[str, str]:
+    text = strip_comments(text)
     aliases: Dict[str, str] = {}
 
     for match in LOOTPACK_ALIAS_PATTERN.finditer(text):
@@ -191,13 +208,83 @@ def build_entry(reference: Dict[str, object], chance: float, quantity: str) -> D
     entry["chance"] = round(chance, 4)
 
     quantity_range = parse_dice_range(quantity)
+    apply_quantity_range(entry, quantity_range)
+
+    return entry
+
+
+def apply_quantity_range(entry: Dict[str, object], quantity_range) -> None:
     if quantity_range.minimum == quantity_range.maximum:
         entry["amount"] = quantity_range.minimum
     else:
         entry["amountMin"] = quantity_range.minimum
         entry["amountMax"] = quantity_range.maximum
 
-    return entry
+
+def try_build_weighted_loot_pack_table(
+    pack_name: str,
+    pack_entries: Sequence[Dict[str, object]],
+    arrays: Dict[str, List[Dict[str, object]]],
+    item_index: Dict[str, Dict[str, object]],
+    tag_index: Dict[str, List[str]],
+    report: Dict[str, object],
+) -> Dict[str, object] | None:
+    if len(pack_entries) != 1:
+        return None
+
+    pack_entry = pack_entries[0]
+    if pack_entry["atSpawn"] or float(pack_entry["chancePercent"]) != 100.0:
+        return None
+
+    quantity_range = parse_dice_range(str(pack_entry["quantity"]))
+    if quantity_range.minimum != quantity_range.maximum:
+        return None
+
+    array_name = str(pack_entry["arrayName"])
+    item_array = arrays.get(array_name)
+    if not item_array or len(item_array) <= 1:
+        return None
+
+    weighted_entries: List[Dict[str, object]] = []
+    seen = set()
+    context = f"loot_pack.{normalize_identifier(pack_name)}"
+
+    for item in item_array:
+        reference = try_resolve_reference(
+            str(item["typeName"]),
+            item_index,
+            tag_index,
+            report,
+            f"{context} via {array_name}",
+        )
+        if reference is None:
+            continue
+
+        frozen = tuple(sorted(reference.items()))
+        if frozen in seen:
+            continue
+
+        seen.add(frozen)
+        entry = dict(reference)
+        entry["weight"] = int(item["weight"])
+        apply_quantity_range(entry, quantity_range)
+        weighted_entries.append(entry)
+
+    if not weighted_entries:
+        append_warning(report, "skipped", f"{context}: unresolved weighted array {array_name}")
+        return None
+
+    return {
+        "type": "loot",
+        "id": context,
+        "name": pack_name,
+        "category": "loot",
+        "description": "",
+        "mode": "weighted",
+        "rolls": 1,
+        "noDropWeight": 0,
+        "entries": weighted_entries,
+    }
 
 
 def expand_loot_pack_entries(
@@ -209,6 +296,7 @@ def expand_loot_pack_entries(
     tag_index: Dict[str, List[str]],
     report: Dict[str, object],
     context: str,
+    include_at_spawn: bool = False,
 ) -> List[Dict[str, object]]:
     resolved_pack_name = aliases.get(pack_name, pack_name)
     pack_entries = packs.get(resolved_pack_name)
@@ -218,7 +306,7 @@ def expand_loot_pack_entries(
 
     generated: List[Dict[str, object]] = []
     for pack_entry in pack_entries:
-        if pack_entry["atSpawn"]:
+        if pack_entry["atSpawn"] and not include_at_spawn:
             continue
 
         array_name = str(pack_entry["arrayName"])
@@ -259,6 +347,68 @@ def expand_loot_pack_entries(
     return generated
 
 
+def build_loot_pack_tables(
+    packs: Dict[str, List[Dict[str, object]]],
+    arrays: Dict[str, List[Dict[str, object]]],
+    aliases: Dict[str, str],
+    item_index: Dict[str, Dict[str, object]],
+    tag_index: Dict[str, List[str]],
+    report: Dict[str, object],
+) -> List[Dict[str, object]]:
+    tables: List[Dict[str, object]] = []
+
+    for pack_name in sorted({*packs.keys(), *aliases.keys()}):
+        resolved_pack_name = aliases.get(pack_name, pack_name)
+        pack_entries = packs.get(resolved_pack_name)
+        if not pack_entries:
+            append_warning(report, "unmappedPatterns", f"loot_pack.{normalize_identifier(pack_name)}: missing pack")
+            continue
+
+        weighted_table = try_build_weighted_loot_pack_table(
+            pack_name,
+            pack_entries,
+            arrays,
+            item_index,
+            tag_index,
+            report,
+        )
+        if weighted_table is not None:
+            tables.append(weighted_table)
+            append_warning(report, "generated", weighted_table["id"])
+            continue
+
+        entries = expand_loot_pack_entries(
+            pack_name,
+            packs,
+            arrays,
+            aliases,
+            item_index,
+            tag_index,
+            report,
+            f"loot_pack.{normalize_identifier(pack_name)}",
+            include_at_spawn=True,
+        )
+        if not entries:
+            append_warning(report, "skipped", f"loot_pack.{normalize_identifier(pack_name)}: no supported entries")
+            continue
+
+        table_id = build_loot_id(pack_name, "loot_pack")
+        tables.append(
+            {
+                "type": "loot",
+                "id": table_id,
+                "name": pack_name,
+                "category": "loot",
+                "description": "",
+                "mode": "additive",
+                "entries": entries,
+            }
+        )
+        append_warning(report, "generated", table_id)
+
+    return tables
+
+
 def parse_generate_loot_tables(
     mobiles_root: Path,
     packs: Dict[str, List[Dict[str, object]]],
@@ -271,7 +421,7 @@ def parse_generate_loot_tables(
     tables: List[Dict[str, object]] = []
 
     for path in sorted(mobiles_root.rglob("*.cs")):
-        text = path.read_text(encoding="utf-8")
+        text = strip_comments(path.read_text(encoding="utf-8"))
         class_match = CREATURE_CLASS_PATTERN.search(text)
         generate_match = GENERATE_LOOT_PATTERN.search(text)
         if class_match is None or generate_match is None:
@@ -322,7 +472,30 @@ def parse_generate_loot_tables(
                 }
             )
 
-        for pack_item_match in re.finditer(r"PackItem\(new (\w+)(?:\((\d+)\))?\);", body):
+        for pack_reg_range in re.finditer(r"PackReg\((\d+),\s*(\d+)\);", body):
+            reference = try_resolve_reference("Reagent", item_index, tag_index, report, context)
+            if reference is None:
+                append_warning(report, "skipped", f"{context}: unresolved PackReg range")
+                continue
+
+            entry = dict(reference)
+            entry["chance"] = 1.0
+            entry["amountMin"] = int(pack_reg_range.group(1))
+            entry["amountMax"] = int(pack_reg_range.group(2))
+            entries.append(entry)
+
+        for pack_reg_fixed in re.finditer(r"PackReg\((\d+)\);", body):
+            reference = try_resolve_reference("Reagent", item_index, tag_index, report, context)
+            if reference is None:
+                append_warning(report, "skipped", f"{context}: unresolved PackReg")
+                continue
+
+            entry = dict(reference)
+            entry["chance"] = 1.0
+            entry["amount"] = int(pack_reg_fixed.group(1))
+            entries.append(entry)
+
+        for pack_item_match in PACK_ITEM_CONSTRUCTOR_PATTERN.finditer(body):
             type_name = pack_item_match.group(1)
             amount = int(pack_item_match.group(2) or "1")
             reference = try_resolve_reference(type_name, item_index, tag_index, report, context)
@@ -333,6 +506,28 @@ def parse_generate_loot_tables(
             entry = dict(reference)
             entry["chance"] = 1.0
             entry["amount"] = amount
+            entries.append(entry)
+
+        for pack_item_match in PACK_ITEM_SEED_FACTORY_PATTERN.finditer(body):
+            reference = try_resolve_reference("Seed", item_index, tag_index, report, context)
+            if reference is None:
+                append_warning(report, "skipped", f"{context}: unresolved PackItem Seed")
+                continue
+
+            entry = dict(reference)
+            entry["chance"] = 1.0
+            entry["amount"] = 1
+            entries.append(entry)
+
+        for pack_item_match in PACK_ITEM_RANDOM_REAGENT_PATTERN.finditer(body):
+            reference = try_resolve_reference("Reagent", item_index, tag_index, report, context)
+            if reference is None:
+                append_warning(report, "skipped", f"{context}: unresolved PackItem reagent")
+                continue
+
+            entry = dict(reference)
+            entry["chance"] = 1.0
+            entry["amount"] = 1
             entries.append(entry)
 
         if not entries:
@@ -703,6 +898,7 @@ def write_report(path: Path, report: Dict[str, object]) -> None:
 
 
 def generate_from_paths(modernuo_root: Path, repo_root: Path) -> Dict[str, object]:
+    ensure_loot_support_items(repo_root)
     item_index, tag_index = load_item_template_index(repo_root)
     report = build_report()
 
@@ -731,6 +927,7 @@ def generate_from_paths(modernuo_root: Path, repo_root: Path) -> Dict[str, objec
             report,
         )
     )
+    loot_packs = sort_tables(build_loot_pack_tables(packs, pack_arrays, pack_aliases, item_index, tag_index, report))
     fillable = sort_tables(
         parse_fillable_content_tables(
             fillable_path,
@@ -746,6 +943,7 @@ def generate_from_paths(modernuo_root: Path, repo_root: Path) -> Dict[str, objec
     write_json_array(output_paths["creatures"], creatures)
     write_json_array(output_paths["treasure_chests"], treasure_chests)
     write_json_array(output_paths["fillable_containers"], fillable)
+    write_json_array(output_paths["loot_packs"], loot_packs)
     write_report(repo_root / "artifacts/loot-import-report.json", report)
 
     return report

--- a/scripts/modernuo_converter/README.md
+++ b/scripts/modernuo_converter/README.md
@@ -2,6 +2,14 @@
 
 Python tool to convert NPC definitions from ModernUO C# source files to Moongate JSON templates.
 
+This converter is part of the ModernUO import pipeline:
+
+1. `python3 scripts/generate_loot_templates.py /path/to/ModernUO .`
+2. `python3 scripts/modernuo_npc_converter.py --all --source /path/to/ModernUO --output moongate_data`
+
+The first step refreshes shared `loot_pack.*` tables, treasure/fillable loot, `loot_support.json`, and reagent tagging.
+The second step regenerates mobiles plus creature-specific `creature.*` loot files.
+
 ## Usage
 
 ```
@@ -27,6 +35,8 @@ python3 scripts/modernuo_npc_converter.py --all \
 - `templates/loot/creatures/*.json` — NPC-specific loot
 - `templates/sell_profiles/*.json` — Vendor sell profiles (placeholders)
 
+When writing creature loot files, the generator also removes stale `templates/loot/creatures/*.json` files that are no longer produced by the current parse result.
+
 ## Post-conversion review
 
 Generated templates need manual review for:
@@ -36,3 +46,9 @@ Generated templates need manual review for:
 
 The converter now emits canonical mobile `variants[]` entries with `appearance` and spawn-time `equipment` for the supported ModernUO patterns it can parse automatically.
 This includes inherited `InitOutfit()` chains, gender-specific `if (Female)` branches, and simple wrapper calls such as `ApplyHue(new Robe(), 0x47E)` when the underlying item constructor can be resolved.
+
+Creature-specific loot generation also normalizes several ModernUO helpers into Moongate-compatible references:
+- `PackReg(...)` and `Loot.Random...Reagent()` become `itemTag: "reagents"`
+- `new RandomTalisman()` becomes `itemTag: "talismans"`
+- `Seed`, `MetalChest`, and `GargoylesPickaxe` resolve through generated support item templates
+- commented `AddLoot(...)` and `PackItem(...)` lines are ignored

--- a/scripts/modernuo_converter/generators/loot_generator.py
+++ b/scripts/modernuo_converter/generators/loot_generator.py
@@ -45,4 +45,21 @@ def generate_all_loot(
         path = generate_creature_loot_file(loot, output_dir, dry_run)
         if path:
             paths.append(path)
+
+    if dry_run:
+        return paths
+
+    out_dir = os.path.join(output_dir, "templates", "loot", "creatures")
+    if not os.path.isdir(out_dir):
+        return paths
+
+    expected_paths = {os.path.normpath(path) for path in paths}
+    for filename in os.listdir(out_dir):
+        if not filename.endswith(".json"):
+            continue
+
+        file_path = os.path.normpath(os.path.join(out_dir, filename))
+        if file_path not in expected_paths:
+            os.remove(file_path)
+
     return paths

--- a/scripts/modernuo_converter/mapper.py
+++ b/scripts/modernuo_converter/mapper.py
@@ -607,14 +607,20 @@ def map_pack_items_to_loot(parsed: dict) -> Optional[dict]:
 
     entries = []
     for item in parsed["pack_items"]:
-        item_snake = _pascal_to_snake(item["item"])
-        entries.append(
-            {
-                "itemTemplateId": item_snake,
+        item_name = item["item"]
+
+        if item_name == "Reagent":
+            entry = {"itemTag": "reagents", "chance": 1.0, "amount": item["amount"]}
+        elif item_name == "RandomTalisman":
+            entry = {"itemTag": "talismans", "chance": 1.0, "amount": item["amount"]}
+        else:
+            entry = {
+                "itemTemplateId": _pascal_to_snake(item_name),
                 "chance": 1.0,
                 "amount": item["amount"],
             }
-        )
+
+        entries.append(entry)
 
     return {
         "type": "loot",

--- a/scripts/modernuo_converter/parser.py
+++ b/scripts/modernuo_converter/parser.py
@@ -1246,10 +1246,12 @@ def _parse_class_definition(
     if control_slots_match:
         data["control_slots"] = int(control_slots_match.group(1))
 
+    loot_content = _strip_comments(class_content)
+
     loot_entries = []
     for match in re.finditer(
         r"AddLoot\s*\(\s*LootPack\.(\w+)(?:\s*,\s*(\d+))?\s*\)",
-        class_content,
+        loot_content,
     ):
         loot_entries.append(
             {
@@ -1263,7 +1265,7 @@ def _parse_class_definition(
     pack_items = []
     for match in re.finditer(
         r"PackItem\s*\(\s*new\s+(\w+)\s*\(\s*(\d+)?\s*\)\s*\)",
-        class_content,
+        loot_content,
     ):
         pack_items.append(
             {
@@ -1271,11 +1273,23 @@ def _parse_class_definition(
                 "amount": int(match.group(2)) if match.group(2) else 1,
             }
         )
-    for match in re.finditer(r"PackReg\s*\(\s*(\d+)\s*\)", class_content):
+    for match in re.finditer(
+        r"PackItem\s*\(\s*Seed\.(?:RandomPeculiarSeed|RandomBonsaiSeed)\s*\([^)]*\)\s*\)",
+        loot_content,
+    ):
+        pack_items.append({"item": "Seed", "amount": 1})
+
+    for match in re.finditer(
+        r"PackItem\s*\(\s*Loot\.Random(?:Possible|Necromancy)?Reagent\s*\(\s*\)\s*\)",
+        loot_content,
+    ):
+        pack_items.append({"item": "Reagent", "amount": 1})
+
+    for match in re.finditer(r"PackReg\s*\(\s*(\d+)\s*\)", loot_content):
         pack_items.append({"item": "Reagent", "amount": int(match.group(1))})
     for match in re.finditer(
         r"PackGold\s*\(\s*(\d+)\s*(?:,\s*(\d+))?\s*\)",
-        class_content,
+        loot_content,
     ):
         min_gold = int(match.group(1))
         max_gold = int(match.group(2)) if match.group(2) else min_gold

--- a/scripts/modernuo_loot_tooling.py
+++ b/scripts/modernuo_loot_tooling.py
@@ -10,6 +10,16 @@ from typing import Dict, Iterable, List, Sequence
 
 ROOT_ITEMS_DIRECTORY = Path("moongate_data/templates/items")
 ROOT_LOOT_DIRECTORY = Path("moongate_data/templates/loot")
+REAGENT_TEMPLATE_IDS = {
+    "black_pearl",
+    "bloodmoss",
+    "garlic",
+    "ginseng",
+    "mandrake_root",
+    "nightshade",
+    "spiders_silk",
+    "sulfurous_ash",
+}
 
 TYPE_TO_TAG = {
     "Amber": "gems",
@@ -19,19 +29,28 @@ TYPE_TO_TAG = {
     "BaseJewel": "jewels",
     "BaseRanged": "weapons",
     "BaseShield": "shields",
+    "BaseTalisman": "talismans",
     "BaseWeapon": "weapons",
     "ClumsyScroll": "skill items",
     "SummonAirElementalScroll": "skill items",
 }
 
+TYPE_TO_REFERENCE = {
+    "RandomTalisman": {"itemTag": "talismans"},
+    "Reagent": {"itemTag": "reagents"},
+}
+
 TYPE_TO_ITEM_ID = {
+    "GargoylesPickaxe": "gargoyles_pickaxe",
     "Gold": "gold",
     "HorseShoes": "horse_shoes",
     "Lockpick": "lockpick",
     "Lockpicks": "lockpick",
+    "MetalChest": "metal_chest",
     "MortarPestle": "mortar_pestle",
     "NightSightPotion": "night_sight_potion",
     "RawLambLeg": "raw_lamb_leg",
+    "Seed": "seed",
     "SheafOfHay": "sheaf_of_hay",
     "SledgeHammer": "sledge_hammer",
     "SmithHammer": "smith_hammer",
@@ -58,6 +77,11 @@ def write_json_array(path: Path, items: List[Dict[str, object]]) -> None:
     path.write_text(f"{json.dumps(items, indent=2)}\n", encoding="utf-8")
 
 
+def strip_comments(text: str) -> str:
+    without_block_comments = re.sub(r"/\*[\s\S]*?\*/", "", text)
+    return re.sub(r"//.*$", "", without_block_comments, flags=re.MULTILINE)
+
+
 def normalize_identifier(name: str) -> str:
     cleaned = re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_")
     with_boundaries = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", cleaned)
@@ -71,11 +95,100 @@ def build_output_paths(repo_root: Path) -> Dict[str, Path]:
         "creatures": loot_root / "creatures.json",
         "treasure_chests": loot_root / "treasure_chests.json",
         "fillable_containers": loot_root / "fillable_containers.json",
+        "loot_packs": loot_root / "loot_packs.json",
     }
 
 
 def build_loot_id(name: str, prefix: str) -> str:
     return f"{prefix}.{normalize_identifier(name)}"
+
+
+def build_loot_support_item_path(repo_root: Path) -> Path:
+    return repo_root / ROOT_ITEMS_DIRECTORY / "loot_support.json"
+
+
+def build_loot_support_items() -> List[Dict[str, object]]:
+    return [
+        {
+            "type": "item",
+            "id": "seed",
+            "name": "Seed",
+            "category": "Loot Support",
+            "description": "Imported support item for ModernUO loot conversion.",
+            "itemId": "0x0DCF",
+            "hue": "0",
+            "goldValue": "0",
+            "weight": 1.0,
+            "scriptId": "none",
+            "isMovable": True,
+            "tags": ["modernuo", "loot_support", "seeds"],
+        },
+        {
+            "type": "item",
+            "id": "metal_chest",
+            "name": "Metal Chest",
+            "category": "Containers",
+            "description": "Imported support item for ModernUO loot conversion.",
+            "itemId": "0x09AB",
+            "hue": "0",
+            "goldValue": "0",
+            "weight": 2.0,
+            "scriptId": "none",
+            "isMovable": True,
+            "tags": ["modernuo", "containers", "loot_support"],
+            "weightMax": 40000,
+            "maxItems": 125,
+            "containerLayoutId": "metal_chest",
+            "gumpId": "0x0048",
+        },
+        {
+            "type": "item",
+            "id": "gargoyles_pickaxe",
+            "name": "Gargoyle's Pickaxe",
+            "category": "Skill Items",
+            "description": "Imported support item for ModernUO loot conversion.",
+            "itemId": "0x0E85",
+            "hue": "0",
+            "goldValue": "0",
+            "weight": 11.0,
+            "scriptId": "none",
+            "isMovable": True,
+            "tags": ["modernuo", "skill items", "loot_support", "flippable"],
+            "flippableItemIds": ["0x0E85", "0x0E86"],
+            "lowDamage": 1,
+            "highDamage": 15,
+            "speed": 35,
+            "strength": 25,
+        },
+    ]
+
+
+def ensure_loot_support_items(repo_root: Path) -> None:
+    write_json_array(build_loot_support_item_path(repo_root), build_loot_support_items())
+
+    resources_path = repo_root / ROOT_ITEMS_DIRECTORY / "resources.json"
+    if not resources_path.exists():
+        return
+
+    resources = load_json_array(resources_path)
+    updated = False
+
+    for item in resources:
+        item_id = item.get("id")
+        if item_id not in REAGENT_TEMPLATE_IDS:
+            continue
+
+        tags = item.get("tags")
+        if not isinstance(tags, list):
+            tags = []
+            item["tags"] = tags
+
+        if "reagents" not in tags:
+            tags.append("reagents")
+            updated = True
+
+    if updated:
+        write_json_array(resources_path, resources)
 
 
 def load_item_template_index(repo_root: Path) -> tuple[Dict[str, Dict[str, object]], Dict[str, List[str]]]:
@@ -110,6 +223,12 @@ def load_item_template_index(repo_root: Path) -> tuple[Dict[str, Dict[str, objec
 def resolve_item_reference(
     type_name: str, item_index: Dict[str, Dict[str, object]], tag_index: Dict[str, List[str]]
 ) -> Dict[str, object] | None:
+    special_reference = TYPE_TO_REFERENCE.get(type_name)
+    if special_reference is not None:
+        item_tag = special_reference.get("itemTag")
+        if isinstance(item_tag, str) and tag_index.get(item_tag):
+            return dict(special_reference)
+
     special_item_id = TYPE_TO_ITEM_ID.get(type_name)
     if special_item_id is not None and special_item_id in item_index:
         return {"itemTemplateId": special_item_id}

--- a/scripts/tests/test_generate_loot_templates.py
+++ b/scripts/tests/test_generate_loot_templates.py
@@ -11,6 +11,14 @@ def write_file(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def find_template(templates: list[dict], template_id: str) -> dict:
+    for template in templates:
+        if template.get("id") == template_id:
+            return template
+
+    raise AssertionError(f"Template '{template_id}' not found")
+
+
 class GenerateLootTemplatesTests(unittest.TestCase):
     def test_generates_creature_fillable_and_treasure_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -223,6 +231,302 @@ class GenerateLootTemplatesTests(unittest.TestCase):
                 [entry["itemTemplateId"] for entry in fillable[0]["entries"]],
             )
             self.assertNotIn("fillable.Tavern: BeverageBottle", "\n".join(report["missingItems"]))
+
+    def test_generates_loot_pack_tables_with_modernuo_prefix_and_ignores_commented_parrot_pack(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            repo_root = root / "repo"
+            modernuo_root = root / "modernuo"
+
+            write_file(
+                repo_root / "moongate_data/templates/items/misc.json",
+                json.dumps([{"id": "gold", "tags": ["currency"]}], indent=2) + "\n",
+            )
+            write_file(
+                repo_root / "moongate_data/templates/items/gems.json",
+                json.dumps([{"id": "amber", "tags": ["gems"]}], indent=2) + "\n",
+            )
+            write_file(
+                repo_root / "moongate_data/templates/items/potions.json",
+                json.dumps(
+                    [
+                        {"id": "agility_potion", "tags": ["potions"]},
+                        {"id": "strength_potion", "tags": ["potions"]},
+                    ],
+                    indent=2,
+                )
+                + "\n",
+            )
+
+            write_file(
+                modernuo_root / "Projects/UOContent/Misc/LootPack.cs",
+                """
+                public class LootPack
+                {
+                    public static readonly LootPackItem[] Gold = [new LootPackItem(typeof(Gold), 1)];
+                    public static readonly LootPackItem[] GemItems = [new LootPackItem(typeof(Amber), 1)];
+                    public static readonly LootPackItem[] PotionItems =
+                    [
+                        new LootPackItem(typeof(AgilityPotion), 1),
+                        new LootPackItem(typeof(StrengthPotion), 1)
+                    ];
+
+                    public static readonly LootPack Average = new(
+                        [
+                            new LootPackEntry(false, Gold, 100.00, "2d10"),
+                            new LootPackEntry(false, GemItems, 50.00, 1)
+                        ]
+                    );
+
+                    public static readonly LootPack MlRich = new(
+                        [new LootPackEntry(false, Gold, 100.00, "4d50+450")]
+                    );
+
+                    public static readonly LootPack AosFilthyRich = new(
+                        [new LootPackEntry(false, Gold, 100.00, "4d50+450")]
+                    );
+
+                    /*
+                    public static readonly LootPackItem[] ParrotItem =
+                    [
+                        new LootPackItem(typeof(ParrotItem), 1)
+                    ];
+
+                    public static readonly LootPack Parrot = new(
+                        [new LootPackEntry(false, ParrotItem, 10.00, 1)]
+                    );
+                    */
+                }
+                """,
+            )
+            write_file(modernuo_root / "Projects/UOContent/Misc/Loot.cs", "public static class Loot { }\n")
+            write_file(
+                modernuo_root / "Projects/UOContent/Items/Containers/Fillable Containers/FillableContent.ContentTypes.cs",
+                """
+                public partial class FillableContent
+                {
+                }
+                """,
+            )
+            write_file(
+                modernuo_root / "Projects/UOContent/Items/Containers/TreasureMapChest.cs",
+                """
+                public partial class TreasureMapChest
+                {
+                    public static void Fill(LockableContainer cont, int level)
+                    {
+                    }
+                }
+                """,
+            )
+
+            report = generate_from_paths(modernuo_root, repo_root)
+
+            loot_packs = json.loads((repo_root / "moongate_data/templates/loot/loot_packs.json").read_text())
+            generated_ids = {template["id"] for template in loot_packs}
+
+            self.assertIn("loot_pack.average", generated_ids)
+            self.assertIn("loot_pack.ml_rich", generated_ids)
+            self.assertIn("loot_pack.aos_filthy_rich", generated_ids)
+            self.assertNotIn("loot_pack.parrot", generated_ids)
+            self.assertNotIn("ParrotItem", "\n".join(report["missingItems"]))
+
+    def test_generates_special_creature_loot_references_and_support_items(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            repo_root = root / "repo"
+            modernuo_root = root / "modernuo"
+
+            write_file(
+                repo_root / "moongate_data/templates/items/resources.json",
+                json.dumps(
+                    [
+                        {"id": "black_pearl", "tags": ["modernuo", "resources"]},
+                        {"id": "bloodmoss", "tags": ["modernuo", "resources"]},
+                        {"id": "garlic", "tags": ["modernuo", "resources"]},
+                        {"id": "ginseng", "tags": ["modernuo", "resources"]},
+                        {"id": "mandrake_root", "tags": ["modernuo", "resources"]},
+                        {"id": "nightshade", "tags": ["modernuo", "resources"]},
+                        {"id": "spiders_silk", "tags": ["modernuo", "resources"]},
+                        {"id": "sulfurous_ash", "tags": ["modernuo", "resources"]},
+                        {"id": "board", "tags": ["modernuo", "resources"]},
+                        {"id": "log", "tags": ["modernuo", "resources"]},
+                    ],
+                    indent=2,
+                )
+                + "\n",
+            )
+            write_file(
+                repo_root / "moongate_data/templates/items/special.json",
+                json.dumps(
+                    [
+                        {"id": "bone", "tags": ["modernuo", "special"]},
+                        {"id": "plague_beast_gland", "tags": ["modernuo", "special"]},
+                    ],
+                    indent=2,
+                )
+                + "\n",
+            )
+            write_file(
+                repo_root / "moongate_data/templates/items/talismans.json",
+                json.dumps(
+                    [
+                        {"id": "runed_switch", "tags": ["modernuo", "talismans"]},
+                        {"id": "runed_prism", "tags": ["modernuo", "talismans"]},
+                    ],
+                    indent=2,
+                )
+                + "\n",
+            )
+
+            write_file(
+                modernuo_root / "Projects/UOContent/Misc/LootPack.cs",
+                """
+                public class LootPack
+                {
+                }
+                """,
+            )
+            write_file(modernuo_root / "Projects/UOContent/Misc/Loot.cs", "public static class Loot { }\n")
+            write_file(
+                modernuo_root / "Projects/UOContent/Items/Containers/Fillable Containers/FillableContent.ContentTypes.cs",
+                """
+                public partial class FillableContent
+                {
+                }
+                """,
+            )
+            write_file(
+                modernuo_root / "Projects/UOContent/Items/Containers/TreasureMapChest.cs",
+                """
+                public partial class TreasureMapChest
+                {
+                    public static void Fill(LockableContainer cont, int level)
+                    {
+                    }
+                }
+                """,
+            )
+
+            write_file(
+                modernuo_root / "Projects/UOContent/Mobiles/Monsters/Humanoid/Magic/BoneMagi.cs",
+                """
+                namespace Server.Mobiles
+                {
+                    public partial class BoneMagi : BaseCreature
+                    {
+                        public override void GenerateLoot()
+                        {
+                            PackItem(new Bone());
+                            PackReg(3);
+                        }
+                    }
+                }
+                """,
+            )
+            write_file(
+                modernuo_root / "Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs",
+                """
+                namespace Server.Mobiles
+                {
+                    public partial class Ilhenir : BaseCreature
+                    {
+                        public override void GenerateLoot()
+                        {
+                            PackItem(new RandomTalisman());
+                        }
+                    }
+                }
+                """,
+            )
+            write_file(
+                modernuo_root / "Projects/UOContent/Mobiles/Monsters/Plant/Melee/BogThing.cs",
+                """
+                namespace Server.Mobiles
+                {
+                    public partial class BogThing : BaseCreature
+                    {
+                        public override void GenerateLoot()
+                        {
+                            PackItem(new Seed());
+                            PackReg(3);
+                        }
+                    }
+                }
+                """,
+            )
+            write_file(
+                modernuo_root / "Projects/UOContent/Mobiles/Monsters/Humanoid/Melee/StoneGargoyle.cs",
+                """
+                namespace Server.Mobiles
+                {
+                    public partial class StoneGargoyle : BaseCreature
+                    {
+                        public override void GenerateLoot()
+                        {
+                            PackItem(new GargoylesPickaxe());
+                        }
+                    }
+                }
+                """,
+            )
+            write_file(
+                modernuo_root / "Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs",
+                """
+                namespace Server.Mobiles
+                {
+                    public partial class PlagueBeast : BaseCreature
+                    {
+                        public override void GenerateLoot()
+                        {
+                            PackItem(new PlagueBeastGland());
+                            PackItem(new MetalChest());
+                            // PackItem(new ParrotItem());
+                        }
+                    }
+                }
+                """,
+            )
+
+            report = generate_from_paths(modernuo_root, repo_root)
+
+            creatures = json.loads((repo_root / "moongate_data/templates/loot/creatures.json").read_text())
+            support_items = json.loads((repo_root / "moongate_data/templates/items/loot_support.json").read_text())
+
+            bone_magi = find_template(creatures, "creature.bone_magi")
+            ilhenir = find_template(creatures, "creature.ilhenir")
+            bog_thing = find_template(creatures, "creature.bog_thing")
+            stone_gargoyle = find_template(creatures, "creature.stone_gargoyle")
+            plague_beast = find_template(creatures, "creature.plague_beast")
+
+            bone_magi_reagent_entry = next(
+                entry for entry in bone_magi["entries"] if entry.get("itemTag") == "reagents"
+            )
+            ilhenir_talisman_entry = next(
+                entry for entry in ilhenir["entries"] if entry.get("itemTag") == "talismans"
+            )
+            bog_thing_seed_entry = next(
+                entry for entry in bog_thing["entries"] if entry.get("itemTemplateId") == "seed"
+            )
+            stone_gargoyle_pickaxe_entry = next(
+                entry for entry in stone_gargoyle["entries"] if entry.get("itemTemplateId") == "gargoyles_pickaxe"
+            )
+            plague_beast_chest_entry = next(
+                entry for entry in plague_beast["entries"] if entry.get("itemTemplateId") == "metal_chest"
+            )
+
+            self.assertNotIn("itemTemplateId", bone_magi_reagent_entry)
+            self.assertEqual(3, bone_magi_reagent_entry["amount"])
+
+            self.assertNotIn("itemTemplateId", ilhenir_talisman_entry)
+
+            self.assertEqual("seed", bog_thing_seed_entry["itemTemplateId"])
+            self.assertEqual("gargoyles_pickaxe", stone_gargoyle_pickaxe_entry["itemTemplateId"])
+            self.assertEqual("metal_chest", plague_beast_chest_entry["itemTemplateId"])
+            self.assertNotIn("ParrotItem", "\n".join(report["missingItems"]))
+
+            support_item_ids = {item["id"] for item in support_items}
+            self.assertEqual({"gargoyles_pickaxe", "metal_chest", "seed"}, support_item_ids)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_modernuo_npc_converter.py
+++ b/scripts/tests/test_modernuo_npc_converter.py
@@ -4,8 +4,13 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from scripts.modernuo_converter.mapper import load_item_template_catalog, map_to_template
+from scripts.modernuo_converter.mapper import (
+    load_item_template_catalog,
+    map_pack_items_to_loot,
+    map_to_template,
+)
 from scripts.modernuo_converter.parser import parse_directory, parse_file
+from scripts.modernuo_converter.generators.loot_generator import generate_all_loot
 
 
 class LoadItemTemplateCatalogTests(unittest.TestCase):
@@ -1362,6 +1367,69 @@ class ParseFileTests(unittest.TestCase):
 
             self.assertIsNone(parsed)
 
+    def test_ignores_commented_loot_pack_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            source_path = Path(tmp_dir) / "UnfrozenMummy.cs"
+            source_path.write_text(
+                textwrap.dedent(
+                    """
+                    namespace Server.Mobiles
+                    {
+                        public class UnfrozenMummy : BaseCreature
+                        {
+                            [Constructible]
+                            public UnfrozenMummy() : base(AIType.AI_Mage)
+                            {
+                            }
+
+                            public override void GenerateLoot()
+                            {
+                                AddLoot(LootPack.UltraRich, 2);
+                                // AddLoot( LootPack.Parrot );
+                                /*
+                                AddLoot(LootPack.Miscellaneous);
+                                */
+                            }
+                        }
+                    }
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            parsed = parse_file(str(source_path))
+
+            self.assertIsNotNone(parsed)
+            self.assertEqual([{"pack": "UltraRich", "count": 2}], parsed["loot"])
+
+
+class MapPackItemsToLootTests(unittest.TestCase):
+    def test_maps_special_pack_items_to_supported_item_references(self) -> None:
+        parsed = {
+            "class_name": "StoneGargoyle",
+            "pack_items": [
+                {"item": "Reagent", "amount": 3},
+                {"item": "RandomTalisman", "amount": 1},
+                {"item": "Seed", "amount": 1},
+                {"item": "MetalChest", "amount": 1},
+                {"item": "GargoylesPickaxe", "amount": 1},
+            ],
+        }
+
+        loot = map_pack_items_to_loot(parsed)
+
+        self.assertIsNotNone(loot)
+        self.assertEqual(
+            [
+                {"itemTag": "reagents", "chance": 1.0, "amount": 3},
+                {"itemTag": "talismans", "chance": 1.0, "amount": 1},
+                {"itemTemplateId": "seed", "chance": 1.0, "amount": 1},
+                {"itemTemplateId": "metal_chest", "chance": 1.0, "amount": 1},
+                {"itemTemplateId": "gargoyles_pickaxe", "chance": 1.0, "amount": 1},
+            ],
+            loot["entries"],
+        )
+
 
 class ParseDirectoryTests(unittest.TestCase):
     def test_parse_directory_emits_each_mobile_class_from_multi_class_file(self) -> None:
@@ -1440,6 +1508,36 @@ class ParseDirectoryTests(unittest.TestCase):
             parsed = parse_directory(tmp_dir, "animals", ".")
 
             self.assertEqual([], parsed)
+
+
+class LootGeneratorTests(unittest.TestCase):
+    def test_generate_all_loot_removes_stale_creature_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_dir = Path(tmp_dir)
+            stale_path = output_dir / "templates" / "loot" / "creatures" / "creature_malefic.json"
+            stale_path.parent.mkdir(parents=True, exist_ok=True)
+            stale_path.write_text("[]\n", encoding="utf-8")
+
+            generated_paths = generate_all_loot(
+                [
+                    {
+                        "type": "loot",
+                        "id": "creature.bone_magi",
+                        "name": "BoneMagi",
+                        "category": "loot",
+                        "description": "",
+                        "mode": "additive",
+                        "entries": [{"itemTemplateId": "bone", "chance": 1.0, "amount": 1}],
+                    }
+                ],
+                str(output_dir),
+            )
+
+            self.assertEqual(
+                [str(output_dir / "templates" / "loot" / "creatures" / "creature_bone_magi.json")],
+                generated_paths,
+            )
+            self.assertFalse(stale_path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/Moongate.Tests/Server/FileLoaders/LootTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/LootTemplateLoaderTests.cs
@@ -147,43 +147,43 @@ public sealed class LootTemplateLoaderTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(lootTemplateService.TryGet("pack.low_scrolls", out var lowScrolls), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.low_scrolls", out var lowScrolls), Is.True);
                 Assert.That(lowScrolls, Is.Not.Null);
                 Assert.That(lowScrolls!.Mode, Is.EqualTo(LootTemplateMode.Additive));
                 Assert.That(lowScrolls.Entries[0].ItemTemplateId, Is.EqualTo("clumsy_scroll"));
 
-                Assert.That(lootTemplateService.TryGet("pack.med_scrolls", out var medScrolls), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.med_scrolls", out var medScrolls), Is.True);
                 Assert.That(medScrolls, Is.Not.Null);
                 Assert.That(medScrolls!.Entries[0].ItemTemplateId, Is.EqualTo("arch_cure_scroll"));
 
-                Assert.That(lootTemplateService.TryGet("pack.high_scrolls", out var highScrolls), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.high_scrolls", out var highScrolls), Is.True);
                 Assert.That(highScrolls, Is.Not.Null);
                 Assert.That(highScrolls!.Entries[0].ItemTemplateId, Is.EqualTo("summon_air_elemental_scroll"));
 
-                Assert.That(lootTemplateService.TryGet("pack.gems", out var gems), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.gems", out var gems), Is.True);
                 Assert.That(gems, Is.Not.Null);
                 Assert.That(gems!.Entries[0].ItemTemplateId, Is.EqualTo("amber"));
 
-                Assert.That(lootTemplateService.TryGet("pack.potions", out var potions), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.potions", out var potions), Is.True);
                 Assert.That(potions, Is.Not.Null);
                 Assert.That(potions!.Mode, Is.EqualTo(LootTemplateMode.Weighted));
                 Assert.That(potions.Rolls, Is.EqualTo(1));
                 Assert.That(potions.Entries, Has.Count.EqualTo(6));
 
-                Assert.That(lootTemplateService.TryGet("pack.poor", out var poor), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.poor", out var poor), Is.True);
                 Assert.That(poor, Is.Not.Null);
                 Assert.That(poor!.Mode, Is.EqualTo(LootTemplateMode.Additive));
                 Assert.That(poor.Entries.Any(entry => entry.ItemTemplateId == "gold"), Is.True);
 
-                Assert.That(lootTemplateService.TryGet("pack.meager", out var meager), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.meager", out var meager), Is.True);
                 Assert.That(meager, Is.Not.Null);
                 Assert.That(meager!.Mode, Is.EqualTo(LootTemplateMode.Additive));
-                Assert.That(meager.Entries.Any(entry => entry.ItemTemplateId == "left_arm"), Is.True);
+                Assert.That(meager.Entries.Any(entry => entry.ItemTemplateId == "gold"), Is.True);
 
-                Assert.That(lootTemplateService.TryGet("pack.average", out var average), Is.True);
+                Assert.That(lootTemplateService.TryGet("loot_pack.average", out var average), Is.True);
                 Assert.That(average, Is.Not.Null);
                 Assert.That(average!.Mode, Is.EqualTo(LootTemplateMode.Additive));
-                Assert.That(average.Entries.Any(entry => entry.ItemTemplateId == "amber"), Is.True);
+                Assert.That(average.Entries.Any(entry => entry.ItemTemplateId == "gold"), Is.True);
             }
         );
     }


### PR DESCRIPTION
## Summary
- generate canonical `loot_pack.*` templates from ModernUO `LootPack.cs` and write support item templates for loot-only references
- normalize ModernUO loot parsing so commented references are ignored and reagent/talisman helpers resolve cleanly
- regenerate mobile and creature loot data, remove stale creature loot files, and align loader tests with `loot_pack.*`

## Test Plan
- [x] `python3 -m unittest scripts.tests.test_generate_loot_templates`
- [x] `python3 -m unittest scripts.tests.test_modernuo_npc_converter`
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~LootTemplateLoaderTests|FullyQualifiedName~TemplateValidationLoaderTests"`
- [x] `dotnet test Moongate.slnx`
- [x] scanned generated data for missing loot table and item template references

Refs #183