### PR TITLE
feat: add template validator dotnet tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,12 @@
 - This includes plan documents and workflow artifacts under `docs/plans/`, `docs/superpowers/`, and nested agent-generated files below those trees.
 - Every completed feature must update the relevant documentation, integrating any missing documentation needed to describe the shipped behavior.
 - When behavior changes, update the relevant docs if the repo already documents that area.
+- When editing shard template content in the Moongate root directory (for example `~/moongate/templates/items`, `~/moongate/templates/mobiles`, `~/moongate/templates/loot`, `~/moongate/templates/factions`, `~/moongate/templates/sell_profiles`, or `~/moongate/data/containers`), always run `moongate-template validate --root-directory ~/moongate` before completion.
 
 ## Special User Commands
 
 - `/vai`: inspect every modified file first. If there are no modified files, stage the untracked files. Then create the commit without asking for confirmation. Use a Conventional Commit subject and include a detailed body covering all relevant `feat`, `fix`, `refactor`, `test`, or `docs` items instead of a single generic line.
+- `/pr`: inspect every modified file first. If there are no modified files, stage the untracked files. Then create the commit without asking for confirmation, using a Conventional Commit subject and a detailed body covering all relevant `feat`, `fix`, `refactor`, `test`, or `docs` items. Push the current branch, create the GitHub pull request targeting `develop`, verify that the PR is mergeable and required checks succeeded, then merge it into `develop` with GitHub CLI and close the tracked GitHub issue. Ask only if a required detail is missing or a GitHub step fails.
 - `/comment`: add XML documentation comments (`///`) to interfaces.
 
 ## Validation Before Completion
@@ -108,6 +110,7 @@
 - Run the narrowest meaningful validation for the area you changed before claiming completion.
 - Backend and shared code changes should normally include targeted `dotnet test` coverage.
 - Frontend changes must follow the validation gates in `ui/AGENTS.md`.
+- Template/data changes in the external shard root must include `moongate-template validate --root-directory ~/moongate` whenever item, mobile, loot, faction, sell-profile, or container data is touched.
 - If you could not run verification, say so explicitly.
 
 ## Repo-Specific Notes

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ cd moongate
 dotnet run --project src/Moongate.Server -- --root-directory ~/moongate --uo-directory ~/uo
 ```
 
+### Validate Templates
+
+Run this every time you change shard template data under your Moongate root, especially `~/moongate/templates/items`,
+`~/moongate/templates/mobiles`, `~/moongate/templates/loot`, `~/moongate/templates/factions`,
+`~/moongate/templates/sell_profiles`, or `~/moongate/data/containers`.
+
+```bash
+dotnet pack tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj -o ./tools/Moongate.TemplateValidator/nupkg
+dotnet tool install --tool-path ./artifacts/template-tool --add-source ./tools/Moongate.TemplateValidator/nupkg Moongate.TemplateValidator
+./artifacts/template-tool/moongate-template validate --root-directory ~/moongate
+```
+
+Published docs: `docs/articles/operations/template-validation.md`
+
 ### Run Server (Docker quick start)
 
 ```bash

--- a/docs/articles/operations/template-validation.md
+++ b/docs/articles/operations/template-validation.md
@@ -1,0 +1,52 @@
+# Template Validation
+
+Use `moongate-template` to validate shard templates from the command line with the same loaders and cross-template checks used during Moongate startup.
+
+This command should be part of the normal workflow whenever you edit shard data in your Moongate root directory, especially:
+
+- `~/moongate/templates/items`
+- `~/moongate/templates/mobiles`
+- `~/moongate/templates/loot`
+- `~/moongate/templates/factions`
+- `~/moongate/templates/sell_profiles`
+- `~/moongate/data/containers`
+
+## Command
+
+```bash
+moongate-template validate --root-directory ~/moongate
+```
+
+`--root-directory` must point at the shard root, not directly at `templates/`. The validator reads both `templates/**` and `data/**`.
+
+## Install From Local Package
+
+```bash
+dotnet pack tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj -o ./tools/Moongate.TemplateValidator/nupkg
+dotnet tool install --tool-path ./artifacts/template-tool --add-source ./tools/Moongate.TemplateValidator/nupkg Moongate.TemplateValidator
+./artifacts/template-tool/moongate-template validate --root-directory ~/moongate
+```
+
+## What It Validates
+
+- item template inheritance and references
+- mobile template inheritance, equipment, and references
+- loot table references
+- faction references
+- sell profile references
+- book template references
+- container layout references
+
+## Expected Result
+
+Success returns exit code `0` and prints a summary such as:
+
+```text
+Template validation completed successfully. ItemTemplates=1660, MobileTemplates=459.
+```
+
+Failures return exit code `1` and print the runtime validation errors so broken references or invalid template combinations can be fixed before server startup.
+
+## Workflow Recommendation
+
+Run the validator immediately after changing shard templates and before pushing or committing related work. This keeps the external shard root aligned with the runtime startup rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ This is the main documentation portal for Moongate v2.
 ## Operations
 
 - [Stress Test](articles/operations/stress-test.md)
+- [Template Validation](articles/operations/template-validation.md)
 - [Console Commands](articles/operations/console-commands.md)
 
 ## Development

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -96,6 +96,8 @@
   items:
   - name: Stress Test
     href: articles/operations/stress-test.md
+  - name: Template Validation
+    href: articles/operations/template-validation.md
   - name: Console Commands
     href: articles/operations/console-commands.md
 

--- a/tests/Moongate.Tests/Moongate.Tests.csproj
+++ b/tests/Moongate.Tests/Moongate.Tests.csproj
@@ -34,6 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\tools\Moongate.TemplateValidator\Moongate.TemplateValidator.csproj"/>
         <ProjectReference Include="..\..\tools\Moongate.Stress\Moongate.Stress.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Network.Packets\Moongate.Network.Packets.csproj"/>

--- a/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidateCommandTests.cs
+++ b/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidateCommandTests.cs
@@ -1,0 +1,135 @@
+using Moongate.Tests.TestSupport;
+using Moongate.TemplateValidator.Commands;
+using Moongate.TemplateValidator.Services;
+using Spectre.Console;
+
+namespace Moongate.Tests.Tools.TemplateValidator;
+
+public class TemplateValidateCommandTests
+{
+    [Test]
+    public async Task RunAsync_WhenRootDirectoryIsMissing_ShouldReturnFailure()
+    {
+        using var writer = new StringWriter();
+        var command = CreateCommand(writer);
+
+        var exitCode = await command.RunAsync(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(writer.ToString(), Does.Contain("Template validation failed"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task RunAsync_WhenValidationSucceeds_ShouldReturnSuccess()
+    {
+        using var tempDirectory = new TempDirectory();
+        using var writer = new StringWriter();
+        var rootDirectory = await CreateValidRootAsync(tempDirectory);
+        var command = CreateCommand(writer);
+
+        var exitCode = await command.RunAsync(rootDirectory);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(writer.ToString(), Does.Contain("Template validation completed successfully"));
+            }
+        );
+    }
+
+    private static TemplateValidateCommand CreateCommand(StringWriter writer)
+    {
+        var console = AnsiConsole.Create(
+            new AnsiConsoleSettings
+            {
+                Out = new AnsiConsoleOutput(writer)
+            }
+        );
+
+        return new()
+        {
+            Runner = new TemplateValidationRunner(),
+            ConsoleWriter = new TemplateValidationConsoleWriter(console)
+        };
+    }
+
+    private static async Task<string> CreateValidRootAsync(TempDirectory tempDirectory)
+    {
+        var rootDirectory = Path.Combine(tempDirectory.Path, "moongate");
+        var containersDirectory = Path.Combine(rootDirectory, "data", "containers");
+        var itemsDirectory = Path.Combine(rootDirectory, "templates", "items");
+        var mobilesDirectory = Path.Combine(rootDirectory, "templates", "mobiles");
+
+        Directory.CreateDirectory(containersDirectory);
+        Directory.CreateDirectory(itemsDirectory);
+        Directory.CreateDirectory(mobilesDirectory);
+
+        await File.WriteAllTextAsync(
+            Path.Combine(containersDirectory, "default_containers.json"),
+            """
+            [
+              { "Id": "backpack", "ItemId": 3701, "Width": 7, "Height": 4, "Name": "Backpack" }
+            ]
+            """
+        );
+
+        await File.WriteAllTextAsync(
+            Path.Combine(itemsDirectory, "items.json"),
+            """
+            [
+              {
+                "type": "item",
+                "category": "clothes",
+                "id": "shirt",
+                "name": "Shirt",
+                "description": "shirt",
+                "container": [],
+                "dyeable": false,
+                "goldValue": "0",
+                "hue": "0",
+                "isMovable": true,
+                "itemId": "0x1517",
+                "lootType": "Regular",
+                "scriptId": "items.shirt",
+                "tags": [],
+                "weight": 1.0
+              }
+            ]
+            """
+        );
+
+        await File.WriteAllTextAsync(
+            Path.Combine(mobilesDirectory, "mobiles.json"),
+            """
+            [
+              {
+                "type": "mobile",
+                "category": "test",
+                "id": "orc",
+                "title": "an orc",
+                "name": "orc",
+                "description": "valid",
+                "variants": [
+                  {
+                    "name": "default",
+                    "appearance": {
+                      "body": "0x0190",
+                      "skinHue": 0,
+                      "hairHue": 0
+                    }
+                  }
+                ]
+              }
+            ]
+            """
+        );
+
+        return rootDirectory;
+    }
+}

--- a/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidationRunnerTests.cs
+++ b/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidationRunnerTests.cs
@@ -1,0 +1,215 @@
+using Moongate.Tests.TestSupport;
+using Moongate.TemplateValidator.Services;
+
+namespace Moongate.Tests.Tools.TemplateValidator;
+
+public class TemplateValidationRunnerTests
+{
+    [Test]
+    public async Task ValidateAsync_WhenRootContainsInvalidTemplates_ShouldReturnFailure()
+    {
+        using var tempDirectory = new TempDirectory();
+        var rootDirectory = await CreateInvalidRootAsync(tempDirectory);
+        var runner = new TemplateValidationRunner();
+
+        var result = await runner.ValidateAsync(rootDirectory);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.Summary, Does.Contain("Template validation failed"));
+                Assert.That(result.Errors, Is.Not.Empty);
+                Assert.That(result.Errors.Any(static error => error.Contains("has no variants", StringComparison.Ordinal)), Is.True);
+            }
+        );
+    }
+
+    [Test]
+    public async Task ValidateAsync_WhenRootContainsValidTemplates_ShouldReturnSuccess()
+    {
+        using var tempDirectory = new TempDirectory();
+        var rootDirectory = await CreateValidRootAsync(tempDirectory);
+        var runner = new TemplateValidationRunner();
+
+        var result = await runner.ValidateAsync(rootDirectory);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(0));
+                Assert.That(result.ItemTemplateCount, Is.EqualTo(1));
+                Assert.That(result.MobileTemplateCount, Is.EqualTo(1));
+                Assert.That(result.Errors, Is.Empty);
+            }
+        );
+    }
+
+    [Test]
+    public async Task ValidateAsync_ShouldNotRequireUoDirectory()
+    {
+        using var tempDirectory = new TempDirectory();
+        var rootDirectory = await CreateValidRootAsync(tempDirectory);
+        var previous = Environment.GetEnvironmentVariable("MOONGATE_UO_DIRECTORY");
+        var runner = new TemplateValidationRunner();
+
+        Environment.SetEnvironmentVariable("MOONGATE_UO_DIRECTORY", null);
+
+        try
+        {
+            var result = await runner.ValidateAsync(rootDirectory);
+
+            Assert.That(result.ExitCode, Is.EqualTo(0));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MOONGATE_UO_DIRECTORY", previous);
+        }
+    }
+
+    [Test]
+    public async Task ValidateAsync_WhenRootDirectoryDoesNotExist_ShouldReturnFailure()
+    {
+        var runner = new TemplateValidationRunner();
+        var missingRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        var result = await runner.ValidateAsync(missingRoot);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(1));
+                Assert.That(result.Summary, Does.Contain("does not exist"));
+                Assert.That(result.Errors, Is.Not.Empty);
+            }
+        );
+    }
+
+    private static async Task<string> CreateInvalidRootAsync(TempDirectory tempDirectory)
+    {
+        var rootDirectory = CreateRootDirectory(tempDirectory);
+        await WriteContainersAsync(rootDirectory);
+        await WriteItemsAsync(rootDirectory);
+        await WriteInvalidMobilesAsync(rootDirectory);
+
+        return rootDirectory;
+    }
+
+    private static async Task<string> CreateValidRootAsync(TempDirectory tempDirectory)
+    {
+        var rootDirectory = CreateRootDirectory(tempDirectory);
+        await WriteContainersAsync(rootDirectory);
+        await WriteItemsAsync(rootDirectory);
+        await WriteValidMobilesAsync(rootDirectory);
+
+        return rootDirectory;
+    }
+
+    private static string CreateRootDirectory(TempDirectory tempDirectory)
+    {
+        var rootDirectory = Path.Combine(tempDirectory.Path, "moongate");
+        Directory.CreateDirectory(rootDirectory);
+
+        return rootDirectory;
+    }
+
+    private static Task WriteContainersAsync(string rootDirectory)
+    {
+        var containersDirectory = Path.Combine(rootDirectory, "data", "containers");
+        Directory.CreateDirectory(containersDirectory);
+
+        return File.WriteAllTextAsync(
+            Path.Combine(containersDirectory, "default_containers.json"),
+            """
+            [
+              { "Id": "backpack", "ItemId": 3701, "Width": 7, "Height": 4, "Name": "Backpack" }
+            ]
+            """
+        );
+    }
+
+    private static Task WriteItemsAsync(string rootDirectory)
+    {
+        var itemsDirectory = Path.Combine(rootDirectory, "templates", "items");
+        Directory.CreateDirectory(itemsDirectory);
+
+        return File.WriteAllTextAsync(
+            Path.Combine(itemsDirectory, "items.json"),
+            """
+            [
+              {
+                "type": "item",
+                "category": "clothes",
+                "id": "shirt",
+                "name": "Shirt",
+                "description": "shirt",
+                "container": [],
+                "dyeable": false,
+                "goldValue": "0",
+                "hue": "0",
+                "isMovable": true,
+                "itemId": "0x1517",
+                "lootType": "Regular",
+                "scriptId": "items.shirt",
+                "tags": [],
+                "weight": 1.0
+              }
+            ]
+            """
+        );
+    }
+
+    private static Task WriteInvalidMobilesAsync(string rootDirectory)
+    {
+        var mobilesDirectory = Path.Combine(rootDirectory, "templates", "mobiles");
+        Directory.CreateDirectory(mobilesDirectory);
+
+        return File.WriteAllTextAsync(
+            Path.Combine(mobilesDirectory, "mobiles.json"),
+            """
+            [
+              {
+                "type": "mobile",
+                "category": "test",
+                "id": "variantless_mobile",
+                "title": "variantless mobile",
+                "name": "variantless mobile",
+                "description": "invalid"
+              }
+            ]
+            """
+        );
+    }
+
+    private static Task WriteValidMobilesAsync(string rootDirectory)
+    {
+        var mobilesDirectory = Path.Combine(rootDirectory, "templates", "mobiles");
+        Directory.CreateDirectory(mobilesDirectory);
+
+        return File.WriteAllTextAsync(
+            Path.Combine(mobilesDirectory, "mobiles.json"),
+            """
+            [
+              {
+                "type": "mobile",
+                "category": "test",
+                "id": "orc",
+                "title": "an orc",
+                "name": "orc",
+                "description": "valid",
+                "variants": [
+                  {
+                    "name": "default",
+                    "appearance": {
+                      "body": "0x0190",
+                      "skinHue": 0,
+                      "hairHue": 0
+                    }
+                  }
+                ]
+              }
+            ]
+            """
+        );
+    }
+}

--- a/tools/Moongate.TemplateValidator/Commands/TemplateValidateCommand.cs
+++ b/tools/Moongate.TemplateValidator/Commands/TemplateValidateCommand.cs
@@ -1,0 +1,42 @@
+using ConsoleAppFramework;
+using Moongate.TemplateValidator.Services;
+
+namespace Moongate.TemplateValidator.Commands;
+
+/// <summary>
+/// Validates all supported shard templates under a Moongate root directory.
+/// </summary>
+public sealed class TemplateValidateCommand
+{
+    private TemplateValidationRunner _runner = new();
+    private TemplateValidationConsoleWriter _consoleWriter = new();
+
+    public TemplateValidationRunner Runner
+    {
+        get => _runner;
+        init => _runner = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public TemplateValidationConsoleWriter ConsoleWriter
+    {
+        get => _consoleWriter;
+        init => _consoleWriter = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public TemplateValidateCommand()
+    {
+    }
+
+    /// <summary>
+    /// Validate the shard templates under a root directory.
+    /// </summary>
+    /// <param name="rootDirectory">Path to the shard root directory.</param>
+    [Command("")]
+    public async Task<int> RunAsync(string rootDirectory, CancellationToken cancellationToken = default)
+    {
+        var result = await _runner.ValidateAsync(rootDirectory, cancellationToken);
+        _consoleWriter.Write(result);
+
+        return result.ExitCode;
+    }
+}

--- a/tools/Moongate.TemplateValidator/Data/Internal/TemplateValidatorRuntimeContext.cs
+++ b/tools/Moongate.TemplateValidator/Data/Internal/TemplateValidatorRuntimeContext.cs
@@ -1,0 +1,75 @@
+using Moongate.Core.Data.Directories;
+using Moongate.Server.Data.Config;
+using Moongate.Server.FileLoaders;
+using Moongate.Server.Services.Scripting;
+using Moongate.UO.Data.Services.Templates;
+
+namespace Moongate.TemplateValidator.Data.Internal;
+
+internal sealed class TemplateValidatorRuntimeContext
+{
+    public DirectoriesConfig DirectoriesConfig { get; }
+
+    public MoongateConfig Config { get; }
+
+    public ItemTemplateService ItemTemplateService { get; }
+
+    public MobileTemplateService MobileTemplateService { get; }
+
+    public LootTemplateService LootTemplateService { get; }
+
+    public FactionTemplateService FactionTemplateService { get; }
+
+    public SellProfileTemplateService SellProfileTemplateService { get; }
+
+    public BookTemplateService BookTemplateService { get; }
+
+    public ContainersDataLoader ContainersDataLoader { get; }
+
+    public ItemTemplateLoader ItemTemplateLoader { get; }
+
+    public MobileTemplateLoader MobileTemplateLoader { get; }
+
+    public LootTemplateLoader LootTemplateLoader { get; }
+
+    public FactionTemplateLoader FactionTemplateLoader { get; }
+
+    public SellProfileTemplateLoader SellProfileTemplateLoader { get; }
+
+    public TemplateValidationLoader TemplateValidationLoader { get; }
+
+    public TemplateValidatorRuntimeContext(
+        DirectoriesConfig directoriesConfig,
+        MoongateConfig config,
+        ItemTemplateService itemTemplateService,
+        MobileTemplateService mobileTemplateService,
+        LootTemplateService lootTemplateService,
+        FactionTemplateService factionTemplateService,
+        SellProfileTemplateService sellProfileTemplateService,
+        BookTemplateService bookTemplateService,
+        ContainersDataLoader containersDataLoader,
+        ItemTemplateLoader itemTemplateLoader,
+        MobileTemplateLoader mobileTemplateLoader,
+        LootTemplateLoader lootTemplateLoader,
+        FactionTemplateLoader factionTemplateLoader,
+        SellProfileTemplateLoader sellProfileTemplateLoader,
+        TemplateValidationLoader templateValidationLoader
+    )
+    {
+        DirectoriesConfig = directoriesConfig;
+        Config = config;
+        ItemTemplateService = itemTemplateService;
+        MobileTemplateService = mobileTemplateService;
+        LootTemplateService = lootTemplateService;
+        FactionTemplateService = factionTemplateService;
+        SellProfileTemplateService = sellProfileTemplateService;
+        BookTemplateService = bookTemplateService;
+        ContainersDataLoader = containersDataLoader;
+        ItemTemplateLoader = itemTemplateLoader;
+        MobileTemplateLoader = mobileTemplateLoader;
+        LootTemplateLoader = lootTemplateLoader;
+        FactionTemplateLoader = factionTemplateLoader;
+        SellProfileTemplateLoader = sellProfileTemplateLoader;
+        TemplateValidationLoader = templateValidationLoader;
+    }
+}

--- a/tools/Moongate.TemplateValidator/Data/TemplateValidationResult.cs
+++ b/tools/Moongate.TemplateValidator/Data/TemplateValidationResult.cs
@@ -1,0 +1,14 @@
+namespace Moongate.TemplateValidator.Data;
+
+public sealed class TemplateValidationResult
+{
+    public int ExitCode { get; init; }
+
+    public int ItemTemplateCount { get; init; }
+
+    public int MobileTemplateCount { get; init; }
+
+    public string Summary { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> Errors { get; init; } = [];
+}

--- a/tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj
+++ b/tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>moongate-template</ToolCommandName>
+        <PackageId>Moongate.TemplateValidator</PackageId>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Description>Installable .NET tool for validating Moongate shard templates with runtime-equivalent loader rules.</Description>
+        <PackageTags>moongate;ultima-online;templates;validator;dotnet-tool</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="ConsoleAppFramework" Version="5.7.13" />
+        <PackageReference Include="Spectre.Console" Version="0.54.0" />
+        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" Visible="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Moongate.Core\Moongate.Core.csproj" />
+        <ProjectReference Include="..\..\src\Moongate.Server\Moongate.Server.csproj" />
+        <ProjectReference Include="..\..\src\Moongate.UO.Data\Moongate.UO.Data.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tools/Moongate.TemplateValidator/Program.cs
+++ b/tools/Moongate.TemplateValidator/Program.cs
@@ -1,0 +1,7 @@
+using ConsoleAppFramework;
+using Moongate.TemplateValidator.Commands;
+
+var app = ConsoleApp.Create();
+app.Add<TemplateValidateCommand>("validate");
+
+await app.RunAsync(args);

--- a/tools/Moongate.TemplateValidator/README.md
+++ b/tools/Moongate.TemplateValidator/README.md
@@ -1,0 +1,20 @@
+# Moongate Template Validator
+
+Validate shard templates from the command line using the same loaders and cross-template validation rules used by Moongate runtime startup.
+
+## Usage
+
+```bash
+moongate-template validate --root-directory ~/moongate
+```
+
+Run the validator after changing shard templates in your Moongate root, especially `templates/items`, `templates/mobiles`,
+`templates/loot`, `templates/factions`, `templates/sell_profiles`, and `data/containers`.
+
+## Install From Local Package
+
+```bash
+dotnet pack tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj -o ./tools/Moongate.TemplateValidator/nupkg
+dotnet tool install --tool-path ./artifacts/template-tool --add-source ./tools/Moongate.TemplateValidator/nupkg Moongate.TemplateValidator
+./artifacts/template-tool/moongate-template validate --root-directory ~/moongate
+```

--- a/tools/Moongate.TemplateValidator/Services/TemplateValidationConsoleWriter.cs
+++ b/tools/Moongate.TemplateValidator/Services/TemplateValidationConsoleWriter.cs
@@ -1,0 +1,46 @@
+using Moongate.TemplateValidator.Data;
+using Spectre.Console;
+
+namespace Moongate.TemplateValidator.Services;
+
+public sealed class TemplateValidationConsoleWriter
+{
+    private readonly IAnsiConsole _console;
+
+    public TemplateValidationConsoleWriter()
+        : this(AnsiConsole.Console)
+    {
+    }
+
+    public TemplateValidationConsoleWriter(IAnsiConsole console)
+    {
+        _console = console ?? throw new ArgumentNullException(nameof(console));
+    }
+
+    public void Write(TemplateValidationResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.ExitCode == 0)
+        {
+            WriteSuccess(result);
+
+            return;
+        }
+
+        WriteFailure(result);
+    }
+
+    private void WriteFailure(TemplateValidationResult result)
+    {
+        _console.MarkupLine($"[red]{Markup.Escape(result.Summary)}[/]");
+
+        foreach (var error in result.Errors)
+        {
+            _console.MarkupLine($"[red]- {Markup.Escape(error)}[/]");
+        }
+    }
+
+    private void WriteSuccess(TemplateValidationResult result)
+        => _console.MarkupLine($"[green]{Markup.Escape(result.Summary)}[/]");
+}

--- a/tools/Moongate.TemplateValidator/Services/TemplateValidationRunner.cs
+++ b/tools/Moongate.TemplateValidator/Services/TemplateValidationRunner.cs
@@ -1,0 +1,107 @@
+using Moongate.Server.Interfaces.Services.Files;
+using Moongate.TemplateValidator.Data;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Moongate.TemplateValidator.Services;
+
+public sealed class TemplateValidationRunner
+{
+    private readonly TemplateValidatorCompositionRoot _compositionRoot;
+
+    public TemplateValidationRunner()
+        : this(new TemplateValidatorCompositionRoot())
+    {
+    }
+
+    public TemplateValidationRunner(TemplateValidatorCompositionRoot compositionRoot)
+    {
+        _compositionRoot = compositionRoot ?? throw new ArgumentNullException(nameof(compositionRoot));
+    }
+
+    public async Task<TemplateValidationResult> ValidateAsync(
+        string rootDirectory,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var previousLogger = Log.Logger;
+        var sink = new ValidationLogSink();
+        using var logger = new LoggerConfiguration()
+                           .MinimumLevel
+                           .Verbose()
+                           .WriteTo
+                           .Sink(sink)
+                           .CreateLogger();
+
+        Log.Logger = logger;
+
+        try
+        {
+            var context = _compositionRoot.Create(rootDirectory);
+
+            await LoadAsync(context.ContainersDataLoader, cancellationToken);
+            await LoadAsync(context.ItemTemplateLoader, cancellationToken);
+            await LoadAsync(context.MobileTemplateLoader, cancellationToken);
+            await LoadAsync(context.LootTemplateLoader, cancellationToken);
+            await LoadAsync(context.FactionTemplateLoader, cancellationToken);
+            await LoadAsync(context.SellProfileTemplateLoader, cancellationToken);
+            await LoadAsync(context.TemplateValidationLoader, cancellationToken);
+
+            return new()
+            {
+                ExitCode = 0,
+                ItemTemplateCount = context.ItemTemplateService.Count,
+                MobileTemplateCount = context.MobileTemplateService.Count,
+                Summary =
+                    $"Template validation completed successfully. ItemTemplates={context.ItemTemplateService.Count}, MobileTemplates={context.MobileTemplateService.Count}."
+            };
+        }
+        catch (Exception ex)
+        {
+            var errors = sink.GetErrors();
+
+            if (errors.Count == 0)
+            {
+                errors.Add(ex.Message);
+            }
+
+            return new()
+            {
+                ExitCode = 1,
+                Summary = $"Template validation failed: {ex.Message}",
+                Errors = errors
+            };
+        }
+        finally
+        {
+            Log.Logger = previousLogger;
+        }
+    }
+
+    private static async Task LoadAsync(IFileLoader loader, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await loader.LoadAsync();
+    }
+
+    private sealed class ValidationLogSink : ILogEventSink
+    {
+        private readonly List<string> _errors = [];
+
+        public void Emit(LogEvent logEvent)
+        {
+            ArgumentNullException.ThrowIfNull(logEvent);
+
+            if (logEvent.Level < LogEventLevel.Error)
+            {
+                return;
+            }
+
+            _errors.Add(logEvent.RenderMessage());
+        }
+
+        public List<string> GetErrors()
+            => [.._errors];
+    }
+}

--- a/tools/Moongate.TemplateValidator/Services/TemplateValidatorCompositionRoot.cs
+++ b/tools/Moongate.TemplateValidator/Services/TemplateValidatorCompositionRoot.cs
@@ -1,0 +1,91 @@
+using Moongate.Core.Data.Directories;
+using Moongate.Core.Json;
+using Moongate.Core.Types;
+using Moongate.Server.Data.Config;
+using Moongate.Server.FileLoaders;
+using Moongate.Server.Json;
+using Moongate.Server.Services.Scripting;
+using Moongate.TemplateValidator.Data.Internal;
+using Moongate.UO.Data.Services.Templates;
+
+namespace Moongate.TemplateValidator.Services;
+
+public sealed class TemplateValidatorCompositionRoot
+{
+    internal TemplateValidatorRuntimeContext Create(string rootDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
+
+        var resolvedRootDirectory = TemplateValidatorRootDirectoryResolver.Resolve(rootDirectory);
+
+        if (!Directory.Exists(resolvedRootDirectory))
+        {
+            throw new DirectoryNotFoundException(
+                $"Root directory '{resolvedRootDirectory}' does not exist."
+            );
+        }
+
+        var directoriesConfig = new DirectoriesConfig(
+            resolvedRootDirectory,
+            DirectoryType.Data,
+            DirectoryType.Templates,
+            DirectoryType.Scripts,
+            DirectoryType.Save,
+            DirectoryType.Logs,
+            DirectoryType.Cache
+        );
+        var config = LoadConfig(resolvedRootDirectory);
+
+        var itemTemplateService = new ItemTemplateService();
+        var mobileTemplateService = new MobileTemplateService();
+        var lootTemplateService = new LootTemplateService();
+        var factionTemplateService = new FactionTemplateService();
+        var sellProfileTemplateService = new SellProfileTemplateService();
+        var bookTemplateService = new BookTemplateService(directoriesConfig, config);
+
+        var containersDataLoader = new ContainersDataLoader(directoriesConfig);
+        var itemTemplateLoader = new ItemTemplateLoader(directoriesConfig, itemTemplateService);
+        var mobileTemplateLoader = new MobileTemplateLoader(directoriesConfig, mobileTemplateService);
+        var lootTemplateLoader = new LootTemplateLoader(directoriesConfig, lootTemplateService);
+        var factionTemplateLoader = new FactionTemplateLoader(directoriesConfig, factionTemplateService);
+        var sellProfileTemplateLoader = new SellProfileTemplateLoader(directoriesConfig, sellProfileTemplateService);
+        var templateValidationLoader = new TemplateValidationLoader(
+            itemTemplateService,
+            mobileTemplateService,
+            factionTemplateService,
+            sellProfileTemplateService,
+            bookTemplateService,
+            lootTemplateService
+        );
+
+        return new(
+            directoriesConfig,
+            config,
+            itemTemplateService,
+            mobileTemplateService,
+            lootTemplateService,
+            factionTemplateService,
+            sellProfileTemplateService,
+            bookTemplateService,
+            containersDataLoader,
+            itemTemplateLoader,
+            mobileTemplateLoader,
+            lootTemplateLoader,
+            factionTemplateLoader,
+            sellProfileTemplateLoader,
+            templateValidationLoader
+        );
+    }
+
+    private static MoongateConfig LoadConfig(string rootDirectory)
+    {
+        var configPath = Path.Combine(rootDirectory, "moongate.json");
+        var config = File.Exists(configPath)
+                         ? JsonUtils.DeserializeFromFile<MoongateConfig>(configPath, MoongateServerJsonContext.Default)
+                         : new MoongateConfig();
+
+        config.RootDirectory = rootDirectory;
+
+        return config;
+    }
+}

--- a/tools/Moongate.TemplateValidator/Services/TemplateValidatorRootDirectoryResolver.cs
+++ b/tools/Moongate.TemplateValidator/Services/TemplateValidatorRootDirectoryResolver.cs
@@ -1,0 +1,19 @@
+using Moongate.Core.Extensions.Directories;
+
+namespace Moongate.TemplateValidator.Services;
+
+public static class TemplateValidatorRootDirectoryResolver
+{
+    public static string Resolve(string? configuredRootDirectory)
+    {
+        var resolved = configuredRootDirectory;
+
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            resolved = Environment.GetEnvironmentVariable("MOONGATE_ROOT_DIRECTORY") ??
+                       Path.Combine(AppContext.BaseDirectory, "moongate");
+        }
+
+        return resolved.ResolvePathAndEnvs();
+    }
+}


### PR DESCRIPTION
## Summary
- add the installable `moongate-template` .NET tool with ConsoleAppFramework and Spectre.Console
- reuse the runtime template loaders and cross-template validation pipeline without requiring full server bootstrap
- document the validator workflow and update contributor rules for template validation and `/pr`

## Verification
- `git diff --check`
- `dotnet build tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj`
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~Moongate.Tests.Tools.TemplateValidator|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.TemplateValidationLoaderTests|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.ItemTemplateLoaderTests|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.MobileTemplateLoaderTests|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.LootTemplateLoaderTests|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.SellProfileTemplateLoaderTests|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.FactionTemplateLoaderTests|FullyQualifiedName~Moongate.Tests.Server.FileLoaders.ContainersDataLoaderTests"`
- `dotnet pack tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj -o ./tools/Moongate.TemplateValidator/nupkg-pr`
- `dotnet tool install --tool-path ./artifacts/template-tool-pr --add-source ./tools/Moongate.TemplateValidator/nupkg-pr Moongate.TemplateValidator`
- `DOTNET_ROOT="$(dirname "$(command -v dotnet)")" ./artifacts/template-tool-pr/moongate-template --help`
- `DOTNET_ROOT="$(dirname "$(command -v dotnet)")" ./artifacts/template-tool-pr/moongate-template validate --root-directory ~/moongate`

Refs #184
