### PR TITLE
refactor: remove obsolete lua il suppressions

### DIFF
--- a/src/Moongate.Scripting/Extensions/Scripts/TableExtensions.cs
+++ b/src/Moongate.Scripting/Extensions/Scripts/TableExtensions.cs
@@ -13,7 +13,6 @@ public static class TableExtensions
     /// <summary>
     /// Converts a MoonSharp Table to a proxy implementing the specified interface.
     /// </summary>
-    [RequiresDynamicCode("DispatchProxy-based Lua table proxy requires runtime code generation.")]
     public static TInterface ToProxy<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TInterface>(
         this Table table
     )

--- a/src/Moongate.Scripting/Internal/LuaModuleLoader.cs
+++ b/src/Moongate.Scripting/Internal/LuaModuleLoader.cs
@@ -140,7 +140,6 @@ internal sealed class LuaModuleLoader
         return moduleTable;
     }
 
-    [RequiresUnreferencedCode("Enum registration uses reflection to access enum metadata.")]
     private void RegisterEnum(Type enumType)
     {
         ArgumentNullException.ThrowIfNull(enumType);

--- a/src/Moongate.Scripting/Internal/LuaReflectionHelper.cs
+++ b/src/Moongate.Scripting/Internal/LuaReflectionHelper.cs
@@ -210,11 +210,6 @@ internal static class LuaReflectionHelper
         };
     }
 
-    [UnconditionalSuppressMessage(
-        "Aot",
-        "IL3050",
-        Justification = "Lua params-array conversion requires runtime element type resolution by reflection."
-    )]
     public static DynValue CreateMethodClosure(ILogger logger, Script script, object instance, MethodInfo method)
     {
         ArgumentNullException.ThrowIfNull(logger);
@@ -285,9 +280,7 @@ internal static class LuaReflectionHelper
         ArgumentNullException.ThrowIfNull(obj);
 
         var table = new Table(script);
-#pragma warning disable IL2075
         var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
-#pragma warning restore IL2075
 
         foreach (var property in properties)
         {

--- a/src/Moongate.Scripting/Services/LuaScriptEngineService.cs
+++ b/src/Moongate.Scripting/Services/LuaScriptEngineService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using DryIoc;
@@ -22,9 +21,6 @@ using Moongate.Scripting.Utils;
 using Moongate.UO.Data.Utils;
 using MoonSharp.Interpreter;
 using Serilog;
-
-#pragma warning disable IL2026 // RequiresUnreferencedCode - Lua scripting uses reflection for dynamic functionality
-#pragma warning disable IL2072 // DynamicallyAccessedMemberTypes - Reflection access is necessary for scripting
 
 namespace Moongate.Scripting.Services;
 
@@ -919,9 +915,6 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
         }
     }
 
-    [RequiresUnreferencedCode(
-        "Lua meta generation relies on reflection-heavy LuaDocumentationGenerator which is not trim-safe."
-    )]
     private async Task GenerateLuaMetaFileAsync(CancellationToken cancellationToken)
     {
         try
@@ -1109,9 +1102,7 @@ public class LuaScriptEngineService : IScriptEngineService, IDisposable
             UserData.RegisterType(scriptUserData.UserType, new GenericUserDataDescriptor(scriptUserData.UserType));
 
             // Check if type has public constructors (instantiable)
-        #pragma warning disable IL2075 // Suppress AOT warning for script proxy
             var publicConstructors = scriptUserData.UserType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-        #pragma warning restore IL2075
 
             if (publicConstructors.Length > 0)
             {

--- a/src/Moongate.Scripting/Utils/LuaDocumentationGenerator.cs
+++ b/src/Moongate.Scripting/Utils/LuaDocumentationGenerator.cs
@@ -13,9 +13,6 @@ namespace Moongate.Scripting.Utils;
 /// Utility class for generating Lua meta files with EmmyLua/LuaLS annotations
 /// Automatically creates meta.lua files with function signatures, types, and documentation
 /// </summary>
-[RequiresUnreferencedCode(
-    "This class uses reflection to analyze types for Lua meta generation and requires full type metadata."
-)]
 public static class LuaDocumentationGenerator
 {
     private static readonly HashSet<Type> _processedTypes = new();
@@ -62,13 +59,6 @@ public static class LuaDocumentationGenerator
             _enumsBuilder.Clear();
         }
     }
-
-    [SuppressMessage("Trimming", "IL2075:Reflection", Justification = "Reflection is required for script module analysis"),
-     SuppressMessage(
-         "Trimming",
-         "IL2072:Reflection",
-         Justification = "Reflection is required for parameter and return type analysis"
-     )]
 
     /// <summary>
     ///     Generates Lua documentation meta file with all module functions, classes, and constants
@@ -283,9 +273,6 @@ public static class LuaDocumentationGenerator
     private static bool CanProcessType(Type type)
         => true;
 
-    [SuppressMessage("Trimming", "IL2070:Reflection", Justification = "Reflection is required for Lua type conversion"),
-     SuppressMessage("Trimming", "IL2072:Reflection", Justification = "Reflection is required for Lua type conversion"),
-     SuppressMessage("Trimming", "IL2062:Reflection", Justification = "Reflection is required for Lua type conversion")]
     private static string ConvertToLuaType(
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods |
@@ -537,11 +524,6 @@ public static class LuaDocumentationGenerator
         return "any";
     }
 
-    [SuppressMessage(
-        "Trimming",
-        "IL2072:Reflection",
-        Justification = "Reflection is required for constant value formatting"
-    )]
     private static string FormatConstantValue(object? value, Type type)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -622,8 +604,6 @@ public static class LuaDocumentationGenerator
     /// <summary>
     /// Generate a single class with properties, constructors, and methods
     /// </summary>
-    [SuppressMessage("Trimming", "IL2070:Reflection", Justification = "Reflection is required for class generation"),
-     SuppressMessage("Trimming", "IL2072:Reflection", Justification = "Reflection is required for class generation")]
     private static void GenerateClass(
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicProperties |
@@ -821,11 +801,6 @@ public static class LuaDocumentationGenerator
         _classesBuilder.AppendLine();
     }
 
-    [SuppressMessage(
-        "Trimming",
-        "IL2070:Reflection",
-        Justification = "Reflection is required for enum class generation"
-    )]
     private static void GenerateEnumClass(Type enumType)
     {
         ArgumentNullException.ThrowIfNull(enumType);
@@ -965,7 +940,6 @@ public static class LuaDocumentationGenerator
     /// <summary>
     /// Check if a type is a C# record type
     /// </summary>
-    [SuppressMessage("Trimming", "IL2070:Reflection", Justification = "Reflection is required for record type detection")]
     private static bool IsRecordType(
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicMethods
@@ -1013,7 +987,6 @@ public static class LuaDocumentationGenerator
         return result;
     }
 
-    [SuppressMessage("Trimming", "IL2072:Reflection", Justification = "Reflection is required for constant type analysis")]
     private static void ProcessConstants(Dictionary<string, object> constants)
     {
         ArgumentNullException.ThrowIfNull(constants);


### PR DESCRIPTION
## Summary
- remove obsolete trimming and AOT-related IL suppression pragmas from the Lua scripting runtime
- drop stale `RequiresUnreferencedCode` and `RequiresDynamicCode` annotations in `Moongate.Scripting`
- keep runtime behavior unchanged while cleaning metadata tied to a removed publish model

## Test Plan
- `dotnet build src/Moongate.Scripting/Moongate.Scripting.csproj`
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~LuaScriptEngineServiceTests|FullyQualifiedName~LuaDocumentationGeneratorTests|FullyQualifiedName~LuaScriptLoaderTests|FullyQualifiedName~LuaNullableBindingTests"`
- `rg -n "#pragma warning disable IL|SuppressMessage\(|UnconditionalSuppressMessage\(|RequiresUnreferencedCode|RequiresDynamicCode" src/Moongate.Scripting -g'*.cs'`

Closes #201
