### PR TITLE
refactor: rename Lua brain think hook to on_think

### DIFF
--- a/docs/articles/scripting/api.md
+++ b/docs/articles/scripting/api.md
@@ -579,7 +579,7 @@ local messages = {
 
 orion = {}
 
-function orion.brain_loop(npc_id)
+function orion.on_think(npc_id)
     local mob = mobile.get(npc_id)
     local last_move, last_speech, last_sound = 0, 0, 0
 

--- a/docs/articles/scripting/intelligent-npcs.md
+++ b/docs/articles/scripting/intelligent-npcs.md
@@ -97,7 +97,7 @@ function lilly.on_speech(npc_id, speaker_id, text, _speech_type, _map_id, _x, _y
     npc:say("hello to you, " .. speaker.name .. "!")
 end
 
-function lilly.brain_loop(npc_id)
+function lilly.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
         if npc ~= nil then

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -6,7 +6,7 @@ This page explains the behavior-oriented Lua AI model used by Moongate v2 NPC br
 
 Keep NPC AI maintainable by separating:
 
-- **brain orchestration** (`brain_loop`, event routing, priorities)
+- **brain orchestration** (`on_think`, event routing, priorities)
 - **behaviors** (small focused units like follow, evade, hold_position)
 - **runtime state** (blackboard values stored per NPC)
 
@@ -73,7 +73,7 @@ Custom shard-authored brains continue to use the same field, for example `ai.bra
 
 Each Lua brain table can expose:
 
-- `brain_loop(npc_serial)` required for coroutine execution
+- `on_think(npc_serial)` required for coroutine execution
 - `on_event(event_type, from_serial, event_obj)` optional
 - `on_in_range(npc_serial, source_serial, event_obj)` optional
 - `on_out_range(npc_serial, source_serial, event_obj)` optional
@@ -322,6 +322,6 @@ The behavior does nothing unless the NPC already has a backpack and at least one
 
 - Keep each behavior focused on one decision.
 - Store tunables in blackboard keys instead of hardcoding in multiple files.
-- Use `on_event` for reactive AI (speech, in-range, out-range), and `brain_loop` for tactical polling.
+- Use `on_event` for reactive AI (speech, in-range, out-range), and `on_think` for tactical polling.
 - Return explicit delay values from behaviors to control tick frequency.
 - For conversational NPCs, prefer `common.npc_dialogue` so deterministic dialogue can claim speech before `ai_dialogue` fallback.

--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -162,7 +162,7 @@ local state = {
     }),
 }
 
-function orion.brain_loop(npc_id)
+function orion.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
 
@@ -483,7 +483,7 @@ local last_move  = 0
 local last_speech = 0
 local last_sound  = 0
 
-function brain_loop(npc_id)
+function on_think(npc_id)
     while true do
         local now = os.clock() * 1000
 
@@ -528,7 +528,7 @@ end
 
 Notes:
 
-- `brain_loop` is resumed by the server tactical runner.
+- `on_think` is resumed by the server tactical runner.
 - `coroutine.yield(ms)` controls the next brain tick delay.
 - `on_event(eventType, fromSerial, eventObject)` is the primary callback for runtime brain events.
 - Current event type: `speech_heard`.
@@ -980,7 +980,7 @@ local speeches = {
     "*rubs against your leg*"
 }
 
-function brain_loop(npc_id)
+function on_think(npc_id)
     local cadence = tick.state({
         move = 1000,
         speech = 2000,

--- a/docs/articles/scripting/tick.md
+++ b/docs/articles/scripting/tick.md
@@ -83,7 +83,7 @@ local state = {
     }),
 }
 
-function orion.brain_loop(npc_id)
+function orion.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
 

--- a/docs/articles/scripting/vendor-context-menus.md
+++ b/docs/articles/scripting/vendor-context-menus.md
@@ -170,7 +170,7 @@ File: `moongate_data/scripts/ai/vendor_brain.lua`
 vendor_brain = {}
 local cliloc = require("common.cliloc_ids")
 
-function vendor_brain.brain_loop(npc_id)
+function vendor_brain.on_think(npc_id)
     while true do
         coroutine.yield(250)
     end

--- a/moongate_data/scripts/ai/brains/ai_animal.lua
+++ b/moongate_data/scripts/ai/brains/ai_animal.lua
@@ -21,7 +21,7 @@ local function clear_target(npc_serial, npc)
     end
 end
 
-function ai_animal.brain_loop(npc_serial)
+function ai_animal.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/ai_archer.lua
+++ b/moongate_data/scripts/ai/brains/ai_archer.lua
@@ -19,7 +19,7 @@ local function clear_target(npc_serial, npc)
     end
 end
 
-function ai_archer.brain_loop(npc_serial)
+function ai_archer.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/ai_berserk.lua
+++ b/moongate_data/scripts/ai/brains/ai_berserk.lua
@@ -18,7 +18,7 @@ local function clear_target(npc_serial, npc)
     end
 end
 
-function ai_berserk.brain_loop(npc_serial)
+function ai_berserk.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/ai_melee.lua
+++ b/moongate_data/scripts/ai/brains/ai_melee.lua
@@ -19,7 +19,7 @@ local function clear_target(npc_serial, npc)
     end
 end
 
-function ai_melee.brain_loop(npc_serial)
+function ai_melee.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/ai_vendor.lua
+++ b/moongate_data/scripts/ai/brains/ai_vendor.lua
@@ -30,7 +30,7 @@ local function handle_threat(npc_serial, threat_serial)
     movement.flee(npc_serial, threat_serial, FLEE_RANGE)
 end
 
-function ai_vendor.brain_loop(npc_serial)
+function ai_vendor.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/animal.lua
+++ b/moongate_data/scripts/ai/brains/animal.lua
@@ -4,7 +4,7 @@ local SEARCH_RANGE = 8
 local TICK_DELAY_MS = 3000
 local WANDER_RADIUS = 4
 
-function animal.brain_loop(npc_serial)
+function animal.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/berserk_combat.lua
+++ b/moongate_data/scripts/ai/brains/berserk_combat.lua
@@ -4,7 +4,7 @@ local SEARCH_RANGE = 12
 local TICK_DELAY_MS = 1000
 local FOLLOW_STOP_RANGE = 1
 
-function berserk_combat.brain_loop(npc_serial)
+function berserk_combat.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -94,7 +94,7 @@ local function initialize_defaults(npc_serial)
     set_default("follow_stop_range", 1)
 end
 
-function guard.brain_loop(npc_serial)
+function guard.on_think(npc_serial)
     initialize_defaults(npc_serial)
 
     while true do

--- a/moongate_data/scripts/ai/brains/healer.lua
+++ b/moongate_data/scripts/ai/brains/healer.lua
@@ -3,7 +3,7 @@ healer = {}
 
 local TICK_DELAY_MS = 3000
 
-function healer.brain_loop(npc_serial)
+function healer.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/mage_combat.lua
+++ b/moongate_data/scripts/ai/brains/mage_combat.lua
@@ -6,7 +6,7 @@ local PREFERRED_RANGE = 8
 local EVADE_THRESHOLD = 4
 local WANDER_RADIUS = 4
 
-function mage_combat.brain_loop(npc_serial)
+function mage_combat.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/melee_combat.lua
+++ b/moongate_data/scripts/ai/brains/melee_combat.lua
@@ -5,7 +5,7 @@ local TICK_DELAY_MS = 1500
 local FOLLOW_STOP_RANGE = 1
 local WANDER_RADIUS = 4
 
-function melee_combat.brain_loop(npc_serial)
+function melee_combat.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/predator.lua
+++ b/moongate_data/scripts/ai/brains/predator.lua
@@ -6,7 +6,7 @@ local TICK_DELAY_MS = 2000
 local FOLLOW_STOP_RANGE = 1
 local WANDER_RADIUS = 4
 
-function predator.brain_loop(npc_serial)
+function predator.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/ranged_combat.lua
+++ b/moongate_data/scripts/ai/brains/ranged_combat.lua
@@ -6,7 +6,7 @@ local PREFERRED_RANGE = 8
 local EVADE_THRESHOLD = 4
 local WANDER_RADIUS = 4
 
-function ranged_combat.brain_loop(npc_serial)
+function ranged_combat.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/test_state_brain.lua
+++ b/moongate_data/scripts/ai/brains/test_state_brain.lua
@@ -46,7 +46,7 @@ local function enter_state(state, duration_ms)
     tick.reset(state.cadence, "advance", time.now_ms(), duration_ms)
 end
 
-function test_state_brain.brain_loop(npc_id)
+function test_state_brain.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
 

--- a/moongate_data/scripts/ai/brains/thief.lua
+++ b/moongate_data/scripts/ai/brains/thief.lua
@@ -5,7 +5,7 @@ local TICK_DELAY_MS = 3000
 local APPROACH_RANGE = 2
 local WANDER_RADIUS = 4
 
-function thief.brain_loop(npc_serial)
+function thief.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/undead_melee.lua
+++ b/moongate_data/scripts/ai/brains/undead_melee.lua
@@ -5,7 +5,7 @@ local TICK_DELAY_MS = 2000
 local FOLLOW_STOP_RANGE = 1
 local WANDER_RADIUS = 4
 
-function undead_melee.brain_loop(npc_serial)
+function undead_melee.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/brains/utility_npc.lua
+++ b/moongate_data/scripts/ai/brains/utility_npc.lua
@@ -8,7 +8,7 @@ local BEHAVIORS = {
     "idle",
 }
 
-function utility_npc.brain_loop(npc_serial)
+function utility_npc.on_think(npc_serial)
     while true do
         local ctx = {
             now_ms = time.now_ms(),

--- a/moongate_data/scripts/ai/brains/vendor.lua
+++ b/moongate_data/scripts/ai/brains/vendor.lua
@@ -3,7 +3,7 @@ vendor = {}
 
 local TICK_DELAY_MS = 5000
 
-function vendor.brain_loop(npc_serial)
+function vendor.on_think(npc_serial)
     while true do
         local npc = mobile.get(npc_serial)
 

--- a/moongate_data/scripts/ai/npcs/lilly.lua
+++ b/moongate_data/scripts/ai/npcs/lilly.lua
@@ -20,7 +20,7 @@ function lilly.on_spawn(npc_id, _ctx)
     ensure_ai_ready(npc)
 end
 
-function lilly.brain_loop(npc_id)
+function lilly.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
         if ensure_ai_ready(npc) then

--- a/moongate_data/scripts/ai/npcs/orion.lua
+++ b/moongate_data/scripts/ai/npcs/orion.lua
@@ -20,7 +20,7 @@ local SOUNDS = {
     0x6A,
 }
 
-function orion.brain_loop(npc_id)
+function orion.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
 

--- a/moongate_data/scripts/ai/npcs/vega.lua
+++ b/moongate_data/scripts/ai/npcs/vega.lua
@@ -20,7 +20,7 @@ local SOUNDS = {
     0x6A,
 }
 
-function vega.brain_loop(npc_id)
+function vega.on_think(npc_id)
     while true do
         local npc = mobile.get(npc_id)
 

--- a/src/Moongate.Server/Data/Internal/Scripting/LuaBrainResolvedHooks.cs
+++ b/src/Moongate.Server/Data/Internal/Scripting/LuaBrainResolvedHooks.cs
@@ -6,7 +6,7 @@ namespace Moongate.Server.Data.Internal.Scripting;
 /// Resolved Lua hook references for a brain table.
 /// </summary>
 public sealed record LuaBrainResolvedHooks(
-    DynValue? BrainLoopFunction,
+    DynValue? OnThinkFunction,
     DynValue? OnSpeechFunction,
     DynValue? OnBeforeDeathFunction,
     DynValue? OnDeathFunction,

--- a/src/Moongate.Server/Services/Scripting/Internal/LuaBrainHookBinder.cs
+++ b/src/Moongate.Server/Services/Scripting/Internal/LuaBrainHookBinder.cs
@@ -23,7 +23,7 @@ internal static class LuaBrainHookBinder
         }
 
         hooks = new(
-            ResolveTableFunction(table, "brain_loop", "BrainLoop", "on_brain_tick", "OnBrainTick"),
+            ResolveTableFunction(table, "on_think", "OnThink"),
             ResolveTableFunction(table, "on_speech", "OnSpeech"),
             ResolveTableFunction(table, "on_before_death", "OnBeforeDeath"),
             ResolveTableFunction(table, "on_death", "OnDeath"),

--- a/src/Moongate.Server/Services/Scripting/Internal/LuaBrainLifecycle.cs
+++ b/src/Moongate.Server/Services/Scripting/Internal/LuaBrainLifecycle.cs
@@ -61,12 +61,12 @@ internal static class LuaBrainLifecycle
         state.OnSelectedContextMenuFunction = hooks.OnSelectedContextMenuFunction;
         state.OnEventFunction = hooks.OnEventFunction;
 
-        var brainLoop = hooks.BrainLoopFunction;
+        var onThink = hooks.OnThinkFunction;
 
-        if (brainLoop is null || brainLoop.Type != DataType.Function)
+        if (onThink is null || onThink.Type != DataType.Function)
         {
             logger.Warning(
-                "Lua brain table {BrainTable} for mobile {MobileId} does not expose brain_loop.",
+                "Lua brain table {BrainTable} for mobile {MobileId} does not expose on_think.",
                 state.BrainTableName,
                 state.MobileId
             );
@@ -77,6 +77,6 @@ internal static class LuaBrainLifecycle
             return;
         }
 
-        state.BrainCoroutine = luaScript.CreateCoroutine(brainLoop).Coroutine;
+        state.BrainCoroutine = luaScript.CreateCoroutine(onThink).Coroutine;
     }
 }

--- a/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainHookBinderTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainHookBinderTests.cs
@@ -6,13 +6,13 @@ namespace Moongate.Tests.Server.Services.Scripting;
 public sealed class LuaBrainHookBinderTests
 {
     [Test]
-    public void TryBind_ShouldResolveCombatOutcomeHooks()
+    public void TryBind_WhenOnThinkExists_ShouldResolveThinkAndCombatOutcomeHooks()
     {
         var script = new Script();
         script.DoString(
             """
             combat_brain = {
-                brain_loop = function(npc_id) coroutine.yield(250) end,
+                on_think = function(npc_id) coroutine.yield(250) end,
                 on_attack = function(target_id, context) end,
                 on_missed_attack = function(target_id, context) end,
                 on_attacked = function(attacker_id, context) end,
@@ -27,10 +27,34 @@ public sealed class LuaBrainHookBinderTests
             () =>
             {
                 Assert.That(bound, Is.True);
+                Assert.That(hooks.OnThinkFunction, Is.Not.Null);
                 Assert.That(hooks.OnAttackFunction, Is.Not.Null);
                 Assert.That(hooks.OnMissedAttackFunction, Is.Not.Null);
                 Assert.That(hooks.OnAttackedFunction, Is.Not.Null);
                 Assert.That(hooks.OnMissedByAttackFunction, Is.Not.Null);
+            }
+        );
+    }
+
+    [Test]
+    public void TryBind_WhenOnlyBrainLoopExists_ShouldNotResolveOnThink()
+    {
+        var script = new Script();
+        script.DoString(
+            """
+            legacy_brain = {
+                brain_loop = function(npc_id) coroutine.yield(250) end
+            }
+            """
+        );
+
+        var bound = LuaBrainHookBinder.TryBind(script, "legacy_brain", out var hooks);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(bound, Is.True);
+                Assert.That(hooks.OnThinkFunction, Is.Null);
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/StandardAiBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/StandardAiBrainAssetTests.cs
@@ -189,6 +189,50 @@ public sealed class StandardAiBrainAssetTests
         );
     }
 
+    [Test]
+    public void ShippedLuaBrains_ShouldExposeOnThinkAndNotBrainLoop()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var relativePaths = new[]
+        {
+            "moongate_data/scripts/ai/brains/ai_animal.lua",
+            "moongate_data/scripts/ai/brains/ai_archer.lua",
+            "moongate_data/scripts/ai/brains/ai_berserk.lua",
+            "moongate_data/scripts/ai/brains/ai_melee.lua",
+            "moongate_data/scripts/ai/brains/ai_vendor.lua",
+            "moongate_data/scripts/ai/brains/animal.lua",
+            "moongate_data/scripts/ai/brains/berserk_combat.lua",
+            "moongate_data/scripts/ai/brains/guard.lua",
+            "moongate_data/scripts/ai/brains/healer.lua",
+            "moongate_data/scripts/ai/brains/mage_combat.lua",
+            "moongate_data/scripts/ai/brains/melee_combat.lua",
+            "moongate_data/scripts/ai/brains/predator.lua",
+            "moongate_data/scripts/ai/brains/ranged_combat.lua",
+            "moongate_data/scripts/ai/brains/test_state_brain.lua",
+            "moongate_data/scripts/ai/brains/thief.lua",
+            "moongate_data/scripts/ai/brains/undead_melee.lua",
+            "moongate_data/scripts/ai/brains/utility_npc.lua",
+            "moongate_data/scripts/ai/brains/vendor.lua",
+            "moongate_data/scripts/ai/npcs/lilly.lua",
+            "moongate_data/scripts/ai/npcs/orion.lua",
+            "moongate_data/scripts/ai/npcs/vega.lua",
+        };
+
+        Assert.Multiple(
+            () =>
+            {
+                foreach (var relativePath in relativePaths)
+                {
+                    var scriptPath = Path.Combine(repositoryRoot, relativePath);
+                    var script = File.ReadAllText(scriptPath);
+
+                    Assert.That(script, Does.Contain(".on_think"), relativePath);
+                    Assert.That(script, Does.Not.Contain(".brain_loop"), relativePath);
+                }
+            }
+        );
+    }
+
     private static string GetRepositoryRoot()
         => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
 }


### PR DESCRIPTION
## Summary
- hard-cut the canonical Lua brain coroutine entry hook from `brain_loop` to `on_think`
- update the C# hook binder/lifecycle and shipped Lua brains/NPC scripts to require `on_think`
- add regression coverage and refresh scripting docs to remove legacy `brain_loop` examples

Closes #189.

## Test Plan
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~LuaBrainHookBinderTests|FullyQualifiedName~StandardAiBrainAssetTests|FullyQualifiedName~GuardBrainAssetTests|FullyQualifiedName~UndeadBrainAssetTests|FullyQualifiedName~TestMobAssetTests|FullyQualifiedName~LillyBrainAssetTests|FullyQualifiedName~MountAssetTests|FullyQualifiedName~HumanNpcTemplateAssetTests|FullyQualifiedName~LuaBrainRunnerTests"`
- `python3 -m unittest scripts.tests.test_modernuo_npc_converter`
- `dotnet test Moongate.slnx`
- `/Users/squid/.dotnet/dotnet /Users/squid/.dotnet/tools/.store/docfx/2.78.5/docfx/2.78.5/tools/net10.0/any/docfx.dll docfx.json --logLevel Warning`
