### PR TITLE
feat(http): versioned REST API plugin with JWT auth and Scalar

### DIFF
--- a/Moongate.slnx
+++ b/Moongate.slnx
@@ -1,6 +1,7 @@
 <Solution>
     <Folder Name="/src/">
         <Project Path="src/Moongate.Core/Moongate.Core.csproj"/>
+        <Project Path="src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj"/>
         <Project Path="src/Moongate.Network/Moongate.Network.csproj"/>
         <Project Path="src/Moongate.Persistence/Moongate.Persistence.csproj"/>
         <Project Path="src/Moongate.Scripting/Moongate.Scripting.csproj"/>

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -28,6 +28,6 @@
       "_enableSearch": true,
       "_disableContribution": true
     },
-    "sitemap": { "baseUrl": "https://moongate-community.github.io/moongate" }
+    "sitemap": { "baseUrl": "https://moongate.sh" }
   }
 }

--- a/docs/under-the-hood/architecture.md
+++ b/docs/under-the-hood/architecture.md
@@ -43,9 +43,11 @@ top to bottom:
 3. **Bootstrap.** `SquidStdBootstrap.Create(...)` builds the host;
    `ConfigureLogging()` brings Serilog up so even plugin loading is visible.
 4. **Plugins.** `UsePlugins(...)` registers drop-in assemblies from the root's
-   `plugins/` directory plus the six built-in Moongate plugins: persistence,
-   scripting, script modules, data loaders, packet handlers and event
-   subscribers.
+   `plugins/` directory plus the seven built-in Moongate plugins: persistence,
+   scripting, script modules, data loaders, packet handlers, event
+   subscribers and HTTP. The last one is genuinely optional — drop its
+   `builder.Add<MoongateHttpPlugin>()` line and the server boots with no web
+   stack at all. See [REST API](rest-api.md).
 5. **Services.** `ConfigureServices(...)` registers the game services
    (accounts, characters, items, mobiles, loot, world, sessions, network) and
    the SquidStd runtime services: main-thread dispatcher, timer wheel, event

--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -1,0 +1,136 @@
+# REST API
+
+Moongate exposes a versioned REST API for administration and for accounts to
+ask about themselves. It is served by `Moongate.Http.Plugin`, one of the
+built-in plugins, and it is genuinely optional: the game server hosts the web
+application rather than the other way round, so removing the plugin removes the
+whole web stack.
+
+## Turning it off
+
+The API is wired in `Program.cs` alongside the other built-in plugins:
+
+```csharp
+builder.Add<MoongateHttpPlugin>();
+```
+
+Remove that line and the server boots with no Kestrel, no listener and no
+`REST API listening` log. Nothing else changes: no other code path asks for it.
+
+## Configuration
+
+The `http:` section of `moongate.yaml`:
+
+```yaml
+http:
+  Address: 0.0.0.0
+  Port: 8933
+  Jwt:
+    SigningKey: ''
+    LifetimeMinutes: 60
+    Issuer: moongate
+```
+
+`SigningKey` signs the tokens that carry account level, so it is the one value
+worth thinking about:
+
+- **Left empty**, the server mints a key on first start and writes it back to
+  `moongate.yaml`. That is why it is minted rather than shipped as a constant:
+  a key baked into the source would let anyone who read it mint
+  `Administrator` tokens against every server that kept the default. Minting it
+  once and persisting it also means tokens survive a restart — a key
+  regenerated on every boot would silently invalidate every token issued
+  before it.
+- **Set but shorter than 32 bytes**, the server refuses to start and says so.
+  HS256 cannot sign with it, and the tokens would be unverifiable. Not
+  configuring a key is an omission worth covering; configuring a bad one is a
+  mistake worth reporting.
+
+## The same container
+
+The web application runs on the game's own DryIoc container, so an endpoint
+resolves the very singletons the game loop holds — there is no second, parallel
+world behind the API.
+
+This is also why the OpenAPI document comes from Swashbuckle rather than
+`Microsoft.AspNetCore.OpenApi`, which would otherwise be the obvious choice on
+.NET 10: `AddOpenApi` resolves its document services by key, and the DryIoc
+adapter does not implement `IKeyedServiceProvider`. Scalar reads the document
+either way.
+
+## Authentication
+
+`POST /api/v1/auth/login` trades account credentials for a bearer token:
+
+```bash
+curl -X POST http://127.0.0.1:8933/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"tom","password":"secret"}'
+```
+
+```json
+{ "token": "eyJhbGciOiJIUzI1NiIs...", "expiresAt": "2026-07-16T17:35:12+00:00" }
+```
+
+Send it back as `Authorization: Bearer <token>`. The token carries the account
+id, the username and the account level; it expires after
+`Jwt.LifetimeMinutes`.
+
+Login answers **one flat 401 whatever the reason** — wrong password, unknown
+username, blocked account. The game client is told which of these it is,
+because a player needs to know, but over HTTP that same detail tells an
+attacker which usernames exist. The real reason goes to the log instead.
+
+## Policies
+
+Two policies divide the surface, both driven by the account level in the token:
+
+| Policy   | Who                            | Applies to      |
+| -------- | ------------------------------ | --------------- |
+| `admin`  | `Administrator`, `GrandMaster` | `/api/v1/admin` |
+| `player` | any authenticated account      | `/api/v1/player`|
+
+A valid player token against an admin route gets a **403**, not a 401: it is a
+good token that is simply not staff.
+
+## Endpoints
+
+| Method | Route                 | Auth     | Returns                              |
+| ------ | --------------------- | -------- | ------------------------------------ |
+| `GET`  | `/api/v1/version`     | none     | shard name and build                 |
+| `POST` | `/api/v1/auth/login`  | none     | a bearer token and its expiry        |
+| `GET`  | `/api/v1/admin/status`| `admin`  | shard name, build, online sessions   |
+| `GET`  | `/api/v1/player/me`   | `player` | the caller's username and level      |
+
+`/api/v1/version` is deliberately unauthenticated: a launcher or the website
+checks compatibility with it, and it reveals nothing an operator would want
+hidden.
+
+`/api/v1/player/me` reports only what the token already carries. It does not
+list the account's characters on purpose: that would read the mobile store,
+which is single-writer on the game loop, and drag loop affinity into what is
+otherwise a probe.
+
+JSON is camelCase on the wire while the DTOs stay PascalCase in C#.
+
+## Browsing the API
+
+[Scalar](https://scalar.com) serves an interactive reference at `/scalar/v1`,
+reading the OpenAPI document published at `/swagger/v1/swagger.json`. There is
+also an unlisted `/health` returning `{"status":"ok"}`, for a load balancer or
+a container probe.
+
+## Adding endpoints
+
+An endpoint group implements `IApiEndpointRegistration` and is registered with
+`RegisterApiEndpoint<T>()`; the server resolves every group and maps it at
+startup. This is the same registration seam used by packet handlers and event
+subscribers.
+
+Groups live in `Moongate.Server`, not in the plugin: `Program.cs` adds the
+plugin, so the plugin cannot reference the server back. The plugin owns the
+plumbing — config, tokens, the server itself — and the game owns the endpoints
+that need game services.
+
+Anything that mutates world state must get onto the game loop first; see
+[Architecture overview](architecture.md). None of the v1 endpoints do.

--- a/docs/under-the-hood/toc.yml
+++ b/docs/under-the-hood/toc.yml
@@ -1,2 +1,4 @@
 - name: Architecture overview
   href: architecture.md
+- name: REST API
+  href: rest-api.md

--- a/src/Moongate.Http.Plugin/Data/ApiTokenResult.cs
+++ b/src/Moongate.Http.Plugin/Data/ApiTokenResult.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>An issued API token and the moment it stops being valid.</summary>
+public readonly record struct ApiTokenResult(string Token, DateTimeOffset ExpiresAt);

--- a/src/Moongate.Http.Plugin/Data/Config/HttpJwtConfig.cs
+++ b/src/Moongate.Http.Plugin/Data/Config/HttpJwtConfig.cs
@@ -1,0 +1,18 @@
+namespace Moongate.Http.Plugin.Data.Config;
+
+/// <summary>JWT settings for the REST API, nested under <c>http.Jwt</c> in moongate.yaml.</summary>
+public sealed class HttpJwtConfig
+{
+    /// <summary>
+    /// The HS256 signing key. It has no usable default on purpose: a key regenerated per restart would
+    /// silently invalidate every issued token on every restart and read as a random bug. At least 32
+    /// bytes; the server refuses to start without one.
+    /// </summary>
+    public string SigningKey { get; set; } = string.Empty;
+
+    /// <summary>How long an issued token stays valid.</summary>
+    public int LifetimeMinutes { get; set; } = 60;
+
+    /// <summary>The <c>iss</c> claim, and the issuer tokens are validated against.</summary>
+    public string Issuer { get; set; } = "moongate";
+}

--- a/src/Moongate.Http.Plugin/Data/Config/MoongateHttpConfig.cs
+++ b/src/Moongate.Http.Plugin/Data/Config/MoongateHttpConfig.cs
@@ -1,0 +1,19 @@
+namespace Moongate.Http.Plugin.Data.Config;
+
+/// <summary>
+/// The REST API's settings, the <c>http</c> section of moongate.yaml. Every field carries a default, so
+/// the section may be omitted entirely — an operator writes one only to override, or to supply
+/// <see cref="HttpJwtConfig.SigningKey" />, which is the one field with no usable default.
+/// </summary>
+public sealed class MoongateHttpConfig
+{
+    /// <summary>
+    /// The interface to listen on. Defaults to every interface, matching the game port — which also
+    /// means the admin API is reachable from outside unless an operator narrows it.
+    /// </summary>
+    public string Address { get; set; } = "0.0.0.0";
+
+    public int Port { get; set; } = 8933;
+
+    public HttpJwtConfig Jwt { get; set; } = new();
+}

--- a/src/Moongate.Http.Plugin/Extensions/ApiEndpointRegistrationExtensions.cs
+++ b/src/Moongate.Http.Plugin/Extensions/ApiEndpointRegistrationExtensions.cs
@@ -1,0 +1,23 @@
+using DryIoc;
+using Moongate.Http.Plugin.Interfaces;
+
+namespace Moongate.Http.Plugin.Extensions;
+
+/// <summary>
+/// Registers REST endpoint groups. Each one is collected under <see cref="IApiEndpointRegistration" />,
+/// the typed list the HTTP server resolves and maps at startup.
+/// </summary>
+public static class ApiEndpointRegistrationExtensions
+{
+    /// <summary>
+    /// Records an endpoint group as a singleton <see cref="IApiEndpointRegistration" /> so it is mapped
+    /// alongside every other group.
+    /// </summary>
+    public static IContainer RegisterApiEndpoint<TEndpoint>(this IContainer container)
+        where TEndpoint : class, IApiEndpointRegistration
+    {
+        container.Register<IApiEndpointRegistration, TEndpoint>(Reuse.Singleton);
+
+        return container;
+    }
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IApiEndpointRegistration.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IApiEndpointRegistration.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Routing;
+
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>
+/// A group of REST endpoints. Implementations are collected from DI and applied by the HTTP server at
+/// startup, so adding endpoints never means touching the server itself — the packet-side and event-side
+/// registrations work the same way.
+/// </summary>
+public interface IApiEndpointRegistration
+{
+    /// <summary>Maps this group's routes onto the application.</summary>
+    void Register(IEndpointRouteBuilder routes);
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IJwtTokenService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IJwtTokenService.cs
@@ -1,0 +1,15 @@
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>Mints the bearer tokens the REST API authenticates with.</summary>
+public interface IJwtTokenService
+{
+    /// <summary>
+    /// Issues a token for an account that has already been authenticated. The account level rides in the
+    /// role claim, which is what the <c>admin</c> and <c>player</c> policies read.
+    /// </summary>
+    ApiTokenResult Issue(Serial accountId, string username, AccountLevelType level);
+}

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -17,14 +17,14 @@
     <ItemGroup>
         <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10"/>
         <!--
-            Microsoft.AspNetCore.OpenApi 10.0.10 drags in Microsoft.OpenApi 2.0.0, which carries
-            GHSA-v5pm-xwqc-g5wc (high: circular schema references can terminate parsing). 2.7.5 is the
-            first patched release. Pinned explicitly to override the transitive version; drop this once
-            AspNetCore.OpenApi ships a patched one itself.
+            Swashbuckle rather than Microsoft.AspNetCore.OpenApi, which is otherwise the obvious choice on
+            .NET 10: AddOpenApi resolves its document services by key, and DryIoc.Microsoft.DependencyInjection
+            6.2.0 — the newest release, and the one SquidStd pins via DryIoc.dll 5.4.3 — does not implement
+            IKeyedServiceProvider, so every OpenAPI request 500s. Swashbuckle needs no keyed services, which is
+            what lets the web app run on the game's own container. Scalar reads the document either way.
         -->
-        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.13"/>
         <PackageReference Include="SquidStd.Abstractions" Version="0.36.0"/>
         <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Moongate.Core\Moongate.Core.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10"/>
+        <!--
+            Microsoft.AspNetCore.OpenApi 10.0.10 drags in Microsoft.OpenApi 2.0.0, which carries
+            GHSA-v5pm-xwqc-g5wc (high: circular schema references can terminate parsing). 2.7.5 is the
+            first patched release. Pinned explicitly to override the transitive version; drop this once
+            AspNetCore.OpenApi ships a patched one itself.
+        -->
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5"/>
+        <PackageReference Include="Scalar.AspNetCore" Version="2.16.13"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>
+        <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -1,0 +1,36 @@
+using DryIoc;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using SquidStd.Abstractions.Extensions.Config;
+using SquidStd.Abstractions.Extensions.Services;
+using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Http.Plugin;
+
+/// <summary>Registers the REST API: its config section, the token service and the server that runs it.</summary>
+public class MoongateHttpPlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.http.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateHttpPlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate HTTP",
+            Description = "Versioned REST API"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        // The signing key is minted and persisted by HttpServerService at startup, not here: Configure runs
+        // before the other sections are registered, and saving the file this early would drop them from it.
+        container.RegisterConfigSection<MoongateHttpConfig>("http");
+
+        container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
+
+        container.RegisterStdService<HttpServerService, HttpServerService>();
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/HttpServerService.cs
+++ b/src/Moongate.Http.Plugin/Services/HttpServerService.cs
@@ -13,6 +13,7 @@ using Moongate.Http.Plugin.Interfaces;
 using Scalar.AspNetCore;
 using Serilog;
 using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Core.Interfaces.Config;
 
 namespace Moongate.Http.Plugin.Services;
 
@@ -49,8 +50,10 @@ public sealed class HttpServerService : ISquidStdService
 
     public async ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
-        // Validated before anything binds, so a missing key is a startup error rather than a 500 on the
-        // first login attempt.
+        EnsureSigningKey();
+
+        // Validated before anything binds, so a bad key is a startup error rather than a 500 on the first
+        // login attempt.
         var signingKey = JwtTokenService.SigningKey(_config.Jwt.SigningKey);
 
         var builder = WebApplication.CreateBuilder();
@@ -124,6 +127,33 @@ public sealed class HttpServerService : ISquidStdService
         await _app.StopAsync(cancellationToken);
         await _app.DisposeAsync();
         _app = null;
+    }
+
+    /// <summary>
+    /// Mints a signing key for a server that has not configured one, and writes it to moongate.yaml.
+    /// <para>
+    /// Persisting matters as much as generating: a key regenerated on every boot would invalidate every
+    /// token issued before the restart, silently. Saving here rather than in the plugin's Configure is
+    /// deliberate — Configure runs before the other config sections are registered, and the file is composed
+    /// from the registered ones, so an early save would drop them.
+    /// </para>
+    /// <para>
+    /// Only an absent key is filled in. A key that is set but unusable is left to fail loudly below: not
+    /// configuring one is an omission worth covering, whereas configuring a bad one is a mistake worth
+    /// reporting.
+    /// </para>
+    /// </summary>
+    private void EnsureSigningKey()
+    {
+        if (!string.IsNullOrWhiteSpace(_config.Jwt.SigningKey))
+        {
+            return;
+        }
+
+        _config.Jwt.SigningKey = JwtTokenService.GenerateSigningKey();
+        _container.Resolve<IConfigManagerService>().Save();
+
+        _logger.Information("No http.Jwt.SigningKey was configured; minted one and saved it to moongate.yaml");
     }
 
     /// <summary>

--- a/src/Moongate.Http.Plugin/Services/HttpServerService.cs
+++ b/src/Moongate.Http.Plugin/Services/HttpServerService.cs
@@ -1,0 +1,140 @@
+using DryIoc;
+using DryIoc.Microsoft.DependencyInjection;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Interfaces;
+using Scalar.AspNetCore;
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// Runs the REST API. SquidStd hosts the process, so this owns the <see cref="WebApplication" />'s
+/// lifetime rather than the other way round — which is what keeps the whole plugin optional: drop its
+/// registration and the game server boots with no web stack at all.
+/// </summary>
+public sealed class HttpServerService : ISquidStdService
+{
+    /// <summary>Administrator or GrandMaster: staff, not players.</summary>
+    public const string AdminPolicy = "admin";
+
+    /// <summary>Any authenticated account.</summary>
+    public const string PlayerPolicy = "player";
+
+    /// <summary>Where Swashbuckle publishes the document, and so where Scalar is pointed to read it.</summary>
+    public const string SwaggerDocumentRoute = "/swagger/v1/swagger.json";
+
+    private readonly ILogger _logger = Log.ForContext<HttpServerService>();
+    private readonly IContainer _container;
+    private readonly MoongateHttpConfig _config;
+
+    private WebApplication? _app;
+
+    public HttpServerService(IContainer container, MoongateHttpConfig config)
+    {
+        _container = container;
+        _config = config;
+    }
+
+    /// <summary>The port actually listened on — the real one when the configured port is 0.</summary>
+    public int BoundPort { get; private set; }
+
+    public async ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        // Validated before anything binds, so a missing key is a startup error rather than a 500 on the
+        // first login attempt.
+        var signingKey = JwtTokenService.SigningKey(_config.Jwt.SigningKey);
+
+        var builder = WebApplication.CreateBuilder();
+
+        // The game's own container, so endpoints resolve the very singletons the game loop holds.
+        builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(_container));
+        builder.WebHost.UseUrls($"http://{_config.Address}:{_config.Port}");
+
+        builder.Services.AddProblemDetails();
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen();
+
+        builder.Services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+                {
+                    options.TokenValidationParameters = new()
+                    {
+                        ValidateIssuer = true,
+                        ValidIssuer = _config.Jwt.Issuer,
+                        ValidateAudience = true,
+                        ValidAudience = _config.Jwt.Issuer,
+                        ValidateIssuerSigningKey = true,
+                        IssuerSigningKey = signingKey,
+                        ValidateLifetime = true
+                    };
+                }
+            );
+
+        builder.Services
+            .AddAuthorizationBuilder()
+            .AddPolicy(
+                AdminPolicy,
+                policy => policy.RequireRole(
+                    nameof(AccountLevelType.Administrator),
+                    nameof(AccountLevelType.GrandMaster)
+                )
+            )
+            .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
+
+        _app = builder.Build();
+
+        _app.UseExceptionHandler();
+        _app.UseStatusCodePages();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+
+        _app.UseSwagger();
+        _app.MapScalarApiReference(options => options.AddDocument("v1", routePattern: SwaggerDocumentRoute));
+        _app.MapGet("/health", () => Results.Ok(new { status = "ok" })).ExcludeFromDescription();
+
+        foreach (var endpoints in _container.Resolve<IEnumerable<IApiEndpointRegistration>>())
+        {
+            endpoints.Register(_app);
+        }
+
+        await _app.StartAsync(cancellationToken);
+
+        BoundPort = ResolveBoundPort(_app);
+
+        _logger.Information("REST API listening on http://{Address}:{Port}", _config.Address, BoundPort);
+    }
+
+    public async ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_app is null)
+        {
+            return;
+        }
+
+        await _app.StopAsync(cancellationToken);
+        await _app.DisposeAsync();
+        _app = null;
+    }
+
+    /// <summary>
+    /// Asks Kestrel what it actually bound. With a configured port of 0 the OS picks one, and this is the
+    /// only way to learn it.
+    /// </summary>
+    private static int ResolveBoundPort(WebApplication app)
+    {
+        var addresses = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+        var address = addresses?.Addresses.FirstOrDefault();
+
+        return address is null ? 0 : new Uri(address).Port;
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/HttpServerService.cs
+++ b/src/Moongate.Http.Plugin/Services/HttpServerService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -65,6 +66,13 @@ public sealed class HttpServerService : ISquidStdService
         builder.Services.AddProblemDetails();
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();
+
+        // camelCase over the wire while the DTOs stay PascalCase in C#. ASP.NET already defaults to this,
+        // but the wire format is a contract clients are written against: stated here it cannot be changed
+        // by a default shifting under us.
+        builder.Services.ConfigureHttpJsonOptions(
+            options => options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        );
 
         builder.Services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/src/Moongate.Http.Plugin/Services/JwtTokenService.cs
+++ b/src/Moongate.Http.Plugin/Services/JwtTokenService.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
 using Moongate.Core.Primitives;
@@ -44,6 +45,15 @@ public sealed class JwtTokenService : IJwtTokenService
 
         return new(new JwtSecurityTokenHandler().WriteToken(token), expiresAt);
     }
+
+    /// <summary>
+    /// A fresh key, for a server whose config has none yet. Generated per install rather than shipped as a
+    /// constant: this key signs the tokens that carry <see cref="AccountLevelType.Administrator" />, so one
+    /// baked into the source would let anyone who reads it mint staff tokens against every server whose
+    /// owner never changed it.
+    /// </summary>
+    internal static string GenerateSigningKey()
+        => Convert.ToBase64String(RandomNumberGenerator.GetBytes(MinimumKeyBytes));
 
     /// <summary>
     /// Turns the configured key into a signing key, refusing anything HS256 cannot sign with. A short key

--- a/src/Moongate.Http.Plugin/Services/JwtTokenService.cs
+++ b/src/Moongate.Http.Plugin/Services/JwtTokenService.cs
@@ -1,0 +1,67 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Interfaces;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <inheritdoc />
+public sealed class JwtTokenService : IJwtTokenService
+{
+    private const int MinimumKeyBytes = 32;
+
+    private readonly MoongateHttpConfig _config;
+    private readonly TimeProvider _timeProvider;
+
+    public JwtTokenService(MoongateHttpConfig config, TimeProvider timeProvider)
+    {
+        _config = config;
+        _timeProvider = timeProvider;
+    }
+
+    public ApiTokenResult Issue(Serial accountId, string username, AccountLevelType level)
+    {
+        var key = SigningKey(_config.Jwt.SigningKey);
+        var expiresAt = _timeProvider.GetUtcNow().AddMinutes(_config.Jwt.LifetimeMinutes);
+
+        var token = new JwtSecurityToken(
+            issuer: _config.Jwt.Issuer,
+            audience: _config.Jwt.Issuer,
+            claims:
+            [
+                new Claim(JwtRegisteredClaimNames.Sub, accountId.Value.ToString()),
+                new Claim(ClaimTypes.Name, username),
+                new Claim(ClaimTypes.Role, level.ToString())
+            ],
+            expires: expiresAt.UtcDateTime,
+            signingCredentials: new(key, SecurityAlgorithms.HmacSha256)
+        );
+
+        return new(new JwtSecurityTokenHandler().WriteToken(token), expiresAt);
+    }
+
+    /// <summary>
+    /// Turns the configured key into a signing key, refusing anything HS256 cannot sign with. A short key
+    /// would otherwise mint tokens that nobody can verify. Shared with the server, which validates
+    /// incoming tokens against the same key and must refuse a bad one the same way.
+    /// </summary>
+    internal static SymmetricSecurityKey SigningKey(string signingKey)
+    {
+        var bytes = Encoding.UTF8.GetBytes(signingKey);
+
+        if (bytes.Length < MinimumKeyBytes)
+        {
+            throw new InvalidOperationException(
+                $"http.Jwt.SigningKey must be at least {MinimumKeyBytes} bytes for HS256; it is {bytes.Length}. " +
+                "Set a longer key in moongate.yaml."
+            );
+        }
+
+        return new(bytes);
+    }
+}

--- a/src/Moongate.Server/Data/Api/AdminStatusResponse.cs
+++ b/src/Moongate.Server/Data/Api/AdminStatusResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>A staff-level snapshot of the shard. No uptime: there is no "shard started at" to read.</summary>
+public sealed record AdminStatusResponse(string ShardName, string Version, int OnlineSessions);

--- a/src/Moongate.Server/Data/Api/LoginRequest.cs
+++ b/src/Moongate.Server/Data/Api/LoginRequest.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>Credentials posted to the login endpoint.</summary>
+public sealed record LoginRequest(string Username, string Password);

--- a/src/Moongate.Server/Data/Api/PlayerMeResponse.cs
+++ b/src/Moongate.Server/Data/Api/PlayerMeResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>Who the caller's token says they are. Deliberately not their characters — see PlayerEndpoints.</summary>
+public sealed record PlayerMeResponse(string Username, string Level);

--- a/src/Moongate.Server/Data/Api/VersionResponse.cs
+++ b/src/Moongate.Server/Data/Api/VersionResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>What the shard calls itself and which build it runs.</summary>
+public sealed record VersionResponse(string ShardName, string Version);

--- a/src/Moongate.Server/Endpoints/AdminEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Data.Config;
+using Moongate.Server.Interfaces.Accounts;
+using SquidStd.Core.Utils;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>Staff-only shard administration.</summary>
+public sealed class AdminEndpoints : IApiEndpointRegistration
+{
+    private readonly MoongateConfig _config;
+    private readonly ISessionManager _sessions;
+
+    public AdminEndpoints(MoongateConfig config, ISessionManager sessions)
+    {
+        _config = config;
+        _sessions = sessions;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/admin/status", Status)
+              .WithName("GetAdminStatus")
+              .WithTags("admin")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>
+    /// A snapshot of the shard. <see cref="ISessionManager.Count" /> is backed by a ConcurrentDictionary,
+    /// so it is safe to read from an ASP.NET thread; nothing here touches world state, which is
+    /// single-writer on the game loop.
+    /// </summary>
+    private IResult Status()
+        => Results.Ok(
+            new AdminStatusResponse(
+                _config.ShardName,
+                VersionUtils.GetVersion(typeof(AdminEndpoints).Assembly),
+                _sessions.Count
+            )
+        );
+}

--- a/src/Moongate.Server/Endpoints/AuthEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AuthEndpoints.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Interfaces.Accounts;
+using Serilog;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>Trades account credentials for a bearer token.</summary>
+public sealed class AuthEndpoints : IApiEndpointRegistration
+{
+    private readonly ILogger _logger = Log.ForContext<AuthEndpoints>();
+    private readonly IAccountService _accounts;
+    private readonly IJwtTokenService _tokens;
+
+    public AuthEndpoints(IAccountService accounts, IJwtTokenService tokens)
+    {
+        _accounts = accounts;
+        _tokens = tokens;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapPost("/api/v1/auth/login", Login)
+              .WithName("Login")
+              .WithTags("auth")
+              .AllowAnonymous();
+    }
+
+    private IResult Login(LoginRequest request)
+    {
+        var result = _accounts.Authenticate(request.Username, request.Password);
+
+        if (!result.Success)
+        {
+            // One flat 401 whatever the reason. AccountAuthResult distinguishes bad credentials from a
+            // blocked account, and the game client needs that — but over HTTP it would tell an attacker
+            // which usernames exist. The real reason goes to the log instead.
+            _logger.Information("API login denied for {Username}: {Reason}", request.Username, result.Reason);
+
+            return Results.Unauthorized();
+        }
+
+        if (_accounts.GetByUsername(request.Username) is not { } account)
+        {
+            return Results.Unauthorized();
+        }
+
+        return Results.Ok(_tokens.Issue(account.Id, account.Username, account.AccountLevel));
+    }
+}

--- a/src/Moongate.Server/Endpoints/PlayerEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/PlayerEndpoints.cs
@@ -1,0 +1,34 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Server.Data.Api;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>What an authenticated account may ask about itself.</summary>
+public sealed class PlayerEndpoints : IApiEndpointRegistration
+{
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/player/me", Me)
+              .WithName("GetPlayerMe")
+              .WithTags("player")
+              .RequireAuthorization(HttpServerService.PlayerPolicy);
+    }
+
+    /// <summary>
+    /// Reports only what the token already carries. It deliberately does not list the account's
+    /// characters: that would read the mobile store, which is single-writer on the game loop, and drag
+    /// loop affinity into a probe endpoint.
+    /// </summary>
+    private static IResult Me(ClaimsPrincipal user)
+        => Results.Ok(
+            new PlayerMeResponse(
+                user.FindFirstValue(ClaimTypes.Name) ?? string.Empty,
+                user.FindFirstValue(ClaimTypes.Role) ?? string.Empty
+            )
+        );
+}

--- a/src/Moongate.Server/Endpoints/VersionEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/VersionEndpoints.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Data.Config;
+using SquidStd.Core.Utils;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>
+/// The shard's name and build. Deliberately unauthenticated: a launcher or the website checks
+/// compatibility with it, and it reveals nothing an operator would want hidden.
+/// </summary>
+public sealed class VersionEndpoints : IApiEndpointRegistration
+{
+    private readonly MoongateConfig _config;
+
+    public VersionEndpoints(MoongateConfig config)
+    {
+        _config = config;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet(
+                  "/api/v1/version",
+                  () => Results.Ok(
+                      new VersionResponse(_config.ShardName, VersionUtils.GetVersion(typeof(VersionEndpoints).Assembly))
+                  )
+              )
+              .WithName("GetVersion")
+              .WithTags("version")
+              .AllowAnonymous();
+    }
+}

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
         <ProjectReference Include="..\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\Moongate.Persistence\Moongate.Persistence.csproj"/>
         <ProjectReference Include="..\Moongate.Scripting\Moongate.Scripting.csproj"/>

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -1,6 +1,7 @@
 using ConsoleAppFramework;
 using DryIoc;
 using Moongate.Core.Interfaces;
+using Moongate.Http.Plugin;
 using Moongate.Persistence;
 using Moongate.Scripting;
 using Moongate.Server;
@@ -99,6 +100,7 @@ await ConsoleApp.RunAsync(
                 builder.Add<MoongateDataLoaderPlugin>();
                 builder.Add<MoongatePacketHandlersPlugin>();
                 builder.Add<MoongateEventSubscribersPlugin>();
+                builder.Add<MoongateHttpPlugin>();
             }
         );
 

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -2,6 +2,7 @@ using ConsoleAppFramework;
 using DryIoc;
 using Moongate.Core.Interfaces;
 using Moongate.Http.Plugin;
+using Moongate.Http.Plugin.Extensions;
 using Moongate.Persistence;
 using Moongate.Scripting;
 using Moongate.Server;
@@ -9,6 +10,7 @@ using Moongate.Server.Autostart;
 using Moongate.Server.Data.Config;
 using Moongate.Server.Data.Events;
 using Moongate.Server.Data.Exceptions;
+using Moongate.Server.Endpoints;
 using Moongate.Server.Interfaces.Accounts;
 using Moongate.Server.Interfaces.Items;
 using Moongate.Server.Interfaces.Mobiles;
@@ -108,6 +110,9 @@ await ConsoleApp.RunAsync(
             {
                 // Binds the SAME cached instance mutated above; the file cannot clobber it.
                 container.RegisterConfigSection<MoongateConfig>("moongate");
+
+                container.RegisterApiEndpoint<VersionEndpoints>();
+                container.RegisterApiEndpoint<AuthEndpoints>();
 
                 container.Register<IAccountService, AccountService>(Reuse.Singleton);
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -113,6 +113,8 @@ await ConsoleApp.RunAsync(
 
                 container.RegisterApiEndpoint<VersionEndpoints>();
                 container.RegisterApiEndpoint<AuthEndpoints>();
+                container.RegisterApiEndpoint<AdminEndpoints>();
+                container.RegisterApiEndpoint<PlayerEndpoints>();
 
                 container.Register<IAccountService, AccountService>(Reuse.Singleton);
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);

--- a/tests/Moongate.Tests/Http/AdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AdminEndpointsTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http;
+
+public class AdminEndpointsTests
+{
+    [Fact]
+    public async Task AdminStatus_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
+    }
+
+    [Theory]
+    [InlineData(AccountLevelType.Administrator)]
+    [InlineData(AccountLevelType.GrandMaster)]
+    public async Task AdminStatus_WithStaffToken_Is200(AccountLevelType level)
+    {
+        await using var server = await TestApiServer.StartAsync(level);
+        await AuthenticateAsync(server);
+
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminStatus_WithPlayerToken_Is403()
+    {
+        // The test that proves the admin/player split exists rather than being asserted: a valid token
+        // that is simply not staff enough.
+        await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
+        await AuthenticateAsync(server);
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
+    }
+
+    [Fact]
+    public async Task PlayerMe_WithAnyToken_ReportsTheAccount()
+    {
+        await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.GetAsync("/api/v1/player/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("tom", body, StringComparison.Ordinal);
+        Assert.Contains("Player", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PlayerMe_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync("/api/v1/player/me")).StatusCode);
+    }
+
+    private static async Task AuthenticateAsync(TestApiServer server)
+    {
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
+        var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
+
+        server.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+    }
+}

--- a/tests/Moongate.Tests/Http/ApiEndpointRegistrationExtensionsTests.cs
+++ b/tests/Moongate.Tests/Http/ApiEndpointRegistrationExtensionsTests.cs
@@ -1,0 +1,50 @@
+using DryIoc;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Http.Plugin.Interfaces;
+
+namespace Moongate.Tests.Http;
+
+public class ApiEndpointRegistrationExtensionsTests
+{
+    private sealed class FirstEndpoints : IApiEndpointRegistration
+    {
+        public void Register(IEndpointRouteBuilder routes)
+        {
+        }
+    }
+
+    private sealed class SecondEndpoints : IApiEndpointRegistration
+    {
+        public void Register(IEndpointRouteBuilder routes)
+        {
+        }
+    }
+
+    [Fact]
+    public void RegisterApiEndpoint_CollectsEveryEndpointUnderTheSameContract()
+    {
+        var container = new Container();
+
+        container.RegisterApiEndpoint<FirstEndpoints>();
+        container.RegisterApiEndpoint<SecondEndpoints>();
+
+        var registrations = container.Resolve<IEnumerable<IApiEndpointRegistration>>().ToList();
+
+        Assert.Equal(2, registrations.Count);
+        Assert.Contains(registrations, r => r is FirstEndpoints);
+        Assert.Contains(registrations, r => r is SecondEndpoints);
+    }
+
+    [Fact]
+    public void RegisterApiEndpoint_RegistersAsSingleton()
+    {
+        var container = new Container();
+        container.RegisterApiEndpoint<FirstEndpoints>();
+
+        var first = container.Resolve<IEnumerable<IApiEndpointRegistration>>().Single();
+        var second = container.Resolve<IEnumerable<IApiEndpointRegistration>>().Single();
+
+        Assert.Same(first, second);
+    }
+}

--- a/tests/Moongate.Tests/Http/AuthEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AuthEndpointsTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Http.Json;
+using Moongate.Http.Plugin.Data;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http;
+
+public class AuthEndpointsTests
+{
+    [Fact]
+    public async Task Login_GoodCredentials_ReturnsAToken()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
+        Assert.False(string.IsNullOrWhiteSpace(token.Token));
+    }
+
+    [Fact]
+    public async Task Login_ReturnsCamelCaseJson()
+    {
+        // The wire format is a contract clients are written against, so it is pinned rather than left to
+        // whatever the serializer defaults to.
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"expiresAt\"", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"ExpiresAt\"", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Login_WrongPassword_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "wrong" }
+        );
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_BlockedAccount_IsAlso401AndSaysNothingMore()
+    {
+        // The game client needs to know why; an HTTP API telling an attacker that a username exists but
+        // is blocked is an oracle. Same flat 401 either way.
+        await using var server = await TestApiServer.StartAsync();
+        server.Accounts.SetActive("tom", false);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.DoesNotContain("block", await response.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Login_UnknownUsername_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "nobody", password = "secret" }
+        );
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Version_NeedsNoTokenAndNamesTheShard()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.GetAsync("/api/v1/version");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Moongate", await response.Content.ReadAsStringAsync());
+    }
+}

--- a/tests/Moongate.Tests/Http/ContainerSharingTests.cs
+++ b/tests/Moongate.Tests/Http/ContainerSharingTests.cs
@@ -1,0 +1,55 @@
+using DryIoc;
+using DryIoc.Microsoft.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Moongate.Tests.Http;
+
+/// <summary>
+/// The REST API is only useful if its endpoints resolve the very singletons the game loop holds.
+/// <c>WithDependencyInjectionAdapter</c> returns a <em>new</em> container and applies
+/// MicrosoftDependencyInjectionRules, so that sharing is an assumption worth pinning: a cloned
+/// registry would hand endpoints a parallel, empty world and still answer 200 OK.
+/// </summary>
+public class ContainerSharingTests
+{
+    /// <summary>Stands in for any Moongate singleton the game loop holds.</summary>
+    private sealed class GameSingleton
+    {
+        public string Marker { get; set; } = "from-the-game-loop";
+    }
+
+    [Fact]
+    public async Task WebApplication_ResolvesTheSameSingletonInstanceTheGameContainerHolds()
+    {
+        // The container as SquidStdBootstrap leaves it: Moongate services already registered.
+        var gameContainer = new Container();
+        gameContainer.Register<GameSingleton>(Reuse.Singleton);
+        var fromGameLoop = gameContainer.Resolve<GameSingleton>();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(gameContainer));
+        await using var app = builder.Build();
+
+        var fromWeb = app.Services.GetRequiredService<GameSingleton>();
+
+        // Reference identity, not mere resolvability: a cloned registry would hand back a different
+        // instance, and no test asserting "200 OK" would ever notice.
+        Assert.Same(fromGameLoop, fromWeb);
+    }
+
+    [Fact]
+    public async Task WebApplication_SeesMutationsMadeThroughTheGameContainer()
+    {
+        var gameContainer = new Container();
+        gameContainer.Register<GameSingleton>(Reuse.Singleton);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(gameContainer));
+        await using var app = builder.Build();
+
+        gameContainer.Resolve<GameSingleton>().Marker = "mutated-on-the-loop";
+
+        Assert.Equal("mutated-on-the-loop", app.Services.GetRequiredService<GameSingleton>().Marker);
+    }
+}

--- a/tests/Moongate.Tests/Http/ContainerSharingTests.cs
+++ b/tests/Moongate.Tests/Http/ContainerSharingTests.cs
@@ -1,15 +1,20 @@
 using DryIoc;
 using DryIoc.Microsoft.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Tests.Support;
 
 namespace Moongate.Tests.Http;
 
 /// <summary>
-/// The REST API is only useful if its endpoints resolve the very singletons the game loop holds.
+/// The REST API is only useful if it answers about the world the game loop is actually running.
 /// <c>WithDependencyInjectionAdapter</c> returns a <em>new</em> container and applies
-/// MicrosoftDependencyInjectionRules, so that sharing is an assumption worth pinning: a cloned
-/// registry would hand endpoints a parallel, empty world and still answer 200 OK.
+/// MicrosoftDependencyInjectionRules, so that sharing is an assumption worth pinning: a cloned registry
+/// would hand endpoints a parallel, empty world and still answer 200 OK.
 /// </summary>
 public class ContainerSharingTests
 {
@@ -17,6 +22,23 @@ public class ContainerSharingTests
     private sealed class GameSingleton
     {
         public string Marker { get; set; } = "from-the-game-loop";
+    }
+
+    /// <summary>
+    /// An endpoint group shaped like a real one: it takes its dependency through the constructor, which
+    /// is where DryIoc hands it the game's instance.
+    /// </summary>
+    private sealed class SingletonProbeEndpoints : IApiEndpointRegistration
+    {
+        private readonly GameSingleton _singleton;
+
+        public SingletonProbeEndpoints(GameSingleton singleton)
+        {
+            _singleton = singleton;
+        }
+
+        public void Register(IEndpointRouteBuilder routes)
+            => routes.MapGet("/singleton-marker", () => Results.Text(_singleton.Marker));
     }
 
     [Fact]
@@ -39,17 +61,20 @@ public class ContainerSharingTests
     }
 
     [Fact]
-    public async Task WebApplication_SeesMutationsMadeThroughTheGameContainer()
+    public async Task Endpoint_ServesMutationsMadeThroughTheGameContainerAfterStartup()
     {
-        var gameContainer = new Container();
-        gameContainer.Register<GameSingleton>(Reuse.Singleton);
+        await using var server = await TestHttpServer.StartAsync(container =>
+            {
+                container.Register<GameSingleton>(Reuse.Singleton);
+                container.RegisterApiEndpoint<SingletonProbeEndpoints>();
+            }
+        );
 
-        var builder = WebApplication.CreateBuilder();
-        builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(gameContainer));
-        await using var app = builder.Build();
+        // Mutated after the routes are mapped, through the container rather than the endpoint: the marker
+        // only comes back changed if the endpoint holds the game's own instance and reads it live. This is
+        // the whole chain the previous test only covers a link of.
+        server.Container.Resolve<GameSingleton>().Marker = "mutated-on-the-loop";
 
-        gameContainer.Resolve<GameSingleton>().Marker = "mutated-on-the-loop";
-
-        Assert.Equal("mutated-on-the-loop", app.Services.GetRequiredService<GameSingleton>().Marker);
+        Assert.Equal("mutated-on-the-loop", await server.Client.GetStringAsync("/singleton-marker"));
     }
 }

--- a/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
+++ b/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
@@ -7,6 +7,7 @@ using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
 using Moongate.Tests.Support;
+using SquidStd.Core.Interfaces.Config;
 
 namespace Moongate.Tests.Http;
 
@@ -49,18 +50,83 @@ public class HttpServerServiceTests
     }
 
     [Fact]
-    public async Task StartAsync_MissingSigningKey_FailsLoudly()
+    public async Task StartAsync_ConfiguredSigningKeyTooShort_FailsLoudly()
     {
-        // A key generated per restart would invalidate every token on every restart and read as a
-        // random bug. Refusing to start says so plainly instead.
+        // Set but unusable: a mistake, not an omission. Starting anyway would mint tokens nobody can
+        // verify, so this is worth stopping for rather than papering over with a generated key.
         var container = new Container();
-        var config = new MoongateHttpConfig { Port = 0, Jwt = new() { SigningKey = string.Empty } };
+        var config = new MoongateHttpConfig { Port = 0, Jwt = new() { SigningKey = "too-short-for-hs256" } };
         container.RegisterInstance(config);
 
         var service = new HttpServerService(container, config);
 
         var error = await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.StartAsync());
         Assert.Contains("SigningKey", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task StartAsync_NoSigningKeyConfigured_MintsOneAndPersistsIt()
+    {
+        // Persisting is the point: a key minted per boot would invalidate every token issued before the
+        // restart, and nothing would say so.
+        var container = new Container();
+        var config = new MoongateHttpConfig { Address = "127.0.0.1", Port = 0, Jwt = new() { SigningKey = string.Empty } };
+        var configManager = new StubConfigManagerService();
+        container.RegisterInstance(config);
+        container.RegisterInstance<IConfigManagerService>(configManager);
+
+        var service = new HttpServerService(container, config);
+        await service.StartAsync();
+
+        try
+        {
+            Assert.NotEmpty(config.Jwt.SigningKey);
+            Assert.Equal(1, configManager.SaveCount);
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_MintsADifferentKeyForEveryServer()
+    {
+        // The reason a constant default was refused: a shared secret lets anyone holding it mint
+        // Administrator tokens against every server that kept it.
+        Assert.NotEqual(await MintedKeyAsync(), await MintedKeyAsync());
+
+        static async Task<string> MintedKeyAsync()
+        {
+            var container = new Container();
+            var config = new MoongateHttpConfig
+            {
+                Address = "127.0.0.1", Port = 0, Jwt = new() { SigningKey = string.Empty }
+            };
+            container.RegisterInstance(config);
+            container.RegisterInstance<IConfigManagerService>(new StubConfigManagerService());
+
+            var service = new HttpServerService(container, config);
+            await service.StartAsync();
+            await service.StopAsync();
+
+            return config.Jwt.SigningKey;
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_SigningKeyAlreadyConfigured_LeavesItAloneAndSavesNothing()
+    {
+        // Rewriting the config file on every boot would be a surprising side effect, and re-minting would
+        // throw away the key the operator chose.
+        var configManager = new StubConfigManagerService();
+
+        await using var server = await TestHttpServer.StartAsync(
+            container => container.RegisterInstance<IConfigManagerService>(configManager)
+        );
+
+        Assert.Equal(TestHttpServer.SigningKey, server.Container.Resolve<MoongateHttpConfig>().Jwt.SigningKey);
+        Assert.Equal(0, configManager.SaveCount);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
+++ b/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using DryIoc;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http;
+
+public class HttpServerServiceTests
+{
+    private sealed class ProbeEndpoints : IApiEndpointRegistration
+    {
+        public void Register(IEndpointRouteBuilder routes)
+            => routes.MapGet("/probe", () => Results.Ok("mapped"));
+    }
+
+    [Fact]
+    public async Task StartAsync_MapsRegisteredEndpointGroups()
+    {
+        await using var server = await TestHttpServer.StartAsync(
+            container => container.RegisterApiEndpointInstance(new ProbeEndpoints())
+        );
+
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/probe")).StatusCode);
+    }
+
+    [Fact]
+    public async Task StartAsync_ServesHealth()
+    {
+        await using var server = await TestHttpServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/health")).StatusCode);
+    }
+
+    [Fact]
+    public async Task StartAsync_ServesTheOpenApiDocumentAndScalar()
+    {
+        await using var server = await TestHttpServer.StartAsync();
+
+        Assert.Equal(
+            HttpStatusCode.OK,
+            (await server.Client.GetAsync(HttpServerService.SwaggerDocumentRoute)).StatusCode
+        );
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/scalar/v1")).StatusCode);
+    }
+
+    [Fact]
+    public async Task StartAsync_MissingSigningKey_FailsLoudly()
+    {
+        // A key generated per restart would invalidate every token on every restart and read as a
+        // random bug. Refusing to start says so plainly instead.
+        var container = new Container();
+        var config = new MoongateHttpConfig { Port = 0, Jwt = new() { SigningKey = string.Empty } };
+        container.RegisterInstance(config);
+
+        var service = new HttpServerService(container, config);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.StartAsync());
+        Assert.Contains("SigningKey", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task StopAsync_ReleasesThePort()
+    {
+        var server = await TestHttpServer.StartAsync();
+        var port = server.Port;
+        await server.DisposeAsync();
+
+        // Binding the same port again proves the listener really let go.
+        await using var second = await TestHttpServer.StartAsync(port: port);
+
+        Assert.Equal(HttpStatusCode.OK, (await second.Client.GetAsync("/health")).StatusCode);
+    }
+}

--- a/tests/Moongate.Tests/Http/JwtTokenServiceTests.cs
+++ b/tests/Moongate.Tests/Http/JwtTokenServiceTests.cs
@@ -1,0 +1,76 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Services;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http;
+
+public class JwtTokenServiceTests
+{
+    [Fact]
+    public void Issue_PutsTheAccountLevelInTheRoleClaim()
+    {
+        var token = Read(Service().Issue(new Serial(5), "tom", AccountLevelType.Administrator).Token);
+
+        Assert.Equal("Administrator", token.Claims.First(c => c.Type == ClaimTypes.Role).Value);
+    }
+
+    [Fact]
+    public void Issue_CarriesTheAccountSerialAndUsername()
+    {
+        var token = Read(Service().Issue(new Serial(5), "tom", AccountLevelType.Player).Token);
+
+        Assert.Equal("5", token.Claims.First(c => c.Type == JwtRegisteredClaimNames.Sub).Value);
+        Assert.Equal("tom", token.Claims.First(c => c.Type == ClaimTypes.Name).Value);
+    }
+
+    [Fact]
+    public void Issue_ExpiresAfterTheConfiguredLifetime()
+    {
+        var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
+        var result = Service(lifetimeMinutes: 30, now: now).Issue(new Serial(5), "tom", AccountLevelType.Player);
+
+        Assert.Equal(now.AddMinutes(30), result.ExpiresAt);
+    }
+
+    [Fact]
+    public void Issue_UsesTheConfiguredIssuer()
+    {
+        var token = Read(Service().Issue(new Serial(5), "tom", AccountLevelType.Player).Token);
+
+        Assert.Equal("moongate", token.Issuer);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("too-short-for-hs256")]
+    public void Issue_KeyShorterThan32Bytes_Throws(string signingKey)
+    {
+        // HS256 needs at least 32 bytes. Failing loudly beats minting tokens nobody can verify.
+        var service = Service(signingKey: signingKey);
+
+        Assert.Throws<InvalidOperationException>(
+            () => service.Issue(new Serial(5), "tom", AccountLevelType.Player)
+        );
+    }
+
+    private static JwtSecurityToken Read(string token)
+        => new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+    private static JwtTokenService Service(
+        string signingKey = "a-signing-key-long-enough-for-hs256!!",
+        int lifetimeMinutes = 60,
+        DateTimeOffset? now = null
+    )
+    {
+        var config = new MoongateHttpConfig
+        {
+            Jwt = new() { SigningKey = signingKey, LifetimeMinutes = lifetimeMinutes, Issuer = "moongate" }
+        };
+
+        return new(config, new FixedTimeProvider(now ?? DateTimeOffset.UtcNow));
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpConfigTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpConfigTests.cs
@@ -1,0 +1,28 @@
+using Moongate.Http.Plugin.Data.Config;
+
+namespace Moongate.Tests.Http;
+
+public class MoongateHttpConfigTests
+{
+    [Fact]
+    public void Defaults_BindEverywhereOn8933()
+    {
+        var config = new MoongateHttpConfig();
+
+        Assert.Equal("0.0.0.0", config.Address);
+        Assert.Equal(8933, config.Port);
+    }
+
+    [Fact]
+    public void Defaults_LeaveJwtPresentSoConfigNeedsNoHttpSection()
+    {
+        // moongate.yaml needs no `http:` section for the plugin to run; only SigningKey must be
+        // supplied, and it deliberately has no usable default.
+        var config = new MoongateHttpConfig();
+
+        Assert.NotNull(config.Jwt);
+        Assert.Equal(60, config.Jwt.LifetimeMinutes);
+        Assert.Equal("moongate", config.Jwt.Issuer);
+        Assert.Empty(config.Jwt.SigningKey);
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -1,0 +1,34 @@
+using DryIoc;
+using Moongate.Http.Plugin;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+
+namespace Moongate.Tests.Http;
+
+public class MoongateHttpPluginTests
+{
+    /// <summary>A container carrying what the real bootstrap supplies around the plugin.</summary>
+    private static IContainer Configured()
+    {
+        var container = new Container();
+        container.RegisterInstance(new MoongateHttpConfig());
+        container.RegisterInstance(TimeProvider.System);
+
+        new MoongateHttpPlugin().Configure(container, new());
+
+        return container;
+    }
+
+    [Fact]
+    public void Configure_RegistersTheTokenService()
+        => Assert.IsType<JwtTokenService>(Configured().Resolve<IJwtTokenService>());
+
+    [Fact]
+    public void Configure_RegistersTheServerThatRunsTheApi()
+        => Assert.NotNull(Configured().Resolve<HttpServerService>());
+
+    [Fact]
+    public void Metadata_IdentifiesThePlugin()
+        => Assert.Equal("moongate.http.plugin", new MoongateHttpPlugin().Metadata.Id);
+}

--- a/tests/Moongate.Tests/Moongate.Tests.csproj
+++ b/tests/Moongate.Tests/Moongate.Tests.csproj
@@ -25,7 +25,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\src\Moongate.Core\Moongate.Core.csproj"/>
+        <ProjectReference Include="..\..\src\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Server\Moongate.Server.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Ultima\Moongate.Ultima.csproj"/>

--- a/tests/Moongate.Tests/Support/ApiEndpointInstanceExtensions.cs
+++ b/tests/Moongate.Tests/Support/ApiEndpointInstanceExtensions.cs
@@ -1,0 +1,20 @@
+using DryIoc;
+using Moongate.Http.Plugin.Interfaces;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Registers an already-built endpoint group, which the production extension cannot do.</summary>
+public static class ApiEndpointInstanceExtensions
+{
+    /// <summary>
+    /// Appends rather than replaces: <see cref="Registrator.RegisterInstance{TService}" /> would
+    /// otherwise keep only the last group registered, and a test wiring several would silently lose all
+    /// but one.
+    /// </summary>
+    public static IContainer RegisterApiEndpointInstance(this IContainer container, IApiEndpointRegistration endpoints)
+    {
+        container.RegisterInstance(endpoints, IfAlreadyRegistered.AppendNotKeyed);
+
+        return container;
+    }
+}

--- a/tests/Moongate.Tests/Support/StubConfigManagerService.cs
+++ b/tests/Moongate.Tests/Support/StubConfigManagerService.cs
@@ -1,0 +1,35 @@
+using SquidStd.Core.Interfaces.Config;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Stands in for the real config manager, recording saves instead of writing moongate.yaml. Only
+/// <see cref="Save" /> is exercised; the rest would be a lie if it pretended to work.
+/// </summary>
+public sealed class StubConfigManagerService : IConfigManagerService
+{
+    public int SaveCount { get; private set; }
+
+    public string ConfigName => "moongate";
+
+    public string ConfigDirectory => string.Empty;
+
+    public string ConfigPath => string.Empty;
+
+    public IReadOnlyCollection<IConfigEntry> Entries => [];
+
+    public event Action? ConfigLoaded;
+
+    public string Compose()
+        => throw new NotSupportedException();
+
+    public TConfig GetConfig<TConfig>()
+        where TConfig : class
+        => throw new NotSupportedException();
+
+    public void Load()
+        => throw new NotSupportedException();
+
+    public void Save()
+        => SaveCount++;
+}

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -1,0 +1,74 @@
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Server.Data.Config;
+using Moongate.Server.Endpoints;
+using Moongate.Server.Interfaces.Accounts;
+using Moongate.Server.Services.Accounts;
+using SquidStd.Core.Interfaces.Config;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Boots the REST API over real game services on fake persistence, with one account: tom / secret. The
+/// endpoints under test are the real ones, reached over real HTTP.
+/// </summary>
+public sealed class TestApiServer : IAsyncDisposable
+{
+    private readonly HttpServerService _service;
+
+    private TestApiServer(HttpServerService service, HttpClient client, IAccountService accounts)
+    {
+        _service = service;
+        Client = client;
+        Accounts = accounts;
+    }
+
+    public HttpClient Client { get; }
+
+    public IAccountService Accounts { get; }
+
+    public static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+    {
+        var container = new Container();
+        var persistence = new FakePersistenceService();
+        var accounts = new AccountService(
+            persistence,
+            CharacterServiceFixture.Create(persistence, new EventBusService()),
+            new StubSessionManager()
+        );
+        accounts.Create("tom", "secret", null, level);
+
+        var config = new MoongateHttpConfig
+        {
+            Address = "127.0.0.1",
+            Port = 0,
+            Jwt = new() { SigningKey = TestHttpServer.SigningKey, LifetimeMinutes = 60, Issuer = "moongate" }
+        };
+        var moongateConfig = new MoongateConfig { ShardName = "Moongate", UltimaDirectory = "/tmp" };
+
+        container.RegisterInstance(config);
+        container.RegisterInstance(TimeProvider.System);
+        container.RegisterInstance(moongateConfig);
+        container.RegisterInstance<IAccountService>(accounts);
+        container.RegisterInstance<IConfigManagerService>(new StubConfigManagerService());
+        container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
+
+        container.RegisterApiEndpointInstance(new VersionEndpoints(moongateConfig));
+        container.RegisterApiEndpointInstance(new AuthEndpoints(accounts, container.Resolve<IJwtTokenService>()));
+
+        var service = new HttpServerService(container, config);
+        await service.StartAsync();
+
+        return new(service, new() { BaseAddress = new($"http://127.0.0.1:{service.BoundPort}") }, accounts);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        await _service.StopAsync();
+    }
+}

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -35,10 +35,11 @@ public sealed class TestApiServer : IAsyncDisposable
     {
         var container = new Container();
         var persistence = new FakePersistenceService();
+        var sessions = new StubSessionManager();
         var accounts = new AccountService(
             persistence,
             CharacterServiceFixture.Create(persistence, new EventBusService()),
-            new StubSessionManager()
+            sessions
         );
         accounts.Create("tom", "secret", null, level);
 
@@ -59,6 +60,8 @@ public sealed class TestApiServer : IAsyncDisposable
 
         container.RegisterApiEndpointInstance(new VersionEndpoints(moongateConfig));
         container.RegisterApiEndpointInstance(new AuthEndpoints(accounts, container.Resolve<IJwtTokenService>()));
+        container.RegisterApiEndpointInstance(new AdminEndpoints(moongateConfig, sessions));
+        container.RegisterApiEndpointInstance(new PlayerEndpoints());
 
         var service = new HttpServerService(container, config);
         await service.StartAsync();

--- a/tests/Moongate.Tests/Support/TestHttpServer.cs
+++ b/tests/Moongate.Tests/Support/TestHttpServer.cs
@@ -1,0 +1,60 @@
+using DryIoc;
+using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Services;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Boots a real <see cref="HttpServerService" /> on an ephemeral port with a usable signing key, and
+/// hands back an <see cref="HttpClient" /> pointed at it. Ephemeral ports keep parallel tests from
+/// colliding on a fixed one.
+/// </summary>
+public sealed class TestHttpServer : IAsyncDisposable
+{
+    public const string SigningKey = "a-test-signing-key-long-enough-for-hs256";
+
+    private readonly HttpServerService _service;
+
+    private TestHttpServer(HttpServerService service, HttpClient client, int port, IContainer container)
+    {
+        _service = service;
+        Client = client;
+        Port = port;
+        Container = container;
+    }
+
+    public HttpClient Client { get; }
+
+    public int Port { get; }
+
+    /// <summary>The game's container, so a test can reach the singletons the endpoints were built from.</summary>
+    public IContainer Container { get; }
+
+    public static async Task<TestHttpServer> StartAsync(Action<IContainer>? configure = null, int port = 0)
+    {
+        var container = new Container();
+        var config = new MoongateHttpConfig
+        {
+            Address = "127.0.0.1",
+            Port = port,
+            Jwt = new() { SigningKey = SigningKey, LifetimeMinutes = 60, Issuer = "moongate" }
+        };
+
+        container.RegisterInstance(config);
+        container.RegisterInstance(TimeProvider.System);
+        configure?.Invoke(container);
+
+        var service = new HttpServerService(container, config);
+        await service.StartAsync();
+
+        var client = new HttpClient { BaseAddress = new($"http://127.0.0.1:{service.BoundPort}") };
+
+        return new(service, client, service.BoundPort, container);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        await _service.StopAsync();
+    }
+}


### PR DESCRIPTION
Adds `Moongate.Http.Plugin`: a versioned REST API (`/api/v1/*`) with JWT auth, admin/player policies and an interactive Scalar reference, served on the game's own DryIoc container.

## What it adds

| Method | Route | Auth | Returns |
| --- | --- | --- | --- |
| `GET` | `/api/v1/version` | none | shard name and build |
| `POST` | `/api/v1/auth/login` | none | a bearer token and its expiry |
| `GET` | `/api/v1/admin/status` | `admin` | shard, build, online sessions |
| `GET` | `/api/v1/player/me` | `player` | the caller's username and level |

Scalar lives at `/scalar/v1`, the OpenAPI document at `/swagger/v1/swagger.json`, plus an unlisted `/health`. JSON is camelCase on the wire; DTOs stay PascalCase in C#.

## Decisions worth reviewing

**The web app runs on the game's container**, so endpoints resolve the very singletons the game loop holds — no parallel, empty world behind the API.

**Swashbuckle instead of `Microsoft.AspNetCore.OpenApi`**, which would otherwise be the obvious choice on .NET 10. `AddOpenApi` resolves its document services *by key*, and `DryIoc.Microsoft.DependencyInjection` 6.2.0 — the newest release, and the one SquidStd pins via `DryIoc.dll` 5.4.3 — does not implement `IKeyedServiceProvider`, so every OpenAPI request 500s. Swashbuckle needs no keyed services; Scalar reads the document either way. It also resolves `Microsoft.OpenApi` 2.7.5, patched for GHSA-v5pm-xwqc-g5wc.

**The JWT signing key is minted on first start and saved to `moongate.yaml`**, not shipped as a constant: that key signs `Administrator` tokens, so one baked into the source would let anyone who read it mint staff tokens against every server that kept the default (CWE-798). Persisting matters as much as generating — a key regenerated per boot would silently invalidate every token issued before the restart. It is minted in `HttpServerService` rather than the plugin's `Configure`, because the config file is composed from the registered sections and `Configure` runs before the others are registered.

A key that is *set but too short* still fails loudly: not configuring one is an omission worth covering, configuring a bad one is a mistake worth reporting.

**Login answers one flat 401** whatever the reason. `AccountAuthResult` tells a bad password from a blocked account and the game client needs that, but over HTTP it would tell an attacker which usernames exist. The real reason goes to the log.

**Endpoints live in `Moongate.Server`, not the plugin.** `Program.cs` adds the plugin, so the plugin cannot reference the server back. The plugin owns the plumbing; the game owns the endpoints that need game services.

## Verification

- 919/919 tests green; `dotnet docfx` at 0 warnings
- Real boot: all four routes published in the OpenAPI document, `/api/v1/version` answers camelCase, `/admin/status` and a bad login both 401
- Key persistence: an existing `moongate.yaml` with no `http` section gains the key on the next boot and reports the same key on the one after; customised values in other sections survive that save
- **The plugin is genuinely optional**: removing `builder.Add<MoongateHttpPlugin>()` boots a full game server (TCP 2593) with no web stack and no errors
- Sabotage-verified: the flat 401 (leaking the reason turns it red), the admin/player split (weakening the policy turns it red), and container sharing (endpoints from another container 404)

## Deliberately out of scope

No world-state writes — v1 never touches the game loop, which is why `/player/me` does not list characters. No refresh tokens, no login rate limiting, no HTTPS (it sits behind a reverse proxy).

Also included: `sitemap.baseUrl` now points at `moongate.sh`, matching where the docs actually live.