### PR TITLE
feat: add optional guard random roam patrol

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,12 @@ UI default URL: `http://localhost:8088/`
 - Docs home: `docs/index.md`
 - Getting started: `docs/articles/getting-started/`
 - Architecture: `docs/articles/architecture/`
-- Scripting: `docs/articles/scripting/`
+- Beginner content authoring: `docs/articles/scripting/create-your-first-content.md`
+- Beginner systems path: `docs/articles/scripting/create-your-first-systems.md`
+- Scripting: `docs/articles/scripting/` including authored dialogues, scheduled events, starting loadout, and loot containers
 - Persistence: `docs/articles/persistence/`
-- Networking/protocol: `docs/articles/networking/`
-- Client encryption: `docs/articles/networking/client-encryption.md`
-- Operations/stress test: `docs/articles/operations/stress-test.md`
+- Networking/protocol: `docs/articles/networking/` including client encryption and the UDP ping server
+- Operations: `docs/articles/operations/` including template validation, in-game item admin commands, and help ticket workflow
 
 Published docs: <https://moongate-community.github.io/moongate/>
 

--- a/docs/articles/architecture/create-your-first-csharp-admin-command.md
+++ b/docs/articles/architecture/create-your-first-csharp-admin-command.md
@@ -1,0 +1,158 @@
+# Create Your First C# Admin Command
+
+This guide adds a compiled command to a Moongate plugin.
+
+By the end, you will:
+
+- create one `ICommandExecutor` class
+- register it from `Plugin.Configure(...)`
+- package the plugin
+- test the command from the server console and in game
+
+## Before You Start
+
+Finish this guide first:
+
+- [Create Your First Plugin](create-your-first-plugin.md)
+
+This tutorial assumes you already have a generated plugin project.
+
+The examples below use a plugin project named `HelloPlugin`, because that is the project name used in
+[Create Your First Plugin](create-your-first-plugin.md).
+
+## Step 1: Add The Command Class
+
+Inside your plugin project, create:
+
+```text
+HelloPlugin/TutorialPingCommand.cs
+```
+
+Paste this content:
+
+```csharp
+using Moongate.Server.Attributes;
+using Moongate.Server.Data.Internal.Commands;
+using Moongate.Server.Interfaces.Services.Console;
+using Moongate.Server.Types.Commands;
+using Moongate.UO.Data.Types;
+
+namespace HelloPlugin;
+
+[RegisterConsoleCommand(
+    "tutorial_ping_cs",
+    "Tutorial plugin command that prints a message.",
+    CommandSourceType.Console | CommandSourceType.InGame,
+    AccountType.GameMaster
+)]
+public sealed class TutorialPingCommand : ICommandExecutor
+{
+    public Task ExecuteCommandAsync(CommandSystemContext context)
+    {
+        context.Print("tutorial_ping_cs executed.");
+
+        return Task.CompletedTask;
+    }
+}
+```
+
+What this does:
+
+- `RegisterConsoleCommand` gives the command its name, description, source, and minimum account level
+- `CommandSourceType.Console | CommandSourceType.InGame` allows both server-console and in-game usage
+- `AccountType.GameMaster` keeps it in the admin/operator bucket
+
+## Step 2: Register The Command In The Plugin
+
+Open:
+
+```text
+HelloPlugin/Plugin.cs
+```
+
+Update `Configure(...)` so it registers the command:
+
+```csharp
+public void Configure(IMoongatePluginContext context)
+{
+    context.RegisterConsoleCommand<TutorialPingCommand>();
+}
+```
+
+## Step 3: Build The Plugin
+
+From the plugin project root, run:
+
+```bash
+dotnet build
+```
+
+This verifies that the command compiles with the plugin.
+
+## Step 4: Package The Plugin
+
+From the same plugin root, run:
+
+```bash
+bash scripts/pack-plugin.sh
+```
+
+Expected output:
+
+- `artifacts/hello-plugin/`
+- `artifacts/hello-plugin.zip`
+
+## Step 5: Copy The Plugin Into The Shard Root
+
+Copy the packaged folder into:
+
+```text
+~/moongate/plugins/hello-plugin/
+```
+
+The final runtime layout should include:
+
+```text
+~/moongate/plugins/hello-plugin/
+  manifest.json
+  bin/
+  data/
+  scripts/
+  assets/
+```
+
+## Step 6: Restart The Server
+
+Restart the server so it loads the updated plugin package.
+
+## Step 7: Test The Command
+
+From the server console, run:
+
+```text
+tutorial_ping_cs
+```
+
+Then, if you are logged in with a GameMaster-capable account, run in game:
+
+```text
+.tutorial_ping_cs
+```
+
+Expected result in both cases:
+
+- the command prints `tutorial_ping_cs executed.`
+
+## Common Mistakes
+
+- Creating the command class but forgetting `context.RegisterConsoleCommand<TutorialPingCommand>()`
+- Copying only the DLL instead of the full packaged plugin folder
+- Expecting the plugin to hot reload without a server restart
+- Setting the command source or account type differently from the way you plan to test it
+
+## Next Step
+
+Once this works, read:
+
+- [Plugin System](plugins.md)
+- [Console Commands](../operations/console-commands.md)

--- a/docs/articles/architecture/create-your-first-plugin.md
+++ b/docs/articles/architecture/create-your-first-plugin.md
@@ -236,6 +236,7 @@ whole plugin folder with `manifest.json` and `bin/`.
 
 After the first plugin is working, move on to:
 
+- [Create Your First C# Admin Command](create-your-first-csharp-admin-command.md) for a focused command tutorial on top of the plugin path
 - [Plugin System](plugins.md) for lifecycle and dependency model details
 - [Custom Persisted Entities](../persistence/custom-persisted-entities.md) if the plugin stores its own entities
 - [Console Commands](../operations/console-commands.md) for command design patterns

--- a/docs/articles/architecture/http-api.md
+++ b/docs/articles/architecture/http-api.md
@@ -75,6 +75,8 @@ When `enableJwt` is true, protected endpoints require a Bearer token obtained fr
 | PUT | `/api/help-tickets/{ticketId}/status` | Update a help ticket status for staff |
 | GET | `/api/help-tickets/me` | List the authenticated player's open or assigned tickets |
 
+For the end-to-end intake, dashboard, and staff triage flow, see [Help Ticket Workflow](../operations/help-ticket-workflow.md).
+
 ### Commands
 
 | Method | Path | Description |

--- a/docs/articles/architecture/plugins.md
+++ b/docs/articles/architecture/plugins.md
@@ -15,6 +15,8 @@ This system is intentionally simple:
 
 If you want the shortest path from zero to a working plugin project, start with
 [Create Your First Plugin](create-your-first-plugin.md).
+If you specifically want a compiled admin/operator command after that, continue with
+[Create Your First C# Admin Command](create-your-first-csharp-admin-command.md).
 
 ## Plugin Folder Layout
 

--- a/docs/articles/architecture/toc.yml
+++ b/docs/articles/architecture/toc.yml
@@ -13,6 +13,8 @@ items:
     href: plugins.md
   - name: Create Your First Plugin
     href: create-your-first-plugin.md
+  - name: Create Your First C# Admin Command
+    href: create-your-first-csharp-admin-command.md
   - name: Solution Structure
     href: solution.md
   - name: Source Generators

--- a/docs/articles/getting-started/configuration.md
+++ b/docs/articles/getting-started/configuration.md
@@ -88,7 +88,9 @@ Top-level shape:
     "timerTickMilliseconds": 250,
     "timerWheelSize": 512,
     "idleCpuEnabled": true,
-    "idleSleepMilliseconds": 1
+    "idleSleepMilliseconds": 1,
+    "pingServerEnabled": true,
+    "pingServerPort": 12000
   },
   "metrics": {
     "enabled": true,
@@ -128,6 +130,16 @@ Top-level shape:
   }
 }
 ```
+
+### Game Networking
+
+Relevant `game` keys for shard reachability checks:
+
+- `Game.PingServerEnabled` (`bool`, default `true`)
+- `Game.PingServerPort` (`int`, default `12000`)
+
+This UDP listener echoes datagrams unchanged and is intended for lightweight monitoring or edge reachability checks.
+For operational behavior and probe examples, see [UDP Ping Server](../networking/udp-ping-server.md).
 
 ## Directories
 

--- a/docs/articles/getting-started/introduction.md
+++ b/docs/articles/getting-started/introduction.md
@@ -107,6 +107,10 @@ Moongate v2 is **actively in development**. The following features are implement
 - [x] Weather and lighting system
 - [x] Visual effects system
 - [x] REST API for user management, sessions, metrics, and item templates
+- [x] In-game help ticket intake plus staff dashboard/API triage flow
+- [x] First-open and refillable loot containers driven by templates
+- [x] GameMaster in-game item and door administration commands
+- [x] UDP ping echo listener for lightweight reachability checks
 - [x] React-based admin web UI
 - [x] Source generators: 9 generators for compile-time registration
 - [x] 24 file loaders for data asset management

--- a/docs/articles/networking/toc.yml
+++ b/docs/articles/networking/toc.yml
@@ -1,6 +1,8 @@
 items:
   - name: Client Encryption
     href: client-encryption.md
+  - name: UDP Ping Server
+    href: udp-ping-server.md
   - name: Packet System
     href: packets.md
   - name: POL Packet Coverage
@@ -9,3 +11,7 @@ items:
     href: packet-handler-performance.md
   - name: Protocol Reference
     href: protocol.md
+  - name: Packet Reference
+    href: packet-reference/index.md
+  - name: Cliloc Notes
+    href: cliloc-notes.md

--- a/docs/articles/networking/udp-ping-server.md
+++ b/docs/articles/networking/udp-ping-server.md
@@ -1,0 +1,53 @@
+# UDP Ping Server
+
+Moongate runs a small UDP echo listener for operational ping checks. It is not part of the game protocol; it exists so operators and tooling can confirm that the shard is reachable over UDP.
+
+## Configuration
+
+Configure it in `moongate.json` under `game`:
+
+```json
+{
+  "game": {
+    "pingServerEnabled": true,
+    "pingServerPort": 12000
+  }
+}
+```
+
+Defaults:
+
+- `game.pingServerEnabled`: `true`
+- `game.pingServerPort`: `12000`
+
+## Runtime Behavior
+
+When the network service starts, it opens one UDP listener per local interface on the configured port.
+
+- Each received datagram is echoed back unchanged to the sender.
+- The server does not parse or transform payloads.
+- If a local bind fails on one interface, Moongate logs a warning and continues with the others.
+- When the network service stops, the UDP listeners are shut down with the rest of the network lifecycle.
+
+## Validation
+
+A simple outside-in check is to send a UDP payload and verify that the same bytes come back. For example:
+
+```bash
+python - <<'PY'
+import socket
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.settimeout(2)
+sock.sendto(b'ping', ('127.0.0.1', 12000))
+data, addr = sock.recvfrom(1024)
+print(data.decode('ascii'), addr)
+PY
+```
+
+Expected result: the command prints `ping`, and the reply comes from the same UDP port you configured.
+
+## Related Docs
+
+- [Configuration Guide](../getting-started/configuration.md)
+- [Protocol Reference](protocol.md)

--- a/docs/articles/operations/console-commands.md
+++ b/docs/articles/operations/console-commands.md
@@ -139,6 +139,19 @@ Spawns a hardcoded "brick" test item and adds it to the player backpack at posit
 
 Context: InGame only. Access: Regular.
 
+#### Live Item Admin Commands
+
+For the GameMaster live-world item and door commands introduced for shard maintenance, see
+[In-Game Item Admin Commands](in-game-item-admin-commands.md).
+
+That page covers:
+
+- `.spawn_item <templateId>`
+- `.add_door [wood|metal]`
+- `.add_wood_door`
+- `.add_metal_door`
+- `.remove_item`
+
 #### `mod_name`
 
 Opens a target cursor and renames the selected item or mobile. Persists the updated `Name` field and pushes a refresh packet so nearby clients pick up the new tooltip/display name.
@@ -300,6 +313,11 @@ Requires JWT authentication when JWT is enabled.
 2. Decorate with `[RegisterConsoleCommand("name", "description")]`.
 3. Implement `ICommandExecutor`.
 4. The source generator handles registration automatically.
+
+Beginner follow-ups:
+
+- [Create Your First Lua Admin Command](../scripting/create-your-first-lua-admin-command.md)
+- [Create Your First C# Admin Command](../architecture/create-your-first-csharp-admin-command.md)
 
 ---
 

--- a/docs/articles/operations/help-ticket-workflow.md
+++ b/docs/articles/operations/help-ticket-workflow.md
@@ -1,0 +1,87 @@
+# Help Ticket Workflow
+
+This page explains the current help ticket flow for shard operators and staff reviewers. It starts with how players create tickets in-game, then describes how staff use the admin dashboard to triage and update them, and finishes with the HTTP API entry points that support the same workflow.
+
+## Player Creation Flow
+
+Players open a help ticket from the client help button. The client request enters Lua through `on_help_request(session_id, character_id)`, and the default help script opens a two-step gump flow:
+
+1. A category picker is shown first.
+2. After a category is chosen, a text-entry gump collects the ticket message.
+3. Submitting the form calls `help_tickets.submit(session_id, category, message)`.
+
+The shipped categories are:
+
+- Question
+- Stuck
+- Bug
+- Account
+- Suggestion
+- Other
+- VerbalHarassment
+- PhysicalHarassment
+
+The Lua script trims the message before submission. On the server side, ticket creation only succeeds when the session is valid and linked to a live character and account. The ticket is then persisted with:
+
+- the sender account and character
+- the selected category
+- the submitted message
+- the sender location at the time of submission
+- an initial `Open` status
+
+Ticket creation also publishes a `TicketOpenedEvent` for downstream scripting or event handling.
+
+## Staff Workflow
+
+Staff review tickets in the admin dashboard under the help tickets page. The list view is designed for triage and shows:
+
+- ticket id
+- category
+- status
+- sender account and character
+- map and coordinates
+- created time
+- assigned account
+
+The list supports server-side pagination and filtering by:
+
+- status
+- category
+- assigned to me
+
+The detail view adds the full ticket message plus the assignment and status history fields currently stored by the server:
+
+- assigned account and character
+- assigned time
+- closed time
+- last updated time
+
+From the detail page, staff can:
+
+- take ownership of a ticket
+- set the status to `Open`
+- set the status to `Assigned`
+- set the status to `Closed`
+
+Current behavior to keep in mind:
+
+- Taking ownership assigns the ticket to the authenticated staff account and marks the ticket `Assigned`.
+- Status changes are immediate updates to the stored ticket record.
+- Closing a ticket sets `ClosedAtUtc`.
+- Reopening a ticket is allowed through the status action, but the current implementation does not clear a previously set closed timestamp.
+
+Operationally, the dashboard is the place to triage and work tickets, while the player-side gump is only the ticket intake path. There is no separate in-game reply thread in the current implementation.
+
+## HTTP API Mapping
+
+The HTTP API mirrors the same workflow and is what the admin dashboard uses behind the scenes. Endpoint details are documented in [HTTP API](../architecture/http-api.md); this section only maps the route to the operator task it supports.
+
+| Method | Path | Workflow use |
+|--------|------|--------------|
+| GET | `/api/help-tickets` | List tickets for staff triage, with pagination and filters |
+| GET | `/api/help-tickets/{ticketId}` | Open one ticket in the staff detail view |
+| PUT | `/api/help-tickets/{ticketId}/assign-to-me` | Take ownership of a ticket |
+| PUT | `/api/help-tickets/{ticketId}/status` | Move a ticket between `Open`, `Assigned`, and `Closed` |
+| GET | `/api/help-tickets/me` | Show the authenticated player's open or assigned tickets |
+
+The `assigned to me` filter on the staff list and the `/me` endpoint both rely on the authenticated account. They are useful when a staff member wants to narrow the queue to their own work items or when a player needs to see the tickets that are still active.

--- a/docs/articles/operations/in-game-item-admin-commands.md
+++ b/docs/articles/operations/in-game-item-admin-commands.md
@@ -1,0 +1,131 @@
+# In-Game Item Admin Commands
+
+Moongate includes a small set of in-game GameMaster commands for live item and door administration. These commands are entered in chat with the leading `.` prefix and only work from an in-game session.
+
+## Shared Workflow
+
+- Type the command in-game, usually with the leading `.` prefix.
+- If the command accepts arguments, enter them before the target cursor opens.
+- After the command validates its arguments, it will usually open a cursor:
+  - `SelectLocation` for spawning items or doors into the world
+  - `SelectObject` for removing an existing item or NPC
+- Click the target tile or object to complete the action.
+
+These commands are meant for live shard maintenance, map fixing, and controlled test placement. There is no undo step.
+
+## `spawn_item`
+
+Spawns an item template at a targeted world location.
+
+```
+.spawn_item <templateId>
+```
+
+Example:
+
+```
+.spawn_item brick
+```
+
+Workflow:
+
+1. Enter a valid item template id.
+2. The server opens a location target cursor.
+3. Click the tile where the item should appear.
+4. The command creates the item, places it on the current map, and adds it to the spatial world.
+
+Behavior notes:
+
+- The template id must resolve to a known item template.
+- The command always spawns one item, not a stack quantity.
+- The item is placed at the clicked `X/Y/Z` location on the player's active map.
+- If the session cannot be resolved to a live in-game character, the command fails before spawning.
+
+Operator caveats:
+
+- Use this for one-off corrections and live testing, not bulk world building.
+- The clicked location is the final placement point, so choose the exact tile you want the item to occupy.
+- If the template is unknown, the command returns `Unknown item template: <id>`.
+
+Context: InGame only. Access: GameMaster.
+
+## `add_door`
+
+Spawns a door at a targeted location and chooses the door facing from nearby wall-like geometry.
+
+```
+.add_door [wood|metal]
+```
+
+Aliases:
+
+```
+.add_wood_door
+.add_metal_door
+```
+
+Examples:
+
+```
+.add_door
+.add_door metal
+.add_wood_door
+.add_metal_door
+```
+
+Workflow:
+
+1. Optionally choose `wood` or `metal`.
+2. The server opens a location target cursor.
+3. Click the tile where the door should be installed.
+4. The command infers the door facing from nearby walls, impassable tiles, windows, doors, and nearby placed items.
+5. The door is created on the current map and added to the spatial world.
+
+Behavior notes:
+
+- If no argument is provided, the command defaults to a wood door.
+- `wood` uses the `light_wood_door` template.
+- `metal` uses the `metal_door` template.
+- The alias form also determines the door type, so `.add_metal_door` spawns a metal door even without arguments.
+- The final item id and direction are adjusted to match the resolved facing.
+
+Operator caveats:
+
+- Target the doorway tile, not the neighboring wall tile, and make sure there is enough surrounding geometry for the facing logic to infer a sensible orientation.
+- The command is intended for wall openings and door fixes, not arbitrary decoration placement.
+- If you need a specific door type, use the explicit `wood` or `metal` argument or the corresponding alias.
+- Invalid arguments return `Usage: .add_door [wood|metal]`.
+
+Context: InGame only. Access: GameMaster.
+
+## `remove_item`
+
+Opens a target cursor and removes the selected item or NPC.
+
+```
+.remove_item
+```
+
+Workflow:
+
+1. Run the command with no arguments.
+2. The server opens an object target cursor.
+3. Click the item or NPC you want to remove.
+4. The command deletes the target and reports what was removed.
+
+Behavior notes:
+
+- Items are deleted through the item service.
+- NPCs are deleted through the mobile service and removed from the spatial world.
+- Player characters are protected and cannot be removed.
+- The command resolves names from the target's `Name` field when present, otherwise it falls back to the target serial.
+
+Operator caveats:
+
+- This is an immediate delete, not a temporary hide or despawn.
+- Double-check the target before clicking. The cursor can select either items or mobiles, so it is easy to remove the wrong object in a busy area.
+- If the target is a player character, the command returns `Cannot remove player characters.`
+- If the target is not a valid item or mobile, the command rejects it instead of guessing.
+- If the server cannot resolve an active in-game session, the command fails before the cursor is sent.
+
+Context: InGame only. Access: GameMaster.

--- a/docs/articles/operations/toc.yml
+++ b/docs/articles/operations/toc.yml
@@ -1,0 +1,11 @@
+items:
+  - name: Stress Test
+    href: stress-test.md
+  - name: Template Validation
+    href: template-validation.md
+  - name: Console Commands
+    href: console-commands.md
+  - name: In-Game Item Admin Commands
+    href: in-game-item-admin-commands.md
+  - name: Help Ticket Workflow
+    href: help-ticket-workflow.md

--- a/docs/articles/scripting/api.md
+++ b/docs/articles/scripting/api.md
@@ -142,6 +142,13 @@ npc_state.get_var(npc_serial, "follow_target_serial")
 npc_state.set_var(npc_serial, "follow_target_serial", target_serial)
 ```
 
+Use canonical AI runtime keys in new Lua code:
+
+- `ai_action`
+- `ai_target_serial`
+
+`npc_state` still accepts the legacy aliases `modernuo_action` and `modernuo_target_serial` for compatibility with older persisted NPC state. On read, the module migrates those values to the canonical keys and clears the legacy alias.
+
 Enemy lookup is viewer-relative. The helper uses the same coarse AI relation model as Lua brain payloads:
 
 - `Friendly`

--- a/docs/articles/scripting/api.md
+++ b/docs/articles/scripting/api.md
@@ -5,6 +5,15 @@ Reference for the Moongate v2 Lua scripting API.
 > `definitions.lua` generated at startup is the source of truth for currently exported modules and signatures.
 > This page contains legacy/planned examples too. Always validate signatures against `moongate_data/scripts/definitions.lua`.
 
+If you are new to Moongate authoring, do not start here. Start with:
+
+- [Create Your First Content](create-your-first-content.md)
+- [Create Your First Systems](create-your-first-systems.md)
+- [Create Your First Item Template](create-your-first-item-template.md)
+- [Create Your First Item Script](create-your-first-item-script.md)
+- [Create Your First NPC Brain](create-your-first-npc-brain.md)
+- [Create Your First NPC Template](create-your-first-npc-template.md)
+
 ## Current Runtime Baseline (Verified)
 
 The following modules are currently wired in runtime:
@@ -292,6 +301,20 @@ Persisted tickets store:
 - map id and location
 - status (`Open`, `Assigned`, `Closed`)
 - timestamps for creation, assignment, closing, and last update
+
+For staff-facing triage, dashboard usage, and endpoint mapping, see
+[Help Ticket Workflow](../operations/help-ticket-workflow.md).
+
+### Loot Containers
+
+Loot containers are data-driven through item templates and loot templates rather than a dedicated Lua module.
+
+- container item templates declare `lootTables`
+- loot templates define the weighted entries that can be generated
+- first-open generation and optional refill behavior are handled by the server when the container is opened
+
+For first-open generation, refillable containers, validation caveats, and real template examples, see
+[Loot Containers](loot-containers.md).
 
 ### Item Script: Apple
 

--- a/docs/articles/scripting/create-your-first-content.md
+++ b/docs/articles/scripting/create-your-first-content.md
@@ -1,0 +1,60 @@
+# Create Your First Content
+
+This page is the beginner starting point for Moongate content authoring.
+
+It is written for someone who already has a running shard root, but does **not** yet understand how Moongate templates and
+Lua scripts fit together.
+
+These guides assume:
+
+- your shard root is `~/moongate`
+- the server is already configured to run with `--root-directory ~/moongate`
+- you can log in to the game with an account that can run in-game admin commands
+- you have the template validator installed as `moongate-template`
+
+Important path rule:
+
+- when you are authoring your shard, edit files under `~/moongate/templates/**` and `~/moongate/scripts/**`
+- when you are reading examples inside this repository, the bundled defaults live under `moongate_data/**`
+
+## Learning Path
+
+Follow the guides in this order:
+
+1. [Create Your First Item Template](create-your-first-item-template.md)
+2. [Create Your First NPC Brain](create-your-first-npc-brain.md)
+3. [Create Your First NPC Template](create-your-first-npc-template.md)
+
+That order keeps the dependency chain simple:
+
+- the item guide teaches template structure without Lua
+- the brain guide teaches Lua behavior without mobile JSON yet
+- the NPC guide connects the two worlds by binding `ai.brain` to the Lua table you just created
+
+## What You Will Use
+
+The hands-on guides use only commands and flows already documented and present in the repo:
+
+- `moongate-template validate --root-directory ~/moongate`
+- `.spawn_item <templateId>`
+- `.add_npc <templateId>`
+
+To keep the first pass deterministic, the guides tell you to restart the server after editing tutorial files instead of
+leaning on hot reload or single-file reload commands.
+
+## If You Only Care About One Topic
+
+- Want to learn item templates only: start with [Create Your First Item Template](create-your-first-item-template.md)
+- Want to learn NPC authoring: do both [Create Your First NPC Brain](create-your-first-npc-brain.md) and
+  [Create Your First NPC Template](create-your-first-npc-template.md)
+
+## After The Tutorials
+
+Once you finish the hands-on path, the deeper reference material is here:
+
+- [Create Your First Systems](create-your-first-systems.md)
+- [Lua Scripting Overview](overview.md)
+- [NPC Behaviors](npc-behaviors.md)
+- [Scripting API Reference](api.md)
+- [In-Game Item Admin Commands](../operations/in-game-item-admin-commands.md)
+- [Template Validation](../operations/template-validation.md)

--- a/docs/articles/scripting/create-your-first-gump.md
+++ b/docs/articles/scripting/create-your-first-gump.md
@@ -1,0 +1,103 @@
+# Create Your First Gump
+
+This guide upgrades the item script from the previous tutorial so it opens a simple UI instead of only sending a text message.
+
+By the end, you will:
+
+- register one `gump.on(...)` callback
+- send a gump from an item script
+- react to a button click
+
+## Before You Start
+
+Finish this guide first:
+
+- [Create Your First Item Script](create-your-first-item-script.md)
+
+You also need:
+
+- your shard root is `~/moongate`
+- your server is configured to run against `~/moongate`
+- you can log in with an account that can run `.spawn_item`
+
+## Step 1: Replace The Item Script With A Gump Version
+
+Open:
+
+```text
+~/moongate/scripts/items/tutorial_brick.lua
+```
+
+Replace the file with this content:
+
+```lua
+local TUTORIAL_BRICK_GUMP_ID = 0xB320
+local TUTORIAL_BRICK_HELLO_BUTTON = 1
+
+gump.on(TUTORIAL_BRICK_GUMP_ID, TUTORIAL_BRICK_HELLO_BUTTON, function(ctx)
+    if ctx == nil or ctx.session_id == nil then
+        return
+    end
+
+    speech.send(ctx.session_id, "You clicked the tutorial gump button.")
+end)
+
+tutorial_brick = {
+    on_double_click = function(ctx)
+        if ctx == nil or ctx.session_id == nil then
+            return
+        end
+
+        local sender = ctx.mobile_id or 0
+
+        local g = gump.create()
+        g:resize_pic(0, 0, 9200, 300, 160)
+        g:no_move()
+        g:text(24, 20, 1152, "Tutorial Brick")
+        g:text(24, 54, 0, "This is my first Moongate gump.")
+        g:button(24, 100, 4005, 4007, TUTORIAL_BRICK_HELLO_BUTTON)
+        g:text(58, 102, 0, "Say hello")
+
+        gump.send(ctx.session_id, g, sender, TUTORIAL_BRICK_GUMP_ID, 120, 80)
+    end,
+}
+```
+
+What changed:
+
+- `gump.on(...)` registers the button callback
+- `on_double_click` now builds and sends a gump
+- the button click sends a text response back to the player
+
+## Step 2: Restart The Server
+
+Restart the server so the updated item script is loaded.
+
+## Step 3: Spawn The Item
+
+In game, run:
+
+```text
+.spawn_item tutorial_brick
+```
+
+Click a nearby tile to place the item.
+
+## Step 4: Open The Gump
+
+Double-click the item.
+
+Expected result:
+
+- a gump titled `Tutorial Brick` opens
+- clicking `Say hello` sends `You clicked the tutorial gump button.`
+
+## Common Mistakes
+
+- Forgetting that `gump.on(...)` must use the same `gumpId` and `buttonId` as the gump you send
+- Editing the item script but not restarting the server
+- Replacing the `tutorial_brick` table name with something that no longer matches the template `scriptId`
+
+## Next Step
+
+Continue with [Create Your First Lua Admin Command](create-your-first-lua-admin-command.md).

--- a/docs/articles/scripting/create-your-first-item-script.md
+++ b/docs/articles/scripting/create-your-first-item-script.md
@@ -1,0 +1,147 @@
+# Create Your First Item Script
+
+This guide is the shortest path from a static item template to an item that does something when a player uses it.
+
+By the end, you will:
+
+- point an item template at a Lua `scriptId`
+- create one Lua file under `~/moongate/scripts/items/`
+- register it in `~/moongate/scripts/items/init.lua`
+- spawn the item and trigger the script in game
+
+## Before You Start
+
+Finish this guide first:
+
+- [Create Your First Item Template](create-your-first-item-template.md)
+
+You also need:
+
+- your shard root is `~/moongate`
+- `moongate-template` is installed
+- your server is configured to run against `~/moongate`
+- you can log in with an account that can run `.spawn_item`
+
+## Step 1: Point The Item Template At A Script
+
+Open:
+
+```text
+~/moongate/templates/items/tutorial/first_item.json
+```
+
+Replace the file with this complete version:
+
+```json
+[
+  {
+    "type": "item",
+    "id": "tutorial_brick",
+    "name": "Tutorial Brick",
+    "category": "tutorial",
+    "description": "My first scripted Moongate item template.",
+    "tags": ["tutorial", "test"],
+    "itemId": "0x1F9E",
+    "hue": "0",
+    "goldValue": "0",
+    "weight": 1,
+    "scriptId": "tutorial_brick",
+    "isMovable": true
+  }
+]
+```
+
+Important part:
+
+- `scriptId` is now `tutorial_brick`
+- that tells the item script dispatcher to look for a Lua table named `tutorial_brick`
+
+## Step 2: Create The Lua Script File
+
+Create:
+
+```text
+~/moongate/scripts/items/tutorial_brick.lua
+```
+
+Paste this content:
+
+```lua
+tutorial_brick = {
+    on_double_click = function(ctx)
+        if ctx == nil or ctx.session_id == nil then
+            return
+        end
+
+        speech.send(ctx.session_id, "Tutorial Brick script executed.")
+    end,
+}
+```
+
+What this does:
+
+- defines the Lua table `tutorial_brick`
+- implements the `on_double_click` item hook
+- sends a message to the player who used the item
+
+## Step 3: Register The Script In `items/init.lua`
+
+Open:
+
+```text
+~/moongate/scripts/items/init.lua
+```
+
+Add this line with the other item script requires:
+
+```lua
+require("items.tutorial_brick")
+```
+
+Why this matters:
+
+- creating the file is not enough
+- `items/init.lua` is the place that loads item script modules into the Lua runtime
+
+## Step 4: Validate The Templates
+
+Run:
+
+```bash
+moongate-template validate --root-directory ~/moongate
+```
+
+The validator checks that the item template is still valid after the `scriptId` change.
+
+## Step 5: Restart The Server
+
+Restart the server so the template change and the new Lua file are both loaded.
+
+This beginner path intentionally uses restart instead of hot reload.
+
+## Step 6: Spawn And Use The Item
+
+In game, run:
+
+```text
+.spawn_item tutorial_brick
+```
+
+Click a nearby tile to place the item, then double-click the item.
+
+Expected result:
+
+- the item appears where you targeted it
+- double-clicking it shows `Tutorial Brick script executed.`
+
+## Common Mistakes
+
+- Leaving `scriptId` as `none`
+- Naming the Lua table differently from the `scriptId`
+- Creating `tutorial_brick.lua` but forgetting `require("items.tutorial_brick")`
+- Editing the repository copy under `moongate_data/` instead of the shard root under `~/moongate/`
+
+## Next Step
+
+Continue with [Create Your First Loot Container](create-your-first-loot-container.md) or
+[Create Your First Gump](create-your-first-gump.md).

--- a/docs/articles/scripting/create-your-first-item-template.md
+++ b/docs/articles/scripting/create-your-first-item-template.md
@@ -1,0 +1,118 @@
+# Create Your First Item Template
+
+This guide walks through the smallest useful Moongate item template from zero.
+
+By the end, you will:
+
+- create one JSON file under your shard root
+- validate it with `moongate-template`
+- spawn the item in game with `.spawn_item`
+
+## Before You Start
+
+- your shard root is `~/moongate`
+- `moongate-template` is installed
+- your server is configured to run against `~/moongate`
+- you can log in with an account that can run `.spawn_item` on your shard
+
+## Step 1: Create A Tutorial Folder
+
+Create this folder in your shard root:
+
+```text
+~/moongate/templates/items/tutorial/
+```
+
+Inside it, create:
+
+```text
+~/moongate/templates/items/tutorial/first_item.json
+```
+
+## Step 2: Paste A Complete Minimal Template
+
+Put this content in the file:
+
+```json
+[
+  {
+    "type": "item",
+    "id": "tutorial_brick",
+    "name": "Tutorial Brick",
+    "category": "tutorial",
+    "description": "My first Moongate item template.",
+    "tags": ["tutorial", "test"],
+    "itemId": "0x1F9E",
+    "hue": "0",
+    "goldValue": "0",
+    "weight": 1,
+    "scriptId": "none",
+    "isMovable": true
+  }
+]
+```
+
+This file is a JSON array with one item template object inside it. Keep the outer `[` and `]`.
+
+Why these fields matter:
+
+- `type`: tells Moongate this document contains an item template
+- `id`: the template id you will use later with `.spawn_item`
+- `name`: the in-game display name
+- `category`: groups the template for humans and tooling
+- `description`: short human-facing note about what this template is for
+- `tags`: optional labels you can use later for organization or loot/tag-based selection
+- `itemId`: the Ultima Online art/body id for the item
+- `hue`: the color; `0` means default hue
+- `goldValue`: economic value metadata; `0` is fine for a tutorial item
+- `weight`: item weight
+- `scriptId`: `none` means this first tutorial item does not use Lua hooks yet
+- `isMovable`: whether players can move the item
+
+## Step 3: Validate The Template
+
+Run:
+
+```bash
+moongate-template validate --root-directory ~/moongate
+```
+
+Expected result:
+
+- the command exits with success
+- the validator reports the shard root and the validation summary
+
+If validation fails, stop and fix the file before trying to spawn the item.
+
+## Step 4: Restart The Server
+
+If your server is already running, restart it so the tutorial template is definitely loaded.
+
+This guide intentionally uses restart instead of more advanced reload flows.
+
+## Step 5: Spawn The Item In Game
+
+Log in with an account that can run in-game admin item commands and type:
+
+```text
+.spawn_item tutorial_brick
+```
+
+Then click a nearby ground tile.
+
+Expected result:
+
+- the item appears at the location you clicked
+- single-clicking it shows the name `Tutorial Brick`
+
+## Common Mistakes
+
+- Forgetting the outer JSON array `[` `]`
+- Using a duplicate `id` that already exists elsewhere in your shard
+- Writing `itemId` without quotes or without the `0x` format
+- Validating the wrong root directory
+
+## Next Step
+
+If you want to keep going into NPC authoring, continue with
+[Create Your First NPC Brain](create-your-first-npc-brain.md).

--- a/docs/articles/scripting/create-your-first-loot-container.md
+++ b/docs/articles/scripting/create-your-first-loot-container.md
@@ -1,0 +1,152 @@
+# Create Your First Loot Container
+
+This guide creates a chest that rolls loot the first time a player opens it.
+
+By the end, you will:
+
+- create one loot template
+- create one container item template that references it
+- validate both files with `moongate-template`
+- spawn the chest and see generated loot in game
+
+## Before You Start
+
+Finish this guide first:
+
+- [Create Your First Item Template](create-your-first-item-template.md)
+
+You also need:
+
+- your shard root is `~/moongate`
+- `moongate-template` is installed
+- your server is configured to run against `~/moongate`
+- you can log in with an account that can run `.spawn_item`
+
+## Step 1: Create The Loot Template
+
+Create this folder:
+
+```text
+~/moongate/templates/loot/tutorial/
+```
+
+Inside it, create:
+
+```text
+~/moongate/templates/loot/tutorial/first_loot_table.json
+```
+
+Paste this content:
+
+```json
+[
+  {
+    "type": "loot",
+    "id": "tutorial_chest_basic",
+    "name": "Tutorial Chest Basic",
+    "category": "tutorial",
+    "description": "My first loot table.",
+    "rolls": 2,
+    "noDropWeight": 0,
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "weight": 5,
+        "amount": 50
+      },
+      {
+        "itemTemplateId": "torch",
+        "weight": 2,
+        "amount": 1
+      }
+    ]
+  }
+]
+```
+
+What this does:
+
+- the table id is `tutorial_chest_basic`
+- the chest will roll twice
+- each roll picks one weighted entry from the list
+
+## Step 2: Create The Chest Item Template
+
+Create:
+
+```text
+~/moongate/templates/items/tutorial/first_loot_chest.json
+```
+
+Paste this content:
+
+```json
+[
+  {
+    "type": "item",
+    "id": "tutorial_loot_chest",
+    "name": "Tutorial Loot Chest",
+    "category": "tutorial",
+    "description": "My first loot container.",
+    "tags": ["tutorial", "container", "loot"],
+    "itemId": "0x0E80",
+    "hue": "0",
+    "goldValue": "0",
+    "weight": 1,
+    "scriptId": "none",
+    "isMovable": true,
+    "container": [],
+    "containerLayoutId": "metal_chest",
+    "weightMax": 40000,
+    "maxItems": 125,
+    "lootTables": ["tutorial_chest_basic"]
+  }
+]
+```
+
+Why these extra fields matter:
+
+- `container`: marks the item as a container template
+- `containerLayoutId`: must match a valid container layout
+- `lootTables`: points to the loot template you created in step 1
+
+## Step 3: Validate Both Templates
+
+Run:
+
+```bash
+moongate-template validate --root-directory ~/moongate
+```
+
+Stop here if validation fails. Loot containers depend on both the item template and the loot template being valid.
+
+## Step 4: Restart The Server
+
+Restart the server so the new templates are loaded.
+
+## Step 5: Spawn The Chest And Open It
+
+In game, run:
+
+```text
+.spawn_item tutorial_loot_chest
+```
+
+Click a nearby tile to place the chest, then double-click the chest to open it.
+
+Expected result:
+
+- the first open generates loot into the container
+- you should see a couple of items based on the weighted table
+- opening the same chest again reuses the generated contents instead of rolling from scratch
+
+## Common Mistakes
+
+- Writing the loot template under the wrong tree instead of `~/moongate/templates/loot/`
+- Forgetting `containerLayoutId`
+- Referencing a loot table id that does not exist
+- Expecting loot generation on chest spawn instead of on first open
+
+## Next Step
+
+Continue with [Create Your First Scheduled Event](create-your-first-scheduled-event.md).

--- a/docs/articles/scripting/create-your-first-lua-admin-command.md
+++ b/docs/articles/scripting/create-your-first-lua-admin-command.md
@@ -1,0 +1,90 @@
+# Create Your First Lua Admin Command
+
+This guide creates one in-game GameMaster command entirely in Lua.
+
+By the end, you will:
+
+- create a command file under `~/moongate/scripts/commands/gm/`
+- register it in `~/moongate/scripts/commands/gm/init.lua`
+- run it in game with the leading `.` prefix
+
+## Before You Start
+
+You need:
+
+- your shard root is `~/moongate`
+- your server is configured to run against `~/moongate`
+- you can log in with a GameMaster-capable account
+
+## Step 1: Create The Command File
+
+Create:
+
+```text
+~/moongate/scripts/commands/gm/tutorial_ping.lua
+```
+
+Paste this content:
+
+```lua
+command.register("tutorial_ping", function(ctx)
+    local args = ctx.arguments or {}
+    local target = args[1] or "traveler"
+
+    speech.broadcast("Lua tutorial command says hello to " .. target .. ".")
+    ctx:print("tutorial_ping executed for " .. target .. ".")
+end, {
+    description = "Tutorial Lua admin command.",
+    minimum_account_type = "GameMaster"
+})
+```
+
+What this does:
+
+- registers a command named `tutorial_ping`
+- reads the first argument from `ctx.arguments`
+- broadcasts a server-wide message
+- prints a private confirmation line back to the caller
+
+## Step 2: Register The Command In `commands/gm/init.lua`
+
+Open:
+
+```text
+~/moongate/scripts/commands/gm/init.lua
+```
+
+Add this line with the other GM command requires:
+
+```lua
+require("commands.gm.tutorial_ping")
+```
+
+## Step 3: Restart The Server
+
+Restart the server so the new command file and the updated init file are both loaded.
+
+## Step 4: Run The Command In Game
+
+In game, type:
+
+```text
+.tutorial_ping moongate
+```
+
+Expected result:
+
+- the shard broadcasts `Lua tutorial command says hello to moongate.`
+- you also see `tutorial_ping executed for moongate.`
+
+## Common Mistakes
+
+- Forgetting the `require("commands.gm.tutorial_ping")` line
+- Using `ctx.arguments[0]` instead of `ctx.arguments[1]`
+- Expecting the command to work without the leading `.` when run in game
+- Setting `minimum_account_type` lower than you intended for an operator command
+
+## Next Step
+
+Continue with [Create Your First Plugin](../architecture/create-your-first-plugin.md) and then
+[Create Your First C# Admin Command](../architecture/create-your-first-csharp-admin-command.md).

--- a/docs/articles/scripting/create-your-first-npc-brain.md
+++ b/docs/articles/scripting/create-your-first-npc-brain.md
@@ -1,0 +1,144 @@
+# Create Your First NPC Brain
+
+This guide creates a small Lua brain that makes an NPC talk on its own and answer when a nearby player says `hello`.
+
+By the end, you will:
+
+- add one Lua file under `~/moongate/scripts/ai/npcs/`
+- register it in `~/moongate/scripts/ai/init.lua`
+- bind it from an NPC template in the next guide
+
+## Before You Start
+
+- your shard root is `~/moongate`
+- your server is configured to run against `~/moongate`
+- your shard already has `~/moongate/scripts/ai/init.lua`
+- if the server is running while you edit these files, use a full restart for this tutorial path
+
+## Step 1: Create The Brain File
+
+Create this file:
+
+```text
+~/moongate/scripts/ai/npcs/tutorial_cat_brain.lua
+```
+
+Paste this content:
+
+```lua
+local tick = require("common.tick")
+
+tutorial_cat_brain = {}
+
+local state_by_npc = {}
+
+local function get_state(npc_id)
+    local state = state_by_npc[npc_id]
+    if state ~= nil then
+        return state
+    end
+
+    state = {
+        cadence = tick.state({
+            speech = 4000,
+        }, time.now_ms()),
+    }
+
+    state_by_npc[npc_id] = state
+    return state
+end
+
+function tutorial_cat_brain.on_think(npc_id)
+    while true do
+        local npc = mobile.get(npc_id)
+
+        if npc ~= nil then
+            local state = get_state(npc_id)
+            local now = time.now_ms()
+
+            tick.run(state.cadence, "speech", now, function()
+                npc:say("Hello! My first Moongate brain is running.")
+            end)
+        end
+
+        coroutine.yield(250)
+    end
+end
+
+function tutorial_cat_brain.on_speech(npc_id, _speaker_id, text, _speech_type, _map_id, _x, _y, _z)
+    local npc = mobile.get(npc_id)
+    if npc == nil or text == nil then
+        return
+    end
+
+    if string.find(string.lower(text), "hello", 1, true) then
+        npc:say("Hello back to you.")
+    end
+end
+```
+
+What this brain does:
+
+- `on_think` runs as the NPC coroutine loop
+- `get_state` creates one cadence state per spawned NPC
+- every 4 seconds it says a line overhead
+- `on_speech` reacts to nearby speech and looks for the word `hello`
+
+Why the `state_by_npc` table matters:
+
+- if you spawn more than one copy of this NPC, each one keeps its own timer
+- this matches the safer pattern already used by more advanced brains in the repo
+
+Why there is only one `require(...)`:
+
+- `common.tick` is a Lua helper script, so you load it with `require`
+- `mobile`, `time`, `coroutine`, and `string` are already available when the Moongate Lua runtime starts
+
+## Step 2: Register The Brain In `ai/init.lua`
+
+Open:
+
+```text
+~/moongate/scripts/ai/init.lua
+```
+
+Add this line with the other brain or NPC requires:
+
+```lua
+require("ai.npcs.tutorial_cat_brain")
+```
+
+Why this step matters:
+
+- creating the file alone is not enough
+- `ai/init.lua` is the place that loads the Lua brain modules used by the server
+
+## Step 3: Restart The Server
+
+Restart the server after editing both files.
+
+This is the safest beginner path because it guarantees the new brain file and the updated `ai/init.lua` are loaded
+together.
+
+## Step 4: Bind It From An NPC Template
+
+The brain is ready, but nothing will use it until an NPC template points to:
+
+```json
+"brain": "tutorial_cat_brain"
+```
+
+Do that in the next guide:
+
+- [Create Your First NPC Template](create-your-first-npc-template.md)
+
+## Common Mistakes
+
+- Naming the Lua table differently from the `ai.brain` value you plan to use
+- Creating the file but forgetting the `require("ai.npcs.tutorial_cat_brain")` line
+- Reusing one shared timer table for every spawned NPC instead of keeping state per NPC
+- Editing the repo copy under `moongate_data/` instead of your shard root under `~/moongate/scripts/`
+
+## Next Step
+
+Continue with [Create Your First NPC Template](create-your-first-npc-template.md).

--- a/docs/articles/scripting/create-your-first-npc-template.md
+++ b/docs/articles/scripting/create-your-first-npc-template.md
@@ -1,0 +1,135 @@
+# Create Your First NPC Template
+
+This guide creates a minimal NPC template and binds it to the Lua brain from the previous tutorial.
+
+By the end, you will:
+
+- create one mobile template JSON file
+- validate it with `moongate-template`
+- spawn the NPC in game with `.add_npc`
+- confirm that the Lua brain is actually running
+
+## Before You Start
+
+Finish this guide first:
+
+- [Create Your First NPC Brain](create-your-first-npc-brain.md)
+
+That guide creates and registers the `tutorial_cat_brain` Lua table used below.
+
+You also need:
+
+- your shard root is `~/moongate`
+- `moongate-template` is installed
+- your server is configured to run against `~/moongate`
+- you can log in with an account that can run `.add_npc` on your shard
+
+## Step 1: Create The Template File
+
+Create this folder:
+
+```text
+~/moongate/templates/mobiles/tutorial/
+```
+
+Inside it, create:
+
+```text
+~/moongate/templates/mobiles/tutorial/first_npc.json
+```
+
+## Step 2: Paste A Complete Minimal NPC Template
+
+Put this content in the file:
+
+```json
+[
+  {
+    "type": "mobile",
+    "id": "tutorial_cat",
+    "category": "tutorial",
+    "description": "My first scripted Moongate NPC.",
+    "tags": ["tutorial", "animals", "test"],
+    "ai": {
+      "brain": "tutorial_cat_brain",
+      "fightMode": "none",
+      "rangePerception": 16,
+      "rangeFight": 1
+    },
+    "name": "Tutorial Cat",
+    "title": "your first scripted NPC",
+    "variants": [
+      {
+        "appearance": {
+          "body": "0x00C9",
+          "skinHue": 779,
+          "hairHue": 0,
+          "hairStyle": 0
+        },
+        "equipment": []
+      }
+    ]
+  }
+]
+```
+
+This file is a JSON array with one mobile template object inside it. Keep the outer `[` and `]`.
+
+What the important fields mean:
+
+- `type`: this document contains mobile templates
+- `id`: the template id you will use with `.add_npc`
+- `ai.brain`: the Lua table name that will drive the NPC behavior
+- `fightMode`, `rangePerception`, `rangeFight`: standard AI fields used by current mobile templates
+- `name` and `title`: the in-game name shown to players
+- `variants`: appearance and equipment choices for the mobile
+- `appearance.body`: the UO body id
+- `equipment`: starting worn or carried equipment for that variant; empty is fine for a tutorial cat
+
+## Step 3: Validate The Template
+
+Run:
+
+```bash
+moongate-template validate --root-directory ~/moongate
+```
+
+Expected result:
+
+- validation completes successfully
+
+If the validator fails, fix that before trying to spawn the NPC.
+
+## Step 4: Restart The Server
+
+If the server is already running, restart it so both the template and the Lua brain are definitely loaded.
+
+## Step 5: Spawn The NPC In Game
+
+Log in with an account that can run the in-game NPC spawn command and type:
+
+```text
+.add_npc tutorial_cat
+```
+
+Then click a nearby ground tile.
+
+Expected result:
+
+- the NPC appears where you clicked
+- after a few seconds, it says `Hello! My first Moongate brain is running.`
+- if you say `hello` near it, it replies `Hello back to you.`
+
+## Common Mistakes
+
+- Typo in `ai.brain`
+- Forgetting to register the Lua brain in `~/moongate/scripts/ai/init.lua`
+- Editing the wrong tree (`moongate_data/` in the repo instead of `~/moongate/` in your shard root)
+- Forgetting the outer JSON array
+
+## Next Step
+
+Once this works, move to the reference docs for deeper behavior work:
+
+- [NPC Behaviors](npc-behaviors.md)
+- [Scripting API Reference](api.md)

--- a/docs/articles/scripting/create-your-first-npc-template.md
+++ b/docs/articles/scripting/create-your-first-npc-template.md
@@ -86,6 +86,19 @@ What the important fields mean:
 - `appearance.body`: the UO body id
 - `equipment`: starting worn or carried equipment for that variant; empty is fine for a tutorial cat
 
+If you later point a template at the `guard` brain, patrol stays opt-in and uses the same `params` shape documented in [NPC Behaviors](npc-behaviors.md#optional-patrol-params):
+
+```json
+{
+  "params": {
+    "patrol_mode": { "type": "string", "value": "random_roam" },
+    "patrol_radius": { "type": "number", "value": 6 }
+  }
+}
+```
+
+The tutorial cat above does not use these settings, and the current production guard templates do not set them either.
+
 ## Step 3: Validate The Template
 
 Run:

--- a/docs/articles/scripting/create-your-first-npc-template.md
+++ b/docs/articles/scripting/create-your-first-npc-template.md
@@ -92,10 +92,12 @@ If you later point a template at the `guard` brain, patrol stays opt-in and uses
 {
   "params": {
     "patrol_mode": { "type": "string", "value": "random_roam" },
-    "patrol_radius": { "type": "number", "value": 6 }
+    "patrol_radius": { "type": "string", "value": "6" }
   }
 }
 ```
+
+`patrol_radius` stays string-backed in template JSON because mobile params do not have a separate numeric param type.
 
 The tutorial cat above does not use these settings, and the current production guard templates do not set them either.
 

--- a/docs/articles/scripting/create-your-first-scheduled-event.md
+++ b/docs/articles/scripting/create-your-first-scheduled-event.md
@@ -1,0 +1,107 @@
+# Create Your First Scheduled Event
+
+This guide creates one shard-level event that fires once at a specific UTC timestamp.
+
+By the end, you will:
+
+- create a Lua file under `~/moongate/scripts/events/`
+- add a global `on_scheduled_event(event)` callback
+- start the server and watch the event fire
+
+## Before You Start
+
+You need:
+
+- your shard root is `~/moongate`
+- your server is configured to run against `~/moongate`
+- you can restart the server
+- you can see the server log output while the shard is running
+
+## Step 1: Create The Event File
+
+Create this folder if it does not exist yet:
+
+```text
+~/moongate/scripts/events/
+```
+
+Inside it, create:
+
+```text
+~/moongate/scripts/events/tutorial_ping_once.lua
+```
+
+Paste this content:
+
+```lua
+local scheduled_events = require("common.scheduled_events")
+
+return scheduled_events.event("tutorial_ping_once", {
+    trigger_name = "tutorial_ping",
+    recurrence = "once",
+    start_at = "REPLACE_WITH_A_UTC_TIMESTAMP_2_MINUTES_IN_THE_FUTURE"
+})
+```
+
+Important note:
+
+- `start_at` must be a real UTC timestamp in the future, for example `2026-03-26T14:30:00Z`
+- if the timestamp is already in the past when the server starts, the event will not fire
+
+## Step 2: Add The Global Callback
+
+Open:
+
+```text
+~/moongate/scripts/init.lua
+```
+
+Add this function below the other global callbacks:
+
+```lua
+function on_scheduled_event(event)
+    if event == nil or event.trigger_name ~= "tutorial_ping" then
+        return
+    end
+
+    log.info("Tutorial scheduled event fired: " .. tostring(event.event_id))
+    speech.broadcast("Tutorial scheduled event fired.")
+end
+```
+
+Why this step matters:
+
+- the event definition schedules the timer
+- the global callback is where you react when the timer fires
+
+## Step 3: Double-Check The Timestamp
+
+Before starting the server, make sure `start_at` is still in the future.
+
+For a first test, give yourself around two minutes of buffer so you have time to restart the shard and watch the log.
+
+## Step 4: Restart The Server
+
+Restart the server after saving both files.
+
+The scheduled event service loads every `.lua` file under `~/moongate/scripts/events/` when it starts.
+
+## Step 5: Wait For The Event To Fire
+
+Leave the server running until the `start_at` time passes.
+
+Expected result:
+
+- the server log prints `Tutorial scheduled event fired: tutorial_ping_once`
+- connected players receive the broadcast `Tutorial scheduled event fired.`
+
+## Common Mistakes
+
+- Using a timestamp that is already in the past
+- Creating the event file outside `~/moongate/scripts/events/`
+- Forgetting to add `on_scheduled_event(event)` in `~/moongate/scripts/init.lua`
+- Restarting the server after the target time has already passed
+
+## Next Step
+
+Continue with [Create Your First Gump](create-your-first-gump.md).

--- a/docs/articles/scripting/create-your-first-systems.md
+++ b/docs/articles/scripting/create-your-first-systems.md
@@ -1,0 +1,85 @@
+# Create Your First Systems
+
+This page is the second beginner path after [Create Your First Content](create-your-first-content.md).
+
+The first path teaches the basics:
+
+- one item template
+- one Lua brain
+- one NPC template
+
+This second path teaches small gameplay systems that combine those building blocks into something more useful.
+
+These guides assume:
+
+- your shard root is `~/moongate`
+- the server already runs against `--root-directory ~/moongate`
+- you can restart the server after changes
+- you can log in with an account that can run in-game admin commands
+- you already know the difference between `~/moongate/**` and the repository `moongate_data/**`
+
+## Learning Path
+
+Follow these in order:
+
+1. [Create Your First Item Script](create-your-first-item-script.md)
+2. [Create Your First Loot Container](create-your-first-loot-container.md)
+3. [Create Your First Scheduled Event](create-your-first-scheduled-event.md)
+4. [Create Your First Gump](create-your-first-gump.md)
+5. [Create Your First Lua Admin Command](create-your-first-lua-admin-command.md)
+6. [Create Your First Plugin](../architecture/create-your-first-plugin.md)
+7. [Create Your First C# Admin Command](../architecture/create-your-first-csharp-admin-command.md)
+
+That order keeps the beginner path clean:
+
+- item script teaches item behavior
+- loot container teaches template-driven item generation
+- scheduled event teaches shard-level timed logic
+- gump teaches player-facing UI on top of the item script path
+- Lua admin command teaches scripted operator workflows
+- plugin and C# command move into compiled extensions only after the Lua path is clear
+
+## Shard Systems
+
+These guides stay inside the shard root:
+
+- `~/moongate/templates/**`
+- `~/moongate/scripts/**`
+
+They are the fastest way to add gameplay and operator tools without compiling C#.
+
+## Extension Path
+
+The last two guides move into compiled extensions:
+
+- [Create Your First Plugin](../architecture/create-your-first-plugin.md)
+- [Create Your First C# Admin Command](../architecture/create-your-first-csharp-admin-command.md)
+
+Use that path when you need:
+
+- a real compiled console command
+- plugin-local services or handlers
+- something you do not want to keep in Lua
+
+## What You Will Use
+
+Across the phase 2 guides you will only see commands and paths that already exist in the repo:
+
+- `moongate-template validate --root-directory ~/moongate`
+- `.spawn_item <templateId>`
+- `dotnet new moongate-plugin ...`
+- `dotnet build`
+- `bash scripts/pack-plugin.sh`
+
+## After These Tutorials
+
+Once you finish this path, the deeper references are here:
+
+- [Lua Scripting Overview](overview.md)
+- [Scripting API Reference](api.md)
+- [Script Modules](modules.md)
+- [Loot Containers](loot-containers.md)
+- [Scheduled Events](scheduled-events.md)
+- [Gump Tutorial](gump-tutorial.md)
+- [Plugin System](../architecture/plugins.md)
+- [Console Commands](../operations/console-commands.md)

--- a/docs/articles/scripting/loot-containers.md
+++ b/docs/articles/scripting/loot-containers.md
@@ -1,0 +1,141 @@
+# Loot Containers
+
+Moongate supports container loot that appears the first time a player opens the container, plus optional refill behavior after the container has been emptied.
+
+This page documents the current runtime behavior for item templates and loot templates only. For API signatures, see the [Scripting API Reference](api.md).
+
+## How The Pieces Connect
+
+Loot containers are driven by two template types:
+
+- item templates declare `lootTables`
+- loot templates declare the actual entries to roll
+
+At runtime, the server resolves the opened container back to its item template through the internal `item_template_id` custom value. If the container is not a container, has no template id, or has no loot tables, nothing is generated.
+
+Item template validation also requires container templates to have a valid `containerLayoutId`. If you inherit from a base item template, an empty child `lootTables` list inherits the parent list.
+
+## Runtime Behavior
+
+When a player double-clicks a container, the interaction flow calls the loot generator before the container window is shown.
+
+Current behavior:
+
+- first open generates loot once and marks the container with `loot_generated = true`
+- generated items are persisted as normal container contents
+- subsequent opens reuse the existing contents
+- if the container is refillable, refill is lazy rather than timer-driven
+- the server only checks refill readiness when the container is opened again
+
+Refill behavior depends on two item template params:
+
+- `loot_refillable` must be `true`
+- `loot_refill_seconds` must be a positive integer
+
+When a refillable container becomes empty, the server records `loot_refill_ready_at_utc`. On a later open, if that timestamp has passed, loot is generated again. If the container still has any items inside, refill does not happen.
+
+If `loot_refill_seconds` is missing, invalid, or non-positive, the container behaves as non-refillable.
+
+## Loot Table Rules
+
+Loot tables currently support weighted generation for loot containers:
+
+- `rolls` defaults to `1`
+- `noDropWeight` adds blank rolls into the weighted pool
+- each entry must define exactly one of:
+  - `itemTemplateId`
+  - `itemId`
+  - `itemTag`
+
+`itemTemplateId` creates an item from another item template. `itemTag` picks a random item template that carries the tag, then creates that template. `itemId` creates a raw static item and fills name, weight, and stackability from tile data, which is mainly useful for imported legacy data.
+
+Each roll resolves independently, so a table with `rolls: 2` can generate two items, two stackables, or one item and one blank result depending on weights.
+
+## Real Template Shape
+
+The repository includes test fixtures that use the same shape operators should use for shard content.
+
+```json
+[
+  {
+    "type": "item",
+    "id": "loot_test_chest",
+    "name": "Loot Test Chest",
+    "category": "Test Containers",
+    "description": "Spawnable chest used to verify first-open loot table generation.",
+    "itemId": "0x0E80",
+    "container": [],
+    "lootTables": ["loot_test_chest_basic"],
+    "containerLayoutId": "metal_chest",
+    "weight": 1.0,
+    "weightMax": 40000,
+    "maxItems": 125,
+    "params": {
+      "loot_refillable": {
+        "type": "string",
+        "value": "true"
+      },
+      "loot_refill_seconds": {
+        "type": "string",
+        "value": "300"
+      }
+    },
+    "goldValue": "0",
+    "hue": "0",
+    "scriptId": "none",
+    "isMovable": true,
+    "tags": ["container", "test", "loot"]
+  }
+]
+```
+
+```json
+[
+  {
+    "type": "loot",
+    "id": "loot_test_chest_basic",
+    "name": "Loot Test Chest Basic",
+    "category": "Test",
+    "description": "Basic weighted loot table for first-open chest testing.",
+    "rolls": 2,
+    "noDropWeight": 0,
+    "entries": [
+      {
+        "itemTemplateId": "gold",
+        "weight": 5,
+        "amount": 125
+      },
+      {
+        "itemTag": "resources",
+        "weight": 3,
+        "amount": 25
+      },
+      {
+        "itemTemplateId": "lockpick",
+        "weight": 2,
+        "amount": 5
+      },
+      {
+        "itemTemplateId": "torch",
+        "weight": 1,
+        "amount": 1
+      }
+    ]
+  }
+]
+```
+
+## Operator Guidance
+
+- Use `lootTables` on container item templates, not on arbitrary items.
+- Make sure the container spawns from a template so `item_template_id` is present at runtime.
+- Keep `containerLayoutId` valid for the chosen container body, or validation will fail at startup.
+- Prefer `itemTemplateId` for shard-authored loot. Use `itemTag` when you want a random member of a tagged family. Reserve `itemId` for imported datasets that still depend on raw tile ids.
+- If you want refill behavior, test the empty-container path. Refill does not begin until the last item is removed.
+
+## Caveats
+
+- The server does not refill containers on a background timer.
+- A container that rolls empty on first open is still marked as generated.
+- Internal loot metadata is managed by the server; operators should not set `loot_generated` or `loot_refill_ready_at_utc` by hand unless they are debugging a broken container state.
+- The same loot template system is also reused for other runtime loot flows, but this page only covers container opening and refill behavior.

--- a/docs/articles/scripting/modules.md
+++ b/docs/articles/scripting/modules.md
@@ -6,6 +6,14 @@ Creating custom script modules in Moongate v2.
 
 Script modules allow you to expose .NET functionality to Lua scripts. This enables powerful customization without recompiling the server.
 
+If you are starting from zero, do not begin with this reference page. Use:
+
+- [Create Your First Systems](create-your-first-systems.md)
+- [Create Your First Item Script](create-your-first-item-script.md)
+- [Create Your First Scheduled Event](create-your-first-scheduled-event.md)
+- [Create Your First Gump](create-your-first-gump.md)
+- [Create Your First Lua Admin Command](create-your-first-lua-admin-command.md)
+
 ## Built-In Runtime Modules (Current)
 
 The following modules are available in the default server runtime:

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -162,12 +162,14 @@ The current `guard` brain also reads optional patrol settings from `params`. Pat
 {
   "params": {
     "patrol_mode": { "type": "string", "value": "random_roam" },
-    "patrol_radius": { "type": "number", "value": 6 }
+    "patrol_radius": { "type": "string", "value": "6" }
   }
 }
 ```
 
-`home_*` remains the patrol center. The guard samples random roam points around the captured home point, and `leash_radius` remains the hard outer boundary because patrol radius is capped to it.
+`patrol_radius` is stored as a string param because mobile template params currently support `string`, `serial`, and `hue` values. `guard.lua` parses the radius with `tonumber(...)` at runtime.
+
+`home_*` remains the patrol center. The guard samples random roam points around the captured home point, and `leash_radius` remains the hard outer boundary because patrol radius is capped to it and immediate boundary breaches hand control back to the existing home-recovery flow in the same think cycle.
 
 Existing production guard templates in `moongate_data/templates/mobiles/guards.json` do not set these patrol params, so their current behavior is unchanged.
 

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -2,6 +2,11 @@
 
 This page explains the behavior-oriented Lua AI model used by Moongate v2 NPC brains.
 
+If you have never authored an NPC before, start with the tutorial path first:
+
+- [Create Your First NPC Brain](create-your-first-npc-brain.md)
+- [Create Your First NPC Template](create-your-first-npc-template.md)
+
 ## Goal
 
 Keep NPC AI maintainable by separating:

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -154,6 +154,23 @@ Combat hooks (`attack`, `missed_attack`, `attacked`, `missed_by_attack`, `combat
 
 Archer guards use `guard_role = "ranged"` and keep a 4-6 tile spacing band. Melee guards use the same brain but prefer direct closure and home recovery.
 
+## Optional Patrol Params
+
+The current `guard` brain also reads optional patrol settings from `params`. Patrol is opt-in: if `patrol_mode` is not set to `random_roam`, or `patrol_radius` is missing or non-positive, the guard keeps its existing idle and return-home behavior.
+
+```json
+{
+  "params": {
+    "patrol_mode": { "type": "string", "value": "random_roam" },
+    "patrol_radius": { "type": "number", "value": 6 }
+  }
+}
+```
+
+`home_*` remains the patrol center. The guard samples random roam points around the captured home point, and `leash_radius` remains the hard outer boundary because patrol radius is capped to it.
+
+Existing production guard templates in `moongate_data/templates/mobiles/guards.json` do not set these patrol params, so their current behavior is unchanged.
+
 `undead_melee.lua` is a simpler fixed-loop brain:
 
 - ticks every `2000ms`

--- a/docs/articles/scripting/npc-behaviors.md
+++ b/docs/articles/scripting/npc-behaviors.md
@@ -20,7 +20,7 @@ Keep NPC AI maintainable by separating:
 ```text
 moongate_data/scripts/ai/
 ├── behavior.lua                 # behavior registry
-├── modernuo/
+├── runtime/
 │   ├── fsm.lua                  # shared phase-1 FSM helpers
 │   ├── movement.lua             # shared movement intentions
 │   └── targeting.lua            # shared fight-mode and targeting helpers
@@ -228,7 +228,7 @@ Current built-in behavior modules under `moongate_data/scripts/ai/behaviors/` ar
 
 ## State (Blackboard)
 
-Behavior state is stored per NPC using `npc_state` module keys, for example:
+Behavior state is stored per NPC using canonical `npc_state` module keys, for example:
 
 - `follow_target_serial`
 - `home_x`
@@ -250,6 +250,13 @@ Behavior state is stored per NPC using `npc_state` module keys, for example:
 This keeps behavior logic stateless and reusable.
 
 The guard brain initializes defaults only when a key is missing. That keeps the scripts KISS while still allowing runtime tuning to override blackboard values without being overwritten every tick.
+
+The shared AI runtime also uses canonical blackboard keys:
+
+- `ai_action`
+- `ai_target_serial`
+
+Legacy aliases from the previous naming (`modernuo_action` and `modernuo_target_serial`) are still accepted by `npc_state` for compatibility. When the runtime reads them, it migrates the value to the canonical key and removes the legacy alias.
 
 ## Guard Ranges
 
@@ -289,7 +296,7 @@ For guards this means:
 - warrior guards notice hostiles at `3`, chase, and attack in melee
 - archer guards can notice hostiles earlier, position at `4-6`, and still fire out to the bow maximum range
 
-When a hostile leaves range, the guard brain now clears both `follow_target_serial` and the active combat target. That avoids stale target state lingering after `out_range`.
+When a hostile leaves `out_range`, the guard brain only clears the per-source engagement flag. It does not immediately drop focus or clear the active combat target from the event hook. Focus cleanup and home recovery are deferred to the next `on_think` tick, where the brain revalidates the target and decides whether to continue, teleport, or return home.
 
 Guards also capture a home point once, then use two simple rules:
 

--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -2,6 +2,19 @@
 
 Moongate v2 includes a powerful Lua scripting subsystem for gameplay customization.
 
+If you are starting from zero, begin with the hands-on tutorial path:
+
+- [Create Your First Content](create-your-first-content.md)
+- [Create Your First Systems](create-your-first-systems.md)
+- [Create Your First Item Template](create-your-first-item-template.md)
+- [Create Your First Item Script](create-your-first-item-script.md)
+- [Create Your First NPC Brain](create-your-first-npc-brain.md)
+- [Create Your First NPC Template](create-your-first-npc-template.md)
+- [Create Your First Loot Container](create-your-first-loot-container.md)
+- [Create Your First Scheduled Event](create-your-first-scheduled-event.md)
+- [Create Your First Gump](create-your-first-gump.md)
+- [Create Your First Lua Admin Command](create-your-first-lua-admin-command.md)
+
 ## Overview
 
 The scripting system is built on **MoonSharp**, a lightweight Lua interpreter for .NET. It provides:
@@ -137,8 +150,11 @@ For OpenAI-backed NPC speech and deterministic-to-generative fallback patterns, 
 [Intelligent NPC Dialogue](intelligent-npcs.md).
 For shard-level timed callbacks and recurring Lua-driven calendar behavior, see
 [Scheduled Events](scheduled-events.md).
+For first-open chest loot and refillable container behavior driven by item and loot templates, see
+[Loot Containers](loot-containers.md).
 For in-game help tickets opened from the client help button and persisted for staff review, see the
-`help_tickets` module and global `on_ticket_opened(event)` callback in the scripting API reference.
+[`help_tickets` module and callback docs](api.md#help-ticketing) plus the operator-facing
+[Help Ticket Workflow](../operations/help-ticket-workflow.md).
 For vendor sell profiles and context menu flow (native + custom Lua), see
 [Vendor and Context Menus](vendor-context-menus.md).
 For packaging gameplay extensions outside the core script tree, see [Lua Plugins](lua-plugins.md).
@@ -178,8 +194,17 @@ function orion.on_think(npc_id)
     end
 end
 
-function orion.on_speech(ctx)
-    -- ctx.source_serial, ctx.text, ctx.range...
+function orion.on_speech(npc_id, speaker_id, text, _speech_type, _map_id, _x, _y, _z)
+    if text == nil then
+        return
+    end
+
+    if string.find(string.lower(text), "hello", 1, true) then
+        local npc = mobile.get(npc_id)
+        if npc ~= nil then
+            npc:say("Meow!")
+        end
+    end
 end
 ```
 

--- a/docs/articles/scripting/toc.yml
+++ b/docs/articles/scripting/toc.yml
@@ -1,4 +1,24 @@
 items:
+  - name: Create Your First Content
+    href: create-your-first-content.md
+  - name: Create Your First Systems
+    href: create-your-first-systems.md
+  - name: Create Your First Item Template
+    href: create-your-first-item-template.md
+  - name: Create Your First Item Script
+    href: create-your-first-item-script.md
+  - name: Create Your First NPC Brain
+    href: create-your-first-npc-brain.md
+  - name: Create Your First NPC Template
+    href: create-your-first-npc-template.md
+  - name: Create Your First Loot Container
+    href: create-your-first-loot-container.md
+  - name: Create Your First Scheduled Event
+    href: create-your-first-scheduled-event.md
+  - name: Create Your First Gump
+    href: create-your-first-gump.md
+  - name: Create Your First Lua Admin Command
+    href: create-your-first-lua-admin-command.md
   - name: Overview
     href: overview.md
   - name: NPC Behaviors
@@ -7,8 +27,12 @@ items:
     href: authored-dialogues.md
   - name: Intelligent NPC Dialogue
     href: intelligent-npcs.md
+  - name: Lua Plugins
+    href: lua-plugins.md
   - name: Scheduled Events
     href: scheduled-events.md
+  - name: Loot Containers
+    href: loot-containers.md
   - name: Vendor and Context Menus
     href: vendor-context-menus.md
   - name: Starting Loadout
@@ -17,6 +41,12 @@ items:
     href: reputation-titles.md
   - name: Quivers
     href: quivers.md
+  - name: Async Jobs
+    href: async-jobs.md
+  - name: Tick Helper
+    href: tick.md
+  - name: Gump Tutorial
+    href: gump-tutorial.md
   - name: Modules
     href: modules.md
   - name: API Reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ This is the main documentation portal for Moongate v2.
 - [Sessions](articles/architecture/sessions.md)
 - [Plugin System](articles/architecture/plugins.md)
 - [Create Your First Plugin](articles/architecture/create-your-first-plugin.md)
+- [Create Your First C# Admin Command](articles/architecture/create-your-first-csharp-admin-command.md)
 - [Generators](articles/architecture/generators.md)
 - [Background Jobs](articles/architecture/background-jobs.md)
 - [Bootstrap System](articles/architecture/bootstrap.md)
@@ -29,11 +30,25 @@ This is the main documentation portal for Moongate v2.
 
 ## Scripting
 
+- [Create Your First Content](articles/scripting/create-your-first-content.md)
+- [Create Your First Systems](articles/scripting/create-your-first-systems.md)
+- [Create Your First Item Template](articles/scripting/create-your-first-item-template.md)
+- [Create Your First Item Script](articles/scripting/create-your-first-item-script.md)
+- [Create Your First NPC Brain](articles/scripting/create-your-first-npc-brain.md)
+- [Create Your First NPC Template](articles/scripting/create-your-first-npc-template.md)
+- [Create Your First Loot Container](articles/scripting/create-your-first-loot-container.md)
+- [Create Your First Scheduled Event](articles/scripting/create-your-first-scheduled-event.md)
+- [Create Your First Gump](articles/scripting/create-your-first-gump.md)
+- [Create Your First Lua Admin Command](articles/scripting/create-your-first-lua-admin-command.md)
 - [Scripting Overview](articles/scripting/overview.md)
+- [Authored Dialogues](articles/scripting/authored-dialogues.md)
+- [Scheduled Events](articles/scripting/scheduled-events.md)
+- [Loot Containers](articles/scripting/loot-containers.md)
 - [Vendor and Context Menus](articles/scripting/vendor-context-menus.md)
 - [Lua Starting Loadout](articles/scripting/starting-loadout.md)
 - [NPC Behaviors](articles/scripting/npc-behaviors.md)
 - [Intelligent NPC Dialogue](articles/scripting/intelligent-npcs.md)
+- [Lua Plugins](articles/scripting/lua-plugins.md)
 - [Gump Tutorial](articles/scripting/gump-tutorial.md)
 - [Script Modules](articles/scripting/modules.md)
 - [Lua API](articles/scripting/api.md)
@@ -47,6 +62,8 @@ This is the main documentation portal for Moongate v2.
 
 ## Networking
 
+- [Client Encryption](articles/networking/client-encryption.md)
+- [UDP Ping Server](articles/networking/udp-ping-server.md)
 - [Packet System](articles/networking/packets.md)
 - [Protocol Reference](articles/networking/protocol.md)
 - [Packet Handler Performance](articles/networking/packet-handler-performance.md)
@@ -58,6 +75,8 @@ This is the main documentation portal for Moongate v2.
 - [Stress Test](articles/operations/stress-test.md)
 - [Template Validation](articles/operations/template-validation.md)
 - [Console Commands](articles/operations/console-commands.md)
+- [In-Game Item Admin Commands](articles/operations/in-game-item-admin-commands.md)
+- [Help Ticket Workflow](articles/operations/help-ticket-workflow.md)
 
 ## Development
 

--- a/docs/templates/moongate/layout/_master.tmpl
+++ b/docs/templates/moongate/layout/_master.tmpl
@@ -1,0 +1,163 @@
+{{!Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license.}}
+{{!include(/^public/.*/)}}
+{{!include(favicon.ico)}}
+{{!include(logo.svg)}}
+<!DOCTYPE html>
+<html {{#_lang}}lang="{{_lang}}"{{/_lang}}>
+  <head>
+    <meta charset="utf-8">
+    {{#redirect_url}}
+      <meta http-equiv="refresh" content="0;URL='{{redirect_url}}'">
+    {{/redirect_url}}
+    {{^redirect_url}}
+      <title>{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
+      {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
+      {{#description}}<meta name="description" content="{{description}}">{{/description}}
+      <link rel="icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
+      <link rel="stylesheet" href="{{_rel}}public/docfx.min.css">
+      <link rel="stylesheet" href="{{_rel}}public/main.css">
+      <meta name="docfx:navrel" content="{{_navRel}}">
+      <meta name="docfx:tocrel" content="{{_tocRel}}">
+      {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
+      {{#_enableSearch}}<meta name="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
+      {{#_disableNewTab}}<meta name="docfx:disablenewtab" content="true">{{/_disableNewTab}}
+      {{#_disableTocFilter}}<meta name="docfx:disabletocfilter" content="true">{{/_disableTocFilter}}
+      {{#docurl}}<meta name="docfx:docurl" content="{{docurl}}">{{/docurl}}
+      <meta name="loc:inThisArticle" content="{{__global.inThisArticle}}">
+      <meta name="loc:searchResultsCount" content="{{__global.searchResultsCount}}">
+      <meta name="loc:searchNoResults" content="{{__global.searchNoResults}}">
+      <meta name="loc:tocFilter" content="{{__global.tocFilter}}">
+      <meta name="loc:nextArticle" content="{{__global.nextArticle}}">
+      <meta name="loc:prevArticle" content="{{__global.prevArticle}}">
+      <meta name="loc:themeLight" content="{{__global.themeLight}}">
+      <meta name="loc:themeDark" content="{{__global.themeDark}}">
+      <meta name="loc:themeAuto" content="{{__global.themeAuto}}">
+      <meta name="loc:changeTheme" content="{{__global.changeTheme}}">
+      <meta name="loc:copy" content="{{__global.copy}}">
+      <meta name="loc:downloadPdf" content="{{__global.downloadPdf}}">
+
+      <script type="module" src="./{{_rel}}public/docfx.min.js"></script>
+
+      <script>
+        try {
+          localStorage.setItem("theme", "dark");
+        } catch (error) {
+        }
+
+        document.documentElement.setAttribute("data-bs-theme", "dark");
+      </script>
+
+      {{#_googleAnalyticsTagId}}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{_googleAnalyticsTagId}}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', '{{_googleAnalyticsTagId}}');
+      </script>
+      {{/_googleAnalyticsTagId}}
+    {{/redirect_url}}
+  </head>
+
+  {{^redirect_url}}
+  <body class="tex2jax_ignore" data-layout="{{_layout}}{{layout}}" data-yaml-mime="{{yamlmime}}">
+    <header class="bg-body border-bottom">
+      {{^_disableNavbar}}
+      <nav id="autocollapse" class="navbar navbar-expand-md" role="navigation">
+        <div class="container-xxl flex-nowrap">
+          <a class="navbar-brand" href="{{_appLogoUrl}}{{^_appLogoUrl}}{{_rel}}index.html{{/_appLogoUrl}}">
+            <img id="logo" class="svg" src="{{_rel}}{{{_appLogoPath}}}{{^_appLogoPath}}logo.svg{{/_appLogoPath}}" alt="{{_appName}}" >
+            {{_appName}}
+          </a>
+          <button class="btn btn-lg d-md-none border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navpanel" aria-controls="navpanel" aria-expanded="false" aria-label="Toggle navigation">
+            <i class="bi bi-three-dots"></i>
+          </button>
+          <div class="collapse navbar-collapse" id="navpanel">
+            <div id="navbar">
+              {{#_enableSearch}}
+              <form class="search" role="search" id="search">
+                <i class="bi bi-search"></i>
+                <input class="form-control" id="search-query" type="search" disabled placeholder="{{__global.search}}" autocomplete="off" aria-label="Search">
+              </form>
+              {{/_enableSearch}}
+            </div>
+          </div>
+        </div>
+      </nav>
+      {{/_disableNavbar}}
+    </header>
+
+    <main class="container-xxl">
+      {{^_disableToc}}
+      <div class="toc-offcanvas">
+        <div class="offcanvas-md offcanvas-start" tabindex="-1" id="tocOffcanvas" aria-labelledby="tocOffcanvasLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="tocOffcanvasLabel">Table of Contents</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#tocOffcanvas" aria-label="Close"></button>
+          </div>
+          <div class="offcanvas-body">
+            <nav class="toc" id="toc"></nav>
+          </div>
+        </div>
+      </div>
+      {{/_disableToc}}
+
+      <div class="content">
+        <div class="actionbar">
+          {{^_disableToc}}
+          <button class="btn btn-lg border-0 d-md-none"
+              type="button" data-bs-toggle="offcanvas" data-bs-target="#tocOffcanvas"
+              aria-controls="tocOffcanvas" aria-expanded="false" aria-label="Show table of contents">
+            <i class="bi bi-list"></i>
+          </button>
+          {{/_disableToc}}
+
+          {{^_disableBreadcrumb}}
+          <nav id="breadcrumb"></nav>
+          {{/_disableBreadcrumb}}
+        </div>
+
+        <article data-uid="{{uid}}">
+          {{!body}}
+        </article>
+
+        {{^_disableContribution}}
+        <div class="contribution d-print-none">
+          {{#sourceurl}}
+          <a href="{{sourceurl}}" class="edit-link">{{__global.improveThisDoc}}</a>
+          {{/sourceurl}}
+          {{^sourceurl}}{{#docurl}}
+          <a href="{{docurl}}" class="edit-link">{{__global.improveThisDoc}}</a>
+          {{/docurl}}{{/sourceurl}}
+        </div>
+        {{/_disableContribution}}
+
+        {{^_disableNextArticle}}
+        <div class="next-article d-print-none border-top" id="nextArticle"></div>
+        {{/_disableNextArticle}}
+
+      </div>
+
+      {{^_disableAffix}}
+      <div class="affix">
+        <nav id="affix"></nav>
+      </div>
+      {{/_disableAffix}}
+    </main>
+
+    {{#_enableSearch}}
+    <div class="container-xxl search-results" id="search-results"></div>
+    {{/_enableSearch}}
+
+    <footer class="border-top text-secondary">
+      <div class="container-xxl">
+        <div class="flex-fill">
+          {{{_appFooter}}}{{^_appFooter}}<span>Made with <a href="https://dotnet.github.io/docfx">docfx</a></span>{{/_appFooter}}
+        </div>
+      </div>
+    </footer>
+  </body>
+  {{/redirect_url}}
+</html>

--- a/docs/templates/moongate/public/main.css
+++ b/docs/templates/moongate/public/main.css
@@ -1,179 +1,990 @@
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap");
 
 :root {
-  --mg-bg: #242130;
-  --mg-bg-soft: #343455;
-  --mg-surface: #3c4d81;
-  --mg-accent: #6aa5da;
-  --mg-accent-2: #7675c3;
-  --mg-text: #f9f4ed;
-  --mg-muted: #b9bbd3;
-  --mg-border: rgba(106, 165, 218, 0.25);
-  --mg-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+  --mg-bg: #0b1118;
+  --mg-bg-elevated: #111926;
+  --mg-bg-panel: rgba(15, 23, 35, 0.94);
+  --mg-bg-panel-strong: rgba(18, 28, 42, 0.98);
+  --mg-surface: #162132;
+  --mg-surface-soft: #1a293d;
+  --mg-surface-muted: #101822;
+  --mg-accent: #5ca3e6;
+  --mg-accent-strong: #86bdf0;
+  --mg-accent-soft: rgba(92, 163, 230, 0.16);
+  --mg-text: #e8edf5;
+  --mg-text-soft: #c6d1e1;
+  --mg-muted: #91a1b6;
+  --mg-muted-soft: #708198;
+  --mg-border: rgba(141, 167, 196, 0.16);
+  --mg-border-strong: rgba(141, 167, 196, 0.28);
+  --mg-border-accent: rgba(92, 163, 230, 0.34);
+  --mg-shadow: 0 22px 48px rgba(3, 8, 15, 0.34);
+  --mg-shadow-soft: 0 14px 32px rgba(3, 8, 15, 0.2);
+  --mg-radius-sm: 8px;
+  --mg-radius: 14px;
+  --mg-radius-lg: 20px;
   --mg-font-ui: "IBM Plex Sans", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   --mg-font-mono: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
 }
 
+html[data-bs-theme="dark"],
+html[data-bs-theme="light"] {
+  color-scheme: dark;
+  --bs-body-bg: var(--mg-bg);
+  --bs-body-color: var(--mg-text);
+  --bs-secondary-color: var(--mg-muted);
+  --bs-tertiary-bg: var(--mg-surface-muted);
+  --bs-border-color: var(--mg-border);
+  --bs-link-color: var(--mg-accent);
+  --bs-link-hover-color: var(--mg-accent-strong);
+  --bs-emphasis-color: var(--mg-text);
+}
+
 html[data-bs-theme="dark"] body,
 html[data-bs-theme="light"] body {
-  background: radial-gradient(circle at top right, #3c4d81 0%, #242130 46%, #1f1c2a 100%);
+  background:
+    radial-gradient(circle at top right, rgba(67, 112, 161, 0.18), transparent 32%),
+    radial-gradient(circle at top left, rgba(30, 64, 111, 0.14), transparent 30%),
+    linear-gradient(180deg, #0e1520 0%, #0b1118 46%, #0a1017 100%);
   color: var(--mg-text);
   font-family: var(--mg-font-ui);
   font-size: 15px;
-  line-height: 1.6;
-  letter-spacing: 0.01em;
+  line-height: 1.72;
+  letter-spacing: 0.004em;
+  min-height: 100vh;
 }
 
-html[data-bs-theme="dark"] .navbar,
-html[data-bs-theme="light"] .navbar,
-html[data-bs-theme="dark"] .content,
-html[data-bs-theme="light"] .content,
-html[data-bs-theme="dark"] .sidetoc,
-html[data-bs-theme="light"] .sidetoc,
-html[data-bs-theme="dark"] .toc,
-html[data-bs-theme="light"] .toc {
-  background-color: rgba(36, 33, 48, 0.9);
-}
-
+body,
 .content,
 .article {
   font-family: var(--mg-font-ui);
+}
+
+::selection {
+  background: rgba(92, 163, 230, 0.28);
+  color: var(--mg-text);
+}
+
+a {
+  color: var(--mg-accent);
+  text-decoration-color: rgba(92, 163, 230, 0.42);
+  text-underline-offset: 0.18em;
+}
+
+a:hover,
+a:focus {
+  color: var(--mg-accent-strong);
+  text-decoration-color: currentcolor;
+}
+
+p,
+li,
+dd,
+dt {
+  color: var(--mg-text-soft);
+}
+
+small,
+.text-muted,
+.article-meta,
+.text-secondary {
+  color: var(--mg-muted) !important;
+}
+
+.bg-body,
+.border-bottom,
+.border-top {
+  border-color: var(--mg-border) !important;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 1030;
+  backdrop-filter: blur(18px);
+  background: rgba(8, 13, 20, 0.76);
+}
+
+.navbar {
+  padding: 0;
+  min-height: 64px;
+  background: rgba(12, 18, 28, 0.78);
+  border-bottom: 1px solid var(--mg-border);
+  box-shadow: 0 10px 28px rgba(5, 10, 16, 0.16);
+}
+
+.navbar > .container-xxl {
+  min-height: 64px;
+  gap: 1rem;
 }
 
 .navbar-brand #logo {
   display: none;
 }
 
-.navbar-brand::before {
-  content: "MOONGATE";
-  margin-right: 0.5rem;
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  opacity: 0.9;
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 0.75rem;
+  color: var(--mg-text) !important;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  white-space: nowrap;
+  padding: 0;
+  margin-right: 2.25rem;
 }
 
-html[data-bs-theme="dark"] .navbar-brand,
-html[data-bs-theme="light"] .navbar-brand,
-html[data-bs-theme="dark"] a,
-html[data-bs-theme="light"] a {
-  color: var(--mg-accent);
+.navbar-brand:hover,
+.navbar-brand:focus {
+  color: var(--mg-text) !important;
+  text-decoration: none;
 }
 
-html[data-bs-theme="dark"] a:hover,
-html[data-bs-theme="light"] a:hover,
-html[data-bs-theme="dark"] a:focus,
-html[data-bs-theme="light"] a:focus {
-  color: var(--mg-accent-2);
+.navbar .btn {
+  color: var(--mg-text-soft);
 }
 
-html[data-bs-theme="dark"] .toc .nav > li > a,
-html[data-bs-theme="light"] .toc .nav > li > a {
+.navbar .btn:hover,
+.navbar .btn:focus {
+  color: var(--mg-text);
+}
+
+.navbar #navbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+#navbar > form.icons > .dropdown,
+#navbar > form.icons > .dropdown-toggle,
+#navbar > form.icons > .dropdown-menu {
+  display: none !important;
+}
+
+.navbar #search {
+  position: relative;
+  min-width: min(100%, 21rem);
+}
+
+.navbar #search > i.bi {
+  left: 0.95rem;
+  color: var(--mg-muted);
+  opacity: 1;
+}
+
+.navbar #search-query {
+  min-height: 2.75rem;
+  padding-left: 2.7rem;
+  border: 1px solid var(--mg-border);
+  border-radius: 999px;
+  background: rgba(20, 29, 42, 0.9);
+  color: var(--mg-text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.navbar #search-query::placeholder {
   color: var(--mg-muted);
 }
 
-html[data-bs-theme="dark"] .toc .nav > li.active > a,
-html[data-bs-theme="light"] .toc .nav > li.active > a {
-  color: var(--mg-text);
-  border-left-color: var(--mg-accent);
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: var(--mg-font-ui);
-  letter-spacing: 0.01em;
-  color: var(--mg-text);
-}
-
-h1 {
-  font-size: 2rem;
-  font-weight: 700;
-  margin-top: 0.2rem;
-  margin-bottom: 1rem;
-}
-
-h2 {
-  font-size: 1.45rem;
-  font-weight: 600;
-  margin-top: 2rem;
-  margin-bottom: 0.8rem;
-}
-
-h3 {
-  font-size: 1.2rem;
-  font-weight: 600;
-  margin-top: 1.6rem;
-}
-
-p,
-li {
-  color: var(--mg-text);
-}
-
-small,
-.text-muted,
-.article-meta {
-  color: var(--mg-muted) !important;
-}
-
-html[data-bs-theme="dark"] code,
-html[data-bs-theme="light"] code,
-html[data-bs-theme="dark"] pre,
-html[data-bs-theme="light"] pre {
-  background-color: rgba(52, 52, 85, 0.65);
-  border-color: var(--mg-border);
-  font-family: var(--mg-font-mono);
-}
-
-code {
-  padding: 0.14rem 0.36rem;
-  font-size: 0.9em;
-}
-
-pre {
-  border: 1px solid var(--mg-border);
-  border-radius: 6px;
-  box-shadow: var(--mg-shadow);
-  padding: 0.9rem 1rem;
-}
-
-.navbar,
-.sidefilter,
-.sidetoc,
-.toc,
-.content {
-  border-color: var(--mg-border) !important;
-}
-
-.sidetoc .toc,
-.toc .nav,
-.sideaffix {
-  font-size: 0.92rem;
-}
-
-.sidetoc .toc a {
-  padding-top: 0.26rem;
-  padding-bottom: 0.26rem;
-}
-
-html[data-bs-theme="dark"] .table > thead > tr > th,
-html[data-bs-theme="dark"] .table > tbody > tr > td,
-html[data-bs-theme="light"] .table > thead > tr > th,
-html[data-bs-theme="light"] .table > tbody > tr > td {
-  border-color: var(--mg-border);
-}
-
-.table thead th {
-  font-weight: 600;
-  letter-spacing: 0.01em;
+.navbar #search-query:focus {
+  border-color: var(--mg-border-accent);
+  box-shadow: 0 0 0 0.2rem rgba(92, 163, 230, 0.14);
 }
 
 .btn,
 .form-control,
-.input-group-text {
+.input-group-text,
+.btn-close {
   font-family: var(--mg-font-ui);
+}
+
+.btn-close {
+  filter: invert(1) opacity(0.72);
+}
+
+main.container-xxl {
+  padding-top: 1.6rem;
+  padding-bottom: 2rem;
+  gap: 1.5rem;
+}
+
+.content,
+.affix,
+#search-results {
+  background: linear-gradient(180deg, var(--mg-bg-panel-strong) 0%, rgba(13, 20, 31, 0.96) 100%);
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius-lg);
+  box-shadow: var(--mg-shadow);
+}
+
+.content {
+  padding: 0;
+  overflow: hidden;
+}
+
+.actionbar {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1rem 1.4rem;
+  border-bottom: 1px solid var(--mg-border);
+  background: linear-gradient(180deg, rgba(21, 31, 46, 0.9) 0%, rgba(16, 24, 36, 0.82) 100%);
+}
+
+#breadcrumb:empty {
+  display: none;
+}
+
+.breadcrumb {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.breadcrumb a {
+  color: var(--mg-muted);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover,
+.breadcrumb a:focus {
+  color: var(--mg-accent-strong);
+}
+
+.divider {
+  color: var(--mg-muted-soft);
+}
+
+article {
+  padding: 1.9rem 1.8rem 2.1rem;
+}
+
+article > :first-child {
+  margin-top: 0;
+}
+
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6 {
+  color: var(--mg-text);
+  font-family: var(--mg-font-ui);
+  line-height: 1.22;
+  letter-spacing: -0.01em;
+}
+
+article h1 {
+  margin: 0 0 1.05rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+article h2 {
+  margin-top: 2.75rem;
+  margin-bottom: 1rem;
+  padding-top: 0.25rem;
+  font-size: 1.56rem;
+  font-weight: 650;
+  border-top: 1px solid rgba(141, 167, 196, 0.12);
+}
+
+article h3 {
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.22rem;
+  font-weight: 600;
+}
+
+article h4 {
+  margin-top: 1.6rem;
+  margin-bottom: 0.55rem;
+  font-size: 1.02rem;
+  font-weight: 600;
+}
+
+article p,
+article ul,
+article ol,
+article dl,
+article table,
+article .tabGroup,
+article .alert,
+article blockquote,
+article .codewrapper,
+article pre {
+  margin-bottom: 1.15rem;
+}
+
+article ul,
+article ol {
+  padding-left: 1.35rem;
+}
+
+article li + li {
+  margin-top: 0.34rem;
+}
+
+article strong,
+article b {
+  color: var(--mg-text);
+}
+
+article hr {
+  margin: 2.2rem 0;
+  border-color: var(--mg-border);
+  opacity: 1;
+}
+
+blockquote {
+  margin: 1.6rem 0 2rem;
+  padding: 1rem 1.2rem;
+  border-left: 3px solid var(--mg-accent);
+  border-radius: 0 var(--mg-radius-sm) var(--mg-radius-sm) 0;
+  background: rgba(92, 163, 230, 0.08);
+  color: var(--mg-text-soft);
+}
+
+blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+code,
+pre,
+pre code,
+.codewrapper code,
+.codewrapper pre {
+  font-family: var(--mg-font-mono);
+}
+
+code {
+  padding: 0.16rem 0.4rem;
+  border: 1px solid rgba(141, 167, 196, 0.16);
+  border-radius: 7px;
+  background: rgba(19, 28, 41, 0.88);
+  color: #d9ebff;
+  font-size: 0.9em;
+}
+
+pre {
+  padding: 1.05rem 1.15rem;
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  background:
+    linear-gradient(180deg, rgba(16, 24, 36, 0.98) 0%, rgba(11, 17, 25, 0.98) 100%);
+  color: var(--mg-text);
+  box-shadow: var(--mg-shadow-soft);
+  overflow-x: auto;
+}
+
+pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 0.92rem;
+}
+
+.codewrapper {
+  position: relative;
+}
+
+pre > .code-action {
+  top: 0.6rem;
+  right: 0.55rem;
+  display: none;
+  padding: 0.12rem 0.32rem;
+  border: 1px solid var(--mg-border);
+  border-radius: 999px;
+  background: rgba(22, 32, 47, 0.92);
+  color: var(--mg-muted);
+}
+
+pre:hover > .code-action {
+  display: inline-flex;
+}
+
+pre > .code-action:hover,
+pre > .code-action:focus {
+  color: var(--mg-text);
+  border-color: var(--mg-border-accent);
+}
+
+.table-responsive {
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  background: rgba(14, 20, 30, 0.78);
+  box-shadow: var(--mg-shadow-soft);
+}
+
+.table,
+article table {
+  margin-bottom: 0;
+  color: var(--mg-text-soft);
+}
+
+.table > thead > tr > th,
+.table > tbody > tr > td,
+.table > tbody > tr > th,
+article table > thead > tr > th,
+article table > tbody > tr > td,
+article table > tbody > tr > th {
+  border-color: var(--mg-border);
+  background: transparent;
+}
+
+.table thead th,
+article table thead th {
+  color: var(--mg-text);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(22, 33, 50, 0.75);
+}
+
+.table tbody tr:nth-of-type(2n) td,
+.table tbody tr:nth-of-type(2n) th,
+article table tbody tr:nth-of-type(2n) td,
+article table tbody tr:nth-of-type(2n) th {
+  background: rgba(255, 255, 255, 0.018);
+}
+
+.alert,
+.NOTE,
+.TIP,
+.WARNING,
+.IMPORTANT,
+.CAUTION {
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  box-shadow: none;
+  padding: 1rem 1.15rem;
+}
+
+.alert h5,
+.NOTE h5,
+.TIP h5,
+.WARNING h5,
+.IMPORTANT h5,
+.CAUTION h5 {
+  margin-bottom: 0.7rem;
+  font-size: 0.88rem;
+  letter-spacing: 0.1em;
+}
+
+.alert-info {
+  background: rgba(47, 94, 147, 0.14);
+  border-color: rgba(92, 163, 230, 0.25);
+  color: var(--mg-text-soft);
+}
+
+.alert-warning {
+  background: rgba(128, 88, 22, 0.16);
+  border-color: rgba(208, 152, 59, 0.28);
+  color: var(--mg-text-soft);
+}
+
+.alert-danger {
+  background: rgba(118, 43, 43, 0.18);
+  border-color: rgba(207, 92, 92, 0.28);
+  color: var(--mg-text-soft);
+}
+
+.NOTE,
+.TIP {
+  background: rgba(47, 94, 147, 0.14);
+  border-color: rgba(92, 163, 230, 0.25);
+}
+
+.WARNING {
+  background: rgba(128, 88, 22, 0.16);
+  border-color: rgba(208, 152, 59, 0.28);
+}
+
+.IMPORTANT,
+.CAUTION {
+  background: rgba(118, 43, 43, 0.18);
+  border-color: rgba(207, 92, 92, 0.28);
+}
+
+.tabGroup > ul {
+  gap: 0.35rem;
+  border-bottom: 1px solid var(--mg-border);
+}
+
+.tabGroup > ul > li > a {
+  color: var(--mg-muted);
+  border: 1px solid transparent;
+  border-radius: var(--mg-radius-sm) var(--mg-radius-sm) 0 0;
+  padding: 0.55rem 0.9rem;
+}
+
+.tabGroup > ul > li > a.active,
+.tabGroup > ul > li > a:hover,
+.tabGroup > ul > li > a:focus {
+  color: var(--mg-text);
+  background: rgba(22, 33, 50, 0.78);
+  border-color: var(--mg-border);
+  text-decoration: none;
+}
+
+.tabGroup > section {
+  margin: 0;
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--mg-border);
+  border-top: 0;
+  border-bottom-left-radius: var(--mg-radius);
+  border-bottom-right-radius: var(--mg-radius);
+  background: rgba(12, 18, 28, 0.76);
+}
+
+.contribution,
+.next-article {
+  margin: 0 1.8rem 1.35rem;
+}
+
+.contribution {
+  padding-top: 0.4rem;
+}
+
+.contribution .edit-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--mg-muted);
+}
+
+.contribution .edit-link:hover,
+.contribution .edit-link:focus {
+  color: var(--mg-accent-strong);
+  text-decoration: none;
+}
+
+.next-article {
+  gap: 0.9rem;
+  padding-top: 1.1rem;
+  border-color: var(--mg-border) !important;
+}
+
+.next-article > div {
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  background: rgba(15, 22, 33, 0.82);
+}
+
+.next-article > div > span {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--mg-muted);
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.next-article > div > a {
+  color: var(--mg-text);
+  text-decoration: none;
+}
+
+.next-article > div > a:hover,
+.next-article > div > a:focus {
+  color: var(--mg-accent-strong);
+}
+
+body:not([data-search]) > main > .affix,
+.affix {
+  padding: 1rem 1rem 1.15rem;
+  background: linear-gradient(180deg, rgba(17, 26, 39, 0.95) 0%, rgba(12, 18, 28, 0.95) 100%);
+}
+
+.affix h5 {
+  display: block;
+  padding: 0 0 0.8rem;
+  margin: 0 0 0.8rem;
+  color: var(--mg-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--mg-border);
+}
+
+.affix ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.affix ul li {
+  margin: 0;
+}
+
+.affix ul li + li {
+  margin-top: 0.2rem;
+}
+
+.affix ul li a,
+.affix a {
+  display: block;
+  padding: 0.34rem 0.55rem;
+  color: var(--mg-muted);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.affix ul li a:hover,
+.affix ul li a:focus,
+.affix li.active > a,
+.affix a.active {
+  color: var(--mg-text);
+  background: rgba(92, 163, 230, 0.1);
+}
+
+.toc-offcanvas .offcanvas-md,
+.offcanvas {
+  background: linear-gradient(180deg, rgba(13, 20, 31, 0.99) 0%, rgba(10, 16, 24, 0.99) 100%);
+  color: var(--mg-text);
+}
+
+.offcanvas-header {
+  border-bottom: 1px solid var(--mg-border);
+}
+
+.offcanvas-title {
+  color: var(--mg-text);
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sidetoc,
+.toc,
+.sidefilter {
+  background: transparent;
+}
+
+.sidefilter {
+  margin-bottom: 0.8rem;
+}
+
+.sidefilter .toc-filter,
+.toc form.filter {
+  display: flex;
+  position: relative;
+  align-items: center;
+}
+
+#toc_filter_input,
+.toc form.filter > input {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.8rem 0.55rem 2.25rem;
+  border: 1px solid var(--mg-border);
+  border-radius: 999px;
+  background: rgba(17, 25, 38, 0.9);
+  color: var(--mg-text);
+}
+
+#toc_filter_input::placeholder,
+.toc form.filter > input::placeholder {
+  color: var(--mg-muted);
+}
+
+.toc form.filter > i.bi,
+.sidefilter .filter-icon {
+  position: absolute;
+  left: 0.8rem;
+  color: var(--mg-muted);
+  opacity: 1;
+  pointer-events: none;
+}
+
+.sidefilter .clear-icon {
+  position: absolute;
+  right: 0.85rem;
+  color: var(--mg-muted);
+}
+
+.toc,
+.sidetoc .toc {
+  min-width: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.toc .nav,
+.toc ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.toc li {
+  position: relative;
+  margin: 0.12rem 0;
+  padding-left: 0.95rem;
+  font-weight: 400;
+}
+
+.toc li > a,
+.toc .nav > li > a {
+  display: block;
+  padding: 0.4rem 0.65rem;
+  border-left: 2px solid transparent;
+  border-radius: 0 8px 8px 0;
+  color: var(--mg-muted);
+  text-decoration: none;
+}
+
+.toc li > a:hover,
+.toc li > a:focus,
+.toc .nav > li > a:hover,
+.toc .nav > li > a:focus {
+  color: var(--mg-text);
+  background: rgba(92, 163, 230, 0.08);
+}
+
+.toc li.active > a,
+.toc .nav > li.active > a {
+  color: var(--mg-text);
+  background: rgba(92, 163, 230, 0.1);
+  border-left-color: var(--mg-accent);
+}
+
+.toc li > ul {
+  margin-top: 0.2rem;
+  padding-left: 0.28rem;
+}
+
+.toc .expand-stub:before {
+  color: var(--mg-muted);
+  font-size: 0.72rem;
+  margin-top: 0.42rem;
+  margin-left: -0.75rem;
+}
+
+.toc span.name-only {
+  display: block;
+  margin: 0.75rem 0 0.45rem;
+  color: var(--mg-text);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.toc > .no-result {
+  color: var(--mg-muted);
+}
+
+#search-results {
+  margin-top: 1.3rem;
+  padding: 1.25rem 1.4rem 1.6rem;
+}
+
+#search-results > .search-list {
+  color: var(--mg-muted);
+}
+
+#search-results .sr-item {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--mg-border);
+}
+
+#search-results .sr-item:last-child {
+  border-bottom: 0;
+}
+
+#search-results .sr-item > .item-title {
+  font-size: 1.2rem;
+}
+
+#search-results .sr-item > .item-href,
+#search-results .sr-item > .item-brief {
+  color: var(--mg-muted);
+}
+
+footer {
+  margin: 1.2rem auto 2rem;
+  background: transparent;
+}
+
+footer > .container-xxl {
+  padding: 1rem 1.4rem;
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  background: rgba(11, 17, 25, 0.72);
+  color: var(--mg-muted);
+}
+
+body[data-yaml-mime="ManagedReference"] article,
+body[data-yaml-mime="ApiPage"] article {
+  padding-top: 1.65rem;
+}
+
+body[data-yaml-mime="ManagedReference"] article h1[data-uid],
+body[data-yaml-mime="ApiPage"] article h1[data-uid] {
+  padding-right: 2.2rem;
+  margin-bottom: 0.9rem;
+}
+
+body[data-yaml-mime="ManagedReference"] article h2.section,
+body[data-yaml-mime="ApiPage"] article h2.section {
+  margin-top: 2.8rem;
+}
+
+body[data-yaml-mime="ManagedReference"] article h3[data-uid],
+body[data-yaml-mime="ApiPage"] article h3[data-uid] {
+  margin-top: 2rem;
+  padding-right: 2rem;
+  border-bottom: 1px solid rgba(141, 167, 196, 0.12);
+}
+
+body[data-yaml-mime="ManagedReference"] article h4.section,
+body[data-yaml-mime="ApiPage"] article h4.section {
+  color: var(--mg-text-soft);
+  font-weight: 600;
+}
+
+body[data-yaml-mime="ManagedReference"] article .facts,
+body[data-yaml-mime="ApiPage"] article .facts {
+  margin: 1rem 0 1.4rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  background: rgba(15, 22, 34, 0.72);
+  color: var(--mg-muted);
+}
+
+body[data-yaml-mime="ManagedReference"] article .facts dt,
+body[data-yaml-mime="ApiPage"] article .facts dt {
+  color: var(--mg-text);
+  font-weight: 600;
+}
+
+body[data-yaml-mime="ManagedReference"] article .header-action,
+body[data-yaml-mime="ApiPage"] article .header-action {
+  right: 0;
+  bottom: 0.15rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border: 1px solid var(--mg-border);
+  border-radius: 999px;
+  background: rgba(15, 23, 35, 0.92);
+  color: var(--mg-muted) !important;
+}
+
+body[data-yaml-mime="ManagedReference"] article .header-action:hover,
+body[data-yaml-mime="ManagedReference"] article .header-action:focus,
+body[data-yaml-mime="ApiPage"] article .header-action:hover,
+body[data-yaml-mime="ApiPage"] article .header-action:focus {
+  color: var(--mg-accent-strong) !important;
+  border-color: var(--mg-border-accent);
+  text-decoration: none;
+}
+
+body[data-yaml-mime="ManagedReference"] article dl.typelist,
+body[data-yaml-mime="ManagedReference"] article dl.parameters,
+body[data-yaml-mime="ApiPage"] article dl.typelist,
+body[data-yaml-mime="ApiPage"] article dl.parameters {
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--mg-border);
+  border-radius: var(--mg-radius);
+  background: rgba(14, 20, 31, 0.75);
+}
+
+body[data-yaml-mime="ManagedReference"] article dl.typelist > dt,
+body[data-yaml-mime="ManagedReference"] article dl.parameters > dt,
+body[data-yaml-mime="ApiPage"] article dl.typelist > dt,
+body[data-yaml-mime="ApiPage"] article dl.parameters > dt {
+  color: var(--mg-text);
+}
+
+body[data-yaml-mime="ManagedReference"] article td.term,
+body[data-yaml-mime="ApiPage"] article td.term {
+  color: var(--mg-text);
+}
+
+.mermaid {
+  background: transparent;
+}
+
+.hljs {
+  display: block;
+  background: transparent;
+  color: inherit;
+}
+
+article img {
+  border-radius: var(--mg-radius-sm);
+}
+
+@media (max-width: 1140px) {
+  main.container-xxl {
+    padding-top: 1.2rem;
+  }
+
+  .content,
+  .affix,
+  #search-results {
+    border-radius: 16px;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .navbar > .container-xxl {
+    min-height: 60px;
+    padding-top: 0.7rem;
+    padding-bottom: 0.7rem;
+  }
+
+  .navbar-brand {
+    gap: 0.55rem;
+    font-size: 0.94rem;
+  }
+
+  .navbar #navbar {
+    align-items: stretch;
+  }
+
+  .navbar #search {
+    width: 100%;
+    min-width: 100%;
+  }
+
+  main.container-xxl {
+    padding-left: 0.85rem;
+    padding-right: 0.85rem;
+    gap: 1rem;
+  }
+
+  .actionbar,
+  article,
+  .contribution,
+  .next-article,
+  #search-results,
+  footer > .container-xxl,
+  .affix {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  article {
+    padding-top: 1.35rem;
+    padding-bottom: 1.6rem;
+  }
+
+  .next-article {
+    flex-direction: column;
+  }
 }

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -32,6 +32,8 @@
     href: articles/architecture/plugins.md
   - name: Create Your First Plugin
     href: articles/architecture/create-your-first-plugin.md
+  - name: Create Your First C# Admin Command
+    href: articles/architecture/create-your-first-csharp-admin-command.md
   - name: Solution Structure
     href: articles/architecture/solution.md
   - name: Source Generators
@@ -52,16 +54,46 @@
 - name: Scripting
   href: articles/scripting/
   items:
+  - name: Create Your First Content
+    href: articles/scripting/create-your-first-content.md
+  - name: Create Your First Systems
+    href: articles/scripting/create-your-first-systems.md
+  - name: Create Your First Item Template
+    href: articles/scripting/create-your-first-item-template.md
+  - name: Create Your First Item Script
+    href: articles/scripting/create-your-first-item-script.md
+  - name: Create Your First NPC Brain
+    href: articles/scripting/create-your-first-npc-brain.md
+  - name: Create Your First NPC Template
+    href: articles/scripting/create-your-first-npc-template.md
+  - name: Create Your First Loot Container
+    href: articles/scripting/create-your-first-loot-container.md
+  - name: Create Your First Scheduled Event
+    href: articles/scripting/create-your-first-scheduled-event.md
+  - name: Create Your First Gump
+    href: articles/scripting/create-your-first-gump.md
+  - name: Create Your First Lua Admin Command
+    href: articles/scripting/create-your-first-lua-admin-command.md
   - name: Overview
     href: articles/scripting/overview.md
+  - name: Authored Dialogues
+    href: articles/scripting/authored-dialogues.md
+  - name: Scheduled Events
+    href: articles/scripting/scheduled-events.md
+  - name: Loot Containers
+    href: articles/scripting/loot-containers.md
   - name: Vendor and Context Menus
     href: articles/scripting/vendor-context-menus.md
+  - name: Starting Loadout
+    href: articles/scripting/starting-loadout.md
   - name: NPC Behaviors
     href: articles/scripting/npc-behaviors.md
   - name: Intelligent NPC Dialogue
     href: articles/scripting/intelligent-npcs.md
   - name: Lua Plugins
     href: articles/scripting/lua-plugins.md
+  - name: Reputation Titles
+    href: articles/scripting/reputation-titles.md
   - name: Script Modules
     href: articles/scripting/modules.md
   - name: API Reference
@@ -82,17 +114,25 @@
 - name: Networking
   href: articles/networking/
   items:
+  - name: Client Encryption
+    href: articles/networking/client-encryption.md
+  - name: UDP Ping Server
+    href: articles/networking/udp-ping-server.md
   - name: Packet System
     href: articles/networking/packets.md
+  - name: POL Packet Coverage
+    href: articles/networking/pol-packet-coverage.md
   - name: Protocol Reference
     href: articles/networking/protocol.md
   - name: Packet Handler Performance
     href: articles/networking/packet-handler-performance.md
+  - name: Cliloc Notes
+    href: articles/networking/cliloc-notes.md
   - name: Packet Reference
     href: articles/networking/packet-reference/index.md
 
 - name: Operations
-  href: articles/operations/stress-test.md
+  href: articles/operations/
   items:
   - name: Stress Test
     href: articles/operations/stress-test.md
@@ -100,6 +140,10 @@
     href: articles/operations/template-validation.md
   - name: Console Commands
     href: articles/operations/console-commands.md
+  - name: In-Game Item Admin Commands
+    href: articles/operations/in-game-item-admin-commands.md
+  - name: Help Ticket Workflow
+    href: articles/operations/help-ticket-workflow.md
 
 - name: Development
   items:

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -78,6 +78,10 @@ local function get_patrol_radius(npc_serial)
     return tonumber(npc_state.get_var(npc_serial, PATROL_RADIUS_KEY) or 0) or 0
 end
 
+local function mark_mode(npc_serial, mode)
+    npc_state.set_var(npc_serial, GUARD_MODE_KEY, mode)
+end
+
 local function clear_focus(npc_serial, npc)
     guards.set_focus(npc_serial, nil)
     fsm.clear_target(npc_serial)
@@ -94,8 +98,40 @@ local function set_focus(npc_serial, target_serial)
     fsm.set_target(npc_serial, target_serial)
 end
 
-local function mark_mode(npc_serial, mode)
-    npc_state.set_var(npc_serial, GUARD_MODE_KEY, mode)
+local function patrol_random_roam(npc_serial, npc)
+    local home_x, home_y, home_z, _, _, leash_radius = get_home_values(npc_serial)
+    local patrol_radius = get_patrol_radius(npc_serial)
+
+    if home_x == nil or home_y == nil or home_z == nil or patrol_radius <= 0 then
+        return false
+    end
+
+    local radius = math.max(0, math.floor(math.min(patrol_radius, leash_radius)))
+    if radius <= 0 then
+        return false
+    end
+
+    local origin_x = math.floor(home_x)
+    local origin_y = math.floor(home_y)
+    local origin_z = math.floor(home_z)
+    local patrol_x = origin_x
+    local patrol_y = origin_y
+
+    for _ = 1, 8 do
+        local offset_x = math.random(-radius, radius)
+        local offset_y = math.random(-radius, radius)
+
+        if (offset_x ~= 0 or offset_y ~= 0) and offset_x * offset_x + offset_y * offset_y <= radius * radius then
+            patrol_x = origin_x + offset_x
+            patrol_y = origin_y + offset_y
+            break
+        end
+    end
+
+    mark_mode(npc_serial, "patrol")
+    fsm.set_action(npc_serial, fsm.actions.wander)
+
+    return steering.move_to(npc_serial, patrol_x, patrol_y, origin_z, 0)
 end
 
 local function move_home(npc_serial, npc)
@@ -291,15 +327,11 @@ function guard.on_think(npc_serial)
                     set_focus(npc_serial, target_serial)
                 else
                     clear_focus(npc_serial, npc)
-                    local patrol_mode = get_patrol_mode(npc_serial)
-                    local patrol_radius = get_patrol_radius(npc_serial)
 
                     if should_return_home(npc_serial, npc) then
                         move_home(npc_serial, npc)
-                    elseif patrol_mode == "random_roam" and patrol_radius > 0 then
-                        mark_mode(npc_serial, "patrol")
-                        fsm.set_action(npc_serial, fsm.actions.wander)
-                        movement.wander(npc_serial, patrol_radius)
+                    elseif get_patrol_mode(npc_serial) == "random_roam" and get_patrol_radius(npc_serial) > 0 then
+                        patrol_random_roam(npc_serial, npc)
                     else
                         mark_mode(npc_serial, "idle")
                         fsm.set_action(npc_serial, fsm.actions.guard)
@@ -315,19 +347,12 @@ function guard.on_think(npc_serial)
                 handle_target(npc_serial, npc, target_serial, range_perception, range_fight)
             elseif should_return_home(npc_serial, npc) then
                 move_home(npc_serial, npc)
+            elseif get_patrol_mode(npc_serial) == "random_roam" and get_patrol_radius(npc_serial) > 0 then
+                patrol_random_roam(npc_serial, npc)
             else
-                local patrol_mode = get_patrol_mode(npc_serial)
-                local patrol_radius = get_patrol_radius(npc_serial)
-
-                if patrol_mode == "random_roam" and patrol_radius > 0 then
-                    mark_mode(npc_serial, "patrol")
-                    fsm.set_action(npc_serial, fsm.actions.wander)
-                    movement.wander(npc_serial, patrol_radius)
-                else
-                    mark_mode(npc_serial, "idle")
-                    fsm.set_action(npc_serial, fsm.actions.guard)
-                    movement.guard(npc_serial)
-                end
+                mark_mode(npc_serial, "idle")
+                fsm.set_action(npc_serial, fsm.actions.guard)
+                movement.guard(npc_serial)
             end
         end
 

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -2,9 +2,9 @@
 -- Guard policy lives here instead of in the generic runner.
 -- Melee and ranged guards share the same focus lifecycle but diverge on spacing.
 
-local fsm = require("ai.modernuo.fsm")
-local movement = require("ai.modernuo.movement")
-local targeting = require("ai.modernuo.targeting")
+local fsm = require("ai.runtime.fsm")
+local movement = require("ai.runtime.movement")
+local targeting = require("ai.runtime.targeting")
 local guards = require("guards")
 
 guard = {}

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -5,7 +5,7 @@
 local fsm = require("ai.runtime.fsm")
 local movement = require("ai.runtime.movement")
 local targeting = require("ai.runtime.targeting")
-local guards = require("guards")
+local guards = guards
 
 guard = {}
 

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -15,6 +15,8 @@ local HOME_Z_KEY = "home_z"
 local HOME_MAP_ID_KEY = "home_map_id"
 local GUARD_MODE_KEY = "guard_mode"
 local GUARD_ROLE_KEY = "guard_role"
+local PATROL_MODE_KEY = "patrol_mode"
+local PATROL_RADIUS_KEY = "patrol_radius"
 local PREFERRED_MIN_RANGE_KEY = "preferred_min_range"
 local PREFERRED_MAX_RANGE_KEY = "preferred_max_range"
 local HOLD_RADIUS_KEY = "hold_radius"
@@ -66,6 +68,14 @@ local function get_home_values(npc_serial)
     local leash_radius = tonumber(npc_state.get_var(npc_serial, LEASH_RADIUS_KEY) or 8) or 8
 
     return home_x, home_y, home_z, home_map_id, hold_radius, leash_radius
+end
+
+local function get_patrol_mode(npc_serial)
+    return tostring(npc_state.get_var(npc_serial, PATROL_MODE_KEY) or ""):lower()
+end
+
+local function get_patrol_radius(npc_serial)
+    return tonumber(npc_state.get_var(npc_serial, PATROL_RADIUS_KEY) or 0) or 0
 end
 
 local function clear_focus(npc_serial, npc)
@@ -281,9 +291,15 @@ function guard.on_think(npc_serial)
                     set_focus(npc_serial, target_serial)
                 else
                     clear_focus(npc_serial, npc)
+                    local patrol_mode = get_patrol_mode(npc_serial)
+                    local patrol_radius = get_patrol_radius(npc_serial)
 
                     if should_return_home(npc_serial, npc) then
                         move_home(npc_serial, npc)
+                    elseif patrol_mode == "random_roam" and patrol_radius > 0 then
+                        mark_mode(npc_serial, "patrol")
+                        fsm.set_action(npc_serial, fsm.actions.wander)
+                        movement.wander(npc_serial, patrol_radius)
                     else
                         mark_mode(npc_serial, "idle")
                         fsm.set_action(npc_serial, fsm.actions.guard)
@@ -300,9 +316,18 @@ function guard.on_think(npc_serial)
             elseif should_return_home(npc_serial, npc) then
                 move_home(npc_serial, npc)
             else
-                mark_mode(npc_serial, "idle")
-                fsm.set_action(npc_serial, fsm.actions.guard)
-                movement.guard(npc_serial)
+                local patrol_mode = get_patrol_mode(npc_serial)
+                local patrol_radius = get_patrol_radius(npc_serial)
+
+                if patrol_mode == "random_roam" and patrol_radius > 0 then
+                    mark_mode(npc_serial, "patrol")
+                    fsm.set_action(npc_serial, fsm.actions.wander)
+                    movement.wander(npc_serial, patrol_radius)
+                else
+                    mark_mode(npc_serial, "idle")
+                    fsm.set_action(npc_serial, fsm.actions.guard)
+                    movement.guard(npc_serial)
+                end
             end
         end
 

--- a/moongate_data/scripts/ai/brains/guard.lua
+++ b/moongate_data/scripts/ai/brains/guard.lua
@@ -131,7 +131,14 @@ local function patrol_random_roam(npc_serial, npc)
     mark_mode(npc_serial, "patrol")
     fsm.set_action(npc_serial, fsm.actions.wander)
 
-    return steering.move_to(npc_serial, patrol_x, patrol_y, origin_z, 0)
+    local moved = steering.move_to(npc_serial, patrol_x, patrol_y, origin_z, 0)
+    local current_npc = mobile.get(npc_serial)
+
+    if current_npc ~= nil and should_return_home(npc_serial, current_npc) then
+        return move_home(npc_serial, current_npc)
+    end
+
+    return moved
 end
 
 local function move_home(npc_serial, npc)

--- a/src/Moongate.Scripting/Internal/LuaReflectionHelper.cs
+++ b/src/Moongate.Scripting/Internal/LuaReflectionHelper.cs
@@ -36,7 +36,11 @@ internal static class LuaReflectionHelper
         {
             DataType.Nil     => null,
             DataType.Boolean => dynValue.Boolean,
-            DataType.Number  => Convert.ChangeType(dynValue.Number, targetType, CultureInfo.InvariantCulture),
+            DataType.Number  => Convert.ChangeType(
+                dynValue.Number,
+                GetConversionTargetType(targetType),
+                CultureInfo.InvariantCulture
+            ),
             DataType.String  => dynValue.String,
             DataType.Table   => dynValue.ToObject(),
             _                => dynValue.ToObject()
@@ -314,5 +318,12 @@ internal static class LuaReflectionHelper
         var converted = ConvertFromLua(firstArg, typeof(TInput));
 
         return converted is null ? default : (TInput?)converted;
+    }
+
+    private static Type GetConversionTargetType(Type targetType)
+    {
+        ArgumentNullException.ThrowIfNull(targetType);
+
+        return Nullable.GetUnderlyingType(targetType) ?? targetType;
     }
 }

--- a/tests/Moongate.Tests/Scripting/LuaNullableBindingTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNullableBindingTests.cs
@@ -1,0 +1,66 @@
+using DryIoc;
+using Moongate.Core.Data.Directories;
+using Moongate.Core.Types;
+using Moongate.Scripting.Attributes.Scripts;
+using Moongate.Scripting.Data.Internal;
+using Moongate.Scripting.Services;
+using Moongate.Tests.TestSupport;
+
+namespace Moongate.Tests.Scripting;
+
+public sealed class LuaNullableBindingTests
+{
+    [ScriptModule("nullable_test")]
+    private sealed class NullableBindingScriptModule
+    {
+        public uint? LastValue { get; private set; }
+
+        [ScriptFunction("capture")]
+        public uint? Capture(uint? value = null)
+        {
+            LastValue = value;
+
+            return value;
+        }
+    }
+
+    [Test]
+    public async Task ExecuteFunction_WhenLuaNumberTargetsNullableUInt_ShouldConvertWithoutThrowing()
+    {
+        using var temp = new TempDirectory();
+        var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDir = dirs[DirectoryType.Scripts];
+        var container = new Container();
+        var module = new NullableBindingScriptModule();
+        Directory.CreateDirectory(scriptsDir);
+        Directory.CreateDirectory(temp.Path);
+        container.RegisterInstance(module);
+
+        var service = new LuaScriptEngineService(
+            dirs,
+            [new(typeof(NullableBindingScriptModule))],
+            container,
+            new(temp.Path, scriptsDir, "0.1.0"),
+            []
+        );
+
+        await service.StartAsync();
+
+        var result = service.ExecuteFunction(
+            """
+            (function()
+                return nullable_test.capture(123)
+            end)()
+            """
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Success, Is.True, result.Message);
+                Assert.That(result.Data, Is.EqualTo(123d));
+                Assert.That(module.LastValue, Is.EqualTo(123u));
+            }
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/FileLoaders/MobileTemplateLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/FileLoaders/MobileTemplateLoaderTests.cs
@@ -334,6 +334,75 @@ public class MobileTemplateLoaderTests
     }
 
     [Test]
+    public async Task LoadAsync_WhenGuardUsesPatrolParams_ShouldLoadStringBackedPatrolValues()
+    {
+        using var tempDirectory = new TempDirectory();
+        var directoriesConfig = new DirectoriesConfig(
+            tempDirectory.Path,
+            DirectoryType.Data,
+            DirectoryType.Templates,
+            DirectoryType.Scripts,
+            DirectoryType.Save,
+            DirectoryType.Logs,
+            DirectoryType.Cache
+        );
+
+        var mobilesDirectory = Path.Combine(directoriesConfig[DirectoryType.Templates], "mobiles");
+        Directory.CreateDirectory(mobilesDirectory);
+
+        var filePath = Path.Combine(mobilesDirectory, "guard-patrol.json");
+        await File.WriteAllTextAsync(
+            filePath,
+            """
+            [
+              {
+                "type": "mobile",
+                "id": "patrol_guard",
+                "name": "Patrol Guard",
+                "ai": {
+                  "brain": "guard"
+                },
+                "variants": [
+                  {
+                    "name": "default",
+                    "appearance": {
+                      "body": "0x0190",
+                      "skinHue": 0,
+                      "hairHue": 0
+                    }
+                  }
+                ],
+                "params": {
+                  "patrol_mode": { "type": "string", "value": "random_roam" },
+                  "patrol_radius": { "type": "string", "value": "6" }
+                }
+              }
+            ]
+            """
+        );
+
+        var mobileTemplateService = new MobileTemplateService();
+        var loader = new MobileTemplateLoader(directoriesConfig, mobileTemplateService);
+
+        await loader.LoadAsync();
+
+        Assert.That(mobileTemplateService.TryGet("patrol_guard", out var template), Is.True);
+        Assert.That(template, Is.Not.Null);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(template!.Params.ContainsKey("patrol_mode"), Is.True);
+                Assert.That(template.Params["patrol_mode"].Type, Is.EqualTo(ItemTemplateParamType.String));
+                Assert.That(template.Params["patrol_mode"].Value, Is.EqualTo("random_roam"));
+                Assert.That(template.Params.ContainsKey("patrol_radius"), Is.True);
+                Assert.That(template.Params["patrol_radius"].Type, Is.EqualTo(ItemTemplateParamType.String));
+                Assert.That(template.Params["patrol_radius"].Value, Is.EqualTo("6"));
+            }
+        );
+    }
+
+    [Test]
     public async Task LoadAsync_WhenBaseMobileHasSellProfile_ShouldInheritSellProfileId()
     {
         using var tempDirectory = new TempDirectory();

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -5,6 +5,24 @@ namespace Moongate.Tests.Server.Services.Scripting;
 public sealed class GuardBrainAssetTests
 {
     [Test]
+    public void GuardBrainScript_ShouldUseAiRuntimeHelpers()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
+        var script = File.ReadAllText(scriptPath);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(script, Does.Contain("require(\"ai.runtime.fsm\")"));
+                Assert.That(script, Does.Contain("require(\"ai.runtime.movement\")"));
+                Assert.That(script, Does.Contain("require(\"ai.runtime.targeting\")"));
+                Assert.That(script, Does.Not.Contain("ai.modernuo."));
+            }
+        );
+    }
+
+    [Test]
     public void GuardBrainScript_ShouldGreetPlayersOnceAndAttackEnemiesOnInRange()
     {
         var repositoryRoot = GetRepositoryRoot();

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -35,6 +35,13 @@ public sealed class GuardBrainAssetTests
         Assert.That(onEventStart, Is.GreaterThan(onThinkStart));
 
         var onThinkScript = script.Substring(onThinkStart, onEventStart - onThinkStart);
+        var noTargetIdleStart = onThinkScript.IndexOf("clear_focus(npc_serial, npc)", StringComparison.Ordinal);
+        var noTargetIdleEnd = onThinkScript.IndexOf("coroutine.yield(TICK_DELAY_MS)", noTargetIdleStart, StringComparison.Ordinal);
+
+        Assert.That(noTargetIdleStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(noTargetIdleEnd, Is.GreaterThan(noTargetIdleStart));
+
+        var noTargetIdleScript = onThinkScript.Substring(noTargetIdleStart, noTargetIdleEnd - noTargetIdleStart);
 
         Assert.Multiple(
             () =>
@@ -43,9 +50,9 @@ public sealed class GuardBrainAssetTests
                     onThinkScript,
                     Does.Match(@"patrol_mode\s*==\s*""random_roam""[\s\S]*(?:movement|steering)\.wander\([^)]*\bpatrol_radius\b[^)]*\)")
                 );
-                Assert.That(onThinkScript, Does.Contain("movement.guard(npc_serial)"));
-                Assert.That(onThinkScript, Does.Contain("should_return_home(npc_serial, npc)"));
-                Assert.That(onThinkScript, Does.Contain("move_home(npc_serial, npc)"));
+                Assert.That(noTargetIdleScript, Does.Contain("should_return_home(npc_serial, npc)"));
+                Assert.That(noTargetIdleScript, Does.Contain("move_home(npc_serial, npc)"));
+                Assert.That(noTargetIdleScript, Does.Contain("movement.guard(npc_serial)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -43,18 +43,14 @@ public sealed class GuardBrainAssetTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(onThinkScript, Does.Contain("patrol_mode"));
+                Assert.That(script, Does.Contain("patrol_mode"));
+                Assert.That(script, Does.Contain("patrol_radius"));
+                Assert.That(script, Does.Match(@"patrol_mode\s*==\s*""random_roam"""));
                 Assert.That(onThinkScript, Does.Contain("patrol_radius"));
-                Assert.That(onThinkScript, Does.Contain("patrol_mode == \"random_roam\""));
                 Assert.That(onThinkScript, Does.Match(@"(?:movement|steering)\.wander\("));
-                Assert.That(
-                    onThinkScript,
-                    Does.Match(
-                        @"if should_return_home\(npc_serial, npc\) then\s+move_home\(npc_serial, npc\)\s+else\s+mark_mode\(npc_serial, ""idle""\)\s+fsm\.set_action\(npc_serial, fsm\.actions\.guard\)\s+movement\.guard\(npc_serial\)"
-                    )
-                );
-                Assert.That(onThinkScript, Does.Contain("local target_serial = guards.get_focus(npc_serial)"));
-                Assert.That(onThinkScript, Does.Contain("set_focus(npc_serial, target_serial)"));
+                Assert.That(onThinkScript, Does.Contain("should_return_home(npc_serial, npc)"));
+                Assert.That(onThinkScript, Does.Contain("move_home(npc_serial, npc)"));
+                Assert.That(onThinkScript, Does.Contain("movement.guard(npc_serial)"));
                 Assert.That(combatHookScript, Does.Contain("guards.try_reveal(npc_serial, source_serial)"));
                 Assert.That(combatHookScript, Does.Contain("set_focus(npc_serial, source_serial)"));
                 Assert.That(combatHookScript, Does.Contain("combat.set_target(npc_serial, source_serial)"));

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -28,13 +28,17 @@ public sealed class GuardBrainAssetTests
         var repositoryRoot = GetRepositoryRoot();
         var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
         var script = File.ReadAllText(scriptPath);
+        var combatHookStart = script.IndexOf("local function handle_combat_hook", StringComparison.Ordinal);
         var onThinkStart = script.IndexOf("function guard.on_think", StringComparison.Ordinal);
         var onEventStart = script.IndexOf("function guard.on_event", StringComparison.Ordinal);
 
+        Assert.That(combatHookStart, Is.GreaterThanOrEqualTo(0));
         Assert.That(onThinkStart, Is.GreaterThanOrEqualTo(0));
         Assert.That(onEventStart, Is.GreaterThan(onThinkStart));
+        Assert.That(combatHookStart, Is.LessThan(onThinkStart));
 
         var onThinkScript = script.Substring(onThinkStart, onEventStart - onThinkStart);
+        var combatHookScript = script.Substring(combatHookStart, onThinkStart - combatHookStart);
 
         Assert.Multiple(
             () =>
@@ -42,18 +46,18 @@ public sealed class GuardBrainAssetTests
                 Assert.That(onThinkScript, Does.Contain("patrol_mode"));
                 Assert.That(onThinkScript, Does.Contain("patrol_radius"));
                 Assert.That(onThinkScript, Does.Contain("patrol_mode == \"random_roam\""));
+                Assert.That(onThinkScript, Does.Match(@"(?:movement|steering)\.wander\("));
                 Assert.That(
-                    onThinkScript.Contains("movement.wander(", StringComparison.Ordinal)
-                        || onThinkScript.Contains("steering.wander(", StringComparison.Ordinal),
-                    Is.True
+                    onThinkScript,
+                    Does.Match(
+                        @"if should_return_home\(npc_serial, npc\) then\s+move_home\(npc_serial, npc\)\s+else\s+mark_mode\(npc_serial, ""idle""\)\s+fsm\.set_action\(npc_serial, fsm\.actions\.guard\)\s+movement\.guard\(npc_serial\)"
+                    )
                 );
-                Assert.That(onThinkScript, Does.Contain("movement.guard(npc_serial)"));
-                Assert.That(onThinkScript, Does.Contain("should_return_home"));
-                Assert.That(script, Does.Contain("guards.get_focus"));
-                Assert.That(script, Does.Contain("guards.set_focus"));
-                Assert.That(script, Does.Contain("handle_combat_hook"));
-                Assert.That(script, Does.Contain("combat.set_target"));
-                Assert.That(script, Does.Contain("set_focus(npc_serial, target_serial)"));
+                Assert.That(onThinkScript, Does.Contain("local target_serial = guards.get_focus(npc_serial)"));
+                Assert.That(onThinkScript, Does.Contain("set_focus(npc_serial, target_serial)"));
+                Assert.That(combatHookScript, Does.Contain("guards.try_reveal(npc_serial, source_serial)"));
+                Assert.That(combatHookScript, Does.Contain("set_focus(npc_serial, source_serial)"));
+                Assert.That(combatHookScript, Does.Contain("combat.set_target(npc_serial, source_serial)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -35,7 +35,7 @@ public sealed class GuardBrainAssetTests
                 Assert.That(
                     script,
                     Does.Match(
-                        @"function guard\.on_think\(npc_serial\)[\s\S]*?elseif[\s\S]*?patrol_mode\s*==\s*""random_roam""[\s\S]*?patrol_radius[\s\S]*(?:movement|steering)\.wander\("
+                        @"function guard\.on_think\(npc_serial\)[\s\S]*?elseif[\s\S]*?patrol_mode\s*==\s*""random_roam""[\s\S]*(?:movement|steering)\.wander\([^)]*\bpatrol_radius\b[^)]*\)"
                     )
                 );
                 Assert.That(
@@ -44,9 +44,6 @@ public sealed class GuardBrainAssetTests
                         @"function guard\.on_think\(npc_serial\)[\s\S]*?if should_return_home\(npc_serial, npc\) then[\s\S]*?move_home\(npc_serial, npc\)[\s\S]*?else[\s\S]*?movement\.guard\(npc_serial\)"
                     )
                 );
-                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?guards\.try_reveal\(npc_serial, source_serial\)"));
-                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?set_focus\(npc_serial, source_serial\)"));
-                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?combat\.set_target\(npc_serial, source_serial\)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -32,12 +32,21 @@ public sealed class GuardBrainAssetTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(script, Does.Contain("patrol_mode"));
-                Assert.That(script, Does.Contain("patrol_radius"));
-                Assert.That(script, Does.Match(@"patrol_mode\s*==\s*""random_roam"""));
-                Assert.That(script, Does.Match(@"elseif[\s\S]*?patrol_mode\s*==\s*""random_roam""[\s\S]*?patrol_radius[\s\S]*(?:movement|steering)\.wander\("));
-                Assert.That(script, Does.Match(@"if should_return_home\(npc_serial, npc\) then[\s\S]*?move_home\(npc_serial, npc\)[\s\S]*?else[\s\S]*?movement\.guard\(npc_serial\)"));
-                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?guards\.try_reveal\(npc_serial, source_serial\)[\s\S]*?set_focus\(npc_serial, source_serial\)[\s\S]*?combat\.set_target\(npc_serial, source_serial\)"));
+                Assert.That(
+                    script,
+                    Does.Match(
+                        @"function guard\.on_think\(npc_serial\)[\s\S]*?elseif[\s\S]*?patrol_mode\s*==\s*""random_roam""[\s\S]*?patrol_radius[\s\S]*(?:movement|steering)\.wander\("
+                    )
+                );
+                Assert.That(
+                    script,
+                    Does.Match(
+                        @"function guard\.on_think\(npc_serial\)[\s\S]*?if should_return_home\(npc_serial, npc\) then[\s\S]*?move_home\(npc_serial, npc\)[\s\S]*?else[\s\S]*?movement\.guard\(npc_serial\)"
+                    )
+                );
+                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?guards\.try_reveal\(npc_serial, source_serial\)"));
+                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?set_focus\(npc_serial, source_serial\)"));
+                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?combat\.set_target\(npc_serial, source_serial\)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -32,7 +32,8 @@ public sealed class GuardBrainAssetTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(script, Does.Contain("local guards = require(\"guards\")"));
+                Assert.That(script, Does.Contain("local guards = guards"));
+                Assert.That(script, Does.Not.Contain("require(\"guards\")"));
                 Assert.That(script, Does.Contain("function guard.on_think"));
                 Assert.That(script, Does.Contain("function guard.on_in_range"));
                 Assert.That(script, Does.Contain("function guard.on_out_range"));

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -28,22 +28,24 @@ public sealed class GuardBrainAssetTests
         var repositoryRoot = GetRepositoryRoot();
         var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
         var script = File.ReadAllText(scriptPath);
+        var onThinkStart = script.IndexOf("function guard.on_think", StringComparison.Ordinal);
+        var onEventStart = script.IndexOf("function guard.on_event", StringComparison.Ordinal);
+
+        Assert.That(onThinkStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(onEventStart, Is.GreaterThan(onThinkStart));
+
+        var onThinkScript = script.Substring(onThinkStart, onEventStart - onThinkStart);
 
         Assert.Multiple(
             () =>
             {
                 Assert.That(
-                    script,
-                    Does.Match(
-                        @"function guard\.on_think\(npc_serial\)[\s\S]*?elseif[\s\S]*?patrol_mode\s*==\s*""random_roam""[\s\S]*(?:movement|steering)\.wander\([^)]*\bpatrol_radius\b[^)]*\)"
-                    )
+                    onThinkScript,
+                    Does.Match(@"patrol_mode\s*==\s*""random_roam""[\s\S]*(?:movement|steering)\.wander\([^)]*\bpatrol_radius\b[^)]*\)")
                 );
-                Assert.That(
-                    script,
-                    Does.Match(
-                        @"function guard\.on_think\(npc_serial\)[\s\S]*?if should_return_home\(npc_serial, npc\) then[\s\S]*?move_home\(npc_serial, npc\)[\s\S]*?else[\s\S]*?movement\.guard\(npc_serial\)"
-                    )
-                );
+                Assert.That(onThinkScript, Does.Contain("movement.guard(npc_serial)"));
+                Assert.That(onThinkScript, Does.Contain("should_return_home(npc_serial, npc)"));
+                Assert.That(onThinkScript, Does.Contain("move_home(npc_serial, npc)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -23,6 +23,42 @@ public sealed class GuardBrainAssetTests
     }
 
     [Test]
+    public void GuardBrainScript_ShouldSupportOptionalRandomRoamPatrolMode()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
+        var script = File.ReadAllText(scriptPath);
+        var onThinkStart = script.IndexOf("function guard.on_think", StringComparison.Ordinal);
+        var onEventStart = script.IndexOf("function guard.on_event", StringComparison.Ordinal);
+
+        Assert.That(onThinkStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(onEventStart, Is.GreaterThan(onThinkStart));
+
+        var onThinkScript = script.Substring(onThinkStart, onEventStart - onThinkStart);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(onThinkScript, Does.Contain("patrol_mode"));
+                Assert.That(onThinkScript, Does.Contain("patrol_radius"));
+                Assert.That(onThinkScript, Does.Contain("random_roam"));
+                Assert.That(
+                    onThinkScript.Contains("movement.wander(", StringComparison.Ordinal)
+                        || onThinkScript.Contains("steering.wander(", StringComparison.Ordinal),
+                    Is.True
+                );
+                Assert.That(onThinkScript, Does.Contain("movement.guard(npc_serial)"));
+                Assert.That(onThinkScript, Does.Contain("should_return_home"));
+                Assert.That(script, Does.Contain("guards.get_focus"));
+                Assert.That(script, Does.Contain("guards.set_focus"));
+                Assert.That(script, Does.Contain("handle_combat_hook"));
+                Assert.That(script, Does.Contain("combat.set_target"));
+                Assert.That(script, Does.Contain("set_focus(npc_serial, target_serial)"));
+            }
+        );
+    }
+
+    [Test]
     public void GuardBrainScript_ShouldGreetPlayersOnceAndAttackEnemiesOnInRange()
     {
         var repositoryRoot = GetRepositoryRoot();

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -63,7 +63,11 @@ public sealed class GuardBrainAssetTests
                 Assert.That(patrolHelperScript, Does.Contain("math.min(patrol_radius, leash_radius)"));
                 Assert.That(patrolHelperScript, Does.Contain("math.random(-radius, radius)"));
                 Assert.That(patrolHelperScript, Does.Contain("offset_x * offset_x + offset_y * offset_y <= radius * radius"));
-                Assert.That(patrolHelperScript, Does.Contain("steering.move_to(npc_serial, patrol_x, patrol_y, origin_z, 0)"));
+                Assert.That(patrolHelperScript, Does.Contain("local moved = steering.move_to(npc_serial, patrol_x, patrol_y, origin_z, 0)"));
+                Assert.That(patrolHelperScript, Does.Contain("local current_npc = mobile.get(npc_serial)"));
+                Assert.That(patrolHelperScript, Does.Contain("should_return_home(npc_serial, current_npc)"));
+                Assert.That(patrolHelperScript, Does.Contain("return move_home(npc_serial, current_npc)"));
+                Assert.That(patrolHelperScript, Does.Contain("return moved"));
                 Assert.That(noTargetIdleScript, Does.Contain("move_home(npc_serial, npc)"));
             }
         );

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -28,17 +28,6 @@ public sealed class GuardBrainAssetTests
         var repositoryRoot = GetRepositoryRoot();
         var scriptPath = Path.Combine(repositoryRoot, "moongate_data", "scripts", "ai", "brains", "guard.lua");
         var script = File.ReadAllText(scriptPath);
-        var combatHookStart = script.IndexOf("local function handle_combat_hook", StringComparison.Ordinal);
-        var onThinkStart = script.IndexOf("function guard.on_think", StringComparison.Ordinal);
-        var onEventStart = script.IndexOf("function guard.on_event", StringComparison.Ordinal);
-
-        Assert.That(combatHookStart, Is.GreaterThanOrEqualTo(0));
-        Assert.That(onThinkStart, Is.GreaterThanOrEqualTo(0));
-        Assert.That(onEventStart, Is.GreaterThan(onThinkStart));
-        Assert.That(combatHookStart, Is.LessThan(onThinkStart));
-
-        var onThinkScript = script.Substring(onThinkStart, onEventStart - onThinkStart);
-        var combatHookScript = script.Substring(combatHookStart, onThinkStart - combatHookStart);
 
         Assert.Multiple(
             () =>
@@ -46,14 +35,9 @@ public sealed class GuardBrainAssetTests
                 Assert.That(script, Does.Contain("patrol_mode"));
                 Assert.That(script, Does.Contain("patrol_radius"));
                 Assert.That(script, Does.Match(@"patrol_mode\s*==\s*""random_roam"""));
-                Assert.That(onThinkScript, Does.Contain("patrol_radius"));
-                Assert.That(onThinkScript, Does.Match(@"(?:movement|steering)\.wander\("));
-                Assert.That(onThinkScript, Does.Contain("should_return_home(npc_serial, npc)"));
-                Assert.That(onThinkScript, Does.Contain("move_home(npc_serial, npc)"));
-                Assert.That(onThinkScript, Does.Contain("movement.guard(npc_serial)"));
-                Assert.That(combatHookScript, Does.Contain("guards.try_reveal(npc_serial, source_serial)"));
-                Assert.That(combatHookScript, Does.Contain("set_focus(npc_serial, source_serial)"));
-                Assert.That(combatHookScript, Does.Contain("combat.set_target(npc_serial, source_serial)"));
+                Assert.That(script, Does.Match(@"elseif[\s\S]*?patrol_mode\s*==\s*""random_roam""[\s\S]*?patrol_radius[\s\S]*(?:movement|steering)\.wander\("));
+                Assert.That(script, Does.Match(@"if should_return_home\(npc_serial, npc\) then[\s\S]*?move_home\(npc_serial, npc\)[\s\S]*?else[\s\S]*?movement\.guard\(npc_serial\)"));
+                Assert.That(script, Does.Match(@"local function handle_combat_hook\(npc_serial, source_serial, event_obj\)[\s\S]*?guards\.try_reveal\(npc_serial, source_serial\)[\s\S]*?set_focus\(npc_serial, source_serial\)[\s\S]*?combat\.set_target\(npc_serial, source_serial\)"));
             }
         );
     }

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -47,7 +47,7 @@ public sealed class GuardBrainAssetTests
             () =>
             {
                 Assert.That(
-                    onThinkScript,
+                    noTargetIdleScript,
                     Does.Match(@"patrol_mode\s*==\s*""random_roam""[\s\S]*(?:movement|steering)\.wander\([^)]*\bpatrol_radius\b[^)]*\)")
                 );
                 Assert.That(noTargetIdleScript, Does.Contain("should_return_home(npc_serial, npc)"));

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -41,7 +41,7 @@ public sealed class GuardBrainAssetTests
             {
                 Assert.That(onThinkScript, Does.Contain("patrol_mode"));
                 Assert.That(onThinkScript, Does.Contain("patrol_radius"));
-                Assert.That(onThinkScript, Does.Contain("random_roam"));
+                Assert.That(onThinkScript, Does.Contain("patrol_mode == \"random_roam\""));
                 Assert.That(
                     onThinkScript.Contains("movement.wander(", StringComparison.Ordinal)
                         || onThinkScript.Contains("steering.wander(", StringComparison.Ordinal),

--- a/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Scripting/GuardBrainAssetTests.cs
@@ -30,11 +30,16 @@ public sealed class GuardBrainAssetTests
         var script = File.ReadAllText(scriptPath);
         var onThinkStart = script.IndexOf("function guard.on_think", StringComparison.Ordinal);
         var onEventStart = script.IndexOf("function guard.on_event", StringComparison.Ordinal);
+        var patrolHelperStart = script.IndexOf("local function patrol_random_roam", StringComparison.Ordinal);
+        var moveHomeStart = script.IndexOf("local function move_home", StringComparison.Ordinal);
 
         Assert.That(onThinkStart, Is.GreaterThanOrEqualTo(0));
         Assert.That(onEventStart, Is.GreaterThan(onThinkStart));
+        Assert.That(patrolHelperStart, Is.GreaterThanOrEqualTo(0));
+        Assert.That(moveHomeStart, Is.GreaterThan(patrolHelperStart));
 
         var onThinkScript = script.Substring(onThinkStart, onEventStart - onThinkStart);
+        var patrolHelperScript = script.Substring(patrolHelperStart, moveHomeStart - patrolHelperStart);
         var noTargetIdleStart = onThinkScript.IndexOf("clear_focus(npc_serial, npc)", StringComparison.Ordinal);
         var noTargetIdleEnd = onThinkScript.IndexOf("coroutine.yield(TICK_DELAY_MS)", noTargetIdleStart, StringComparison.Ordinal);
 
@@ -46,13 +51,20 @@ public sealed class GuardBrainAssetTests
         Assert.Multiple(
             () =>
             {
-                Assert.That(
-                    noTargetIdleScript,
-                    Does.Match(@"patrol_mode\s*==\s*""random_roam""[\s\S]*(?:movement|steering)\.wander\([^)]*\bpatrol_radius\b[^)]*\)")
-                );
                 Assert.That(noTargetIdleScript, Does.Contain("should_return_home(npc_serial, npc)"));
-                Assert.That(noTargetIdleScript, Does.Contain("move_home(npc_serial, npc)"));
+                Assert.That(noTargetIdleScript, Does.Contain("patrol_random_roam(npc_serial, npc)"));
                 Assert.That(noTargetIdleScript, Does.Contain("movement.guard(npc_serial)"));
+                Assert.That(noTargetIdleScript, Does.Not.Contain("movement.wander(npc_serial, patrol_radius)"));
+                Assert.That(patrolHelperScript, Does.Contain("home_x"));
+                Assert.That(patrolHelperScript, Does.Contain("home_y"));
+                Assert.That(patrolHelperScript, Does.Contain("home_z"));
+                Assert.That(patrolHelperScript, Does.Contain("leash_radius"));
+                Assert.That(patrolHelperScript, Does.Contain("patrol_radius"));
+                Assert.That(patrolHelperScript, Does.Contain("math.min(patrol_radius, leash_radius)"));
+                Assert.That(patrolHelperScript, Does.Contain("math.random(-radius, radius)"));
+                Assert.That(patrolHelperScript, Does.Contain("offset_x * offset_x + offset_y * offset_y <= radius * radius"));
+                Assert.That(patrolHelperScript, Does.Contain("steering.move_to(npc_serial, patrol_x, patrol_y, origin_z, 0)"));
+                Assert.That(noTargetIdleScript, Does.Contain("move_home(npc_serial, npc)"));
             }
         );
     }


### PR DESCRIPTION
## Summary
- add opt-in `patrol_mode` / `patrol_radius` support to the existing `guard` Lua brain with home-centered roaming and same-tick recovery back to the normal home-return flow on boundary breach
- lock the feature with guard brain asset coverage plus a loader-level test that proves patrol params load as supported string-backed template params
- document the guard patrol params in the scripting guides and clarify that existing production guard templates remain unchanged

## Test Plan
- [x] `dotnet test Moongate.slnx`
- [x] `luac -p moongate_data/scripts/ai/brains/guard.lua`
- [x] `docfx docs/docfx.json --logLevel Warning`

Closes #196
