### PR TITLE
Release: merge develop into main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install git
+      - name: Install git and python
         run: |
           apt-get update
-          apt-get install -y git
+          apt-get install -y git python3
 
       - name: Check for release label
         id: release_check


### PR DESCRIPTION
## Summary
- release the current `develop` branch to `main`
- include the follow-up release workflow fix from `515fcdb9`
- keep the normal semantic-release path by labeling this PR as `release`

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/release.yml`
- `docker run --rm mcr.microsoft.com/dotnet/sdk:10.0 bash -lc 'apt-get update >/dev/null && apt-get install -y python3 >/dev/null && python3 --version'`
- inspected failing job `68869317816` and confirmed the root cause was `/bin/sh: 1: python3: not found`
