### PR TITLE
feat: add reusable gump layout helpers

### DIFF
--- a/docs/articles/scripting/create-your-first-gump.md
+++ b/docs/articles/scripting/create-your-first-gump.md
@@ -98,6 +98,53 @@ Expected result:
 - Editing the item script but not restarting the server
 - Replacing the `tutorial_brick` table name with something that no longer matches the template `scriptId`
 
+## Optional: Layout Helpers For Vertical Rhythm
+
+When a gump starts to grow, stop hand-counting every vertical offset. Moongate includes two small helpers for the most repetitive spacing work:
+
+- `gumps.layout.header` for `title + subtitle`
+- `gumps.layout.stack` for vertical lists and stacked blocks
+
+Example:
+
+```lua
+local header = require("gumps.layout.header")
+local stack = require("gumps.layout.stack")
+
+local layout = {
+    ui = {},
+    handlers = {}
+}
+
+local next_y = header.add(layout.ui, {
+    x = 24,
+    y = 20,
+    width = 260,
+    title = "Tutorial Brick",
+    subtitle = "Use helpers for repeated vertical rhythm, not for every coordinate."
+})
+
+local cursor = stack.cursor(next_y)
+local first_button_y = cursor:add(20, 12)
+
+layout.ui[#layout.ui + 1] = {
+    type = "button",
+    id = TUTORIAL_BRICK_HELLO_BUTTON,
+    x = 24,
+    y = first_button_y,
+    normal_id = 4005,
+    pressed_id = 4007,
+    onclick = "on_click"
+}
+```
+
+Use these helpers when:
+
+- you have repeated vertical spacing
+- you want the next `y` without recounting by hand
+
+Do not use them as a full layout system. Keep explicit coordinates when they make the gump easier to read.
+
 ## Next Step
 
 Continue with [Create Your First Lua Admin Command](create-your-first-lua-admin-command.md).

--- a/docs/articles/scripting/gump-tutorial.md
+++ b/docs/articles/scripting/gump-tutorial.md
@@ -176,11 +176,61 @@ Notes:
   - start with only `background + label`
   - add components one at a time
 
+## 7) Layout helpers for headers and lists
+
+For bigger file-based gumps, use the built-in helpers for repeated vertical rhythm instead of manually chaining `y = y + ...` everywhere.
+
+Available helpers:
+
+- `gumps.layout.header`
+- `gumps.layout.stack`
+
+Example:
+
+```lua
+local header = require("gumps.layout.header")
+local stack = require("gumps.layout.stack")
+
+local layout = {
+    ui = {},
+    handlers = {}
+}
+
+local next_y = header.add(layout.ui, {
+    x = 24,
+    y = 20,
+    width = 320,
+    title = "World Tools",
+    subtitle = "Keep repeated vertical spacing intentional."
+})
+
+local cursor = stack.cursor(next_y)
+local button_y = cursor:add(20, 10)
+
+layout.ui[#layout.ui + 1] = {
+    type = "button",
+    id = BTN_SPAWN_DOORS,
+    x = 24,
+    y = button_y,
+    normal_id = 4005,
+    pressed_id = 4007,
+    onclick = "on_click"
+}
+```
+
+Use them for:
+
+- title + subtitle blocks
+- vertical lists with a repeated cadence
+
+Do not turn them into a general-purpose layout DSL. If explicit coordinates make the gump easier to understand, keep them.
+
 ## Best Practices
 
 - use `gump.send_layout` for complex gumps
 - use `text.render(...)` for long text, welcome messages, rules, and books
 - keep `ui` and `handlers` in the same module file
 - use constants for `gumpId` and `buttonId`
+- use `gumps.layout.header` and `gumps.layout.stack` only for repeated vertical spacing
 - do not rely on “magic” fallbacks for `sender_serial`
 - log important clicks during debugging

--- a/moongate_data/scripts/gumps/gm_menu/sections/add.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/add.lua
@@ -1,8 +1,12 @@
 local c = require("gumps.gm_menu.constants")
 local ui = require("gumps.gm_menu.ui")
 local gm_state = require("gumps.gm_menu.state")
+local header = require("gumps.layout.header")
+local stack = require("gumps.layout.stack")
 
 local add_section = {}
+local RESULT_ROW_LINE_GAP = 16
+local RESULT_ROW_PITCH = 38
 
 local function create_default_add_state()
   return {
@@ -271,13 +275,14 @@ local function render_results(layout_ui, add_state, results)
   ui.push(layout_ui, { type = "image_tiled", x = 196, y = 150, width = 260, height = 286, gump_id = 2624 })
   ui.push(layout_ui, { type = "label", x = 208, y = 160, hue = c.TITLE_HUE, text = "Results" })
 
-  local row_y = 188
+  local row_cursor = stack.cursor(188)
 
   for index, result in ipairs(results) do
     local button_id = c.BUTTON_RESULT_BASE + index - 1
     local is_selected = add_state.selected ~= nil and add_state.selected.kind == result.kind and add_state.selected.template_id == result.template_id
     local display_hue = is_selected and c.ACCENT_HUE or c.LABEL_HUE
     local meta_text = result.template_id
+    local row_y = row_cursor:peek()
 
     if result.kind == "item" and result.item_id > 0 then
       meta_text = result.template_id .. " • " .. format_item_id(result.item_id)
@@ -296,14 +301,14 @@ local function render_results(layout_ui, add_state, results)
     ui.push(layout_ui, {
       type = "label_cropped",
       x = 236,
-      y = row_y + 14,
+      y = row_y + RESULT_ROW_LINE_GAP,
       width = 208,
       height = 18,
       hue = c.MUTED_HUE,
       text = meta_text
     })
 
-    row_y = row_y + 34
+    row_cursor:advance(RESULT_ROW_PITCH)
   end
 
   if #results == 0 then
@@ -450,15 +455,18 @@ function add_section.add_content(layout, session_id, character_id, current_state
   local results = load_results(add_state)
 
   ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 428, gump_id = 2624 })
-  ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Search Items and NPCs" })
-  ui.push(layout_ui, {
-    type = "label_cropped",
+  header.add(layout_ui, {
     x = 196,
-    y = 72,
+    y = 62,
     width = 480,
-    height = 18,
-    hue = c.MUTED_HUE,
-    text = "Free search with preview, backpack add, ground target and brush."
+    title = "Search Items and NPCs",
+    subtitle = "Free search with preview, backpack add, ground target and brush.",
+    title_hue = c.TITLE_HUE,
+    subtitle_hue = c.MUTED_HUE,
+    title_height = 10,
+    subtitle_height = 18,
+    title_gap = 0,
+    after_gap = 0
   })
 
   render_filter_buttons(layout_ui, add_state)

--- a/moongate_data/scripts/gumps/gm_menu/sections/probe.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/probe.lua
@@ -1,5 +1,7 @@
 local c = require("gumps.gm_menu.constants")
 local ui = require("gumps.gm_menu.ui")
+local header = require("gumps.layout.header")
+local stack = require("gumps.layout.stack")
 
 local probe_section = {}
 
@@ -15,9 +17,11 @@ local SAMPLE_ROWS = {
 }
 
 local function add_sample_rows(layout_ui, panel_x, panel_y, inner_line_gap, row_pitch)
-  local row_y = panel_y
+  local row_cursor = stack.cursor(panel_y)
 
   for _, sample in ipairs(SAMPLE_ROWS) do
+    local row_y = row_cursor:peek()
+
     ui.push(layout_ui, {
       type = "label_cropped",
       x = panel_x,
@@ -37,16 +41,20 @@ local function add_sample_rows(layout_ui, panel_x, panel_y, inner_line_gap, row_
       text = sample.meta
     })
 
-    row_y = row_y + row_pitch
+    row_cursor:advance(row_pitch)
   end
 end
 
-local function add_probe_panel(layout_ui, x, title, subtitle, inner_line_gap, row_pitch)
-  ui.push(layout_ui, { type = "image_tiled", x = x, y = 112, width = 150, height = 312, gump_id = 2624 })
+local function add_probe_panel(layout_ui, x, panel_y, title, subtitle, inner_line_gap, row_pitch)
+  local panel_cursor = stack.cursor(panel_y + 12)
+  local title_y = panel_cursor:add(20, 0)
+  local subtitle_y = panel_cursor:add(28, 14)
+
+  ui.push(layout_ui, { type = "image_tiled", x = x, y = panel_y, width = 150, height = 312, gump_id = 2624 })
   ui.push(layout_ui, {
     type = "label_cropped",
     x = x + 10,
-    y = 124,
+    y = title_y,
     width = 130,
     height = 20,
     hue = c.ACCENT_HUE,
@@ -55,34 +63,33 @@ local function add_probe_panel(layout_ui, x, title, subtitle, inner_line_gap, ro
   ui.push(layout_ui, {
     type = "label_cropped",
     x = x + 10,
-    y = 144,
+    y = subtitle_y,
     width = 130,
     height = 28,
     hue = c.MUTED_HUE,
     text = subtitle
   })
 
-  add_sample_rows(layout_ui, x + 10, 186, inner_line_gap, row_pitch)
+  add_sample_rows(layout_ui, x + 10, panel_cursor:peek(), inner_line_gap, row_pitch)
 end
 
 function probe_section.add_content(layout, session_id, character_id, reopen_callback)
   local layout_ui = layout.ui
 
   ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 428, gump_id = 2624 })
-  ui.push(layout_ui, { type = "label", x = 196, y = 62, hue = c.TITLE_HUE, text = "Spacing Probe" })
-  ui.push(layout_ui, {
-    type = "label_cropped",
+  local panel_y = header.add(layout_ui, {
     x = 196,
-    y = 72,
+    y = 62,
     width = 496,
-    height = 28,
-    hue = c.MUTED_HUE,
-    text = "Compare result row spacing in-client before changing the production Add tab rhythm."
+    title = "Spacing Probe",
+    subtitle = "Compare result row spacing in-client before changing the production Add tab rhythm.",
+    title_hue = c.TITLE_HUE,
+    subtitle_hue = c.MUTED_HUE
   })
 
-  add_probe_panel(layout_ui, 196, "Compact 16/36", "Tight but still readable.", 16, 36)
-  add_probe_panel(layout_ui, 362, "Balanced 16/38", "Closer to staff/admin gump cadence.", 16, 38)
-  add_probe_panel(layout_ui, 528, "Relaxed 18/40", "Most breathable option.", 18, 40)
+  add_probe_panel(layout_ui, 196, panel_y, "Compact 16/36", "Tight but still readable.", 16, 36)
+  add_probe_panel(layout_ui, 362, panel_y, "Balanced 16/38", "Closer to staff/admin gump cadence.", 16, 38)
+  add_probe_panel(layout_ui, 528, panel_y, "Relaxed 18/40", "Most breathable option.", 18, 40)
 
   _ = session_id
   _ = character_id

--- a/moongate_data/scripts/gumps/layout/header.lua
+++ b/moongate_data/scripts/gumps/layout/header.lua
@@ -1,0 +1,67 @@
+local header = {}
+
+local DEFAULT_TITLE_HUE = 1152
+local DEFAULT_SUBTITLE_HUE = 1102
+local DEFAULT_WIDTH = 320
+local DEFAULT_TITLE_HEIGHT = 20
+local DEFAULT_SUBTITLE_HEIGHT = 28
+local DEFAULT_TITLE_GAP = 4
+local DEFAULT_AFTER_GAP = 10
+
+local function push(layout_ui, entry)
+  layout_ui[#layout_ui + 1] = entry
+end
+
+local function get_number(value, fallback)
+  local parsed = tonumber(value)
+
+  if parsed == nil then
+    return fallback
+  end
+
+  return parsed
+end
+
+function header.add(layout_ui, options)
+  local x = get_number(options.x, 0)
+  local y = get_number(options.y, 0)
+  local width = get_number(options.width, DEFAULT_WIDTH)
+  local title_hue = get_number(options.title_hue, DEFAULT_TITLE_HUE)
+  local subtitle_hue = get_number(options.subtitle_hue, DEFAULT_SUBTITLE_HUE)
+  local title_height = get_number(options.title_height, DEFAULT_TITLE_HEIGHT)
+  local subtitle_height = get_number(options.subtitle_height, DEFAULT_SUBTITLE_HEIGHT)
+  local title_gap = get_number(options.title_gap, DEFAULT_TITLE_GAP)
+  local after_gap = get_number(options.after_gap, DEFAULT_AFTER_GAP)
+  local title = tostring(options.title or "")
+  local subtitle = tostring(options.subtitle or "")
+
+  push(layout_ui, {
+    type = "label",
+    x = x,
+    y = y,
+    hue = title_hue,
+    text = title
+  })
+
+  local next_y = y + title_height
+
+  if subtitle ~= "" then
+    local subtitle_y = next_y + title_gap
+
+    push(layout_ui, {
+      type = "label_cropped",
+      x = x,
+      y = subtitle_y,
+      width = width,
+      height = subtitle_height,
+      hue = subtitle_hue,
+      text = subtitle
+    })
+
+    next_y = subtitle_y + subtitle_height
+  end
+
+  return next_y + after_gap
+end
+
+return header

--- a/moongate_data/scripts/gumps/layout/stack.lua
+++ b/moongate_data/scripts/gumps/layout/stack.lua
@@ -1,0 +1,31 @@
+local stack = {}
+
+local cursor_methods = {}
+
+function cursor_methods:peek()
+  return self.current_y
+end
+
+function cursor_methods:add(height, gap)
+  local y = self.current_y
+
+  self.current_y = self.current_y + (tonumber(height) or 0) + (tonumber(gap) or 0)
+
+  return y
+end
+
+function cursor_methods:advance(amount)
+  self.current_y = self.current_y + (tonumber(amount) or 0)
+
+  return self.current_y
+end
+
+function stack.cursor(start_y)
+  return setmetatable({
+    current_y = tonumber(start_y) or 0
+  }, {
+    __index = cursor_methods
+  })
+end
+
+return stack

--- a/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
@@ -1341,6 +1341,7 @@ public sealed class GmMenuLuaRuntimeTests
         var luarcDir = temp.Path;
         Directory.CreateDirectory(Path.Combine(scriptsDir, "interaction"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "layout"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "gm_menu"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "gm_menu", "sections"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "teleports"));
@@ -1350,6 +1351,8 @@ public sealed class GmMenuLuaRuntimeTests
             Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
         CopyScript(repoRoot, scriptsDir, "interaction/gm_menu.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/layout/header.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/layout/stack.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/constants.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/state.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/ui.lua");


### PR DESCRIPTION
## Summary
- add reusable Lua helpers for gump headers and vertical stack cursors
- refactor the GM menu Probe and Add tabs to use shared spacing helpers
- document the helper pattern in the scripting gump guides

## Test Plan
- luac -p moongate_data/scripts/gumps/layout/header.lua
- luac -p moongate_data/scripts/gumps/layout/stack.lua
- luac -p moongate_data/scripts/gumps/gm_menu/sections/probe.lua
- luac -p moongate_data/scripts/gumps/gm_menu/sections/add.lua
- dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~GmMenuLuaRuntimeTests"
- docfx docs/docfx.json --logLevel Warning

Closes #205