### PR TITLE
Release: merge develop into main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Configure authenticated remote for release push
         if: steps.release_check.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
- release the current `develop` branch to `main`
- include the follow-up release workflow fix from `6c049e9b`
- keep the normal semantic-release path by labeling this PR as `release`

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/release.yml`
- inspected failing job `68868553987` and confirmed the root cause was Git `dubious ownership`
- verified the workflow now adds `$GITHUB_WORKSPACE` to global `safe.directory`
