### PR TITLE
feat: add gm menu spawn and broadcast tabs

### DIFF
--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -160,6 +160,7 @@ For vendor sell profiles and context menu flow (native + custom Lua), see
 For packaging gameplay extensions outside the core script tree, see [Lua Plugins](lua-plugins.md).
 For background-safe named jobs callable from Lua, see [Async Jobs](async-jobs.md).
 For recurring coroutine cadences in NPC brains, see [Tick Helper](tick.md).
+For routine staff operations in-game, the built-in GM menu now centralizes template add/search, travel, curated spawn tools, and server broadcast actions under one gump shell.
 
 ### NPC Brain Example
 

--- a/moongate_data/scripts/gumps/gm_menu/constants.lua
+++ b/moongate_data/scripts/gumps/gm_menu/constants.lua
@@ -15,9 +15,12 @@ constants.MUTED_HUE = 1102
 constants.BUTTON_TAB_ADD = 10
 constants.BUTTON_TAB_TRAVEL = 11
 constants.BUTTON_TAB_PROBE = 12
+constants.BUTTON_TAB_SPAWN = 13
+constants.BUTTON_TAB_BROADCAST = 14
 
 constants.TEXT_ENTRY_SEARCH = 1
 constants.TEXT_ENTRY_QUANTITY = 2
+constants.TEXT_ENTRY_BROADCAST_MESSAGE = 3
 
 constants.BUTTON_FILTER_ITEMS = 100
 constants.BUTTON_FILTER_NPCS = 101
@@ -32,6 +35,9 @@ constants.BUTTON_TARGET_GROUND = 300
 constants.BUTTON_ADD_TO_BACKPACK = 301
 constants.BUTTON_BRUSH = 302
 constants.BUTTON_STOP_BRUSH = 303
+
+constants.BUTTON_SPAWN_BASE = 500
+constants.BUTTON_BROADCAST_SEND = 600
 
 constants.PAGE_SIZE = 7
 constants.MAX_ITEM_QUANTITY = 100

--- a/moongate_data/scripts/gumps/gm_menu/controller.lua
+++ b/moongate_data/scripts/gumps/gm_menu/controller.lua
@@ -34,6 +34,18 @@ function controller.build_layout(session_id, character_id, reopen_callback)
       return
     end
 
+    if button_id == c.BUTTON_TAB_SPAWN then
+      state.set_active_tab(ctx.session_id, "spawn")
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    if button_id == c.BUTTON_TAB_BROADCAST then
+      state.set_active_tab(ctx.session_id, "broadcast")
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
     if button_id == c.BUTTON_TAB_ADD then
       state.set_active_tab(ctx.session_id, "add")
       reopen_callback(ctx.session_id, ctx.character_id)

--- a/moongate_data/scripts/gumps/gm_menu/render.lua
+++ b/moongate_data/scripts/gumps/gm_menu/render.lua
@@ -1,5 +1,7 @@
 local add_section = require("gumps.gm_menu.sections.add")
+local broadcast_section = require("gumps.gm_menu.sections.broadcast")
 local probe_section = require("gumps.gm_menu.sections.probe")
+local spawn_section = require("gumps.gm_menu.sections.spawn")
 local travel_section = require("gumps.gm_menu.sections.travel")
 
 local render = {}
@@ -11,6 +13,14 @@ function render.add_content(layout, session_id, character_id, current_state, reo
 
   if current_state.active_tab == "probe" then
     return probe_section.add_content(layout, session_id, character_id, reopen_callback)
+  end
+
+  if current_state.active_tab == "spawn" then
+    return spawn_section.add_content(layout, session_id, character_id, current_state, reopen_callback)
+  end
+
+  if current_state.active_tab == "broadcast" then
+    return broadcast_section.add_content(layout, session_id, character_id, current_state, reopen_callback)
   end
 
   return add_section.add_content(layout, session_id, character_id, current_state, reopen_callback)

--- a/moongate_data/scripts/gumps/gm_menu/sections/broadcast.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/broadcast.lua
@@ -1,0 +1,110 @@
+local c = require("gumps.gm_menu.constants")
+local ui = require("gumps.gm_menu.ui")
+local header = require("gumps.layout.header")
+
+local broadcast_section = {}
+
+local function ensure_broadcast_state(current_state)
+  if current_state.broadcast == nil then
+    current_state.broadcast = {
+      message = ""
+    }
+  end
+
+  return current_state.broadcast
+end
+
+local function get_message(text_entries, fallback)
+  if text_entries == nil then
+    return fallback or ""
+  end
+
+  local value = text_entries[c.TEXT_ENTRY_BROADCAST_MESSAGE]
+  if value == nil then
+    return fallback or ""
+  end
+
+  return tostring(value)
+end
+
+local function trim(value)
+  return (tostring(value or ""):gsub("^%s*(.-)%s*$", "%1"))
+end
+
+function broadcast_section.add_content(layout, session_id, character_id, current_state, reopen_callback)
+  local layout_ui = layout.ui
+  local broadcast_state = ensure_broadcast_state(current_state)
+
+  ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 428, gump_id = 2624 })
+  local content_y = header.add(layout_ui, {
+    x = 196,
+    y = 62,
+    width = 480,
+    title = "Broadcast Message",
+    subtitle = "Send a server-wide announcement with the fixed SERVER: prefix.",
+    title_hue = c.TITLE_HUE,
+    subtitle_hue = c.MUTED_HUE
+  })
+
+  ui.push(layout_ui, { type = "label", x = 206, y = content_y + 10, hue = c.LABEL_HUE, text = "Message" })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 206,
+    y = content_y + 34,
+    width = 470,
+    height = 20,
+    hue = c.MUTED_HUE,
+    text = "SERVER:"
+  })
+  ui.push(layout_ui, {
+    type = "text_entry_limited",
+    x = 206,
+    y = content_y + 58,
+    width = 470,
+    height = 20,
+    hue = c.LABEL_HUE,
+    entry_id = c.TEXT_ENTRY_BROADCAST_MESSAGE,
+    text = tostring(broadcast_state.message or ""),
+    size = 160
+  })
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 206,
+    y = content_y + 94,
+    width = 470,
+    height = 36,
+    hue = c.MUTED_HUE,
+    text = "Use this for operational announcements. The prefix is applied automatically."
+  })
+
+  ui.push(layout_ui, { type = "button", id = c.BUTTON_BROADCAST_SEND, x = 206, y = content_y + 146, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  ui.push(layout_ui, { type = "label", x = 236, y = content_y + 148, hue = c.LABEL_HUE, text = "Send" })
+
+  _ = session_id
+  _ = character_id
+
+  return function(ctx)
+    local button_id = tonumber(ctx.button_id) or 0
+    local state_for_session = ensure_broadcast_state(current_state)
+    state_for_session.message = get_message(ctx.text_entries, state_for_session.message)
+
+    if button_id ~= c.BUTTON_BROADCAST_SEND then
+      return
+    end
+
+    local message = trim(state_for_session.message)
+
+    if message == "" then
+      speech.send(ctx.session_id, "Broadcast message cannot be empty.")
+      reopen_callback(ctx.session_id, ctx.character_id)
+      return
+    end
+
+    speech.broadcast("SERVER: " .. message)
+    state_for_session.message = ""
+    speech.send(ctx.session_id, "Broadcast sent.")
+    reopen_callback(ctx.session_id, ctx.character_id)
+  end
+end
+
+return broadcast_section

--- a/moongate_data/scripts/gumps/gm_menu/sections/spawn.lua
+++ b/moongate_data/scripts/gumps/gm_menu/sections/spawn.lua
@@ -1,0 +1,109 @@
+local c = require("gumps.gm_menu.constants")
+local ui = require("gumps.gm_menu.ui")
+local header = require("gumps.layout.header")
+local stack = require("gumps.layout.stack")
+
+local spawn_section = {}
+
+local COMMANDS = {
+  { button_id = c.BUTTON_SPAWN_BASE, label = "Spawn Doors", command = "spawn_doors" },
+  { button_id = c.BUTTON_SPAWN_BASE + 1, label = "Spawn Signs", command = "spawn_signs" },
+  { button_id = c.BUTTON_SPAWN_BASE + 2, label = "Spawn Decorations", command = "spawn_decorations" },
+  { button_id = c.BUTTON_SPAWN_BASE + 3, label = "Create Spawners", command = "create_spawners" }
+}
+
+local function find_command(button_id)
+  for _, entry in ipairs(COMMANDS) do
+    if entry.button_id == button_id then
+      return entry
+    end
+  end
+
+  return nil
+end
+
+local function add_commands(layout_ui)
+  local cursor = stack.cursor(144)
+
+  for _, entry in ipairs(COMMANDS) do
+    local row_y = cursor:peek()
+
+    ui.push(layout_ui, { type = "button", id = entry.button_id, x = 206, y = row_y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 236,
+      y = row_y,
+      width = 214,
+      height = 20,
+      hue = c.LABEL_HUE,
+      text = entry.label
+    })
+    ui.push(layout_ui, {
+      type = "label_cropped",
+      x = 236,
+      y = row_y + 16,
+      width = 214,
+      height = 18,
+      hue = c.MUTED_HUE,
+      text = "." .. entry.command
+    })
+
+    cursor:advance(38)
+  end
+end
+
+function spawn_section.add_content(layout, session_id, character_id, current_state, reopen_callback)
+  local layout_ui = layout.ui
+
+  ui.push(layout_ui, { type = "image_tiled", x = 188, y = 48, width = 520, height = 428, gump_id = 2624 })
+  local content_y = header.add(layout_ui, {
+    x = 196,
+    y = 62,
+    width = 480,
+    title = "Spawn Tools",
+    subtitle = "Execute curated world generation commands from the GM menu.",
+    title_hue = c.TITLE_HUE,
+    subtitle_hue = c.MUTED_HUE
+  })
+
+  ui.push(layout_ui, { type = "image_tiled", x = 196, y = content_y, width = 496, height = 244, gump_id = 2624 })
+  add_commands(layout_ui)
+
+  ui.push(layout_ui, {
+    type = "label_cropped",
+    x = 206,
+    y = content_y + 258,
+    width = 470,
+    height = 40,
+    hue = c.MUTED_HUE,
+    text = "These actions port the legacy spawn_tools gump into the GM menu without exposing arbitrary command execution."
+  })
+
+  _ = session_id
+  _ = character_id
+  _ = current_state
+
+  return function(ctx)
+    local button_id = tonumber(ctx.button_id) or 0
+    local selected = find_command(button_id)
+
+    if selected == nil then
+      return
+    end
+
+    speech.send(ctx.session_id, "Executing ." .. selected.command .. " ...")
+    local lines = command.execute(selected.command, 1)
+
+    if lines ~= nil then
+      for _, line in ipairs(lines) do
+        if type(line) == "string" and line ~= "" then
+          speech.send(ctx.session_id, line)
+        end
+      end
+    end
+
+    reopen_callback(ctx.session_id, ctx.character_id)
+  end
+end
+
+return spawn_section

--- a/moongate_data/scripts/gumps/gm_menu/state.lua
+++ b/moongate_data/scripts/gumps/gm_menu/state.lua
@@ -22,10 +22,17 @@ local function create_default_add_state()
   }
 end
 
+local function create_default_broadcast_state()
+  return {
+    message = ""
+  }
+end
+
 local function create_default_state()
   return {
     active_tab = "add",
-    add = create_default_add_state()
+    add = create_default_add_state(),
+    broadcast = create_default_broadcast_state()
   }
 end
 
@@ -61,6 +68,10 @@ function state.set_active_tab(session_id, active_tab)
     current.active_tab = "travel"
   elseif active_tab == "probe" then
     current.active_tab = "probe"
+  elseif active_tab == "spawn" then
+    current.active_tab = "spawn"
+  elseif active_tab == "broadcast" then
+    current.active_tab = "broadcast"
   else
     current.active_tab = "add"
   end

--- a/moongate_data/scripts/gumps/gm_menu/ui.lua
+++ b/moongate_data/scripts/gumps/gm_menu/ui.lua
@@ -17,28 +17,30 @@ function ui.add_frame(layout_ui)
 end
 
 function ui.add_sidebar(layout_ui, current_state)
-  local add_hue = c.LABEL_HUE
-  local travel_hue = c.LABEL_HUE
-  local probe_hue = c.LABEL_HUE
+  local function get_tab_hue(tab_name)
+    if current_state.active_tab == tab_name then
+      return c.ACCENT_HUE
+    end
 
-  if current_state.active_tab == "add" then
-    add_hue = c.ACCENT_HUE
-  elseif current_state.active_tab == "travel" then
-    travel_hue = c.ACCENT_HUE
-  else
-    probe_hue = c.ACCENT_HUE
+    return c.LABEL_HUE
   end
 
   push(layout_ui, { type = "label", x = 32, y = 62, hue = c.TITLE_HUE, text = "Tools" })
 
   push(layout_ui, { type = "button", id = c.BUTTON_TAB_ADD, x = 32, y = 94, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  push(layout_ui, { type = "label", x = 64, y = 96, hue = add_hue, text = "Add" })
+  push(layout_ui, { type = "label", x = 64, y = 96, hue = get_tab_hue("add"), text = "Add" })
 
   push(layout_ui, { type = "button", id = c.BUTTON_TAB_TRAVEL, x = 32, y = 126, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  push(layout_ui, { type = "label", x = 64, y = 128, hue = travel_hue, text = "Travel" })
+  push(layout_ui, { type = "label", x = 64, y = 128, hue = get_tab_hue("travel"), text = "Travel" })
 
   push(layout_ui, { type = "button", id = c.BUTTON_TAB_PROBE, x = 32, y = 158, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
-  push(layout_ui, { type = "label", x = 64, y = 160, hue = probe_hue, text = "Probe" })
+  push(layout_ui, { type = "label", x = 64, y = 160, hue = get_tab_hue("probe"), text = "Probe" })
+
+  push(layout_ui, { type = "button", id = c.BUTTON_TAB_SPAWN, x = 32, y = 190, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = 64, y = 192, hue = get_tab_hue("spawn"), text = "Spawn" })
+
+  push(layout_ui, { type = "button", id = c.BUTTON_TAB_BROADCAST, x = 32, y = 222, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = 64, y = 224, hue = get_tab_hue("broadcast"), text = "Broadcast" })
 end
 
 return ui

--- a/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/GmMenuLuaRuntimeTests.cs
@@ -13,12 +13,14 @@ using Moongate.Network.Packets.Outgoing.Speech;
 using Moongate.Network.Packets.Outgoing.UI;
 using Moongate.Network.Packets.Types.Targeting;
 using Moongate.Scripting.Services;
+using Moongate.Server.Data.Internal.Commands;
 using Moongate.Server.Data.Internal.Cursors;
 using Moongate.Server.Data.Items;
 using Moongate.Server.Data.Session;
 using Moongate.Server.Data.World;
 using Moongate.Server.Interfaces.Characters;
 using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Console;
 using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Interaction;
 using Moongate.Server.Interfaces.Services.Packets;
@@ -29,6 +31,7 @@ using Moongate.Server.Interfaces.Services.Speech;
 using Moongate.Server.Interfaces.Services.World;
 using Moongate.Server.Modules;
 using Moongate.Server.Services.Scripting;
+using Moongate.Server.Types.Commands;
 using Moongate.Tests.Server.Services.Spatial;
 using Moongate.Tests.Server.Support;
 using Moongate.Tests.TestSupport;
@@ -257,6 +260,12 @@ public sealed class GmMenuLuaRuntimeTests
 
     private sealed class GmMenuLuaRuntimeSpeechService : ISpeechService
     {
+        public List<string> SessionMessages { get; } = [];
+
+        public int BroadcastCallCount { get; private set; }
+
+        public string? LastBroadcastText { get; private set; }
+
         public Task<int> BroadcastFromServerAsync(
             string text,
             short hue = 946,
@@ -264,7 +273,8 @@ public sealed class GmMenuLuaRuntimeTests
             string language = "ENU"
         )
         {
-            _ = text;
+            BroadcastCallCount++;
+            LastBroadcastText = text;
             _ = hue;
             _ = font;
             _ = language;
@@ -307,7 +317,7 @@ public sealed class GmMenuLuaRuntimeTests
         )
         {
             _ = session;
-            _ = text;
+            SessionMessages.Add(text);
             _ = hue;
             _ = font;
             _ = language;
@@ -337,6 +347,75 @@ public sealed class GmMenuLuaRuntimeTests
 
             return Task.FromResult(0);
         }
+    }
+
+    private sealed class GmMenuLuaRuntimeCommandSystemService : ICommandSystemService
+    {
+        public string? LastExecuteCommandText { get; private set; }
+
+        public CommandSourceType LastExecuteSource { get; private set; }
+
+        public IReadOnlyList<string> ExecuteOutput { get; set; } = [];
+
+        public Task ExecuteCommandAsync(
+            string commandWithArgs,
+            CommandSourceType source = CommandSourceType.Console,
+            GameSession? session = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = session;
+            _ = cancellationToken;
+            LastExecuteCommandText = commandWithArgs;
+            LastExecuteSource = source;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ExecuteCommandWithOutputAsync(
+            string commandWithArgs,
+            CommandSourceType source = CommandSourceType.Console,
+            GameSession? session = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _ = session;
+            _ = cancellationToken;
+            LastExecuteCommandText = commandWithArgs;
+            LastExecuteSource = source;
+
+            return Task.FromResult(ExecuteOutput);
+        }
+
+        public IReadOnlyList<string> GetAutocompleteSuggestions(string commandWithArgs)
+        {
+            _ = commandWithArgs;
+
+            return [];
+        }
+
+        public void RegisterCommand(
+            string commandName,
+            Func<CommandSystemContext, Task> handler,
+            string description = "",
+            CommandSourceType source = CommandSourceType.Console,
+            AccountType minimumAccountType = AccountType.Administrator,
+            Func<CommandAutocompleteContext, IReadOnlyList<string>>? autocompleteProvider = null
+        )
+        {
+            _ = commandName;
+            _ = handler;
+            _ = description;
+            _ = source;
+            _ = minimumAccountType;
+            _ = autocompleteProvider;
+        }
+
+        public Task StartAsync()
+            => Task.CompletedTask;
+
+        public Task StopAsync()
+            => Task.CompletedTask;
     }
 
     private sealed class GmMenuLuaRuntimeItemTemplateService : IItemTemplateService
@@ -723,6 +802,8 @@ public sealed class GmMenuLuaRuntimeTests
             GmMenuLuaRuntimeMobileService mobileService,
             GmMenuLuaRuntimeSpatialWorldService spatialWorldService,
             GmMenuLuaRuntimePlayerTargetService targetService,
+            GmMenuLuaRuntimeSpeechService speechService,
+            GmMenuLuaRuntimeCommandSystemService commandSystemService,
             GameSession session,
             MoongateTCPClient client
         )
@@ -737,6 +818,8 @@ public sealed class GmMenuLuaRuntimeTests
             MobileService = mobileService;
             SpatialWorldService = spatialWorldService;
             TargetService = targetService;
+            SpeechService = speechService;
+            CommandSystemService = commandSystemService;
             Session = session;
             Client = client;
         }
@@ -760,6 +843,10 @@ public sealed class GmMenuLuaRuntimeTests
         public GmMenuLuaRuntimeSpatialWorldService SpatialWorldService { get; }
 
         public GmMenuLuaRuntimePlayerTargetService TargetService { get; }
+
+        public GmMenuLuaRuntimeSpeechService SpeechService { get; }
+
+        public GmMenuLuaRuntimeCommandSystemService CommandSystemService { get; }
 
         public GameSession Session { get; }
 
@@ -799,6 +886,8 @@ public sealed class GmMenuLuaRuntimeTests
                 Assert.That(gump.TextLines, Does.Contain("GM Menu"));
                 Assert.That(gump.TextLines, Does.Contain("Add"));
                 Assert.That(gump.TextLines, Does.Contain("Travel"));
+                Assert.That(gump.TextLines, Does.Contain("Spawn"));
+                Assert.That(gump.TextLines, Does.Contain("Broadcast"));
                 Assert.That(gump.TextLines, Does.Contain("Search Items and NPCs"));
             }
         );
@@ -1310,6 +1399,161 @@ public sealed class GmMenuLuaRuntimeTests
     }
 
     [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenSwitchingToSpawn_ShouldRenderSpawnActions()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        var spawnPacket = new GumpMenuSelectionPacket();
+        Assert.That(
+            spawnPacket.TryParse(BuildGumpResponsePacket((uint)context.Session.CharacterId, 0xB930, 13)),
+            Is.True
+        );
+        Assert.That(context.GumpDispatcher.TryDispatch(context.Session, spawnPacket), Is.True);
+        Assert.That(context.Queue.TryDequeue(out var spawnOutbound), Is.True);
+        Assert.That(spawnOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var spawnGump = (CompressedGumpPacket)spawnOutbound.Packet;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(spawnGump.TextLines, Does.Contain("Spawn Tools"));
+                Assert.That(spawnGump.TextLines, Does.Contain("Spawn Doors"));
+                Assert.That(spawnGump.TextLines, Does.Contain("Spawn Signs"));
+                Assert.That(spawnGump.TextLines, Does.Contain("Spawn Decorations"));
+                Assert.That(spawnGump.TextLines, Does.Contain("Create Spawners"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenUsingSpawnTab_ShouldExecuteConfiguredCommand()
+    {
+        using var context = await CreateRuntimeContextAsync();
+        context.CommandSystemService.ExecuteOutput = ["Doors spawned."];
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(context, 0xB930, 13);
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(context, 0xB930, 500);
+        Assert.That(context.Queue.TryDequeue(out var reopenedOutbound), Is.True);
+        Assert.That(reopenedOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.CommandSystemService.LastExecuteCommandText, Is.EqualTo("spawn_doors"));
+                Assert.That(context.CommandSystemService.LastExecuteSource, Is.EqualTo(CommandSourceType.InGame));
+                Assert.That(context.SpeechService.SessionMessages, Does.Contain("Executing .spawn_doors ..."));
+                Assert.That(context.SpeechService.SessionMessages, Does.Contain("Doors spawned."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenSwitchingToBroadcast_ShouldRenderBroadcastComposer()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(context, 0xB930, 14);
+        Assert.That(context.Queue.TryDequeue(out var broadcastOutbound), Is.True);
+        Assert.That(broadcastOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+        var broadcastGump = (CompressedGumpPacket)broadcastOutbound.Packet;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(broadcastGump.TextLines, Does.Contain("Broadcast Message"));
+                Assert.That(broadcastGump.TextLines, Does.Contain("Send"));
+                Assert.That(broadcastGump.TextLines, Has.Some.Contains("SERVER:"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenBroadcastMessageIsBlank_ShouldNotBroadcast()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(context, 0xB930, 14);
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            600,
+            new Dictionary<ushort, string>
+            {
+                [3] = "   "
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out var reopenedOutbound), Is.True);
+        Assert.That(reopenedOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.SpeechService.BroadcastCallCount, Is.EqualTo(0));
+                Assert.That(context.SpeechService.SessionMessages, Does.Contain("Broadcast message cannot be empty."));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithGmMenuScripts_WhenBroadcastMessageIsProvided_ShouldBroadcastWithServerPrefix()
+    {
+        using var context = await CreateRuntimeContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return on_gm_menu_request({context.Session.SessionId}, {(uint)context.Session.CharacterId}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(context, 0xB930, 14);
+        Assert.That(context.Queue.TryDequeue(out _), Is.True);
+
+        DispatchButton(
+            context,
+            0xB930,
+            600,
+            new Dictionary<ushort, string>
+            {
+                [3] = "Server restart in 5 minutes"
+            }
+        );
+        Assert.That(context.Queue.TryDequeue(out var reopenedOutbound), Is.True);
+        Assert.That(reopenedOutbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.SpeechService.BroadcastCallCount, Is.EqualTo(1));
+                Assert.That(context.SpeechService.LastBroadcastText, Is.EqualTo("SERVER: Server restart in 5 minutes"));
+                Assert.That(context.SpeechService.SessionMessages, Does.Contain("Broadcast sent."));
+            }
+        );
+    }
+
+    [Test]
     public async Task StartAsync_WithTeleportScripts_ShouldStillOpenStandaloneTeleportBrowser()
     {
         using var context = await CreateRuntimeContextAsync();
@@ -1359,7 +1603,9 @@ public sealed class GmMenuLuaRuntimeTests
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/controller.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/render.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/add.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/broadcast.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/probe.lua");
+        CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/spawn.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/gm_menu/sections/travel.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/teleports.lua");
         CopyScript(repoRoot, scriptsDir, "gumps/teleports/constants.lua");
@@ -1380,6 +1626,7 @@ public sealed class GmMenuLuaRuntimeTests
         var gumpDispatcher = new GumpScriptDispatcherService();
         var characterService = new GmMenuLuaRuntimeCharacterService();
         var speechService = new GmMenuLuaRuntimeSpeechService();
+        var commandSystemService = new GmMenuLuaRuntimeCommandSystemService();
         var itemTemplateService = new GmMenuLuaRuntimeItemTemplateService();
         itemTemplateService.Upsert(
             new ItemTemplateDefinition
@@ -1454,6 +1701,7 @@ public sealed class GmMenuLuaRuntimeTests
         container.RegisterInstance<IGumpScriptDispatcherService>(gumpDispatcher);
         container.RegisterInstance<ICharacterService>(characterService);
         container.RegisterInstance<ISpeechService>(speechService);
+        container.RegisterInstance<ICommandSystemService>(commandSystemService);
         container.RegisterInstance<IItemTemplateService>(itemTemplateService);
         container.RegisterInstance<IMobileTemplateService>(mobileTemplateService);
         container.RegisterInstance<IItemService>(itemService);
@@ -1466,8 +1714,10 @@ public sealed class GmMenuLuaRuntimeTests
             dirs,
             [
                 new(typeof(GumpModule)),
+                new(typeof(CommandModule)),
                 new(typeof(ItemModule)),
                 new(typeof(MobileModule)),
+                new(typeof(SpeechModule)),
                 new(typeof(TargetModule)),
                 new(typeof(LocationModule))
             ],
@@ -1489,6 +1739,8 @@ public sealed class GmMenuLuaRuntimeTests
             mobileService,
             spatialWorldService,
             targetService,
+            speechService,
+            commandSystemService,
             session,
             client
         );


### PR DESCRIPTION
## Summary
- add native Spawn and Broadcast tabs to the GM menu shell
- port the curated spawn_tools actions into a GM menu section with in-game feedback
- add fixed SERVER:-prefixed broadcast composition and document the staff workflow

Closes #209

## Test Plan
- [x] luac -p moongate_data/scripts/gumps/gm_menu/constants.lua
- [x] luac -p moongate_data/scripts/gumps/gm_menu/ui.lua
- [x] luac -p moongate_data/scripts/gumps/gm_menu/state.lua
- [x] luac -p moongate_data/scripts/gumps/gm_menu/render.lua
- [x] luac -p moongate_data/scripts/gumps/gm_menu/controller.lua
- [x] luac -p moongate_data/scripts/gumps/gm_menu/sections/spawn.lua
- [x] luac -p moongate_data/scripts/gumps/gm_menu/sections/broadcast.lua
- [x] dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~GmMenuLuaRuntimeTests"
- [x] docfx docs/docfx.json --logLevel Warning