### PR TITLE
feat: port guard policy into lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Run the validator:
 moongate-template validate --root-directory ~/moongate
 ```
 
+Each validation run prints the validator version and the target root directory before the validation summary.
+
 Update an existing global installation:
 
 ```bash

--- a/docs/articles/scripting/modules.md
+++ b/docs/articles/scripting/modules.md
@@ -20,6 +20,7 @@ The following modules are available in the default server runtime:
 - `combat`
 - `steering`
 - `perception`
+- `guards`
 - `npc_state`
 - `mobile`
 - `item`
@@ -164,6 +165,15 @@ steering.stop(npcSerial)
 steering.wander(npcSerial, radius)
 ```
 
+`guards` runtime helpers:
+
+```lua
+guards.set_focus(guardSerial, targetSerialOrNil) -- stores or clears the current guard focus
+guards.get_focus(guardSerial)                    -- returns the current focus serial, or nil
+guards.teleport_to_target(guardSerial, targetSerial) -- teleports the guard to the target
+guards.try_reveal(guardSerial, targetSerial)      -- attempts to reveal a hidden target in the same map
+```
+
 `perception` runtime helpers:
 
 ```lua
@@ -172,9 +182,11 @@ perception.in_range(sourceSerial, targetSerial, range)
 perception.find_nearest_enemy(npcSerial, range)
 perception.find_nearest_player_enemy(npcSerial, range)
 perception.find_nearest_friend(npcSerial, range)
+perception.find_best_target(npcSerial, range, fightMode, playersOnly)
 ```
 
 `find_nearest_enemy(...)` and `find_nearest_player_enemy(...)` use viewer-relative AI relation resolution. This means same-faction mobiles are skipped as enemies, guards ignore innocent players, and hostile monsters can still acquire players.
+`find_best_target(...)` uses the supplied fight mode to select the best hostile target in range.
 
 `npc_state` runtime helpers:
 

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -16,7 +16,7 @@ Keep NPC AI maintainable by separating:
 moongate_data/scripts/ai/
 ├── behavior.lua                 # behavior registry
 ├── modernuo/
-│   ├── fsm.lua                  # shared phase-1 ModernUO state helpers
+│   ├── fsm.lua                  # shared phase-1 FSM helpers
 │   ├── movement.lua             # shared movement intentions
 │   └── targeting.lua            # shared fight-mode and targeting helpers
 ├── runners/
@@ -126,27 +126,28 @@ The utility runner selects the highest score, applies anti-jitter hold (`min_hol
 
 ## Guard Brain Example
 
-`guard.lua` uses these isolated behaviors:
+`guard.lua` is a custom Lua brain with explicit guard policy, not a standard `ai_archer` wrapper and not a generic utility-runner behavior set.
 
-- `leash`
-- `self_bandage`
-- `leash`
-- `evade`
-- `follow` for melee guards
-- `ranged_keep_distance` for archer guards
-- `return_home`
-- `hold_position`
+The brain owns:
+
+- focus lifecycle through `guards.set_focus(...)` and `guards.get_focus(...)`
+- melee vs ranged branching through `guard_role`
+- guard recovery / return-home behavior
+- teleport and reveal decisions through the `guards` module
+- combat-hook recovery when guards are attacked
 
 At each tick:
 
-1. build context (`now_ms`, `min_hold_ms`)
-2. ask `utility_runner` for the best behavior
-3. execute behavior
-4. `coroutine.yield(delay_ms)`
+1. read `ai.rangePerception` and `ai.rangeFight` from the template/runtime data
+2. resolve or refresh the current focus target
+3. fall back to `guard_role`-specific policy inside Lua
+4. decide whether to engage, back off, teleport, or return home
+5. `coroutine.yield(TICK_DELAY_MS)`
 
-Speech events are ignored by the guard brain for targeting decisions.
-On in-range events, the guard can greet a player once per source mobile and start combat only when a hostile target enters range.
-On ranged guard templates, `params.guard_role = "ranged"` switches the brain to a 4-6 tile spacing behavior and a longer hostile-acquisition radius.
+Speech events are still handled separately from combat. In-range events greet players once per source mobile and can arm combat when a hostile target enters range.
+Combat hooks (`attack`, `missed_attack`, `attacked`, `missed_by_attack`, `combat`) refresh focus directly from the aggressor serial.
+
+Archer guards use `guard_role = "ranged"` and keep a 4-6 tile spacing band. Melee guards use the same brain but prefer direct closure and home recovery.
 
 `undead_melee.lua` is a simpler fixed-loop brain:
 
@@ -251,13 +252,24 @@ There are three different ranges involved in guard combat:
 
 1. Acquisition range
    - This is the distance at which the Lua brain receives `in_range` for a hostile target.
-   - Melee guards use `3` tiles.
-   - Guards with `params.guard_role = "ranged"` use `10` tiles.
+   - The runner now reads `ai.rangePerception` from the template data instead of special-casing guards.
+   - Guards still use explicit template values so melee and ranged guards can differ without runner heuristics.
 2. Preferred movement band
    - Archer guards try to stay between `4` and `6` tiles from the target.
-   - Melee guards use `follow_stop_range = 1`.
+   - Melee guards close directly and recover to home when the target escapes.
 3. Actual weapon attack range
    - This is resolved by `CombatService` from the equipped weapon profile.
+
+## Guard Runtime Boundary
+
+The guard brain currently depends on:
+
+- `guards.set_focus(...)`
+- `guards.get_focus(...)`
+- `guards.teleport_to_target(...)`
+- `guards.try_reveal(...)`
+
+The generic runner is intentionally not guard-aware anymore. Guard policy lives in Lua, while C# provides thin primitives for focus, teleport, and reveal.
    - The current bow template uses `maxRange = 10`.
    - Melee weapons without explicit range metadata fall back to `1`.
 

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -1,13 +1,11 @@
 -- guard.lua
--- Utility/priority brain with isolated behaviors:
--- - "leash": drop chase when pulled too far from home
--- - "evade": run away when a threat is near or HP is low
--- - "follow": follow a target set in the blackboard
--- - "ranged_keep_distance": maintain a 4-6 tile firing band for ranged guards
--- - "return_home": walk back to the guard home point
--- - "hold_position": hold near the home point
+-- Guard policy lives here instead of in the generic runner.
+-- Melee and ranged guards share the same focus lifecycle but diverge on spacing.
 
-local utility_runner = require("ai.runners.utility_runner")
+local fsm = require("ai.modernuo.fsm")
+local movement = require("ai.modernuo.movement")
+local targeting = require("ai.modernuo.targeting")
+local guards = require("guards")
 
 guard = {}
 
@@ -15,6 +13,13 @@ local HOME_X_KEY = "home_x"
 local HOME_Y_KEY = "home_y"
 local HOME_Z_KEY = "home_z"
 local HOME_MAP_ID_KEY = "home_map_id"
+local GUARD_MODE_KEY = "guard_mode"
+local GUARD_ROLE_KEY = "guard_role"
+local PREFERRED_MIN_RANGE_KEY = "preferred_min_range"
+local PREFERRED_MAX_RANGE_KEY = "preferred_max_range"
+local HOLD_RADIUS_KEY = "hold_radius"
+local LEASH_RADIUS_KEY = "leash_radius"
+local TICK_DELAY_MS = 1500
 
 local function get_seen_key(source_serial)
     return "guard_seen_" .. tostring(source_serial)
@@ -24,100 +29,291 @@ local function get_engaged_key(source_serial)
     return "guard_engaged_" .. tostring(source_serial)
 end
 
--- Logical behavior order. The winner is selected by score.
-local MELEE_BEHAVIORS = {
-    "leash",
-    "self_bandage",
-    "evade",
-    "follow",
-    "return_home",
-    "hold_position",
-}
-
-local RANGED_BEHAVIORS = {
-    "leash",
-    "self_bandage",
-    "evade",
-    "ranged_keep_distance",
-    "return_home",
-    "hold_position",
-}
-
 local function is_ranged_guard(npc_serial)
-    return npc_state.get_var(npc_serial, "guard_role") == "ranged"
+    return tostring(npc_state.get_var(npc_serial, GUARD_ROLE_KEY) or "melee"):lower() == "ranged"
 end
 
-local function get_behaviors(npc_serial)
-    if is_ranged_guard(npc_serial) then
-        return RANGED_BEHAVIORS
+local function set_default(npc_serial, key, value)
+    if npc_state.get_var(npc_serial, key) == nil then
+        npc_state.set_var(npc_serial, key, value)
     end
-
-    return MELEE_BEHAVIORS
 end
 
--- Initialize minimal blackboard values for behaviors.
 local function initialize_defaults(npc_serial)
     local npc = mobile.get(npc_serial)
-
-    local function set_default(key, value)
-        if npc_state.get_var(npc_serial, key) == nil then
-            npc_state.set_var(npc_serial, key, value)
-        end
-    end
+    local ranged_guard = is_ranged_guard(npc_serial)
 
     if npc ~= nil then
-        set_default(HOME_X_KEY, npc.location_x)
-        set_default(HOME_Y_KEY, npc.location_y)
-        set_default(HOME_Z_KEY, npc.location_z)
-        set_default(HOME_MAP_ID_KEY, npc.map_id)
+        set_default(npc_serial, HOME_X_KEY, npc.location_x)
+        set_default(npc_serial, HOME_Y_KEY, npc.location_y)
+        set_default(npc_serial, HOME_Z_KEY, npc.location_z)
+        set_default(npc_serial, HOME_MAP_ID_KEY, npc.map_id)
     end
 
-    set_default("hold_radius", 1)
-    set_default("leash_radius", 8)
+    set_default(npc_serial, HOLD_RADIUS_KEY, 1)
+    set_default(npc_serial, LEASH_RADIUS_KEY, 8)
+    set_default(npc_serial, GUARD_MODE_KEY, ranged_guard and "ranged" or "melee")
+    set_default(npc_serial, PREFERRED_MIN_RANGE_KEY, ranged_guard and 4 or 1)
+    set_default(npc_serial, PREFERRED_MAX_RANGE_KEY, ranged_guard and 6 or 1)
+end
 
-    -- Guards should not kite by default. Ranged positioning is handled by
-    -- ranged_keep_distance, and low-hp retreat is handled by evade_hp_threshold.
-    set_default("evade_desired_range", 0)
+local function get_home_values(npc_serial)
+    local home_x = tonumber(npc_state.get_var(npc_serial, HOME_X_KEY))
+    local home_y = tonumber(npc_state.get_var(npc_serial, HOME_Y_KEY))
+    local home_z = tonumber(npc_state.get_var(npc_serial, HOME_Z_KEY))
+    local home_map_id = tonumber(npc_state.get_var(npc_serial, HOME_MAP_ID_KEY))
+    local hold_radius = tonumber(npc_state.get_var(npc_serial, HOLD_RADIUS_KEY) or 1) or 1
+    local leash_radius = tonumber(npc_state.get_var(npc_serial, LEASH_RADIUS_KEY) or 8) or 8
 
-    -- Below this HP threshold, evade gets a score bonus
-    set_default("evade_hp_threshold", 0.40)
-    set_default("self_bandage_hp_threshold", 0.45)
-    set_default("self_bandage_score_bonus", 70)
+    return home_x, home_y, home_z, home_map_id, hold_radius, leash_radius
+end
+
+local function clear_focus(npc_serial, npc)
+    guards.set_focus(npc_serial, nil)
+    fsm.clear_target(npc_serial)
+    combat.clear_target(npc_serial)
+    npc_state.set_var(npc_serial, GUARD_MODE_KEY, "idle")
+
+    if npc ~= nil then
+        npc:set_war_mode(false)
+    end
+end
+
+local function set_focus(npc_serial, target_serial)
+    guards.set_focus(npc_serial, target_serial)
+    fsm.set_target(npc_serial, target_serial)
+end
+
+local function mark_mode(npc_serial, mode)
+    npc_state.set_var(npc_serial, GUARD_MODE_KEY, mode)
+end
+
+local function move_home(npc_serial, npc)
+    local home_x, home_y, home_z, home_map_id, hold_radius = get_home_values(npc_serial)
+    if home_x == nil or home_y == nil or home_z == nil then
+        return false
+    end
+
+    mark_mode(npc_serial, "return_home")
+    fsm.set_action(npc_serial, fsm.actions.guard)
+    combat.clear_target(npc_serial)
+
+    if npc ~= nil then
+        npc:set_war_mode(false)
+    end
+
+    if npc ~= nil and home_map_id ~= nil and npc.map_id ~= home_map_id then
+        return mobile.teleport(npc_serial, home_map_id, math.floor(home_x), math.floor(home_y), math.floor(home_z))
+    end
+
+    steering.move_to(npc_serial, math.floor(home_x), math.floor(home_y), math.floor(home_z), math.max(0, math.floor(hold_radius)))
+
+    return true
+end
+
+local function should_return_home(npc_serial, npc)
+    local home_x, home_y, _, home_map_id, _, leash_radius = get_home_values(npc_serial)
+    if home_x == nil or home_y == nil or npc == nil then
+        return false
+    end
+
+    if home_map_id ~= nil and npc.map_id ~= home_map_id then
+        return true
+    end
+
+    return math.abs(npc.location_x - home_x) > leash_radius or math.abs(npc.location_y - home_y) > leash_radius
+end
+
+local function engage_target(npc_serial, target_serial)
+    local npc = mobile.get(npc_serial)
+    local target = mobile.get(target_serial)
+
+    if npc == nil or target == nil then
+        return false
+    end
+
+    set_focus(npc_serial, target_serial)
+    npc:set_target(target)
+    npc:set_war_mode(true)
+    combat.set_target(npc_serial, target_serial)
+
+    return true
+end
+
+local function handle_melee_guard(npc_serial, npc, target_serial, target, range_perception, range_fight)
+    local distance = perception.distance(npc_serial, target_serial)
+    if distance < 0 then
+        clear_focus(npc_serial, npc)
+        return false
+    end
+
+    if distance > range_perception + 2 then
+        if guards.teleport_to_target(npc_serial, target_serial) == true then
+            mark_mode(npc_serial, "combat")
+            fsm.set_action(npc_serial, fsm.actions.combat)
+            movement.combat(npc_serial, target_serial, range_fight)
+            return true
+        end
+
+        clear_focus(npc_serial, npc)
+        return move_home(npc_serial, npc)
+    end
+
+    if distance > range_fight then
+        mark_mode(npc_serial, "combat")
+        fsm.set_action(npc_serial, fsm.actions.combat)
+        movement.combat(npc_serial, target_serial, range_fight)
+        return true
+    end
+
+    mark_mode(npc_serial, "guard")
+    fsm.set_action(npc_serial, fsm.actions.guard)
+    guards.try_reveal(npc_serial, target_serial)
+    movement.guard(npc_serial)
+
+    return true
+end
+
+local function handle_ranged_guard(npc_serial, npc, target_serial, target, range_perception, range_fight)
+    local distance = perception.distance(npc_serial, target_serial)
+    if distance < 0 then
+        clear_focus(npc_serial, npc)
+        return false
+    end
+
+    local preferred_min_range = tonumber(npc_state.get_var(npc_serial, PREFERRED_MIN_RANGE_KEY) or 4) or 4
+    local preferred_max_range = tonumber(npc_state.get_var(npc_serial, PREFERRED_MAX_RANGE_KEY) or 6) or 6
+    local attack_range = combat.get_attack_range(npc_serial)
+    local follow_range = math.max(preferred_max_range, attack_range)
+
+    if distance > range_perception + 2 then
+        if guards.teleport_to_target(npc_serial, target_serial) == true then
+            mark_mode(npc_serial, "combat")
+            fsm.set_action(npc_serial, fsm.actions.combat)
+            movement.combat(npc_serial, target_serial, follow_range)
+            return true
+        end
+
+        clear_focus(npc_serial, npc)
+        return move_home(npc_serial, npc)
+    end
+
+    if distance < preferred_min_range then
+        mark_mode(npc_serial, "backoff")
+        fsm.set_action(npc_serial, fsm.actions.backoff)
+        guards.try_reveal(npc_serial, target_serial)
+        movement.backoff(npc_serial, target_serial, preferred_max_range)
+        return true
+    end
+
+    if distance > follow_range then
+        mark_mode(npc_serial, "combat")
+        fsm.set_action(npc_serial, fsm.actions.combat)
+        movement.combat(npc_serial, target_serial, follow_range)
+        return true
+    end
+
+    mark_mode(npc_serial, "guard")
+    fsm.set_action(npc_serial, fsm.actions.guard)
+    guards.try_reveal(npc_serial, target_serial)
+    movement.guard(npc_serial)
+
+    return true
+end
+
+local function handle_target(npc_serial, npc, target_serial, range_perception, range_fight)
+    local target = mobile.get(target_serial)
+    if target == nil then
+        clear_focus(npc_serial, npc)
+        return false
+    end
+
+    if target.map_id ~= npc.map_id then
+        clear_focus(npc_serial, npc)
+        return move_home(npc_serial, npc)
+    end
+
+    engage_target(npc_serial, target_serial)
 
     if is_ranged_guard(npc_serial) then
-        set_default("preferred_min_range", 4)
-        set_default("preferred_max_range", 6)
+        return handle_ranged_guard(npc_serial, npc, target_serial, target, range_perception, range_fight)
+    end
+
+    return handle_melee_guard(npc_serial, npc, target_serial, target, range_perception, range_fight)
+end
+
+local function maybe_acquire_target(npc_serial, range_perception)
+    local fight_mode = targeting.get_fight_mode(npc_serial, "aggressor")
+    return targeting.find_hostile_target(npc_serial, range_perception, fight_mode)
+end
+
+local function handle_combat_hook(npc_serial, source_serial, event_obj)
+    local npc = mobile.get(npc_serial)
+    local source = mobile.get(source_serial)
+    if npc == nil or source == nil or type(event_obj) ~= "table" then
         return
     end
 
-    -- Minimum distance while following a target
-    set_default("follow_stop_range", 1)
+    guards.try_reveal(npc_serial, source_serial)
+    set_focus(npc_serial, source_serial)
+    npc:set_target(source)
+    npc:set_war_mode(true)
+    combat.set_target(npc_serial, source_serial)
+    npc_state.set_var(npc_serial, get_engaged_key(source_serial), true)
+    mark_mode(npc_serial, is_ranged_guard(npc_serial) and "ranged" or "melee")
 end
 
 function guard.on_think(npc_serial)
     initialize_defaults(npc_serial)
 
     while true do
-        -- Context object available to behaviors
-        local ctx = {
-            now_ms = time.now_ms(),
+        local npc = mobile.get(npc_serial)
 
-            -- Prevent rapid behavior flipping for a short window
-            min_hold_ms = 600,
-        }
+        if npc ~= nil then
+            local range_perception = mobile.get_ai_range_perception(npc_serial) or (is_ranged_guard(npc_serial) and 10 or 3)
+            local range_fight = mobile.get_ai_range_fight(npc_serial) or 1
+            local target_serial = guards.get_focus(npc_serial)
 
-        -- Select best-score behavior and execute run()
-        local delay_ms = utility_runner.tick(npc_serial, ctx, get_behaviors(npc_serial))
+            if not targeting.is_target_valid(npc_serial, target_serial) then
+                target_serial = maybe_acquire_target(npc_serial, range_perception)
 
-        -- The brain decides the next tick interval
-        coroutine.yield(delay_ms)
+                if target_serial ~= nil and target_serial > 0 then
+                    set_focus(npc_serial, target_serial)
+                else
+                    clear_focus(npc_serial, npc)
+
+                    if should_return_home(npc_serial, npc) then
+                        move_home(npc_serial, npc)
+                    else
+                        mark_mode(npc_serial, "idle")
+                        fsm.set_action(npc_serial, fsm.actions.guard)
+                        movement.guard(npc_serial)
+                    end
+
+                    coroutine.yield(TICK_DELAY_MS)
+                    goto continue
+                end
+            end
+
+            if target_serial ~= nil and target_serial > 0 then
+                handle_target(npc_serial, npc, target_serial, range_perception, range_fight)
+            elseif should_return_home(npc_serial, npc) then
+                move_home(npc_serial, npc)
+            else
+                mark_mode(npc_serial, "idle")
+                fsm.set_action(npc_serial, fsm.actions.guard)
+                movement.guard(npc_serial)
+            end
+        end
+
+        coroutine.yield(TICK_DELAY_MS)
+        ::continue::
     end
 end
 
 function guard.on_event(event_type, from_serial, event_obj)
     local npc_serial = 0
 
-    -- Standard event payload: listener_npc_id for speech/in_range/out_range.
     if type(event_obj) == "table" then
         npc_serial = tonumber(event_obj.listener_npc_id or event_obj.mobile_id or 0) or 0
     end
@@ -126,8 +322,25 @@ function guard.on_event(event_type, from_serial, event_obj)
         return
     end
 
-    -- Forward the event to the active behavior (if it implements on_event)
-    utility_runner.on_event(npc_serial, {}, event_type, from_serial, event_obj)
+    if event_type == "in_range" then
+        guard.on_in_range(npc_serial, from_serial, event_obj)
+        return
+    end
+
+    if event_type == "out_range" then
+        guard.on_out_range(npc_serial, from_serial, event_obj)
+        return
+    end
+
+    if
+        event_type == "attack"
+        or event_type == "missed_attack"
+        or event_type == "attacked"
+        or event_type == "missed_by_attack"
+        or event_type == "combat"
+    then
+        handle_combat_hook(npc_serial, from_serial, event_obj)
+    end
 end
 
 function guard.on_in_range(npc_serial, source_serial, event_obj)
@@ -148,29 +361,27 @@ function guard.on_in_range(npc_serial, source_serial, event_obj)
         npc_state.set_var(npc_serial, seen_key, true)
     end
 
-    if source_is_enemy and npc_state.get_var(npc_serial, engaged_key) ~= true then
-        npc:set_target(source)
-        npc:set_war_mode(true)
-        if combat.set_target(npc_serial, source_serial) == true then
-            npc_state.set_var(npc_serial, "follow_target_serial", source_serial)
-            npc_state.set_var(npc_serial, engaged_key, true)
-        end
-    end
-
     if source_is_enemy then
-        utility_runner.on_event(npc_serial, {}, "in_range", source_serial, event_obj)
+        guards.try_reveal(npc_serial, source_serial)
+
+        if npc_state.get_var(npc_serial, engaged_key) ~= true then
+            set_focus(npc_serial, source_serial)
+            npc:set_target(source)
+            npc:set_war_mode(true)
+            combat.set_target(npc_serial, source_serial)
+            npc_state.set_var(npc_serial, engaged_key, true)
+            mark_mode(npc_serial, is_ranged_guard(npc_serial) and "ranged" or "melee")
+        end
     end
 end
 
 function guard.on_out_range(npc_serial, source_serial, event_obj)
+    _ = event_obj
+
     npc_state.set_var(npc_serial, get_engaged_key(source_serial), nil)
-    npc_state.set_var(npc_serial, "follow_target_serial", nil)
-    combat.clear_target(npc_serial)
-    utility_runner.on_event(npc_serial, {}, "out_range", source_serial, event_obj)
 end
 
 function guard.on_death(by_character, context)
-    -- Optional hook: keep empty for now.
-    -- Future example:
-    -- log.info("Guard died. killer={0}", tostring(by_character))
+    _ = by_character
+    _ = context
 end

--- a/moongate_data/templates/mobiles/guards.json
+++ b/moongate_data/templates/mobiles/guards.json
@@ -18,7 +18,9 @@
     "hits": 100,
     "ai": {
       "brain": "guard",
-      "fightMode": "aggressor"
+      "fightMode": "aggressor",
+      "rangePerception": 3,
+      "rangeFight": 1
     },
     "defaultFactionId": "true_britannians",
     "lootTables": [
@@ -84,7 +86,9 @@
     "hits": 100,
     "ai": {
       "brain": "guard",
-      "fightMode": "aggressor"
+      "fightMode": "aggressor",
+      "rangePerception": 3,
+      "rangeFight": 1
     },
     "defaultFactionId": "true_britannians",
     "lootTables": [
@@ -142,7 +146,9 @@
     "hits": 100,
     "ai": {
       "brain": "guard",
-      "fightMode": "aggressor"
+      "fightMode": "aggressor",
+      "rangePerception": 10,
+      "rangeFight": 1
     },
     "defaultFactionId": "true_britannians",
     "lootTables": [
@@ -226,7 +232,9 @@
     "hits": 100,
     "ai": {
       "brain": "guard",
-      "fightMode": "aggressor"
+      "fightMode": "aggressor",
+      "rangePerception": 10,
+      "rangeFight": 1
     },
     "defaultFactionId": "true_britannians",
     "lootTables": [

--- a/src/Moongate.Server/Modules/GuardsModule.cs
+++ b/src/Moongate.Server/Modules/GuardsModule.cs
@@ -1,0 +1,213 @@
+using Moongate.Network.Packets.Incoming.Speech;
+using Moongate.Network.Packets.Outgoing.Speech;
+using Moongate.Scripting.Attributes.Scripts;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.EvenLoop;
+using Moongate.Server.Interfaces.Services.Events;
+using Moongate.Server.Interfaces.Services.Movement;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.Server.Interfaces.Services.Speech;
+using Moongate.Server.Modules.Internal;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Types;
+using Moongate.UO.Data.Utils;
+
+namespace Moongate.Server.Modules;
+
+[ScriptModule("guards", "Provides thin guard primitives for Lua brains.")]
+
+/// <summary>
+/// Exposes guard-specific runtime helpers to Lua scripts.
+/// </summary>
+public sealed class GuardsModule
+{
+    private const string GuardFocusSerialKey = "guard_focus_serial";
+    private readonly ISpatialWorldService _spatialWorldService;
+    private readonly MobileMovementModule _movementModule;
+
+    public GuardsModule(
+        ISpatialWorldService spatialWorldService,
+        IGameNetworkSessionService gameNetworkSessionService,
+        IMovementValidationService? movementValidationService = null,
+        IPathfindingService? pathfindingService = null,
+        IGameEventBusService? gameEventBusService = null,
+        IBackgroundJobService? backgroundJobService = null,
+        ISpeechService? speechService = null
+    )
+    {
+        _spatialWorldService = spatialWorldService;
+        _movementModule = new(
+            speechService ?? NullSpeechService.Instance,
+            gameNetworkSessionService,
+            spatialWorldService,
+            movementValidationService,
+            pathfindingService,
+            gameEventBusService,
+            backgroundJobService
+        );
+    }
+
+    [ScriptFunction("set_focus", "Sets or clears the guard focus target serial.")]
+    public bool SetFocus(uint guardSerial, uint? targetSerial = null)
+    {
+        if (!MobileScriptResolver.TryResolveMobile(_spatialWorldService, guardSerial, out var resolvedGuard))
+        {
+            return false;
+        }
+
+        var guard = resolvedGuard!;
+
+        if (targetSerial is null)
+        {
+            if (!guard.CustomProperties.ContainsKey(GuardFocusSerialKey))
+            {
+                return true;
+            }
+
+            return guard.RemoveCustomProperty(GuardFocusSerialKey);
+        }
+
+        if (targetSerial == 0)
+        {
+            return false;
+        }
+
+        if (!MobileScriptResolver.TryResolveMobile(_spatialWorldService, targetSerial.Value, out var resolvedTarget))
+        {
+            return false;
+        }
+
+        guard.SetCustomInteger(GuardFocusSerialKey, (long)resolvedTarget!.Id);
+
+        return true;
+    }
+
+    [ScriptFunction("get_focus", "Gets the guard focus target serial, or nil when unavailable.")]
+    public uint? GetFocus(uint guardSerial)
+    {
+        if (!MobileScriptResolver.TryResolveMobile(_spatialWorldService, guardSerial, out var resolvedGuard))
+        {
+            return null;
+        }
+
+        var guard = resolvedGuard!;
+
+        if (!guard.TryGetCustomInteger(GuardFocusSerialKey, out var focusSerial) ||
+            focusSerial <= 0 ||
+            focusSerial > uint.MaxValue ||
+            !MobileScriptResolver.TryResolveMobile(_spatialWorldService, (uint)focusSerial, out _))
+        {
+            return null;
+        }
+
+        return (uint)focusSerial;
+    }
+
+    [ScriptFunction("teleport_to_target", "Teleports the guard to the target mobile location.")]
+    public bool TeleportToTarget(uint guardSerial, uint targetSerial)
+    {
+        if (!MobileScriptResolver.TryResolveMobile(_spatialWorldService, guardSerial, out var resolvedGuard) ||
+            !MobileScriptResolver.TryResolveMobile(_spatialWorldService, targetSerial, out var resolvedTarget))
+        {
+            return false;
+        }
+
+        var guard = resolvedGuard!;
+        var target = resolvedTarget!;
+
+        return _movementModule.Teleport(
+            guard,
+            target.MapId,
+            target.Location.X,
+            target.Location.Y,
+            target.Location.Z
+        );
+    }
+
+    private sealed class NullSpeechService : ISpeechService
+    {
+        public static readonly NullSpeechService Instance = new();
+
+        public Task<int> BroadcastFromServerAsync(
+            string text,
+            short hue = SpeechHues.System,
+            short font = SpeechHues.DefaultFont,
+            string language = "ENU"
+        )
+        {
+            _ = text;
+            _ = hue;
+            _ = font;
+            _ = language;
+
+            return Task.FromResult(0);
+        }
+
+        public Task HandleOpenChatWindowAsync(
+            GameSession session,
+            OpenChatWindowPacket packet,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = session;
+            _ = packet;
+            _ = cancellationToken;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<UnicodeSpeechMessagePacket?> ProcessIncomingSpeechAsync(
+            GameSession session,
+            UnicodeSpeechPacket speechPacket,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = session;
+            _ = speechPacket;
+            _ = cancellationToken;
+
+            return Task.FromResult<UnicodeSpeechMessagePacket?>(null);
+        }
+
+        public Task<bool> SendMessageFromServerAsync(
+            GameSession session,
+            string text,
+            short hue = SpeechHues.System,
+            short font = SpeechHues.DefaultFont,
+            string language = "ENU"
+        )
+        {
+            _ = session;
+            _ = text;
+            _ = hue;
+            _ = font;
+            _ = language;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<int> SpeakAsMobileAsync(
+            UOMobileEntity speaker,
+            string text,
+            int range = 12,
+            ChatMessageType messageType = ChatMessageType.Regular,
+            short hue = SpeechHues.Default,
+            short font = SpeechHues.DefaultFont,
+            string language = "ENU",
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = speaker;
+            _ = text;
+            _ = range;
+            _ = messageType;
+            _ = hue;
+            _ = font;
+            _ = language;
+            _ = cancellationToken;
+
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/Moongate.Server/Modules/GuardsModule.cs
+++ b/src/Moongate.Server/Modules/GuardsModule.cs
@@ -125,6 +125,28 @@ public sealed class GuardsModule
         );
     }
 
+    [ScriptFunction("try_reveal", "Attempts to reveal a hidden target mobile for the provided guard.")]
+    public bool TryReveal(uint guardSerial, uint targetSerial)
+    {
+        if (!MobileScriptResolver.TryResolveMobile(_spatialWorldService, guardSerial, out var resolvedGuard) ||
+            !MobileScriptResolver.TryResolveMobile(_spatialWorldService, targetSerial, out var resolvedTarget))
+        {
+            return false;
+        }
+
+        var guard = resolvedGuard!;
+        var target = resolvedTarget!;
+
+        if (guard.MapId != target.MapId || !target.IsHidden)
+        {
+            return false;
+        }
+
+        target.IsHidden = false;
+
+        return true;
+    }
+
     private sealed class NullSpeechService : ISpeechService
     {
         public static readonly NullSpeechService Instance = new();

--- a/src/Moongate.Server/Services/Scripting/LuaBrainRunner.cs
+++ b/src/Moongate.Server/Services/Scripting/LuaBrainRunner.cs
@@ -37,7 +37,6 @@ public sealed class LuaBrainRunner
       IGameEventListener<MobileSpawnedFromSpawnerEvent>
 {
     private const int DefaultInRangeEnterDistance = 3;
-    private const int RangedGuardInRangeEnterDistance = 10;
     private const int DefaultTickMilliseconds = 250;
     private const int FaultRetryMilliseconds = 1000;
 
@@ -393,10 +392,11 @@ public sealed class LuaBrainRunner
 
     private static int ResolveAcquisitionRange(UOMobileEntity mobile)
     {
-        if (mobile.TryGetCustomString("guard_role", out var guardRole) &&
-            string.Equals(guardRole, "ranged", StringComparison.OrdinalIgnoreCase))
+        if (mobile.TryGetCustomInteger(MobileCustomParamKeys.Ai.RangePerception, out var rangePerception) &&
+            rangePerception > 0 &&
+            rangePerception <= int.MaxValue)
         {
-            return RangedGuardInRangeEnterDistance;
+            return (int)rangePerception;
         }
 
         return DefaultInRangeEnterDistance;

--- a/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
@@ -436,6 +436,40 @@ public sealed class GuardsModuleTests
     }
 
     [Test]
+    public void SetFocus_WhenTargetSerialIsZero_ShouldReturnFalse()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x403u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        spatial.AddMobile(guard);
+        mobileService.Seed(guard);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "SetFocus", (uint)guard.Id, (uint?)0u);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.False);
+                Assert.That(guard.CustomProperties.ContainsKey(GuardFocusKey), Is.False);
+            }
+        );
+    }
+
+    [Test]
     public void TeleportToTarget_WhenTargetExists_ShouldMoveGuardToTargetLocation()
     {
         var moduleType = ResolveModuleType();

--- a/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
@@ -1,31 +1,436 @@
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Interfaces;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Interaction;
+using Moongate.Server.Interfaces.Services.Movement;
+using Moongate.Server.Interfaces.Services.Scripting;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Spatial;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Json.Regions;
+using Moongate.UO.Data.Maps;
+using Moongate.UO.Data.Persistence.Entities;
+using Moongate.UO.Data.Utils;
+using Moongate.UO.Data.Types;
+
 namespace Moongate.Tests.Server.Modules;
 
 public sealed class GuardsModuleTests
 {
+    private const string GuardFocusKey = "guard_focus_serial";
+    private const string ModuleTypeName = "Moongate.Server.Modules.GuardsModule, Moongate.Server";
+
+    private sealed class GuardsModuleTestSpatialWorldService : ISpatialWorldService
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = [];
+        private readonly List<MapSector> _sectors = [];
+
+        public void AddMobile(UOMobileEntity mobile)
+        {
+            _mobiles[mobile.Id] = mobile;
+            var sector = new MapSector(
+                mobile.MapId,
+                mobile.Location.X >> MapSectorConsts.SectorShift,
+                mobile.Location.Y >> MapSectorConsts.SectorShift
+            );
+            sector.AddEntity(mobile);
+            _sectors.Add(sector);
+        }
+
+        public void AddOrUpdateItem(UOItemEntity item, int mapId)
+        {
+            _ = item;
+            _ = mapId;
+        }
+
+        public void AddOrUpdateMobile(UOMobileEntity mobile)
+            => AddMobile(mobile);
+
+        public void AddRegion(JsonRegion region)
+        {
+            _ = region;
+        }
+
+        public Task<int> BroadcastToPlayersAsync(
+            IGameNetworkPacket packet,
+            int mapId,
+            Point3D location,
+            int? range = null,
+            long? excludeSessionId = null
+        )
+        {
+            _ = packet;
+            _ = mapId;
+            _ = location;
+            _ = range;
+            _ = excludeSessionId;
+
+            return Task.FromResult(0);
+        }
+
+        public List<MapSector> GetActiveSectors()
+            => [.. _sectors];
+
+        public List<UOMobileEntity> GetMobilesInSectorRange(int mapId, int centerSectorX, int centerSectorY, int radius = 2)
+        {
+            _ = mapId;
+            _ = centerSectorX;
+            _ = centerSectorY;
+            _ = radius;
+
+            return [];
+        }
+
+        public int GetMusic(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return 0;
+        }
+
+        public List<UOItemEntity> GetNearbyItems(Point3D location, int range, int mapId)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return [];
+        }
+
+        public List<UOMobileEntity> GetNearbyMobiles(Point3D location, int range, int mapId)
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+
+            return [];
+        }
+
+        public List<GameSession> GetPlayersInRange(
+            Point3D location,
+            int range,
+            int mapId,
+            GameSession? excludeSession = null
+        )
+        {
+            _ = location;
+            _ = range;
+            _ = mapId;
+            _ = excludeSession;
+
+            return [];
+        }
+
+        public List<UOMobileEntity> GetPlayersInSector(int mapId, int sectorX, int sectorY)
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+
+            return [];
+        }
+
+        public JsonRegion? GetRegionById(int regionId)
+        {
+            _ = regionId;
+
+            return null;
+        }
+
+        public MapSector? GetSectorByLocation(int mapId, Point3D location)
+        {
+            _ = mapId;
+            _ = location;
+
+            return null;
+        }
+
+        public SectorSystemStats GetStats()
+            => new();
+
+        public void OnItemMoved(UOItemEntity item, int mapId, Point3D oldLocation, Point3D newLocation)
+        {
+            _ = item;
+            _ = mapId;
+            _ = oldLocation;
+            _ = newLocation;
+        }
+
+        public void OnMobileMoved(UOMobileEntity mobile, Point3D oldLocation, Point3D newLocation)
+        {
+            _ = mobile;
+            _ = oldLocation;
+            _ = newLocation;
+        }
+
+        public void RemoveEntity(Serial serial)
+        {
+            _ = serial;
+        }
+    }
+
+    private sealed class GuardsModuleTestMobileService : IMobileService
+    {
+        private readonly Dictionary<Serial, UOMobileEntity> _mobiles = [];
+
+        public void Seed(UOMobileEntity mobile)
+            => _mobiles[mobile.Id] = mobile;
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles[mobile.Id] = mobile;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            return Task.FromResult(_mobiles.Remove(id));
+        }
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            _mobiles.TryGetValue(id, out var mobile);
+
+            return Task.FromResult(mobile);
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(
+            int mapId,
+            int sectorX,
+            int sectorY,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = mapId;
+            _ = sectorX;
+            _ = sectorY;
+            _ = cancellationToken;
+
+            return Task.FromResult(new List<UOMobileEntity>());
+        }
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = templateId;
+            _ = location;
+            _ = mapId;
+            _ = accountId;
+            _ = cancellationToken;
+
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> TryMountAsync(Serial riderId, Serial mountId, CancellationToken cancellationToken = default)
+        {
+            _ = riderId;
+            _ = mountId;
+            _ = cancellationToken;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(
+            string templateId,
+            Point3D location,
+            int mapId,
+            Serial? accountId = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = templateId;
+            _ = location;
+            _ = mapId;
+            _ = accountId;
+            _ = cancellationToken;
+
+            return Task.FromResult((false, (UOMobileEntity?)null));
+        }
+    }
+
+    private sealed class GuardsModuleTestCombatService : ICombatService
+    {
+        public Task<bool> ClearCombatantAsync(Serial attackerId, CancellationToken cancellationToken = default)
+        {
+            _ = attackerId;
+            _ = cancellationToken;
+
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> TrySetCombatantAsync(
+            Serial attackerId,
+            Serial defenderId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = attackerId;
+            _ = defenderId;
+            _ = cancellationToken;
+
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class GuardsModuleTestMovementValidationService : IMovementValidationService
+    {
+        public bool TryResolveMove(UOMobileEntity mobile, DirectionType direction, out Point3D newLocation)
+        {
+            _ = direction;
+            newLocation = mobile.Location;
+
+            return true;
+        }
+    }
+
+    private sealed class GuardsModuleTestPathfindingService : IPathfindingService
+    {
+        public bool TryFindPath(
+            UOMobileEntity mobile,
+            Point3D targetLocation,
+            out IReadOnlyList<DirectionType> path,
+            int maxVisitedNodes = 1024
+        )
+        {
+            _ = mobile;
+            _ = targetLocation;
+            _ = maxVisitedNodes;
+            path = [];
+
+            return false;
+        }
+    }
+
+    private sealed class GuardsModuleTestGameNetworkSessionService : IGameNetworkSessionService
+    {
+        public int Count => 0;
+
+        public void Clear()
+        {
+        }
+
+        public IReadOnlyCollection<GameSession> GetAll()
+            => [];
+
+        public GameSession GetOrCreate(MoongateTCPClient client)
+        {
+            _ = client;
+
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(long sessionId)
+        {
+            _ = sessionId;
+
+            return false;
+        }
+
+        public bool TryGet(long sessionId, out GameSession session)
+        {
+            _ = sessionId;
+            session = null!;
+
+            return false;
+        }
+
+        public bool TryGetByCharacterId(Serial characterId, out GameSession session)
+        {
+            _ = characterId;
+            session = null!;
+
+            return false;
+        }
+    }
+
+    private sealed class GuardsModuleTestNpcAiRuntimeStateService : INpcAiRuntimeStateService
+    {
+        public void BindPromptFile(Serial npcId, string promptFile)
+        {
+            _ = npcId;
+            _ = promptFile;
+        }
+
+        public bool TryAcquireIdle(Serial npcId, long nowMilliseconds, int cooldownMilliseconds)
+        {
+            _ = npcId;
+            _ = nowMilliseconds;
+            _ = cooldownMilliseconds;
+
+            return false;
+        }
+
+        public bool TryAcquireListener(Serial npcId, long nowMilliseconds, int cooldownMilliseconds)
+        {
+            _ = npcId;
+            _ = nowMilliseconds;
+            _ = cooldownMilliseconds;
+
+            return false;
+        }
+
+        public bool TryGetPromptFile(Serial npcId, out string? promptFile)
+        {
+            _ = npcId;
+            promptFile = null;
+
+            return false;
+        }
+    }
+
     [Test]
     public void SetFocus_WhenGuardAndTargetExist_ShouldPersistFocus()
     {
-        var moduleType = GetGuardsModuleType();
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x401u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var target = new UOMobileEntity
+        {
+            Id = (Serial)0x402u,
+            MapId = 1,
+            Location = new(106, 104, 0)
+        };
+        spatial.AddMobile(guard);
+        spatial.AddMobile(target);
+        mobileService.Seed(guard);
+        mobileService.Seed(target);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "SetFocus", (uint)guard.Id, (uint?)target.Id);
+        var focus = InvokeNullableUInt(moduleType, module, "GetFocus", (uint)guard.Id);
 
         Assert.Multiple(
             () =>
             {
-                Assert.That(moduleType, Is.Not.Null);
-
-                if (moduleType is null)
-                {
-                    return;
-                }
-
-                var setFocus = moduleType.GetMethod("SetFocus");
-                var getFocus = moduleType.GetMethod("GetFocus");
-
-                Assert.That(setFocus, Is.Not.Null);
-                Assert.That(getFocus, Is.Not.Null);
-                Assert.That(setFocus!.ReturnType, Is.EqualTo(typeof(bool)));
-                Assert.That(setFocus.GetParameters().Select(parameter => parameter.ParameterType), Is.EqualTo([typeof(uint), typeof(uint?)]));
-                Assert.That(getFocus!.ReturnType, Is.EqualTo(typeof(uint?)));
-                Assert.That(getFocus.GetParameters(), Is.Empty);
+                Assert.That(result, Is.True);
+                Assert.That(focus, Is.EqualTo((uint?)target.Id));
+                Assert.That(guard.TryGetCustomInteger(GuardFocusKey, out var focusSerial), Is.True);
+                Assert.That(focusSerial, Is.EqualTo((long)target.Id));
             }
         );
     }
@@ -33,27 +438,128 @@ public sealed class GuardsModuleTests
     [Test]
     public void TeleportToTarget_WhenTargetExists_ShouldMoveGuardToTargetLocation()
     {
-        var moduleType = GetGuardsModuleType();
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x411u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var target = new UOMobileEntity
+        {
+            Id = (Serial)0x412u,
+            MapId = 1,
+            Location = new(111, 122, 5)
+        };
+        spatial.AddMobile(guard);
+        spatial.AddMobile(target);
+        mobileService.Seed(guard);
+        mobileService.Seed(target);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "TeleportToTarget", (uint)guard.Id, (uint)target.Id);
 
         Assert.Multiple(
             () =>
             {
-                Assert.That(moduleType, Is.Not.Null);
-
-                if (moduleType is null)
-                {
-                    return;
-                }
-
-                var teleportToTarget = moduleType.GetMethod("TeleportToTarget");
-
-                Assert.That(teleportToTarget, Is.Not.Null);
-                Assert.That(teleportToTarget!.ReturnType, Is.EqualTo(typeof(bool)));
-                Assert.That(teleportToTarget.GetParameters().Select(parameter => parameter.ParameterType), Is.EqualTo([typeof(uint), typeof(uint)]));
+                Assert.That(result, Is.True);
+                Assert.That(guard.Location, Is.EqualTo(target.Location));
+                Assert.That(guard.MapId, Is.EqualTo(target.MapId));
             }
         );
     }
 
-    private static Type? GetGuardsModuleType()
-        => Type.GetType("Moongate.Server.Modules.GuardsModule, Moongate.Server", throwOnError: false);
+    private static object CreateModule(
+        Type moduleType,
+        GuardsModuleTestSpatialWorldService spatial,
+        GuardsModuleTestMobileService mobileService
+    )
+    {
+        var constructor = moduleType.GetConstructors().OrderByDescending(ctor => ctor.GetParameters().Length).First();
+        var arguments = constructor
+                        .GetParameters()
+                        .Select(parameter => ResolveParameter(parameter.ParameterType, spatial, mobileService))
+                        .ToArray();
+
+        return constructor.Invoke(arguments);
+    }
+
+    private static object? ResolveParameter(
+        Type parameterType,
+        GuardsModuleTestSpatialWorldService spatial,
+        GuardsModuleTestMobileService mobileService
+    )
+    {
+        if (parameterType == typeof(ISpatialWorldService))
+        {
+            return spatial;
+        }
+
+        if (parameterType == typeof(IMobileService))
+        {
+            return mobileService;
+        }
+
+        if (parameterType == typeof(ICombatService))
+        {
+            return new GuardsModuleTestCombatService();
+        }
+
+        if (parameterType == typeof(IMovementValidationService))
+        {
+            return new GuardsModuleTestMovementValidationService();
+        }
+
+        if (parameterType == typeof(IPathfindingService))
+        {
+            return new GuardsModuleTestPathfindingService();
+        }
+
+        if (parameterType == typeof(IGameNetworkSessionService))
+        {
+            return new GuardsModuleTestGameNetworkSessionService();
+        }
+
+        if (parameterType == typeof(INpcAiRuntimeStateService))
+        {
+            return new GuardsModuleTestNpcAiRuntimeStateService();
+        }
+
+        if (!parameterType.IsValueType)
+        {
+            return null;
+        }
+
+        return Activator.CreateInstance(parameterType);
+    }
+
+    private static bool InvokeBool(Type moduleType, object module, string methodName, params object?[] arguments)
+    {
+        var method = moduleType.GetMethod(methodName);
+        Assert.That(method, Is.Not.Null, $"Expected {methodName} to exist on GuardsModule.");
+
+        var result = method!.Invoke(module, arguments);
+
+        return result is bool boolResult && boolResult;
+    }
+
+    private static uint? InvokeNullableUInt(Type moduleType, object module, string methodName, params object?[] arguments)
+    {
+        var method = moduleType.GetMethod(methodName);
+        Assert.That(method, Is.Not.Null, $"Expected {methodName} to exist on GuardsModule.");
+
+        return method!.Invoke(module, arguments) is uint value ? value : null;
+    }
+
+    private static Type? ResolveModuleType()
+        => Type.GetType(ModuleTypeName, throwOnError: false);
 }

--- a/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
@@ -418,6 +418,7 @@ public sealed class GuardsModuleTests
                     GetScriptFunctionName(moduleType, "TeleportToTarget"),
                     Is.EqualTo("teleport_to_target")
                 );
+                Assert.That(GetScriptFunctionName(moduleType, "TryReveal"), Is.EqualTo("try_reveal"));
             }
         );
     }
@@ -699,6 +700,77 @@ public sealed class GuardsModuleTests
         var module = CreateModule(moduleType, spatial, mobileService);
 
         var result = InvokeBool(moduleType, module, "TeleportToTarget", (uint)guard.Id, 0u);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void TryReveal_WhenTargetIsHidden_ShouldRevealTarget()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x431u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var target = new UOMobileEntity
+        {
+            Id = (Serial)0x432u,
+            MapId = 1,
+            Location = new(101, 100, 0),
+            IsHidden = true
+        };
+        spatial.AddMobile(guard);
+        spatial.AddMobile(target);
+        mobileService.Seed(guard);
+        mobileService.Seed(target);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "TryReveal", (uint)guard.Id, (uint)target.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result, Is.True);
+                Assert.That(target.IsHidden, Is.False);
+            }
+        );
+    }
+
+    [Test]
+    public void TryReveal_WhenTargetSerialIsInvalid_ShouldReturnFalse()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x433u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        spatial.AddMobile(guard);
+        mobileService.Seed(guard);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "TryReveal", (uint)guard.Id, 0u);
 
         Assert.That(result, Is.False);
     }

--- a/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
@@ -1,5 +1,6 @@
 using Moongate.Network.Client;
 using Moongate.Network.Packets.Interfaces;
+using Moongate.Scripting.Attributes.Scripts;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Interaction;
@@ -391,6 +392,37 @@ public sealed class GuardsModuleTests
     }
 
     [Test]
+    public void GuardsModule_ShouldExposeExpectedLuaModuleAndFunctionNames()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var moduleAttribute = moduleType.GetCustomAttributes(typeof(ScriptModuleAttribute), inherit: false)
+                                        .Cast<ScriptModuleAttribute>()
+                                        .SingleOrDefault();
+
+        Assert.That(moduleAttribute, Is.Not.Null, "Expected GuardsModule to declare ScriptModuleAttribute.");
+        Assert.That(moduleAttribute!.Name, Is.EqualTo("guards"));
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(GetScriptFunctionName(moduleType, "SetFocus"), Is.EqualTo("set_focus"));
+                Assert.That(GetScriptFunctionName(moduleType, "GetFocus"), Is.EqualTo("get_focus"));
+                Assert.That(
+                    GetScriptFunctionName(moduleType, "TeleportToTarget"),
+                    Is.EqualTo("teleport_to_target")
+                );
+            }
+        );
+    }
+
+    [Test]
     public void SetFocus_WhenGuardAndTargetExist_ShouldPersistFocus()
     {
         var moduleType = ResolveModuleType();
@@ -436,6 +468,80 @@ public sealed class GuardsModuleTests
     }
 
     [Test]
+    public void GetFocus_WhenUnset_ShouldReturnNull()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x402u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        spatial.AddMobile(guard);
+        mobileService.Seed(guard);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var focus = InvokeNullableUInt(moduleType, module, "GetFocus", (uint)guard.Id);
+
+        Assert.That(focus, Is.Null);
+    }
+
+    [Test]
+    public void SetFocus_WhenTargetIsNil_ShouldClearExistingFocus()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x4021u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        var target = new UOMobileEntity
+        {
+            Id = (Serial)0x4022u,
+            MapId = 1,
+            Location = new(101, 100, 0)
+        };
+        spatial.AddMobile(guard);
+        spatial.AddMobile(target);
+        mobileService.Seed(guard);
+        mobileService.Seed(target);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var setResult = InvokeBool(moduleType, module, "SetFocus", (uint)guard.Id, (uint?)target.Id);
+        var clearResult = InvokeBool(moduleType, module, "SetFocus", (uint)guard.Id, null);
+        var focus = InvokeNullableUInt(moduleType, module, "GetFocus", (uint)guard.Id);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(setResult, Is.True);
+                Assert.That(clearResult, Is.True);
+                Assert.That(focus, Is.Null);
+                Assert.That(guard.CustomProperties.ContainsKey(GuardFocusKey), Is.False);
+            }
+        );
+    }
+
+    [Test]
     public void SetFocus_WhenTargetSerialIsZero_ShouldReturnFalse()
     {
         var moduleType = ResolveModuleType();
@@ -467,6 +573,35 @@ public sealed class GuardsModuleTests
                 Assert.That(guard.CustomProperties.ContainsKey(GuardFocusKey), Is.False);
             }
         );
+    }
+
+    [Test]
+    public void GetFocus_WhenFocusPointsToMissingTarget_ShouldReturnNull()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x404u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        guard.SetCustomInteger(GuardFocusKey, 0x499u);
+        spatial.AddMobile(guard);
+        mobileService.Seed(guard);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var focus = InvokeNullableUInt(moduleType, module, "GetFocus", (uint)guard.Id);
+
+        Assert.That(focus, Is.Null);
     }
 
     [Test]
@@ -510,6 +645,62 @@ public sealed class GuardsModuleTests
                 Assert.That(guard.MapId, Is.EqualTo(target.MapId));
             }
         );
+    }
+
+    [Test]
+    public void TeleportToTarget_WhenGuardSerialIsInvalid_ShouldReturnFalse()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var target = new UOMobileEntity
+        {
+            Id = (Serial)0x421u,
+            MapId = 1,
+            Location = new(111, 122, 5)
+        };
+        spatial.AddMobile(target);
+        mobileService.Seed(target);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "TeleportToTarget", 0u, (uint)target.Id);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void TeleportToTarget_WhenTargetSerialIsInvalid_ShouldReturnFalse()
+    {
+        var moduleType = ResolveModuleType();
+        Assert.That(moduleType, Is.Not.Null, "Create Moongate.Server.Modules.GuardsModule first.");
+
+        if (moduleType is null)
+        {
+            return;
+        }
+
+        var spatial = new GuardsModuleTestSpatialWorldService();
+        var mobileService = new GuardsModuleTestMobileService();
+        var guard = new UOMobileEntity
+        {
+            Id = (Serial)0x422u,
+            MapId = 1,
+            Location = new(100, 100, 0)
+        };
+        spatial.AddMobile(guard);
+        mobileService.Seed(guard);
+        var module = CreateModule(moduleType, spatial, mobileService);
+
+        var result = InvokeBool(moduleType, module, "TeleportToTarget", (uint)guard.Id, 0u);
+
+        Assert.That(result, Is.False);
     }
 
     private static object CreateModule(
@@ -592,6 +783,17 @@ public sealed class GuardsModuleTests
         Assert.That(method, Is.Not.Null, $"Expected {methodName} to exist on GuardsModule.");
 
         return method!.Invoke(module, arguments) is uint value ? value : null;
+    }
+
+    private static string? GetScriptFunctionName(Type moduleType, string methodName)
+    {
+        var method = moduleType.GetMethod(methodName);
+        Assert.That(method, Is.Not.Null, $"Expected {methodName} to exist on GuardsModule.");
+
+        return method!.GetCustomAttributes(typeof(ScriptFunctionAttribute), inherit: false)
+                      .Cast<ScriptFunctionAttribute>()
+                      .SingleOrDefault()
+                      ?.FunctionName;
     }
 
     private static Type? ResolveModuleType()

--- a/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Modules/GuardsModuleTests.cs
@@ -1,0 +1,59 @@
+namespace Moongate.Tests.Server.Modules;
+
+public sealed class GuardsModuleTests
+{
+    [Test]
+    public void SetFocus_WhenGuardAndTargetExist_ShouldPersistFocus()
+    {
+        var moduleType = GetGuardsModuleType();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(moduleType, Is.Not.Null);
+
+                if (moduleType is null)
+                {
+                    return;
+                }
+
+                var setFocus = moduleType.GetMethod("SetFocus");
+                var getFocus = moduleType.GetMethod("GetFocus");
+
+                Assert.That(setFocus, Is.Not.Null);
+                Assert.That(getFocus, Is.Not.Null);
+                Assert.That(setFocus!.ReturnType, Is.EqualTo(typeof(bool)));
+                Assert.That(setFocus.GetParameters().Select(parameter => parameter.ParameterType), Is.EqualTo([typeof(uint), typeof(uint?)]));
+                Assert.That(getFocus!.ReturnType, Is.EqualTo(typeof(uint?)));
+                Assert.That(getFocus.GetParameters(), Is.Empty);
+            }
+        );
+    }
+
+    [Test]
+    public void TeleportToTarget_WhenTargetExists_ShouldMoveGuardToTargetLocation()
+    {
+        var moduleType = GetGuardsModuleType();
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(moduleType, Is.Not.Null);
+
+                if (moduleType is null)
+                {
+                    return;
+                }
+
+                var teleportToTarget = moduleType.GetMethod("TeleportToTarget");
+
+                Assert.That(teleportToTarget, Is.Not.Null);
+                Assert.That(teleportToTarget!.ReturnType, Is.EqualTo(typeof(bool)));
+                Assert.That(teleportToTarget.GetParameters().Select(parameter => parameter.ParameterType), Is.EqualTo([typeof(uint), typeof(uint)]));
+            }
+        );
+    }
+
+    private static Type? GetGuardsModuleType()
+        => Type.GetType("Moongate.Server.Modules.GuardsModule, Moongate.Server", throwOnError: false);
+}

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -163,9 +163,19 @@ public sealed class GuardBrainAssetTests
                                          StringComparison.Ordinal
                                      )
                                  );
+            var ai = archer.GetProperty("ai");
 
-            Assert.That(archer.GetProperty("ai").GetProperty("rangePerception").GetInt32(), Is.EqualTo(10));
-            Assert.That(archer.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()), Is.EqualTo(new[] { "guard.archer" }));
+            Assert.Multiple(
+                () =>
+                {
+                    Assert.That(ai.TryGetProperty("rangePerception", out var rangePerception), Is.True);
+                    Assert.That(rangePerception.GetInt32(), Is.EqualTo(10));
+                    Assert.That(
+                        archer.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),
+                        Is.EqualTo(new[] { "guard.archer" })
+                    );
+                }
+            );
         }
     }
 
@@ -185,13 +195,23 @@ public sealed class GuardBrainAssetTests
                                   .First(
                                       element => string.Equals(
                                           element.GetProperty("id").GetString(),
-                                          warriorId,
-                                          StringComparison.Ordinal
-                                      )
-                                  );
+                                         warriorId,
+                                         StringComparison.Ordinal
+                                     )
+                                 );
+            var ai = warrior.GetProperty("ai");
 
-            Assert.That(warrior.GetProperty("ai").GetProperty("rangePerception").GetInt32(), Is.EqualTo(3));
-            Assert.That(warrior.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()), Is.EqualTo(new[] { "guard.warrior" }));
+            Assert.Multiple(
+                () =>
+                {
+                    Assert.That(ai.TryGetProperty("rangePerception", out var rangePerception), Is.True);
+                    Assert.That(rangePerception.GetInt32(), Is.EqualTo(3));
+                    Assert.That(
+                        warrior.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),
+                        Is.EqualTo(new[] { "guard.warrior" })
+                    );
+                }
+            );
         }
     }
 

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -168,8 +168,15 @@ public sealed class GuardBrainAssetTests
             Assert.Multiple(
                 () =>
                 {
-                    Assert.That(ai.TryGetProperty("rangePerception", out var rangePerception), Is.True);
-                    Assert.That(rangePerception.GetInt32(), Is.EqualTo(10));
+                    if (ai.TryGetProperty("rangePerception", out var rangePerception))
+                    {
+                        Assert.That(rangePerception.GetInt32(), Is.EqualTo(10));
+                    }
+                    else
+                    {
+                        Assert.Fail("Expected ai.rangePerception to exist for archer guards.");
+                    }
+
                     Assert.That(
                         archer.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),
                         Is.EqualTo(new[] { "guard.archer" })
@@ -204,8 +211,15 @@ public sealed class GuardBrainAssetTests
             Assert.Multiple(
                 () =>
                 {
-                    Assert.That(ai.TryGetProperty("rangePerception", out var rangePerception), Is.True);
-                    Assert.That(rangePerception.GetInt32(), Is.EqualTo(3));
+                    if (ai.TryGetProperty("rangePerception", out var rangePerception))
+                    {
+                        Assert.That(rangePerception.GetInt32(), Is.EqualTo(3));
+                    }
+                    else
+                    {
+                        Assert.Fail("Expected ai.rangePerception to exist for warrior guards.");
+                    }
+
                     Assert.That(
                         warrior.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),
                         Is.EqualTo(new[] { "guard.warrior" })

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -20,6 +20,8 @@ public sealed class GuardBrainAssetTests
                 Assert.That(script, Does.Contain("npc:set_target(source)"));
                 Assert.That(script, Does.Contain("npc:set_war_mode(true)"));
                 Assert.That(script, Does.Contain("combat.set_target(npc_serial, source_serial)"));
+                Assert.That(script, Does.Contain("guards.set_focus"));
+                Assert.That(script, Does.Contain("guards.teleport_to_target"));
                 Assert.That(script, Does.Contain("local function set_default(key, value)"));
                 Assert.That(script, Does.Contain("set_default(\"evade_desired_range\", 0)"));
                 Assert.That(script, Does.Contain("set_default(HOME_X_KEY, npc.location_x)"));
@@ -136,8 +138,8 @@ public sealed class GuardBrainAssetTests
 
             Assert.That(ai.GetProperty("brain").GetString(), Is.EqualTo("guard"));
             Assert.That(ai.GetProperty("fightMode").GetString(), Is.EqualTo("aggressor"));
-            Assert.That(ai.TryGetProperty("rangePerception", out _), Is.False);
-            Assert.That(ai.TryGetProperty("rangeFight", out _), Is.False);
+            Assert.That(ai.GetProperty("rangePerception").GetInt32(), Is.EqualTo(10));
+            Assert.That(ai.GetProperty("rangeFight").GetInt32(), Is.EqualTo(1));
             Assert.That(guard.TryGetProperty("brain", out _), Is.False);
             Assert.That(guard.GetProperty("defaultFactionId").GetString(), Is.EqualTo("true_britannians"));
         }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -14,112 +14,158 @@ public sealed class GuardBrainAssetTests
         Assert.Multiple(
             () =>
             {
+                Assert.That(script, Does.Contain("local guards = require(\"guards\")"));
+                Assert.That(script, Does.Contain("function guard.on_think"));
                 Assert.That(script, Does.Contain("function guard.on_in_range"));
+                Assert.That(script, Does.Contain("function guard.on_out_range"));
+                Assert.That(script, Does.Contain("function guard.on_death"));
                 Assert.That(script, Does.Contain("Hello, \" .. source_name .. \", How do you feel today?"));
                 Assert.That(script, Does.Contain("source_is_enemy"));
                 Assert.That(script, Does.Contain("npc:set_target(source)"));
                 Assert.That(script, Does.Contain("npc:set_war_mode(true)"));
                 Assert.That(script, Does.Contain("combat.set_target(npc_serial, source_serial)"));
                 Assert.That(script, Does.Contain("guards.set_focus"));
+                Assert.That(script, Does.Contain("guards.get_focus"));
                 Assert.That(script, Does.Contain("guards.teleport_to_target"));
-                Assert.That(script, Does.Contain("local function set_default(key, value)"));
-                Assert.That(script, Does.Contain("set_default(\"evade_desired_range\", 0)"));
-                Assert.That(script, Does.Contain("set_default(HOME_X_KEY, npc.location_x)"));
-                Assert.That(script, Does.Contain("set_default(\"hold_radius\", 1)"));
-                Assert.That(script, Does.Contain("set_default(\"leash_radius\", 8)"));
-                Assert.That(script, Does.Contain("\"self_bandage\""));
-                Assert.That(script, Does.Contain("set_default(\"self_bandage_hp_threshold\", 0.45)"));
-                Assert.That(script, Does.Contain("set_default(\"self_bandage_score_bonus\", 70)"));
-                Assert.That(script, Does.Not.Contain("npc_state.set_var(npc_serial, get_seen_key(source_serial), nil)"));
-                Assert.That(script, Does.Contain("if source_is_enemy then"));
-                Assert.That(script, Does.Not.Contain("event_type == \"speech_heard\""));
+                Assert.That(script, Does.Contain("guards.try_reveal"));
+                Assert.That(script, Does.Contain("guard_role"));
+                Assert.That(script, Does.Contain("guard_mode"));
+                Assert.That(script, Does.Contain("mobile.get_ai_range_perception"));
+                Assert.That(script, Does.Contain("mobile.get_ai_range_fight"));
+                Assert.That(script, Does.Contain("targeting.find_hostile_target"));
+                Assert.That(script, Does.Contain("fsm.set_target"));
+                Assert.That(script, Does.Contain("fsm.clear_target"));
+                Assert.That(script, Does.Not.Contain("utility_runner"));
             }
         );
     }
 
     [Test]
-    public void GuardBrainScript_ShouldUseRangedKeepDistanceForRangedGuards()
+    public void GuardBrainScript_ShouldBranchOnGuardRoleAndRoleSpecificRanges()
     {
         var repositoryRoot = GetRepositoryRoot();
         var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
         var script = File.ReadAllText(scriptPath);
-        var behaviorInitPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "init.lua");
-        var behaviorInit = File.ReadAllText(behaviorInitPath);
-        var behaviorPath = Path.Combine(
-            repositoryRoot,
-            "moongate_data",
-            "scripts",
-            "ai",
-            "behaviors",
-            "ranged_keep_distance.lua"
-        );
-        var followBehaviorPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "follow.lua");
-        var holdPositionPath = Path.Combine(
-            repositoryRoot,
-            "moongate_data",
-            "scripts",
-            "ai",
-            "behaviors",
-            "hold_position.lua"
-        );
-        var returnHomePath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "return_home.lua");
-        var leashPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "behaviors", "leash.lua");
-        var selfBandageBehaviorPath = Path.Combine(
-            repositoryRoot,
-            "moongate_data",
-            "scripts",
-            "ai",
-            "behaviors",
-            "self_bandage.lua"
-        );
-        var rangedKeepDistance = File.ReadAllText(behaviorPath);
-        var followBehavior = File.ReadAllText(followBehaviorPath);
-        var holdPosition = File.ReadAllText(holdPositionPath);
-        var returnHome = File.ReadAllText(returnHomePath);
-        var leash = File.ReadAllText(leashPath);
-        var selfBandageBehavior = File.ReadAllText(selfBandageBehaviorPath);
 
         Assert.Multiple(
             () =>
             {
-                Assert.That(File.Exists(behaviorPath), Is.True);
-                Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.hold_position\")"));
-                Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.return_home\")"));
-                Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.leash\")"));
-                Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.ranged_keep_distance\")"));
-                Assert.That(script, Does.Contain("\"leash\""));
-                Assert.That(script, Does.Contain("\"return_home\""));
-                Assert.That(script, Does.Contain("\"hold_position\""));
-                Assert.That(behaviorInit, Does.Contain("require(\"ai.behaviors.self_bandage\")"));
-                Assert.That(script, Does.Contain("\"ranged_keep_distance\""));
-                Assert.That(script, Does.Contain("\"leash\""));
-                Assert.That(script, Does.Contain("\"return_home\""));
-                Assert.That(script, Does.Contain("\"hold_position\""));
+                Assert.That(script, Does.Contain("local function is_ranged_guard(npc_serial)"));
                 Assert.That(script, Does.Contain("guard_role"));
+                Assert.That(script, Does.Contain("local function handle_melee_guard"));
+                Assert.That(script, Does.Contain("local function handle_ranged_guard"));
                 Assert.That(script, Does.Contain("preferred_min_range"));
                 Assert.That(script, Does.Contain("preferred_max_range"));
-                Assert.That(script, Does.Contain("local function set_default(key, value)"));
-                Assert.That(script, Does.Contain("combat.clear_target(npc_serial)"));
-                Assert.That(rangedKeepDistance, Does.Contain("combat.set_target(npc_serial, target_serial)"));
-                Assert.That(
-                    rangedKeepDistance,
-                    Does.Contain("if combat.set_target(npc_serial, target_serial) ~= true then")
-                );
-                Assert.That(rangedKeepDistance, Does.Contain("npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)"));
-                Assert.That(followBehavior, Does.Contain("combat.set_target(npc_serial, target_serial)"));
-                Assert.That(followBehavior, Does.Contain("if combat.set_target(npc_serial, target_serial) ~= true then"));
-                Assert.That(followBehavior, Does.Contain("npc_state.set_var(npc_serial, FOLLOW_TARGET_KEY, nil)"));
-                Assert.That(rangedKeepDistance, Does.Not.Contain("require(\"combat\")"));
-                Assert.That(followBehavior, Does.Not.Contain("require(\"combat\")"));
-                Assert.That(holdPosition, Does.Contain("behavior.register(\"hold_position\", M)"));
-                Assert.That(returnHome, Does.Contain("steering.move_to(npc_serial"));
-                Assert.That(returnHome, Does.Contain("behavior.register(\"return_home\", M)"));
-                Assert.That(leash, Does.Contain("combat.clear_target(npc_serial)"));
-                Assert.That(leash, Does.Contain("behavior.register(\"leash\", M)"));
-                Assert.That(selfBandageBehavior, Does.Contain("healing.begin_self_bandage(npc_serial)"));
-                Assert.That(selfBandageBehavior, Does.Contain("healing.has_bandage(npc_serial)"));
-                Assert.That(selfBandageBehavior, Does.Contain("healing.is_bandaging(npc_serial)"));
-                Assert.That(selfBandageBehavior, Does.Contain("behavior.register(\"self_bandage\", M)"));
+                Assert.That(script, Does.Contain("set_default(npc_serial, PREFERRED_MIN_RANGE_KEY, ranged_guard and 4 or 1)"));
+                Assert.That(script, Does.Contain("set_default(npc_serial, PREFERRED_MAX_RANGE_KEY, ranged_guard and 6 or 1)"));
+                Assert.That(script, Does.Contain("set_default(npc_serial, GUARD_MODE_KEY, ranged_guard and \"ranged\" or \"melee\")"));
+                Assert.That(script, Does.Contain("should_return_home"));
+                Assert.That(script, Does.Contain("move_home(npc_serial, npc)"));
+                Assert.That(script, Does.Contain("guards.try_reveal"));
+                Assert.That(script, Does.Contain("guards.teleport_to_target"));
+                Assert.That(script, Does.Contain("set_focus(npc_serial, target_serial)"));
+                Assert.That(script, Does.Contain("clear_focus(npc_serial, npc)"));
+                Assert.That(script, Does.Not.Contain("utility_runner"));
+                Assert.That(script, Does.Not.Contain("behavior.register(\"hold_position\""));
+                Assert.That(script, Does.Not.Contain("\"ranged_keep_distance\""));
+            }
+        );
+    }
+
+    [Test]
+    public void GuardBrainScript_ShouldPreserveFocusCleanupOnOutRange()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
+        var script = File.ReadAllText(scriptPath);
+        var onOutRangeStart = script.IndexOf("function guard.on_out_range", StringComparison.Ordinal);
+        var onDeathStart = script.IndexOf("function guard.on_death", StringComparison.Ordinal);
+
+        Assert.That(onOutRangeStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(onDeathStart, Is.GreaterThan(onOutRangeStart));
+
+        var onOutRangeScript = script.Substring(onOutRangeStart, onDeathStart - onOutRangeStart);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(onOutRangeScript, Does.Contain("npc_state.set_var(npc_serial, get_engaged_key(source_serial), nil)"));
+                Assert.That(onOutRangeScript, Does.Not.Contain("clear_focus(npc_serial, npc)"));
+                Assert.That(onOutRangeScript, Does.Not.Contain("guards.set_focus(npc_serial, nil)"));
+                Assert.That(onOutRangeScript, Does.Not.Contain("fsm.clear_target(npc_serial)"));
+                Assert.That(onOutRangeScript, Does.Not.Contain("combat.clear_target(npc_serial)"));
+            }
+        );
+    }
+
+    [Test]
+    public void GuardBrainScript_ShouldRefreshFocusFromCombatHooksWithoutInRangePayloadFields()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
+        var script = File.ReadAllText(scriptPath);
+        var combatHelperStart = script.IndexOf("local function handle_combat_hook", StringComparison.Ordinal);
+        var combatHelperEnd = script.IndexOf("function guard.on_think", StringComparison.Ordinal);
+        var eventHandlerStart = script.IndexOf("function guard.on_event", StringComparison.Ordinal);
+        var inRangeStart = script.IndexOf("function guard.on_in_range", StringComparison.Ordinal);
+
+        Assert.That(combatHelperStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(combatHelperEnd, Is.GreaterThan(combatHelperStart));
+        Assert.That(eventHandlerStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(inRangeStart, Is.GreaterThan(eventHandlerStart));
+
+        var combatHelperScript = script.Substring(combatHelperStart, combatHelperEnd - combatHelperStart);
+        var eventHandlerScript = script.Substring(eventHandlerStart, inRangeStart - eventHandlerStart);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(combatHelperScript, Does.Contain("guards.try_reveal(npc_serial, source_serial)"));
+                Assert.That(combatHelperScript, Does.Contain("set_focus(npc_serial, source_serial)"));
+                Assert.That(combatHelperScript, Does.Contain("npc:set_target(source)"));
+                Assert.That(combatHelperScript, Does.Contain("combat.set_target(npc_serial, source_serial)"));
+                Assert.That(combatHelperScript, Does.Not.Contain("source_is_enemy"));
+                Assert.That(combatHelperScript, Does.Not.Contain("source_name"));
+                Assert.That(eventHandlerScript, Does.Contain("event_type == \"attack\""));
+                Assert.That(eventHandlerScript, Does.Contain("event_type == \"missed_attack\""));
+                Assert.That(eventHandlerScript, Does.Contain("event_type == \"attacked\""));
+                Assert.That(eventHandlerScript, Does.Contain("event_type == \"missed_by_attack\""));
+                Assert.That(eventHandlerScript, Does.Contain("handle_combat_hook(npc_serial, from_serial, event_obj)"));
+            }
+        );
+    }
+
+    [Test]
+    public void GuardBrainScript_ShouldUseHomeMapForRecoveryAndBlockCrossMapTargets()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
+        var script = File.ReadAllText(scriptPath);
+        var moveHomeStart = script.IndexOf("local function move_home", StringComparison.Ordinal);
+        var shouldReturnHomeStart = script.IndexOf("local function should_return_home", StringComparison.Ordinal);
+        var handleTargetStart = script.IndexOf("local function handle_target", StringComparison.Ordinal);
+        var combatHelperStart = script.IndexOf("local function handle_combat_hook", StringComparison.Ordinal);
+
+        Assert.That(moveHomeStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(shouldReturnHomeStart, Is.GreaterThan(moveHomeStart));
+        Assert.That(handleTargetStart, Is.GreaterThan(shouldReturnHomeStart));
+        Assert.That(combatHelperStart, Is.GreaterThan(handleTargetStart));
+
+        var moveHomeScript = script.Substring(moveHomeStart, shouldReturnHomeStart - moveHomeStart);
+        var handleTargetScript = script.Substring(handleTargetStart, combatHelperStart - handleTargetStart);
+        var shouldReturnHomeScript = script.Substring(shouldReturnHomeStart, handleTargetStart - shouldReturnHomeStart);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(moveHomeScript, Does.Contain("home_map_id"));
+                Assert.That(moveHomeScript, Does.Contain("mobile.teleport(npc_serial, home_map_id"));
+                Assert.That(moveHomeScript, Does.Contain("steering.move_to(npc_serial"));
+                Assert.That(shouldReturnHomeScript, Does.Contain("home_map_id ~= nil and npc.map_id ~= home_map_id"));
+                Assert.That(shouldReturnHomeScript, Does.Contain("return true"));
+                Assert.That(handleTargetScript, Does.Contain("target.map_id ~= npc.map_id"));
+                Assert.That(handleTargetScript, Does.Contain("clear_focus(npc_serial, npc)"));
+                Assert.That(handleTargetScript, Does.Contain("return move_home(npc_serial, npc)"));
             }
         );
     }
@@ -177,6 +223,8 @@ public sealed class GuardBrainAssetTests
                         Assert.Fail("Expected ai.rangePerception to exist for archer guards.");
                     }
 
+                    Assert.That(ai.GetProperty("rangeFight").GetInt32(), Is.EqualTo(1));
+
                     Assert.That(
                         archer.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),
                         Is.EqualTo(new[] { "guard.archer" })
@@ -219,6 +267,8 @@ public sealed class GuardBrainAssetTests
                     {
                         Assert.Fail("Expected ai.rangePerception to exist for warrior guards.");
                     }
+
+                    Assert.That(ai.GetProperty("rangeFight").GetInt32(), Is.EqualTo(1));
 
                     Assert.That(
                         warrior.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -138,8 +138,6 @@ public sealed class GuardBrainAssetTests
 
             Assert.That(ai.GetProperty("brain").GetString(), Is.EqualTo("guard"));
             Assert.That(ai.GetProperty("fightMode").GetString(), Is.EqualTo("aggressor"));
-            Assert.That(ai.GetProperty("rangePerception").GetInt32(), Is.EqualTo(10));
-            Assert.That(ai.GetProperty("rangeFight").GetInt32(), Is.EqualTo(1));
             Assert.That(guard.TryGetProperty("brain", out _), Is.False);
             Assert.That(guard.GetProperty("defaultFactionId").GetString(), Is.EqualTo("true_britannians"));
         }
@@ -166,10 +164,7 @@ public sealed class GuardBrainAssetTests
                                      )
                                  );
 
-            Assert.That(
-                archer.GetProperty("params").GetProperty("guard_role").GetProperty("value").GetString(),
-                Is.EqualTo("ranged")
-            );
+            Assert.That(archer.GetProperty("ai").GetProperty("rangePerception").GetInt32(), Is.EqualTo(10));
             Assert.That(archer.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()), Is.EqualTo(new[] { "guard.archer" }));
         }
     }
@@ -195,10 +190,8 @@ public sealed class GuardBrainAssetTests
                                       )
                                   );
 
-            Assert.That(
-                warrior.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()),
-                Is.EqualTo(new[] { "guard.warrior" })
-            );
+            Assert.That(warrior.GetProperty("ai").GetProperty("rangePerception").GetInt32(), Is.EqualTo(3));
+            Assert.That(warrior.GetProperty("lootTables").EnumerateArray().Select(element => element.GetString()), Is.EqualTo(new[] { "guard.warrior" }));
         }
     }
 

--- a/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
@@ -214,12 +214,16 @@ public sealed class LuaBrainRunnerTests
     }
 
     [Test]
-    public void ResolveAcquisitionRange_ShouldNotSpecialCaseGuardRole()
+    public void ResolveAcquisitionRange_ShouldUseExplicitAiRangePerception()
     {
         var repositoryRoot = GetRepositoryRoot();
         var runnerPath = Path.Combine(repositoryRoot, "src", "Moongate.Server", "Services", "Scripting", "LuaBrainRunner.cs");
         var source = File.ReadAllText(runnerPath);
 
+        Assert.That(
+            source,
+            Does.Contain("MobileCustomParamKeys.Ai.RangePerception")
+        );
         Assert.That(
             source,
             Does.Not.Contain("guard_role")

--- a/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
@@ -205,6 +205,9 @@ public sealed class LuaBrainRunnerTests
                 if (inRangeEvents.Count == 1)
                 {
                     Assert.That(inRangeEvents[0].Args[1], Is.EqualTo((uint)zombie.Id));
+                    var payload = (Dictionary<string, object>)inRangeEvents[0].Args[2]!;
+                    Assert.That(payload["listener_npc_id"], Is.EqualTo((uint)archerGuard.Id));
+                    Assert.That(payload["listener_npc_id"], Is.Not.EqualTo((uint)warriorGuard.Id));
                 }
             }
         );

--- a/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
@@ -214,6 +214,19 @@ public sealed class LuaBrainRunnerTests
     }
 
     [Test]
+    public void ResolveAcquisitionRange_ShouldNotSpecialCaseGuardRole()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var runnerPath = Path.Combine(repositoryRoot, "src", "Moongate.Server", "Services", "Scripting", "LuaBrainRunner.cs");
+        var source = File.ReadAllText(runnerPath);
+
+        Assert.That(
+            source,
+            Does.Not.Contain("guard_role")
+        );
+    }
+
+    [Test]
     public async Task HandleAsync_WhenEnemyMobileWithoutBrainIsAdded_ShouldPreserveEnemyPayload()
     {
         using var temp = new TempDirectory();
@@ -951,4 +964,7 @@ public sealed class LuaBrainRunnerTests
             }
         );
     }
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
 }

--- a/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/LuaBrainRunnerTests.cs
@@ -147,7 +147,7 @@ public sealed class LuaBrainRunnerTests
 
     [Test]
     public async Task
-        HandleAsync_WhenEnemyMobileIsWithinRangedGuardAcquisitionRange_ShouldNotifyRangedGuardButNotMeleeGuard()
+        HandleAsync_WhenEnemyMobileUsesTemplateRangePerception_ShouldNotifyRangedGuardButNotMeleeGuard()
     {
         using var temp = new TempDirectory();
         var timerService = new LuaBrainRunnerTimerServiceSpy();
@@ -180,7 +180,8 @@ public sealed class LuaBrainRunnerTests
             Notoriety = Notoriety.CanBeAttacked
         };
 
-        archerGuard.SetCustomString("guard_role", "ranged");
+        archerGuard.SetCustomInteger(MobileCustomParamKeys.Ai.RangePerception, 10);
+        warriorGuard.SetCustomInteger(MobileCustomParamKeys.Ai.RangePerception, 3);
 
         runner.Register(archerGuard, archerGuard.BrainId);
         runner.Register(warriorGuard, warriorGuard.BrainId);

--- a/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidateCommandTests.cs
+++ b/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidateCommandTests.cs
@@ -11,14 +11,18 @@ public class TemplateValidateCommandTests
     public async Task RunAsync_WhenRootDirectoryIsMissing_ShouldReturnFailure()
     {
         using var writer = new StringWriter();
+        var rootDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         var command = CreateCommand(writer);
 
-        var exitCode = await command.RunAsync(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var exitCode = await command.RunAsync(rootDirectory);
+        var normalizedOutput = writer.ToString().Replace(Environment.NewLine, string.Empty);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(exitCode, Is.EqualTo(1));
+                Assert.That(writer.ToString(), Does.Contain("Moongate Template Validator 1.1.0"));
+                Assert.That(normalizedOutput, Does.Contain(rootDirectory));
                 Assert.That(writer.ToString(), Does.Contain("Template validation failed"));
             }
         );
@@ -33,11 +37,14 @@ public class TemplateValidateCommandTests
         var command = CreateCommand(writer);
 
         var exitCode = await command.RunAsync(rootDirectory);
+        var normalizedOutput = writer.ToString().Replace(Environment.NewLine, string.Empty);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(exitCode, Is.EqualTo(0));
+                Assert.That(writer.ToString(), Does.Contain("Moongate Template Validator 1.1.0"));
+                Assert.That(normalizedOutput, Does.Contain(rootDirectory));
                 Assert.That(writer.ToString(), Does.Contain("Template validation completed successfully"));
             }
         );

--- a/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidatorVersionMetadataTests.cs
+++ b/tests/Moongate.Tests/Tools/TemplateValidator/TemplateValidatorVersionMetadataTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Moongate.TemplateValidator.Commands;
+
+namespace Moongate.Tests.Tools.TemplateValidator;
+
+public sealed class TemplateValidatorVersionMetadataTests
+{
+    [Test]
+    public void TemplateValidatorAssemblyInformationalVersion_ShouldMatchRepositoryVersion()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var directoryBuildPropsPath = Path.Combine(repositoryRoot, "Directory.Build.props");
+        var document = XDocument.Load(directoryBuildPropsPath);
+        var expectedVersion = document.Root?
+            .Elements("PropertyGroup")
+            .Elements("Version")
+            .Select(static element => element.Value.Trim())
+            .FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+        var assembly = typeof(TemplateValidateCommand).Assembly;
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(expectedVersion, Is.Not.Null.And.Not.Empty);
+                Assert.That(informationalVersion, Is.EqualTo(expectedVersion));
+            }
+        );
+    }
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+}

--- a/tools/Moongate.TemplateValidator/Commands/TemplateValidateCommand.cs
+++ b/tools/Moongate.TemplateValidator/Commands/TemplateValidateCommand.cs
@@ -35,7 +35,7 @@ public sealed class TemplateValidateCommand
     public async Task<int> RunAsync(string rootDirectory, CancellationToken cancellationToken = default)
     {
         var result = await _runner.ValidateAsync(rootDirectory, cancellationToken);
-        _consoleWriter.Write(result);
+        _consoleWriter.Write(rootDirectory, result);
 
         return result.ExitCode;
     }

--- a/tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj
+++ b/tools/Moongate.TemplateValidator/Moongate.TemplateValidator.csproj
@@ -8,6 +8,8 @@
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>moongate-template</ToolCommandName>
         <PackageId>Moongate.TemplateValidator</PackageId>
+        <InformationalVersion>$(Version)</InformationalVersion>
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Description>Installable .NET tool for validating Moongate shard templates with runtime-equivalent loader rules.</Description>
         <PackageTags>moongate;ultima-online;templates;validator;dotnet-tool</PackageTags>

--- a/tools/Moongate.TemplateValidator/README.md
+++ b/tools/Moongate.TemplateValidator/README.md
@@ -11,6 +11,8 @@ moongate-template validate --root-directory ~/moongate
 Run the validator after changing shard templates in your Moongate root, especially `templates/items`, `templates/mobiles`,
 `templates/loot`, `templates/factions`, `templates/sell_profiles`, and `data/containers`.
 
+Each validation run prints the validator version and the target root directory before the validation summary.
+
 ## Install From NuGet
 
 ```bash

--- a/tools/Moongate.TemplateValidator/Services/TemplateValidationConsoleWriter.cs
+++ b/tools/Moongate.TemplateValidator/Services/TemplateValidationConsoleWriter.cs
@@ -1,10 +1,12 @@
 using Moongate.TemplateValidator.Data;
 using Spectre.Console;
+using System.Reflection;
 
 namespace Moongate.TemplateValidator.Services;
 
 public sealed class TemplateValidationConsoleWriter
 {
+    private const string ToolName = "Moongate Template Validator";
     private readonly IAnsiConsole _console;
 
     public TemplateValidationConsoleWriter()
@@ -17,9 +19,12 @@ public sealed class TemplateValidationConsoleWriter
         _console = console ?? throw new ArgumentNullException(nameof(console));
     }
 
-    public void Write(TemplateValidationResult result)
+    public void Write(string rootDirectory, TemplateValidationResult result)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
         ArgumentNullException.ThrowIfNull(result);
+
+        WriteHeader(rootDirectory);
 
         if (result.ExitCode == 0)
         {
@@ -29,6 +34,19 @@ public sealed class TemplateValidationConsoleWriter
         }
 
         WriteFailure(result);
+    }
+
+    private void WriteHeader(string rootDirectory)
+    {
+        var informationalVersion = typeof(TemplateValidationConsoleWriter)
+            .Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        var version = string.IsNullOrWhiteSpace(informationalVersion) ? "unknown" : informationalVersion;
+
+        _console.MarkupLine($"[grey]{Markup.Escape($"{ToolName} {version}")}[/]");
+        _console.MarkupLine($"[grey]Root directory: {Markup.Escape(rootDirectory)}[/]");
     }
 
     private void WriteFailure(TemplateValidationResult result)


### PR DESCRIPTION
## Summary
- move guard-specific behavior out of the generic Lua brain runner and into `guard.lua`
- add thin `guards` module primitives for focus, teleport, and reveal support
- make guard acquisition explicit in templates and document the new guard/runtime boundary

Closes #194

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~GuardsModuleTests|FullyQualifiedName~GuardBrainAssetTests|FullyQualifiedName~LuaBrainRunnerTests|FullyQualifiedName~StandardAiBrainAssetTests"`
- [x] `dotnet test Moongate.slnx`
- [x] `docfx docs/docfx.json --logLevel Warning`
- [x] `luac -p moongate_data/scripts/ai/brains/guard.lua`
