### PR TITLE
fix: normalize resolved directories to absolute paths

### DIFF
--- a/src/Moongate.Core/Extensions/Directories/DirectoriesExtension.cs
+++ b/src/Moongate.Core/Extensions/Directories/DirectoriesExtension.cs
@@ -8,10 +8,11 @@ namespace Moongate.Core.Extensions.Directories;
 public static class DirectoriesExtension
 {
     /// <summary>
-    /// Resolves path by expanding tilde (~) to user home directory and expanding environment variables
+    /// Resolves path by expanding tilde (~) to user home directory, expanding environment variables,
+    /// and normalizing the result to an absolute path.
     /// </summary>
     /// <param name="path">The path to resolve</param>
-    /// <returns>The fully resolved path with expanded environment variables</returns>
+    /// <returns>The fully resolved absolute path with expanded environment variables</returns>
     /// <exception cref="ArgumentException">Thrown when path is null or empty</exception>
     public static string ResolvePathAndEnvs(this string path)
     {
@@ -24,6 +25,6 @@ public static class DirectoriesExtension
 
         path = Environment.ExpandEnvironmentVariables(path).ExpandEnvironmentVariables();
 
-        return path;
+        return Path.GetFullPath(path);
     }
 }

--- a/tests/Moongate.Tests/Core/Extensions/Directories/DirectoriesExtensionTests.cs
+++ b/tests/Moongate.Tests/Core/Extensions/Directories/DirectoriesExtensionTests.cs
@@ -1,0 +1,17 @@
+using Moongate.Core.Extensions.Directories;
+
+namespace Moongate.Tests.Core.Extensions.Directories;
+
+public sealed class DirectoriesExtensionTests
+{
+    [Test]
+    public void ResolvePathAndEnvs_WhenPathIsRelative_ShouldReturnAbsolutePath()
+    {
+        var relativePath = Path.Combine("moongate_data", "web");
+
+        var resolvedPath = relativePath.ResolvePathAndEnvs();
+
+        Assert.That(Path.IsPathRooted(resolvedPath), Is.True);
+        Assert.That(resolvedPath, Is.EqualTo(Path.GetFullPath(relativePath)));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize `ResolvePathAndEnvs` through `Path.GetFullPath` so relative root paths resolve cleanly before downstream services use them
- add regression coverage for relative path resolution in the shared directories extension
- prevent HTTP/UI hosting from failing when the server is started with a relative `--root-directory`

## Test Plan
- [x] `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~DirectoriesExtensionTests"`
- [x] `dotnet test Moongate.slnx`
- [x] `dotnet run --project src/Moongate.Server -- --root-directory moongate_data --uo-directory /Users/squid/uo`

Closes #228