### PR TITLE
feat: enable default patrol on guards

### DIFF
--- a/moongate_data/templates/mobiles/guards.json
+++ b/moongate_data/templates/mobiles/guards.json
@@ -26,6 +26,16 @@
     "lootTables": [
       "guard.warrior"
     ],
+    "params": {
+      "patrol_mode": {
+        "type": "string",
+        "value": "random_roam"
+      },
+      "patrol_radius": {
+        "type": "string",
+        "value": "4"
+      }
+    },
     "skills": {
       "Anatomy": 1200,
       "Tactics": 1200,
@@ -94,6 +104,16 @@
     "lootTables": [
       "guard.warrior"
     ],
+    "params": {
+      "patrol_mode": {
+        "type": "string",
+        "value": "random_roam"
+      },
+      "patrol_radius": {
+        "type": "string",
+        "value": "4"
+      }
+    },
     "skills": {
       "Anatomy": 1200,
       "Tactics": 1200,
@@ -158,6 +178,14 @@
       "guard_role": {
         "type": "string",
         "value": "ranged"
+      },
+      "patrol_mode": {
+        "type": "string",
+        "value": "random_roam"
+      },
+      "patrol_radius": {
+        "type": "string",
+        "value": "4"
       }
     },
     "skills": {
@@ -244,6 +272,14 @@
       "guard_role": {
         "type": "string",
         "value": "ranged"
+      },
+      "patrol_mode": {
+        "type": "string",
+        "value": "random_roam"
+      },
+      "patrol_radius": {
+        "type": "string",
+        "value": "4"
       }
     },
     "skills": {


### PR DESCRIPTION
## Summary
- enable `random_roam` patrol by default on all existing guard templates
- set a default guard patrol radius of `4`
- keep the guard brain unchanged and express the behavior through template params only

## Test Plan
- moongate-template validate against a temporary shard root wired to the feature worktree templates

Closes #207