### PR TITLE
feat: add gm menu spacing probe

### DIFF
--- a/moongate_data/scripts/gumps/gm_menu/constants.lua
+++ b/moongate_data/scripts/gumps/gm_menu/constants.lua
@@ -14,6 +14,7 @@ constants.MUTED_HUE = 1102
 
 constants.BUTTON_TAB_ADD = 10
 constants.BUTTON_TAB_TRAVEL = 11
+constants.BUTTON_TAB_PROBE = 12
 
 constants.TEXT_ENTRY_SEARCH = 1
 constants.TEXT_ENTRY_QUANTITY = 2

--- a/moongate_data/scripts/gumps/gm_menu/controller.lua
+++ b/moongate_data/scripts/gumps/gm_menu/controller.lua
@@ -28,6 +28,12 @@ function controller.build_layout(session_id, character_id, reopen_callback)
       return
     end
 
+    if button_id == c.BUTTON_TAB_PROBE then
+      state.set_active_tab(ctx.session_id, "probe")
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
     if button_id == c.BUTTON_TAB_ADD then
       state.set_active_tab(ctx.session_id, "add")
       reopen_callback(ctx.session_id, ctx.character_id)

--- a/moongate_data/scripts/gumps/gm_menu/render.lua
+++ b/moongate_data/scripts/gumps/gm_menu/render.lua
@@ -1,4 +1,5 @@
 local add_section = require("gumps.gm_menu.sections.add")
+local probe_section = require("gumps.gm_menu.sections.probe")
 local travel_section = require("gumps.gm_menu.sections.travel")
 
 local render = {}
@@ -6,6 +7,10 @@ local render = {}
 function render.add_content(layout, session_id, character_id, current_state, reopen_callback)
   if current_state.active_tab == "travel" then
     return travel_section.add_content(layout, session_id, character_id, reopen_callback)
+  end
+
+  if current_state.active_tab == "probe" then
+    return probe_section.add_content(layout, session_id, character_id, reopen_callback)
   end
 
   return add_section.add_content(layout, session_id, character_id, current_state, reopen_callback)

--- a/moongate_data/scripts/gumps/gm_menu/sections/probe.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/probe.lua
@@ -1,0 +1,95 @@
+local c = require("gumps.gm_menu.constants")
+local ui = require("gumps.gm_menu.ui")
+
+local probe_section = {}
+
+local SAMPLE_ROWS = {
+  {
+    name = "Extremely Long Decorative Plate Legs East",
+    meta = "decorative_plate_legs_east • 0x2B6D"
+  },
+  {
+    name = "Zombie Shipwright Veteran",
+    meta = "zombie_shipwright_veteran"
+  }
+}
+
+local function add_sample_rows(layout_ui, panel_x, panel_y, inner_line_gap, row_pitch)
+  local row_y = panel_y
+
+  for _, sample in ipairs(SAMPLE_ROWS) do
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = panel_x,
+      y = row_y,
+      width = 126,
+      height = 18,
+      hue = c.LABEL_HUE,
+      text = sample.name
+    })
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = panel_x,
+      y = row_y + inner_line_gap,
+      width = 126,
+      height = 18,
+      hue = c.MUTED_HUE,
+      text = sample.meta
+    })
+
+    row_y = row_y + row_pitch
+  end
+end
+
+local function add_probe_panel(layout_ui, x, title, subtitle, inner_line_gap, row_pitch)
+  ui.push(layout_ui, { type = "image_tiled", x = x, y = 112, width = 150, height = 312, gump_id = 2624 })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = x + 10,
+    y = 124,
+    width = 130,
+    height = 20,
+    hue = c.ACCENT_HUE,
+    text = title
+  })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = x + 10,
+    y = 144,
+    width = 130,
+    height = 28,
+    hue = c.MUTED_HUE,
+    text = subtitle
+  })
+
+  add_sample_rows(layout_ui, x + 10, 186, inner_line_gap, row_pitch)
+end
+
+function probe_section.add_content(layout, session_id, character_id, reopen_callback)
+  local layout_ui = layout.ui
+
+  ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 428, gump_id = 2624 })
+  ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Spacing Probe" })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 196,
+    y = 72,
+    width = 496,
+    height = 28,
+    hue = c.MUTED_HUE,
+    text = "Compare result row spacing in-client before changing the production Add tab rhythm."
+  })
+
+  add_probe_panel(layout_ui, 196, "Compact 16/36", "Tight but still readable.", 16, 36)
+  add_probe_panel(layout_ui, 362, "Balanced 16/38", "Closer to staff/admin gump cadence.", 16, 38)
+  add_probe_panel(layout_ui, 528, "Relaxed 18/40", "Most breathable option.", 18, 40)
+
+  _ = session_id
+  _ = character_id
+  _ = reopen_callback
+
+  return function()
+  end
+end
+
+return probe_section

--- a/moongate_data/scripts/gumps/gm_menu/state.lua
+++ b/moongate_data/scripts/gumps/gm_menu/state.lua
@@ -59,6 +59,8 @@ function state.set_active_tab(session_id, active_tab)
 
   if active_tab == "travel" then
     current.active_tab = "travel"
+  elseif active_tab == "probe" then
+    current.active_tab = "probe"
   else
     current.active_tab = "add"
   end

--- a/moongate_data/scripts/gumps/gm_menu/ui.lua
+++ b/moongate_data/scripts/gumps/gm_menu/ui.lua
@@ -19,11 +19,14 @@ end
 function ui.add_sidebar(layout_ui, current_state)
   local add_hue = c.LABEL_HUE
   local travel_hue = c.LABEL_HUE
+  local probe_hue = c.LABEL_HUE
 
   if current_state.active_tab == "add" then
     add_hue = c.ACCENT_HUE
-  else
+  elseif current_state.active_tab == "travel" then
     travel_hue = c.ACCENT_HUE
+  else
+    probe_hue = c.ACCENT_HUE
   end
 
   push(layout_ui, { type = "label", x = 32, y = 62, hue = c.TITLE_HUE, text = "Tools" })
@@ -33,6 +36,9 @@ function ui.add_sidebar(layout_ui, current_state)
 
   push(layout_ui, { type = "button", id = c.BUTTON_TAB_TRAVEL, x = 32, y = 126, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
   push(layout_ui, { type = "label", x = 64, y = 128, hue = travel_hue, text = "Travel" })
+
+  push(layout_ui, { type = "button", id = c.BUTTON_TAB_PROBE, x = 32, y = 158, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = 64, y = 160, hue = probe_hue, text = "Probe" })
 end
 
 return ui

--- a/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
@@ -1274,6 +1274,42 @@ public sealed class GmMenuLuaRuntimeTests
     }
 
     [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenSwitchingToProbe_ShouldRenderSpacingCalibrationSamples()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out var initialOutbound), Is.True);
+        Assert.That(initialOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var initialGump = (CompressedGumpPacket)initialOutbound.Packet;
+        Assert.That(initialGump.TextLines, Does.Contain("Probe"));
+
+        var probePacket = new GumpMenuSelectionPacket();
+        Assert.That(
+            probePacket.TryParse(BuildGumpResponsePacket((uint)context.Session.CharacterId, 0xB930, 12)),
+            Is.True
+        );
+        Assert.That(context.GumpDispatcher.TryDispatch(context.Session, probePacket), Is.True);
+        Assert.That(context.Queue.TryDequeue(out var probeOutbound), Is.True);
+        Assert.That(probeOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var probeGump = (CompressedGumpPacket)probeOutbound.Packet;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(probeGump.TextLines, Does.Contain("Spacing Probe"));
+                Assert.That(probeGump.TextLines, Does.Contain("Compact 16/36"));
+                Assert.That(probeGump.TextLines, Does.Contain("Balanced 16/38"));
+                Assert.That(probeGump.TextLines, Does.Contain("Relaxed 18/40"));
+                Assert.That(probeGump.TextLines, Has.Some.Contains("Extremely Long Decorative Plate Legs"));
+                Assert.That(probeGump.TextLines, Has.Some.Contains("decorative_plate_legs_east"));
+            }
+        );
+    }
+
+    [Test]
     public async Task StartAsync_WithTeleportScripts_ShouldStillOpenStandaloneTeleportBrowser()
     {
         using var context = await CreateRuntimeContextAsync();
@@ -1320,6 +1356,7 @@ public sealed class GmMenuLuaRuntimeTests
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/controller.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/render.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/add.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/probe.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/travel.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/teleports.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/teleports/constants.lua");


### PR DESCRIPTION
## Summary
- add a Probe tab to the GM menu for empirical layout spacing calibration
- render three spacing variants with realistic long labels and metadata samples
- keep Add and Travel behavior unchanged while exposing an in-client comparison surface

## Test Plan
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~GmMenuLuaRuntimeTests"`
- `luac -p moongate_data/scripts/gumps/gm_menu/sections/probe.lua`
- `luac -p moongate_data/scripts/gumps/gm_menu/controller.lua`
- `luac -p moongate_data/scripts/gumps/gm_menu/render.lua`
- `luac -p moongate_data/scripts/gumps/gm_menu/ui.lua`
- `luac -p moongate_data/scripts/gumps/gm_menu/state.lua`

Closes #203
