### PR TITLE
feat: add public moongate gump

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ UI default URL: `http://localhost:8088/`
 - Architecture: `docs/articles/architecture/`
 - Beginner content authoring: `docs/articles/scripting/create-your-first-content.md`
 - Beginner systems path: `docs/articles/scripting/create-your-first-systems.md`
-- Scripting: `docs/articles/scripting/` including authored dialogues, scheduled events, starting loadout, and loot containers
+- Scripting: `docs/articles/scripting/` including authored dialogues, quests, public moongates, scheduled events, starting loadout, and loot containers
 - Persistence: `docs/articles/persistence/`
 - Networking/protocol: `docs/articles/networking/` including client encryption and the UDP ping server
 - Operations: `docs/articles/operations/` including template validation, in-game item admin commands, and help ticket workflow

--- a/docs/articles/scripting/create-your-first-item-script.md
+++ b/docs/articles/scripting/create-your-first-item-script.md
@@ -145,3 +145,6 @@ Expected result:
 
 Continue with [Create Your First Loot Container](create-your-first-loot-container.md) or
 [Create Your First Gump](create-your-first-gump.md).
+
+If you want a shared travel item with a dedicated gump and a shard-wide destination list, continue with
+[Public Moongates](public-moongates.md).

--- a/docs/articles/scripting/overview.md
+++ b/docs/articles/scripting/overview.md
@@ -157,6 +157,8 @@ For first-open chest loot and refillable container behavior driven by item and l
 For in-game help tickets opened from the client help button and persisted for staff review, see the
 [`help_tickets` module and callback docs](api.md#help-ticketing) plus the operator-facing
 [Help Ticket Workflow](../operations/help-ticket-workflow.md).
+For shard-wide moongate travel authored in Lua and opened from a dedicated item gump, see
+[Public Moongates](public-moongates.md).
 For vendor sell profiles and context menu flow (native + custom Lua), see
 [Vendor and Context Menus](vendor-context-menus.md).
 For Lua-authored quests compiled into validated runtime templates, plus the shared NPC dialog and client journal flows, see

--- a/docs/articles/scripting/public-moongates.md
+++ b/docs/articles/scripting/public-moongates.md
@@ -1,0 +1,95 @@
+# Public Moongates
+
+Moongate public moongates are a separate item flow from generic teleporters.
+
+- `public_moongate` opens a shared destination gump
+- destinations are authored once for the shard
+- players double click the moongate and choose where to go
+
+This is different from the existing `moongate` template, which is still used by spell-created moongates such as `Gate Travel`.
+
+## Authoring Model
+
+The shared destination list lives in:
+
+- `moongate_data/scripts/moongates/data.lua`
+
+That file returns grouped destinations, for example:
+
+```lua
+local data = {}
+
+function data.load()
+  return {
+    {
+      id = "britannia",
+      name = "Britannia",
+      destinations = {
+        { id = "moonglow", name = "Moonglow", map = "felucca", x = 4467, y = 1283, z = 5 },
+        { id = "britain", name = "Britain", map = "felucca", x = 1336, y = 1997, z = 5 }
+      }
+    }
+  }
+end
+
+return data
+```
+
+Each destination entry uses:
+
+- `id`: stable destination key
+- `name`: player-facing label in the gump
+- `map`: map name or id-like value resolved through the `map` script module
+- `x`, `y`, `z`: world coordinates
+
+## Item Template
+
+The public gump flow uses the `public_moongate` template:
+
+```json
+{
+  "id": "public_moongate",
+  "base_item": "teleporter",
+  "itemId": "0x0F6C",
+  "scriptId": "items.public_moongate"
+}
+```
+
+Use this when you want a shard-wide moongate network.
+
+Use `teleporter` or other single-destination teleporter templates when the item should go to exactly one configured location.
+
+## Runtime Behavior
+
+On double click:
+
+1. the item validates that the player is next to the moongate
+2. the shared gump opens
+3. the player chooses a destination
+4. the selection is revalidated against the live item, player range, and current destination dataset
+5. the player teleports
+
+The current V1 flow is intentionally simple:
+
+- double click only
+- no move-over activation
+- no expansion-specific destination filtering
+- no special criminal or young-player rules
+
+## Files Involved
+
+- `moongate_data/scripts/items/public_moongate.lua`
+- `moongate_data/scripts/gumps/moongates/public_moongate.lua`
+- `moongate_data/scripts/gumps/moongates/constants.lua`
+- `moongate_data/scripts/gumps/moongates/state.lua`
+- `moongate_data/scripts/gumps/moongates/ui.lua`
+- `moongate_data/scripts/gumps/moongates/render.lua`
+- `moongate_data/scripts/moongates/data.lua`
+
+## Recommended Workflow
+
+When you change the shared destinations:
+
+1. update `moongate_data/scripts/moongates/data.lua`
+2. reload scripts or restart the server
+3. verify the gump still opens and the destinations still travel correctly

--- a/docs/articles/scripting/toc.yml
+++ b/docs/articles/scripting/toc.yml
@@ -33,6 +33,8 @@ items:
     href: scheduled-events.md
   - name: Quests
     href: quests.md
+  - name: Public Moongates
+    href: public-moongates.md
   - name: Loot Containers
     href: loot-containers.md
   - name: Vendor and Context Menus

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,8 @@ This is the main documentation portal for Moongate v2.
 - [Scheduled Events](articles/scripting/scheduled-events.md)
 - [Loot Containers](articles/scripting/loot-containers.md)
 - [Vendor and Context Menus](articles/scripting/vendor-context-menus.md)
+- [Quests](articles/scripting/quests.md)
+- [Public Moongates](articles/scripting/public-moongates.md)
 - [Lua Starting Loadout](articles/scripting/starting-loadout.md)
 - [NPC Behaviors](articles/scripting/npc-behaviors.md)
 - [Intelligent NPC Dialogue](articles/scripting/intelligent-npcs.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -86,6 +86,10 @@
     href: articles/scripting/loot-containers.md
   - name: Vendor and Context Menus
     href: articles/scripting/vendor-context-menus.md
+  - name: Quests
+    href: articles/scripting/quests.md
+  - name: Public Moongates
+    href: articles/scripting/public-moongates.md
   - name: Starting Loadout
     href: articles/scripting/starting-loadout.md
   - name: NPC Behaviors

--- a/moongate_data/scripts/gumps/moongates/constants.lua
+++ b/moongate_data/scripts/gumps/moongates/constants.lua
@@ -8,5 +8,7 @@ constants.HEIGHT = 260
 constants.BUTTON_CLOSE = 1
 constants.BUTTON_GROUP_BASE = 1000
 constants.BUTTON_DEST_BASE = 2000
+constants.TELEPORT_EFFECT_ITEM_ID = 0x3728
+constants.TELEPORT_SOUND_ID = 0x01FE
 
 return constants

--- a/moongate_data/scripts/gumps/moongates/constants.lua
+++ b/moongate_data/scripts/gumps/moongates/constants.lua
@@ -1,0 +1,12 @@
+local constants = {}
+
+constants.GUMP_ID = 0xB960
+constants.GUMP_X = 120
+constants.GUMP_Y = 90
+constants.WIDTH = 420
+constants.HEIGHT = 260
+constants.BUTTON_CLOSE = 1
+constants.BUTTON_GROUP_BASE = 1000
+constants.BUTTON_DEST_BASE = 2000
+
+return constants

--- a/moongate_data/scripts/gumps/moongates/public_moongate.lua
+++ b/moongate_data/scripts/gumps/moongates/public_moongate.lua
@@ -1,0 +1,50 @@
+local c = require("gumps.moongates.constants")
+local state = require("gumps.moongates.state")
+local render = require("gumps.moongates.render")
+local data = require("moongates.data")
+
+local public_moongate = {}
+
+local function build_layout(session_id, item_serial)
+  local current_state = state.set_source(session_id, item_serial)
+  local layout = { ui = {}, handlers = {} }
+
+  render.build(layout.ui, c, current_state)
+
+  layout.handlers.on_click = function(ctx)
+    local button_id = tonumber(ctx.button_id) or 0
+
+    if button_id == c.BUTTON_CLOSE then
+      state.clear(ctx.session_id)
+      return false
+    end
+
+    if button_id >= c.BUTTON_GROUP_BASE and button_id < c.BUTTON_DEST_BASE then
+      local groups = data.groups()
+      local group_index = button_id - c.BUTTON_GROUP_BASE + 1
+      local group = groups[group_index]
+
+      if group ~= nil then
+        state.set_group(ctx.session_id, group.id)
+      end
+
+      return public_moongate.open(ctx.session_id, ctx.character_id, current_state.source_item_serial)
+    end
+
+    return false
+  end
+
+  return layout
+end
+
+function public_moongate.open(session_id, character_id, item_serial)
+  if session_id == nil or character_id == nil or item_serial == nil then
+    return false
+  end
+
+  local layout = build_layout(session_id, item_serial)
+
+  return gump.send_layout(session_id, layout, character_id, c.GUMP_ID, c.GUMP_X, c.GUMP_Y)
+end
+
+return public_moongate

--- a/moongate_data/scripts/gumps/moongates/public_moongate.lua
+++ b/moongate_data/scripts/gumps/moongates/public_moongate.lua
@@ -5,6 +5,80 @@ local data = require("moongates.data")
 
 local public_moongate = {}
 
+local function is_in_range(source_item, actor)
+  if source_item == nil or actor == nil then
+    return false
+  end
+
+  if tonumber(source_item.map_id) ~= tonumber(actor.map_id) then
+    return false
+  end
+
+  local dx = math.abs((tonumber(source_item.location_x) or 0) - (tonumber(actor.location_x) or 0))
+  local dy = math.abs((tonumber(source_item.location_y) or 0) - (tonumber(actor.location_y) or 0))
+
+  return math.max(dx, dy) <= 1
+end
+
+local function is_same_destination(actor, destination_map_id, destination)
+  if actor == nil or destination == nil then
+    return false
+  end
+
+  return tonumber(actor.map_id) == tonumber(destination_map_id) and
+         tonumber(actor.location_x) == tonumber(destination.x) and
+         tonumber(actor.location_y) == tonumber(destination.y) and
+         tonumber(actor.location_z) == tonumber(destination.z)
+end
+
+local function send_effect_if_available(map_id, x, y, z)
+  if effect == nil then
+    return
+  end
+
+  effect.send(map_id, x, y, z, c.TELEPORT_EFFECT_ITEM_ID, 10, 10)
+end
+
+local function try_travel(session_id, character_id, current_state, destination_index)
+  local groups = data.groups()
+  local selected_group = data.find_group(groups, current_state.group_id)
+  if selected_group == nil then
+    return false
+  end
+
+  local destination = selected_group.destinations[destination_index]
+  if destination == nil then
+    return false
+  end
+
+  local actor = mobile.get(character_id)
+  local source_item = item.get(current_state.source_item_serial)
+  if not is_in_range(source_item, actor) then
+    return false
+  end
+
+  local destination_map_id = map.to_id(destination.map, tonumber(actor.map_id) or 0)
+  if destination_map_id < 0 then
+    return false
+  end
+
+  if is_same_destination(actor, destination_map_id, destination) then
+    return false
+  end
+
+  send_effect_if_available(tonumber(actor.map_id) or 0, tonumber(actor.location_x) or 0, tonumber(actor.location_y) or 0, tonumber(actor.location_z) or 0)
+
+  if not actor:teleport(destination_map_id, destination.x, destination.y, destination.z) then
+    return false
+  end
+
+  send_effect_if_available(destination_map_id, destination.x, destination.y, destination.z)
+  actor:play_sound(c.TELEPORT_SOUND_ID)
+  state.clear(session_id)
+
+  return true
+end
+
 local function build_layout(session_id, item_serial)
   local current_state = state.set_source(session_id, item_serial)
   local layout = { ui = {}, handlers = {} }
@@ -29,6 +103,12 @@ local function build_layout(session_id, item_serial)
       end
 
       return public_moongate.open(ctx.session_id, ctx.character_id, current_state.source_item_serial)
+    end
+
+    if button_id >= c.BUTTON_DEST_BASE then
+      local destination_index = button_id - c.BUTTON_DEST_BASE
+
+      return try_travel(ctx.session_id, ctx.character_id, current_state, destination_index)
     end
 
     return false

--- a/moongate_data/scripts/gumps/moongates/render.lua
+++ b/moongate_data/scripts/gumps/moongates/render.lua
@@ -1,0 +1,57 @@
+local stack = require("gumps.layout.stack")
+local ui = require("gumps.moongates.ui")
+local data = require("moongates.data")
+
+local render = {}
+
+local GROUP_PITCH = 26
+local DESTINATION_PITCH = 24
+
+function render.build(layout_ui, constants, current_state)
+  local groups = data.groups()
+  local selected_group = data.find_group(groups, current_state.group_id)
+
+  if selected_group == nil then
+    selected_group = data.first_group(groups)
+    if selected_group ~= nil then
+      current_state.group_id = selected_group.id
+    end
+  end
+
+  local start_y = ui.add_frame(layout_ui, constants)
+  local groups_cursor = stack.cursor(start_y)
+  local destinations_cursor = stack.cursor(start_y)
+
+  for index, group in ipairs(groups) do
+    local row_y = groups_cursor:add(20, GROUP_PITCH - 20)
+    ui.add_group_button(
+      layout_ui,
+      constants,
+      24,
+      row_y,
+      constants.BUTTON_GROUP_BASE + index,
+      group.name,
+      selected_group ~= nil and selected_group.id == group.id
+    )
+  end
+
+  if selected_group ~= nil then
+    for index, destination in ipairs(selected_group.destinations or {}) do
+      local row_y = destinations_cursor:add(20, DESTINATION_PITCH - 20)
+      ui.add_destination_button(
+        layout_ui,
+        constants,
+        180,
+        row_y,
+        constants.BUTTON_DEST_BASE + index,
+        destination.name
+      )
+    end
+  else
+    ui.push(layout_ui, { type = "label", x = 180, y = start_y, hue = 1102, text = "No destinations configured." })
+  end
+
+  return selected_group
+end
+
+return render

--- a/moongate_data/scripts/gumps/moongates/state.lua
+++ b/moongate_data/scripts/gumps/moongates/state.lua
@@ -1,0 +1,36 @@
+local state = {}
+
+local sessions = {}
+
+function state.get(session_id)
+  local key = tostring(tonumber(session_id) or 0)
+
+  if sessions[key] == nil then
+    sessions[key] = {
+      group_id = nil,
+      source_item_serial = 0
+    }
+  end
+
+  return sessions[key]
+end
+
+function state.set_source(session_id, item_serial)
+  local current = state.get(session_id)
+  current.source_item_serial = tonumber(item_serial) or 0
+
+  return current
+end
+
+function state.set_group(session_id, group_id)
+  local current = state.get(session_id)
+  current.group_id = group_id == nil and nil or tostring(group_id)
+
+  return current
+end
+
+function state.clear(session_id)
+  sessions[tostring(tonumber(session_id) or 0)] = nil
+end
+
+return state

--- a/moongate_data/scripts/gumps/moongates/ui.lua
+++ b/moongate_data/scripts/gumps/moongates/ui.lua
@@ -1,0 +1,44 @@
+local header = require("gumps.layout.header")
+
+local ui = {}
+
+local function push(layout_ui, entry)
+  layout_ui[#layout_ui + 1] = entry
+end
+
+function ui.push(layout_ui, entry)
+  push(layout_ui, entry)
+end
+
+function ui.add_frame(layout_ui, constants)
+  push(layout_ui, { type = "background", x = 0, y = 0, gump_id = 5054, width = constants.WIDTH, height = constants.HEIGHT })
+  push(layout_ui, { type = "alpha_region", x = 10, y = 10, width = constants.WIDTH - 20, height = constants.HEIGHT - 20 })
+
+  local content_y = header.add(layout_ui, {
+    x = 24,
+    y = 20,
+    width = constants.WIDTH - 48,
+    title = "Public Moongate",
+    subtitle = "Choose a destination from the shard-wide moongate network."
+  })
+
+  push(layout_ui, { type = "button", id = constants.BUTTON_CLOSE, x = constants.WIDTH - 42, y = 18, normal_id = 4017, pressed_id = 4019, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = 24, y = content_y + 4, hue = 1152, text = "Realms" })
+  push(layout_ui, { type = "label", x = 180, y = content_y + 4, hue = 1152, text = "Destinations" })
+
+  return content_y + 28
+end
+
+function ui.add_group_button(layout_ui, constants, x, y, button_id, text, selected)
+  local hue = selected and 1153 or 1102
+
+  push(layout_ui, { type = "button", id = button_id, x = x, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = x + 32, y = y + 2, hue = hue, text = tostring(text or "") })
+end
+
+function ui.add_destination_button(layout_ui, constants, x, y, button_id, text)
+  push(layout_ui, { type = "button", id = button_id, x = x, y = y, normal_id = 4005, pressed_id = 4007, onclick = "on_click" })
+  push(layout_ui, { type = "label", x = x + 32, y = y + 2, hue = 0, text = tostring(text or "") })
+end
+
+return ui

--- a/moongate_data/scripts/items/public_moongate.lua
+++ b/moongate_data/scripts/items/public_moongate.lua
@@ -1,0 +1,39 @@
+local public_moongate = require("gumps.moongates.public_moongate")
+
+items_public_moongate = {}
+
+local function is_in_range(source_item, actor)
+  if source_item == nil or actor == nil then
+    return false
+  end
+
+  if tonumber(source_item.map_id) ~= tonumber(actor.map_id) then
+    return false
+  end
+
+  local dx = math.abs((tonumber(source_item.location_x) or 0) - (tonumber(actor.location_x) or 0))
+  local dy = math.abs((tonumber(source_item.location_y) or 0) - (tonumber(actor.location_y) or 0))
+
+  return math.max(dx, dy) <= 1
+end
+
+items_public_moongate.on_double_click = function(ctx)
+  if
+    ctx == nil or
+    ctx.session_id == nil or
+    ctx.mobile_id == nil or
+    ctx.item == nil or
+    ctx.item.serial == nil
+  then
+    return false
+  end
+
+  local source_item = item.get(ctx.item.serial)
+  local actor = mobile.get(ctx.mobile_id)
+
+  if not is_in_range(source_item, actor) then
+    return false
+  end
+
+  return public_moongate.open(ctx.session_id, ctx.mobile_id, ctx.item.serial)
+end

--- a/moongate_data/scripts/moongates/data.lua
+++ b/moongate_data/scripts/moongates/data.lua
@@ -1,0 +1,84 @@
+local data = {}
+
+local function clone_destination(entry)
+  return {
+    id = tostring(entry.id or ""),
+    name = tostring(entry.name or "Unnamed"),
+    map = tostring(entry.map or ""),
+    x = tonumber(entry.x) or 0,
+    y = tonumber(entry.y) or 0,
+    z = tonumber(entry.z) or 0
+  }
+end
+
+local function clone_group(entry)
+  local destinations = {}
+
+  for _, destination in ipairs(entry.destinations or {}) do
+    destinations[#destinations + 1] = clone_destination(destination)
+  end
+
+  return {
+    id = tostring(entry.id or ""),
+    name = tostring(entry.name or "Unknown"),
+    destinations = destinations
+  }
+end
+
+function data.load()
+  return {
+    {
+      id = "britannia",
+      name = "Britannia",
+      destinations = {
+        { id = "moonglow", name = "Moonglow", map = "felucca", x = 4467, y = 1283, z = 5 },
+        { id = "britain", name = "Britain", map = "felucca", x = 1336, y = 1997, z = 5 },
+        { id = "trinsic", name = "Trinsic", map = "felucca", x = 1828, y = 2948, z = -20 }
+      }
+    },
+    {
+      id = "ilshenar",
+      name = "Ilshenar",
+      destinations = {
+        { id = "compassion", name = "Compassion", map = "ilshenar", x = 1215, y = 467, z = -13 },
+        { id = "honor", name = "Honor", map = "ilshenar", x = 744, y = 724, z = -28 }
+      }
+    }
+  }
+end
+
+function data.groups()
+  local result = {}
+
+  for _, entry in ipairs(data.load()) do
+    result[#result + 1] = clone_group(entry)
+  end
+
+  return result
+end
+
+function data.first_group(groups)
+  if groups == nil or #groups == 0 then
+    return nil
+  end
+
+  return groups[1]
+end
+
+function data.find_group(groups, group_id)
+  if groups == nil or group_id == nil then
+    return nil
+  end
+
+  local normalized = tostring(group_id)
+
+  for _, group in ipairs(groups) do
+    if tostring(group.id) == normalized then
+      return group
+    end
+  end
+
+  return nil
+end
+
+return data

--- a/moongate_data/templates/items/misc.json
+++ b/moongate_data/templates/items/misc.json
@@ -1731,17 +1731,21 @@
     "type": "item",
     "id": "public_moongate",
     "name": "Public Moongate",
-    "category": "Misc",
-    "description": "",
+    "category": "Structure",
+    "description": "Shared destination moongate.",
+    "base_item": "teleporter",
     "itemId": "0x0F6C",
     "hue": "0",
     "goldValue": "0",
-    "weight": 0,
-    "scriptId": "none",
-    "isMovable": true,
+    "weight": 10,
+    "scriptId": "items.public_moongate",
+    "isMovable": false,
     "tags": [
-      "modernuo",
-      "misc"
+      "moongate",
+      "teleport",
+      "worldgen",
+      "public",
+      "modernuo"
     ]
   },
   {

--- a/tests/Moongate.Tests/Scripting/PublicMoongateLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/PublicMoongateLuaRuntimeTests.cs
@@ -1,8 +1,10 @@
+using System.Buffers.Binary;
 using System.Net.Sockets;
 using DryIoc;
 using Moongate.Core.Data.Directories;
 using Moongate.Core.Types;
 using Moongate.Network.Client;
+using Moongate.Network.Packets.Incoming.UI;
 using Moongate.Network.Packets.Outgoing.UI;
 using Moongate.Scripting.Services;
 using Moongate.Server.Data.Session;
@@ -29,7 +31,95 @@ public sealed class PublicMoongateLuaRuntimeTests
     [Test]
     public async Task StartAsync_WithPublicMoongateScripts_ShouldOpenSharedPublicMoongateGump()
     {
-        using var temp = new TempDirectory();
+        using var context = await CreateContextAsync();
+        var result = context.Service.ExecuteFunction(
+            $"(function() return items_public_moongate.on_double_click({{ session_id = {context.Session.SessionId}, mobile_id = {(uint)context.Session.CharacterId}, item = {{ serial = 0x00006010 }} }}) end)()"
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Data, Is.EqualTo(true));
+                Assert.That(context.Queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+                var gump = (CompressedGumpPacket)outbound.Packet;
+                Assert.That(gump.TextLines, Contains.Item("Public Moongate"));
+                Assert.That(gump.TextLines, Contains.Item("Britannia"));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithPublicMoongateScripts_ShouldTeleportToSelectedDestination()
+    {
+        using var context = await CreateContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return items_public_moongate.on_double_click({{ session_id = {context.Session.SessionId}, mobile_id = {(uint)context.Session.CharacterId}, item = {{ serial = 0x00006010 }} }}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out var outbound), Is.True);
+        Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+
+        var packet = new GumpMenuSelectionPacket();
+        Assert.That(packet.TryParse(BuildGumpResponsePacket((uint)context.Session.CharacterId, 0xB960, 2001)), Is.True);
+        Assert.That(context.GumpDispatcher.TryDispatch(context.Session, packet), Is.True);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.Session.Character!.MapId, Is.EqualTo(0));
+                Assert.That(context.Session.Character.Location, Is.EqualTo(new Point3D(4467, 1283, 5)));
+            }
+        );
+    }
+
+    [Test]
+    public async Task StartAsync_WithPublicMoongateScripts_ShouldNotTeleportWhenPlayerLeavesMoongateRangeBeforeConfirm()
+    {
+        using var context = await CreateContextAsync();
+
+        _ = context.Service.ExecuteFunction(
+            $"(function() return items_public_moongate.on_double_click({{ session_id = {context.Session.SessionId}, mobile_id = {(uint)context.Session.CharacterId}, item = {{ serial = 0x00006010 }} }}) end)()"
+        );
+        Assert.That(context.Queue.TryDequeue(out var outbound), Is.True);
+        Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+
+        context.Session.Character!.Location = new Point3D(140, 140, 0);
+
+        var packet = new GumpMenuSelectionPacket();
+        Assert.That(packet.TryParse(BuildGumpResponsePacket((uint)context.Session.CharacterId, 0xB960, 2001)), Is.True);
+        Assert.That(context.GumpDispatcher.TryDispatch(context.Session, packet), Is.True);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(context.Session.Character!.MapId, Is.EqualTo(0));
+                Assert.That(context.Session.Character.Location, Is.EqualTo(new Point3D(140, 140, 0)));
+            }
+        );
+    }
+
+    private static byte[] BuildGumpResponsePacket(uint characterId, uint gumpId, int buttonId)
+    {
+        var buffer = new byte[23];
+        buffer[0] = 0xB1;
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(1, 2), (ushort)buffer.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(3, 4), characterId);
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(7, 4), gumpId);
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(11, 4), (uint)buttonId);
+        BinaryPrimitives.WriteInt32BigEndian(buffer.AsSpan(15, 4), 0);
+        BinaryPrimitives.WriteInt32BigEndian(buffer.AsSpan(19, 4), 0);
+
+        return buffer;
+    }
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+
+    private static async Task<PublicMoongateLuaRuntimeContext> CreateContextAsync()
+    {
+        var temp = new TempDirectory();
         var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
         var scriptsDir = dirs[DirectoryType.Scripts];
         var luarcDir = temp.Path;
@@ -123,7 +213,7 @@ public sealed class PublicMoongateLuaRuntimeTests
 
         var service = new LuaScriptEngineService(
             dirs,
-            [new(typeof(GumpModule)), new(typeof(ItemModule)), new(typeof(MobileModule))],
+            [new(typeof(GumpModule)), new(typeof(ItemModule)), new(typeof(MobileModule)), new(typeof(MapModule))],
             container,
             new(luarcDir, scriptsDir, "0.1.0"),
             []
@@ -131,26 +221,33 @@ public sealed class PublicMoongateLuaRuntimeTests
 
         await service.StartAsync();
 
-        var result = service.ExecuteFunction(
-            "(function() return items_public_moongate.on_double_click({ session_id = 1, mobile_id = 0x00005010, item = { serial = 0x00006010 } }) end)()"
-        );
-
-        Assert.Multiple(
-            () =>
-            {
-                Assert.That(result.Success, Is.True);
-                Assert.That(result.Data, Is.EqualTo(true));
-                Assert.That(queue.TryDequeue(out var outbound), Is.True);
-                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
-                var gump = (CompressedGumpPacket)outbound.Packet;
-                Assert.That(gump.TextLines, Contains.Item("Public Moongate"));
-                Assert.That(gump.TextLines, Contains.Item("Britannia"));
-            }
+        return new(
+            temp,
+            queue,
+            gumpDispatcher,
+            mobileService,
+            itemService,
+            session,
+            service
         );
     }
 
-    private static string GetRepositoryRoot()
-        => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+    private sealed record PublicMoongateLuaRuntimeContext(
+        TempDirectory TempDirectory,
+        BasePacketListenerTestOutgoingPacketQueue Queue,
+        GumpScriptDispatcherService GumpDispatcher,
+        PublicMoongateLuaRuntimeMobileService MobileService,
+        PublicMoongateLuaRuntimeItemService ItemService,
+        GameSession Session,
+        LuaScriptEngineService Service
+    ) : IDisposable
+    {
+        public void Dispose()
+        {
+            Service.Dispose();
+            TempDirectory.Dispose();
+        }
+    }
 
     private sealed class PublicMoongateLuaRuntimeMobileService : IMobileService
     {

--- a/tests/Moongate.Tests/Scripting/PublicMoongateLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/PublicMoongateLuaRuntimeTests.cs
@@ -12,6 +12,7 @@ using Moongate.Server.Interfaces.Services.Entities;
 using Moongate.Server.Interfaces.Services.Packets;
 using Moongate.Server.Interfaces.Services.Scripting;
 using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Interfaces.Services.Speech;
 using Moongate.Server.Modules;
 using Moongate.Server.Services.Scripting;
 using Moongate.Tests.Server.Services.Spatial;
@@ -34,6 +35,7 @@ public sealed class PublicMoongateLuaRuntimeTests
         var luarcDir = temp.Path;
         Directory.CreateDirectory(Path.Combine(scriptsDir, "items"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "moongates"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "layout"));
         Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "moongates"));
         Directory.CreateDirectory(luarcDir);
 
@@ -66,6 +68,14 @@ public sealed class PublicMoongateLuaRuntimeTests
             Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "moongates", "render.lua"),
             Path.Combine(scriptsDir, "gumps", "moongates", "render.lua")
         );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "layout", "header.lua"),
+            Path.Combine(scriptsDir, "gumps", "layout", "header.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "layout", "stack.lua"),
+            Path.Combine(scriptsDir, "gumps", "layout", "stack.lua")
+        );
         await File.WriteAllTextAsync(Path.Combine(scriptsDir, "init.lua"), "require(\"items.public_moongate\")\n");
 
         var queue = new BasePacketListenerTestOutgoingPacketQueue();
@@ -74,6 +84,7 @@ public sealed class PublicMoongateLuaRuntimeTests
         var mobileService = new PublicMoongateLuaRuntimeMobileService();
         var itemService = new PublicMoongateLuaRuntimeItemService();
         var characterService = new PublicMoongateLuaRuntimeCharacterService();
+        var speechService = new PublicMoongateLuaRuntimeSpeechService();
 
         using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
         var session = new GameSession(new(client))
@@ -108,6 +119,7 @@ public sealed class PublicMoongateLuaRuntimeTests
         container.RegisterInstance<IMobileService>(mobileService);
         container.RegisterInstance<IItemService>(itemService);
         container.RegisterInstance<ICharacterService>(characterService);
+        container.RegisterInstance<ISpeechService>(speechService);
 
         var service = new LuaScriptEngineService(
             dirs,
@@ -271,5 +283,36 @@ public sealed class PublicMoongateLuaRuntimeTests
 
         public Task<bool> RemoveCharacterFromAccountAsync(Serial accountId, Serial characterId)
             => Task.FromResult(true);
+    }
+
+    private sealed class PublicMoongateLuaRuntimeSpeechService : ISpeechService
+    {
+        public Task<int> BroadcastFromServerAsync(string text, short hue = 946, short font = 3, string language = "ENU")
+            => Task.FromResult(0);
+
+        public Task HandleOpenChatWindowAsync(GameSession session, Moongate.Network.Packets.Incoming.Speech.OpenChatWindowPacket packet, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<Moongate.Network.Packets.Outgoing.Speech.UnicodeSpeechMessagePacket?> ProcessIncomingSpeechAsync(
+            GameSession session,
+            Moongate.Network.Packets.Incoming.Speech.UnicodeSpeechPacket speechPacket,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult<Moongate.Network.Packets.Outgoing.Speech.UnicodeSpeechMessagePacket?>(null);
+
+        public Task<bool> SendMessageFromServerAsync(GameSession session, string text, short hue = 946, short font = 3, string language = "ENU")
+            => Task.FromResult(true);
+
+        public Task<int> SpeakAsMobileAsync(
+            UOMobileEntity speaker,
+            string text,
+            int range = 12,
+            Moongate.UO.Data.Types.ChatMessageType messageType = Moongate.UO.Data.Types.ChatMessageType.Regular,
+            short hue = 946,
+            short font = 3,
+            string language = "ENU",
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult(0);
     }
 }

--- a/tests/Moongate.Tests/Scripting/PublicMoongateLuaRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/PublicMoongateLuaRuntimeTests.cs
@@ -1,0 +1,275 @@
+using System.Net.Sockets;
+using DryIoc;
+using Moongate.Core.Data.Directories;
+using Moongate.Core.Types;
+using Moongate.Network.Client;
+using Moongate.Network.Packets.Outgoing.UI;
+using Moongate.Scripting.Services;
+using Moongate.Server.Data.Session;
+using Moongate.Server.Interfaces.Characters;
+using Moongate.Server.Interfaces.Items;
+using Moongate.Server.Interfaces.Services.Entities;
+using Moongate.Server.Interfaces.Services.Packets;
+using Moongate.Server.Interfaces.Services.Scripting;
+using Moongate.Server.Interfaces.Services.Sessions;
+using Moongate.Server.Modules;
+using Moongate.Server.Services.Scripting;
+using Moongate.Tests.Server.Services.Spatial;
+using Moongate.Tests.Server.Support;
+using Moongate.Tests.TestSupport;
+using Moongate.UO.Data.Geometry;
+using Moongate.UO.Data.Ids;
+using Moongate.UO.Data.Persistence.Entities;
+
+namespace Moongate.Tests.Scripting;
+
+public sealed class PublicMoongateLuaRuntimeTests
+{
+    [Test]
+    public async Task StartAsync_WithPublicMoongateScripts_ShouldOpenSharedPublicMoongateGump()
+    {
+        using var temp = new TempDirectory();
+        var dirs = new DirectoriesConfig(temp.Path, Enum.GetNames<DirectoryType>());
+        var scriptsDir = dirs[DirectoryType.Scripts];
+        var luarcDir = temp.Path;
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "items"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "moongates"));
+        Directory.CreateDirectory(Path.Combine(scriptsDir, "gumps", "moongates"));
+        Directory.CreateDirectory(luarcDir);
+
+        var repoRoot = GetRepositoryRoot();
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "items", "public_moongate.lua"),
+            Path.Combine(scriptsDir, "items", "public_moongate.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "moongates", "data.lua"),
+            Path.Combine(scriptsDir, "moongates", "data.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "moongates", "public_moongate.lua"),
+            Path.Combine(scriptsDir, "gumps", "moongates", "public_moongate.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "moongates", "constants.lua"),
+            Path.Combine(scriptsDir, "gumps", "moongates", "constants.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "moongates", "state.lua"),
+            Path.Combine(scriptsDir, "gumps", "moongates", "state.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "moongates", "ui.lua"),
+            Path.Combine(scriptsDir, "gumps", "moongates", "ui.lua")
+        );
+        File.Copy(
+            Path.Combine(repoRoot, "moongate_data", "scripts", "gumps", "moongates", "render.lua"),
+            Path.Combine(scriptsDir, "gumps", "moongates", "render.lua")
+        );
+        await File.WriteAllTextAsync(Path.Combine(scriptsDir, "init.lua"), "require(\"items.public_moongate\")\n");
+
+        var queue = new BasePacketListenerTestOutgoingPacketQueue();
+        var sessionService = new FakeGameNetworkSessionService();
+        var gumpDispatcher = new GumpScriptDispatcherService();
+        var mobileService = new PublicMoongateLuaRuntimeMobileService();
+        var itemService = new PublicMoongateLuaRuntimeItemService();
+        var characterService = new PublicMoongateLuaRuntimeCharacterService();
+
+        using var client = new MoongateTCPClient(new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp));
+        var session = new GameSession(new(client))
+        {
+            CharacterId = (Serial)0x00005010u,
+            Character = new()
+            {
+                Id = (Serial)0x00005010u,
+                MapId = 0,
+                Location = new Point3D(100, 100, 0),
+                IsPlayer = true
+            }
+        };
+        sessionService.Add(session);
+
+        mobileService.MobilesById[session.Character!.Id] = session.Character!;
+
+        itemService.ItemsById[(Serial)0x00006010u] = new()
+        {
+            Id = (Serial)0x00006010u,
+            Name = "Public Moongate",
+            MapId = 0,
+            Location = new Point3D(100, 101, 0),
+            ScriptId = "items.public_moongate",
+            ItemId = 0x0F6C
+        };
+
+        var container = new Container();
+        container.RegisterInstance<IOutgoingPacketQueue>(queue);
+        container.RegisterInstance<IGameNetworkSessionService>(sessionService);
+        container.RegisterInstance<IGumpScriptDispatcherService>(gumpDispatcher);
+        container.RegisterInstance<IMobileService>(mobileService);
+        container.RegisterInstance<IItemService>(itemService);
+        container.RegisterInstance<ICharacterService>(characterService);
+
+        var service = new LuaScriptEngineService(
+            dirs,
+            [new(typeof(GumpModule)), new(typeof(ItemModule)), new(typeof(MobileModule))],
+            container,
+            new(luarcDir, scriptsDir, "0.1.0"),
+            []
+        );
+
+        await service.StartAsync();
+
+        var result = service.ExecuteFunction(
+            "(function() return items_public_moongate.on_double_click({ session_id = 1, mobile_id = 0x00005010, item = { serial = 0x00006010 } }) end)()"
+        );
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(result.Success, Is.True);
+                Assert.That(result.Data, Is.EqualTo(true));
+                Assert.That(queue.TryDequeue(out var outbound), Is.True);
+                Assert.That(outbound.Packet, Is.TypeOf<CompressedGumpPacket>());
+                var gump = (CompressedGumpPacket)outbound.Packet;
+                Assert.That(gump.TextLines, Contains.Item("Public Moongate"));
+                Assert.That(gump.TextLines, Contains.Item("Britannia"));
+            }
+        );
+    }
+
+    private static string GetRepositoryRoot()
+        => Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+
+    private sealed class PublicMoongateLuaRuntimeMobileService : IMobileService
+    {
+        public Dictionary<Serial, UOMobileEntity> MobilesById { get; } = [];
+
+        public Task CreateOrUpdateAsync(UOMobileEntity mobile, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+            MobilesById[mobile.Id] = mobile;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(Serial id, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<UOMobileEntity?> GetAsync(Serial id, CancellationToken cancellationToken = default)
+        {
+            _ = cancellationToken;
+
+            return Task.FromResult(MobilesById.GetValueOrDefault(id));
+        }
+
+        public Task<List<UOMobileEntity>> GetPersistentMobilesInSectorAsync(int mapId, int sectorX, int sectorY, CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<UOMobileEntity>());
+
+        public Task<UOMobileEntity> SpawnFromTemplateAsync(string templateId, Point3D location, int mapId, Serial? accountId = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<(bool Spawned, UOMobileEntity? Mobile)> TrySpawnFromTemplateAsync(string templateId, Point3D location, int mapId, Serial? accountId = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class PublicMoongateLuaRuntimeItemService : IItemService
+    {
+        public Dictionary<Serial, UOItemEntity> ItemsById { get; } = [];
+
+        public Task BulkUpsertItemsAsync(IReadOnlyList<UOItemEntity> items)
+            => Task.CompletedTask;
+
+        public UOItemEntity Clone(UOItemEntity item, bool generateNewSerial = true)
+            => item;
+
+        public Task<UOItemEntity?> CloneAsync(Serial itemId, bool generateNewSerial = true)
+            => Task.FromResult<UOItemEntity?>(null);
+
+        public Task<Serial> CreateItemAsync(UOItemEntity item)
+            => Task.FromResult(item.Id);
+
+        public Task<bool> DeleteItemAsync(Serial itemId)
+            => Task.FromResult(ItemsById.Remove(itemId));
+
+        public Task<Moongate.Server.Data.Items.DropItemToGroundResult?> DropItemToGroundAsync(Serial itemId, Point3D location, int mapId, long sessionId = 0)
+            => Task.FromResult<Moongate.Server.Data.Items.DropItemToGroundResult?>(null);
+
+        public Task<bool> EquipItemAsync(Serial itemId, Serial mobileId, Moongate.UO.Data.Types.ItemLayerType layer)
+            => Task.FromResult(true);
+
+        public Task<List<UOItemEntity>> GetGroundItemsInSectorAsync(int mapId, int sectorX, int sectorY)
+            => Task.FromResult(new List<UOItemEntity>());
+
+        public Task<UOItemEntity?> GetItemAsync(Serial itemId)
+            => Task.FromResult(ItemsById.GetValueOrDefault(itemId));
+
+        public Task<List<UOItemEntity>> GetItemsInContainerAsync(Serial containerId)
+            => Task.FromResult(new List<UOItemEntity>());
+
+        public Task<bool> MoveItemToContainerAsync(Serial itemId, Serial containerId, Point2D position, long sessionId = 0)
+            => Task.FromResult(true);
+
+        public Task<bool> MoveItemToWorldAsync(Serial itemId, Point3D location, int mapId, long sessionId = 0)
+        {
+            if (!ItemsById.TryGetValue(itemId, out var item))
+            {
+                return Task.FromResult(false);
+            }
+
+            item.Location = location;
+            item.MapId = mapId;
+
+            return Task.FromResult(true);
+        }
+
+        public Task<UOItemEntity> SpawnFromTemplateAsync(string itemTemplateId)
+            => Task.FromResult(new UOItemEntity { Id = (Serial)1u, Amount = 1 });
+
+        public Task<(bool Found, UOItemEntity? Item)> TryToGetItemAsync(Serial itemId)
+            => Task.FromResult((ItemsById.TryGetValue(itemId, out var item), item));
+
+        public Task UpsertItemAsync(UOItemEntity item)
+        {
+            ItemsById[item.Id] = item;
+
+            return Task.CompletedTask;
+        }
+
+        public Task UpsertItemsAsync(params UOItemEntity[] items)
+        {
+            foreach (var item in items)
+            {
+                ItemsById[item.Id] = item;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class PublicMoongateLuaRuntimeCharacterService : ICharacterService
+    {
+        public Task<bool> AddCharacterToAccountAsync(Serial accountId, Serial characterId)
+            => Task.FromResult(true);
+
+        public Task ApplyStarterEquipmentHuesAsync(Serial characterId, short shirtHue, short pantsHue)
+            => Task.CompletedTask;
+
+        public Task<Serial> CreateCharacterAsync(UOMobileEntity character)
+            => Task.FromResult(character.Id);
+
+        public Task<UOItemEntity?> GetBackpackWithItemsAsync(UOMobileEntity character)
+            => Task.FromResult<UOItemEntity?>(null);
+
+        public Task<UOItemEntity?> GetBankBoxWithItemsAsync(UOMobileEntity character)
+            => Task.FromResult<UOItemEntity?>(null);
+
+        public Task<UOMobileEntity?> GetCharacterAsync(Serial characterId)
+            => Task.FromResult<UOMobileEntity?>(null);
+
+        public Task<List<UOMobileEntity>> GetCharactersForAccountAsync(Serial accountId)
+            => Task.FromResult(new List<UOMobileEntity>());
+
+        public Task<bool> RemoveCharacterFromAccountAsync(Serial accountId, Serial characterId)
+            => Task.FromResult(true);
+    }
+}


### PR DESCRIPTION
Closes #230

## Summary
- add a dedicated `public_moongate` item flow separate from spell-created moongates
- add a shared Lua-authored public moongate destination dataset and shared gump UI
- add runtime coverage, template wiring, and authoring documentation for public moongates

## Verification
- `dotnet test tests/Moongate.Tests/Moongate.Tests.csproj --filter "FullyQualifiedName~PublicMoongateLuaRuntimeTests|FullyQualifiedName~GateTravelSpellTests"`
- `moongate-template validate --root-directory /Users/squid/projects/personal/moongatev2/.worktrees/feature-230-public-moongate/moongate_data`
- `docfx docs/docfx.json --logLevel Warning`
- `dotnet test Moongate.slnx`
