### PR TITLE
feat(http): account CRUD over the REST API

### DIFF
--- a/docs/under-the-hood/architecture.md
+++ b/docs/under-the-hood/architecture.md
@@ -43,11 +43,11 @@ top to bottom:
 3. **Bootstrap.** `SquidStdBootstrap.Create(...)` builds the host;
    `ConfigureLogging()` brings Serilog up so even plugin loading is visible.
 4. **Plugins.** `UsePlugins(...)` registers drop-in assemblies from the root's
-   `plugins/` directory plus the seven built-in Moongate plugins: persistence,
+   `plugins/` directory plus the eight built-in Moongate plugins: persistence,
    scripting, script modules, data loaders, packet handlers, event
-   subscribers and HTTP. The last one is genuinely optional — drop its
-   `builder.Add<MoongateHttpPlugin>()` line and the server boots with no web
-   stack at all. See [REST API](rest-api.md).
+   subscribers, HTTP and API endpoints. The last two are genuinely optional —
+   start with `--disable-web-plugin` and the server runs with no web stack at
+   all. See [REST API](rest-api.md).
 5. **Services.** `ConfigureServices(...)` registers the game services
    (accounts, characters, items, mobiles, loot, world, sessions, network) and
    the SquidStd runtime services: main-thread dispatcher, timer wheel, event

--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -98,12 +98,17 @@ good token that is simply not staff.
 
 ## Endpoints
 
-| Method | Route                 | Auth     | Returns                              |
-| ------ | --------------------- | -------- | ------------------------------------ |
-| `GET`  | `/api/v1/version`     | none     | shard name and build                 |
-| `POST` | `/api/v1/auth/login`  | none     | a bearer token and its expiry        |
-| `GET`  | `/api/v1/admin/status`| `admin`  | shard name, build, online sessions   |
-| `GET`  | `/api/v1/player/me`   | `player` | the caller's username and level      |
+| Method   | Route                                | Auth     | Returns                            |
+| -------- | ------------------------------------ | -------- | ---------------------------------- |
+| `GET`    | `/api/v1/version`                    | none     | shard name and build               |
+| `POST`   | `/api/v1/auth/login`                 | none     | a bearer token and its expiry      |
+| `GET`    | `/api/v1/admin/status`               | `admin`  | shard name, build, online sessions |
+| `GET`    | `/api/v1/player/me`                  | `player` | the caller's username and level    |
+| `GET`    | `/api/v1/admin/accounts`             | `admin`  | every account                      |
+| `GET`    | `/api/v1/admin/accounts/{username}`  | `admin`  | one account, or 404                |
+| `POST`   | `/api/v1/admin/accounts`             | `admin`  | 201 and a `Location`, or 400 / 409 |
+| `PATCH`  | `/api/v1/admin/accounts/{username}`  | `admin`  | the updated account, or 400 / 404  |
+| `DELETE` | `/api/v1/admin/accounts/{username}`  | `admin`  | 204, or 404 / 409 / 503            |
 
 `/api/v1/version` is deliberately unauthenticated: a launcher or the website
 checks compatibility with it, and it reveals nothing an operator would want
@@ -115,6 +120,59 @@ which is single-writer on the game loop, and drag loop affinity into what is
 otherwise a probe.
 
 JSON is camelCase on the wire while the DTOs stay PascalCase in C#.
+
+## Managing accounts
+
+The account routes are the REST twin of Lua's `account.*` module, and reach the
+same `IAccountService`.
+
+```bash
+curl -X POST http://127.0.0.1:8933/api/v1/admin/accounts \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"secret","email":"a@b.c","level":"Player"}'
+```
+
+An omitted `level` means `Player`: an account that gains staff rights by
+accident is the wrong way to fail. A level that is not an `AccountLevelType`
+name is a 400, checked before anything is written, so a bad request cannot
+leave a half-made account behind.
+
+`PATCH` changes only the fields it carries — `level`, `isActive` and
+`password` are each optional, and an absent one is left alone:
+
+```bash
+curl -X PATCH http://127.0.0.1:8933/api/v1/admin/accounts/alice \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"isActive":false}'
+```
+
+**Email cannot be changed after creation**: the account service has no setter
+for it.
+
+**The password is write-only.** It goes in through `POST` and `PATCH` and
+appears in no response: the account resource reports `username`, `email`,
+`level`, `isActive` and `characterCount`, and nothing else. `AccountEntity`
+holds a password hash and an activation token, and neither ever leaves the
+server.
+
+**These routes say why they failed**, which looks like the opposite of the
+login rule above and is not. Login answers a flat 401 because anyone can call
+it, and the difference between "no such user" and "wrong password" tells an
+attacker which usernames exist. Here the caller already holds a staff token, so
+naming the reason is operational information for someone entitled to it.
+
+### Deleting
+
+`DELETE` removes the account **and every character on it**, with everything
+those characters carry. It is the only route that touches world state, so it
+does its work on the game loop and the request waits for the answer: deleting
+checks whether a character is being played and then deletes, login runs on the
+loop, and doing that check anywhere else lets a player log in between the two
+and lose their character from under them.
+
+- **409** — a character on the account is being played. Nothing is deleted.
+- **503** — the game loop did not answer within five seconds. Nothing is
+  deleted; the shard is unwell and the log says so.
 
 ## Browsing the API
 

--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -8,14 +8,17 @@ whole web stack.
 
 ## Turning it off
 
-The API is wired in `Program.cs` alongside the other built-in plugins:
+Start the server with `--disable-web-plugin`:
 
-```csharp
-builder.Add<MoongateHttpPlugin>();
+```bash
+dotnet run --project src/Moongate.Server -- --disable-web-plugin
 ```
 
-Remove that line and the server boots with no Kestrel, no listener and no
-`REST API listening` log. Nothing else changes: no other code path asks for it.
+The server then runs with no Kestrel, no listener and no `REST API listening`
+log — it logs `HTTP is disabled` and nothing else changes, because no other
+code path asks for it. Two plugins are skipped: `MoongateHttpPlugin`, which
+owns the API's plumbing, and `MoongateApiEndpointsPlugin`, which registers the
+endpoint groups the server would map.
 
 ## Configuration
 
@@ -122,13 +125,17 @@ a container probe.
 
 ## Adding endpoints
 
-An endpoint group implements `IApiEndpointRegistration` and is registered with
-`RegisterApiEndpoint<T>()`; the server resolves every group and maps it at
-startup. This is the same registration seam used by packet handlers and event
-subscribers.
+An endpoint group implements `IApiEndpointRegistration` and is registered in
+`MoongateApiEndpointsPlugin` with `RegisterApiEndpoint<T>()`; the server
+resolves every group and maps it at startup. This is the same registration seam
+used by packet handlers and event subscribers, and each of those has its own
+plugin too.
 
-Groups live in `Moongate.Server`, not in the plugin: `Program.cs` adds the
-plugin, so the plugin cannot reference the server back. The plugin owns the
+A group that is never registered is not a startup error: the server comes up
+and the route simply 404s, and Scalar shows a reference with nothing in it.
+
+Groups live in `Moongate.Server`, not in `Moongate.Http.Plugin`: `Program.cs`
+adds that plugin, so it cannot reference the server back. The plugin owns the
 plumbing — config, tokens, the server itself — and the game owns the endpoints
 that need game services.
 

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE_TAG="${IMAGE_TAG:-moongate-server:local}"
+DOCKERFILE_PATH="${DOCKERFILE_PATH:-$REPO_ROOT/src/Moongate.Server/Dockerfile}"
+PLATFORM="${PLATFORM:-}"
+PUSH_IMAGE="false"
+NO_CACHE="false"
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Build Moongate Docker image from repository root Dockerfile.
+
+Options:
+  -t, --tag <tag>           Image tag (default: moongate-server:local)
+  -f, --file <path>         Dockerfile path (default: ./Dockerfile)
+  -p, --platform <platform> Buildx platform (e.g. linux/amd64,linux/arm64)
+      --push                Push image after build (uses docker buildx)
+      --no-cache            Build without cache
+  -h, --help                Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -t | --tag)
+    IMAGE_TAG="$2"
+    shift 2
+    ;;
+  -f | --file)
+    DOCKERFILE_PATH="$2"
+    shift 2
+    ;;
+  -p | --platform)
+    PLATFORM="$2"
+    shift 2
+    ;;
+  --push)
+    PUSH_IMAGE="true"
+    shift
+    ;;
+  --no-cache)
+    NO_CACHE="true"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+if [[ ! -f "$DOCKERFILE_PATH" ]]; then
+  echo "Dockerfile not found: $DOCKERFILE_PATH" >&2
+  exit 1
+fi
+
+BUILD_CMD=(docker buildx build -f "$DOCKERFILE_PATH" -t "$IMAGE_TAG")
+
+if [[ -n "$PLATFORM" ]]; then
+  BUILD_CMD+=(--platform "$PLATFORM")
+fi
+
+if [[ "$NO_CACHE" == "true" ]]; then
+  BUILD_CMD+=(--no-cache)
+fi
+
+if [[ "$PUSH_IMAGE" == "true" ]]; then
+  BUILD_CMD+=(--push)
+else
+  BUILD_CMD+=(--load)
+fi
+
+BUILD_CMD+=("$REPO_ROOT")
+
+echo "Building image: $IMAGE_TAG"
+"${BUILD_CMD[@]}"
+
+echo "Done."

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+RELEASE="Debug"
+
+#AOT in not supported
+IS_AOT=false
+# Detect OS and architecture
+UNAME_OS="$(uname -s)"
+UNAME_ARCH="$(uname -m)"
+
+# Map architecture
+case "$UNAME_ARCH" in
+arm64 | aarch64) ARCH="arm64" ;;
+x86_64) ARCH="x64" ;;
+*)
+  echo "Unsupported architecture: $UNAME_ARCH"
+  exit 1
+  ;;
+esac
+
+# Map operating system
+case "$UNAME_OS" in
+Darwin) RID="osx-$ARCH" ;;
+Linux) RID="linux-$ARCH" ;;
+MINGW* | MSYS* | CYGWIN*) RID="win-$ARCH" ;;
+*)
+  echo "Unsupported operating system: $UNAME_OS"
+  exit 1
+  ;;
+esac
+
+# Build and run
+dotnet publish -r "$RID" -o dist -p:PublishAot=$IS_AOT -c $RELEASE src/Moongate.Server &&
+  ./dist/Moongate.Server "$@" &&
+  rm -rf dist

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10"/>
+        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <!--
             Swashbuckle rather than Microsoft.AspNetCore.OpenApi, which is otherwise the obvious choice on
             .NET 10: AddOpenApi resolves its document services by key, and DryIoc.Microsoft.DependencyInjection

--- a/src/Moongate.Http.Plugin/Services/HttpServerService.cs
+++ b/src/Moongate.Http.Plugin/Services/HttpServerService.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Moongate.Core.Types;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces;
@@ -15,6 +16,7 @@ using Scalar.AspNetCore;
 using Serilog;
 using SquidStd.Abstractions.Interfaces.Services;
 using SquidStd.Core.Interfaces.Config;
+using ILogger = Serilog.ILogger;
 
 namespace Moongate.Http.Plugin.Services;
 
@@ -31,8 +33,18 @@ public sealed class HttpServerService : ISquidStdService
     /// <summary>Any authenticated account.</summary>
     public const string PlayerPolicy = "player";
 
-    /// <summary>Where Swashbuckle publishes the document, and so where Scalar is pointed to read it.</summary>
+    /// <summary>The v1 document's route, as Swashbuckle publishes it.</summary>
     public const string SwaggerDocumentRoute = "/swagger/v1/swagger.json";
+
+    /// <summary>
+    /// The same route as a pattern, which is what Scalar needs: it substitutes the document name per
+    /// document. Without it Scalar looks for its own default, <c>openapi/{documentName}.json</c>, which
+    /// nothing serves here — the page still renders, and shows an empty reference.
+    /// </summary>
+    private const string SwaggerRoutePattern = "/swagger/{documentName}/swagger.json";
+
+    /// <summary>The only document served. Scalar's reference for it lives at <c>/scalar/v1</c>.</summary>
+    private const string DocumentName = "v1";
 
     private readonly ILogger _logger = Log.ForContext<HttpServerService>();
     private readonly IContainer _container;
@@ -61,6 +73,7 @@ public sealed class HttpServerService : ISquidStdService
 
         // The game's own container, so endpoints resolve the very singletons the game loop holds.
         builder.Host.UseServiceProviderFactory(new DryIocServiceProviderFactory(_container));
+        builder.Logging.ClearProviders().AddSerilog(_logger);
         builder.WebHost.UseUrls($"http://{_config.Address}:{_config.Port}");
 
         builder.Services.AddProblemDetails();
@@ -75,32 +88,33 @@ public sealed class HttpServerService : ISquidStdService
         );
 
         builder.Services
-            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
-                {
-                    options.TokenValidationParameters = new()
-                    {
-                        ValidateIssuer = true,
-                        ValidIssuer = _config.Jwt.Issuer,
-                        ValidateAudience = true,
-                        ValidAudience = _config.Jwt.Issuer,
-                        ValidateIssuerSigningKey = true,
-                        IssuerSigningKey = signingKey,
-                        ValidateLifetime = true
-                    };
-                }
-            );
+               .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+               .AddJwtBearer(
+                   options =>
+                   {
+                       options.TokenValidationParameters = new()
+                       {
+                           ValidateIssuer = true,
+                           ValidIssuer = _config.Jwt.Issuer,
+                           ValidateAudience = true,
+                           ValidAudience = _config.Jwt.Issuer,
+                           ValidateIssuerSigningKey = true,
+                           IssuerSigningKey = signingKey,
+                           ValidateLifetime = true
+                       };
+                   }
+               );
 
         builder.Services
-            .AddAuthorizationBuilder()
-            .AddPolicy(
-                AdminPolicy,
-                policy => policy.RequireRole(
-                    nameof(AccountLevelType.Administrator),
-                    nameof(AccountLevelType.GrandMaster)
-                )
-            )
-            .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
+               .AddAuthorizationBuilder()
+               .AddPolicy(
+                   AdminPolicy,
+                   policy => policy.RequireRole(
+                       nameof(AccountLevelType.Administrator),
+                       nameof(AccountLevelType.GrandMaster)
+                   )
+               )
+               .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
 
         _app = builder.Build();
 
@@ -110,8 +124,16 @@ public sealed class HttpServerService : ISquidStdService
         _app.UseAuthorization();
 
         _app.UseSwagger();
-        _app.MapScalarApiReference(options => options.AddDocument("v1", routePattern: SwaggerDocumentRoute));
+        _app.MapScalarApiReference(
+            options =>
+            {
+                options.WithOpenApiRoutePattern(SwaggerRoutePattern);
+                options.AddDocument(DocumentName);
+            }
+        );
         _app.MapGet("/health", () => Results.Ok(new { status = "ok" })).ExcludeFromDescription();
+
+        _app.MapGet("/", () => Results.Ok(new { message = "Welcome to Moongate API" })).ExcludeFromDescription();
 
         foreach (var endpoints in _container.Resolve<IEnumerable<IApiEndpointRegistration>>())
         {
@@ -132,8 +154,12 @@ public sealed class HttpServerService : ISquidStdService
             return;
         }
 
+        // StopAsync releases the listener and the port; DisposeAsync would go further and dispose the
+        // WebApplication's service provider — which is the game's container, since that is what the app
+        // was built on. Its singletons are the game's, not the API's, and disposing them here takes them
+        // down while the game is still running: the services that stop after this one then fail on
+        // objects already disposed. The container's lifetime belongs to the bootstrap that owns it.
         await _app.StopAsync(cancellationToken);
-        await _app.DisposeAsync();
         _app = null;
     }
 

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -5,6 +5,7 @@ using Moongate.Persistence.Entities;
 using Moongate.Persistence.Generators;
 using Serilog;
 using SquidStd.Core.Directories;
+using SquidStd.Core.Json;
 using SquidStd.Core.Utils;
 using SquidStd.Persistence.Abstractions.Data;
 using SquidStd.Persistence.Extensions;
@@ -47,6 +48,8 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
             (entity, id) => entity.Id = id,
             new DefaultSerialGenerator()
         );
+
+
 
         container.RegisterPersistedEntity<MobileEntity, Serial>(
             2,

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -5,7 +5,6 @@ using Moongate.Persistence.Entities;
 using Moongate.Persistence.Generators;
 using Serilog;
 using SquidStd.Core.Directories;
-using SquidStd.Core.Json;
 using SquidStd.Core.Utils;
 using SquidStd.Persistence.Abstractions.Data;
 using SquidStd.Persistence.Extensions;

--- a/src/Moongate.Server/Data/Api/AccountResponse.cs
+++ b/src/Moongate.Server/Data/Api/AccountResponse.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>
+/// An account as the API reports it. Deliberately not <c>AccountEntity</c>, which carries PasswordHash
+/// and ActivationToken: returning the entity would publish both to every caller, log and proxy cache on
+/// the way. Naming the fields here means a field added to the entity later cannot leak by default.
+/// </summary>
+public sealed record AccountResponse(
+    string Username,
+    string? Email,
+    string Level,
+    bool IsActive,
+    int CharacterCount
+);

--- a/src/Moongate.Server/Data/Api/CreateAccountRequest.cs
+++ b/src/Moongate.Server/Data/Api/CreateAccountRequest.cs
@@ -1,0 +1,7 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>
+/// A new account. <c>Level</c> is the <c>AccountLevelType</c> name; omitted means Player, the safe
+/// default — an account that gains staff rights by accident is the wrong way to fail.
+/// </summary>
+public sealed record CreateAccountRequest(string Username, string Password, string? Email, string? Level);

--- a/src/Moongate.Server/Data/Api/UpdateAccountRequest.cs
+++ b/src/Moongate.Server/Data/Api/UpdateAccountRequest.cs
@@ -1,0 +1,8 @@
+namespace Moongate.Server.Data.Api;
+
+/// <summary>
+/// The fields to change. Every one is optional: absent means "leave alone", which is what makes this a
+/// PATCH rather than a PUT. Password is write-only — it enters here and never appears in a response.
+/// Email is not here: the account service has no setter for it.
+/// </summary>
+public sealed record UpdateAccountRequest(string? Level, bool? IsActive, string? Password);

--- a/src/Moongate.Server/Endpoints/AccountEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AccountEndpoints.cs
@@ -30,6 +30,7 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         group.MapGet("/", List).WithName("ListAccounts");
         group.MapGet("/{username}", Get).WithName("GetAccount");
         group.MapPost("/", Create).WithName("CreateAccount");
+        group.MapPatch("/{username}", Update).WithName("UpdateAccount");
     }
 
     private IResult List()
@@ -71,6 +72,46 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
                 statusCode: StatusCodes.Status500InternalServerError
             )
         };
+    }
+
+    /// <summary>
+    /// Applies the fields that are present and leaves the rest alone.
+    /// <para>
+    /// Applying several is not atomic: nothing rolls the level back if a later setter fails. Accepted
+    /// rather than solved — the setters fail only when the account is missing, which is ruled out a line
+    /// earlier, so a delete would have to race this patch for the window to open at all, and closing it
+    /// properly needs a transaction the store does not offer. The level, the one input a caller can get
+    /// wrong, is validated before any setter runs.
+    /// </para>
+    /// </summary>
+    private IResult Update(string username, UpdateAccountRequest request)
+    {
+        if (_accounts.GetByUsername(username) is null)
+        {
+            return NotFound(username);
+        }
+
+        if (!TryParseLevel(request.Level, AccountLevelType.Player, out var level))
+        {
+            return InvalidLevel(request.Level);
+        }
+
+        if (request.Level is not null)
+        {
+            _accounts.SetLevel(username, level);
+        }
+
+        if (request.IsActive is { } isActive)
+        {
+            _accounts.SetActive(username, isActive);
+        }
+
+        if (!string.IsNullOrEmpty(request.Password))
+        {
+            _accounts.SetPassword(username, request.Password);
+        }
+
+        return Results.Ok(ToResponse(_accounts.GetByUsername(username)!));
     }
 
     /// <summary>

--- a/src/Moongate.Server/Endpoints/AccountEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AccountEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Types;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
@@ -8,18 +9,29 @@ using Moongate.Persistence.Entities;
 using Moongate.Server.Data.Api;
 using Moongate.Server.Interfaces.Accounts;
 using Moongate.Server.Types;
+using Serilog;
 
 namespace Moongate.Server.Endpoints;
 
 /// <summary>Account administration: the REST twin of Lua's <c>account.*</c> module.</summary>
 public sealed class AccountEndpoints : IApiEndpointRegistration
 {
+    private readonly ILogger _logger = Log.ForContext<AccountEndpoints>();
     private readonly IAccountService _accounts;
+    private readonly IGameLoopContext _loop;
 
-    public AccountEndpoints(IAccountService accounts)
+    public AccountEndpoints(IAccountService accounts, IGameLoopContext loop)
     {
         _accounts = accounts;
+        _loop = loop;
     }
+
+    /// <summary>
+    /// How long to wait for the game loop before calling it unresponsive. Init-only rather than a
+    /// mutable static: xUnit runs test classes in parallel, and one test shortening a shared value would
+    /// change another's timeout mid-run.
+    /// </summary>
+    public TimeSpan DeleteTimeout { get; init; } = TimeSpan.FromSeconds(5);
 
     public void Register(IEndpointRouteBuilder routes)
     {
@@ -31,6 +43,65 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         group.MapGet("/{username}", Get).WithName("GetAccount");
         group.MapPost("/", Create).WithName("CreateAccount");
         group.MapPatch("/{username}", Update).WithName("UpdateAccount");
+        group.MapDelete("/{username}", Delete).WithName("DeleteAccount");
+    }
+
+    /// <summary>
+    /// The only route that mutates world state: deleting an account cascades into its characters and
+    /// everything they carry.
+    /// <para>
+    /// It also checks <c>IsCharacterPlayed</c> and then deletes, and login runs on the game loop — so off
+    /// the loop a player can log in between the two and lose their character from under them. The stores
+    /// lock internally, so the damage would not be corruption; it would be a silent, permanent loss.
+    /// Handing the work to the loop puts check and act on login's own thread, where they cannot
+    /// interleave.
+    /// </para>
+    /// <para>
+    /// The timeout is why a stalled loop fails the request instead of hanging it forever, and 503 is the
+    /// honest answer: the game loop is not responding.
+    /// </para>
+    /// </summary>
+    private async Task<IResult> Delete(string username)
+    {
+        var completion = new TaskCompletionSource<AccountDeleteResultType>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        _loop.Post(() => completion.SetResult(_accounts.Delete(username)));
+
+        AccountDeleteResultType result;
+
+        try
+        {
+            result = await completion.Task.WaitAsync(DeleteTimeout);
+        }
+        catch (TimeoutException)
+        {
+            _logger.Error(
+                "Account delete for {Username} timed out after {Timeout}; the game loop did not answer",
+                username,
+                DeleteTimeout
+            );
+
+            return Results.Problem(
+                "The game loop did not respond; the account was not deleted.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        return result switch
+        {
+            AccountDeleteResultType.Deleted => Results.NoContent(),
+            AccountDeleteResultType.NotFound => NotFound(username),
+            AccountDeleteResultType.CharacterBeingPlayed => Results.Problem(
+                $"'{username}' has a character being played; it cannot be deleted right now.",
+                statusCode: StatusCodes.Status409Conflict
+            ),
+            _ => Results.Problem(
+                "Unknown account delete result.",
+                statusCode: StatusCodes.Status500InternalServerError
+            )
+        };
     }
 
     private IResult List()

--- a/src/Moongate.Server/Endpoints/AccountEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AccountEndpoints.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Types;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Data.Api;
 using Moongate.Server.Interfaces.Accounts;
+using Moongate.Server.Types;
 
 namespace Moongate.Server.Endpoints;
 
@@ -27,6 +29,7 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
 
         group.MapGet("/", List).WithName("ListAccounts");
         group.MapGet("/{username}", Get).WithName("GetAccount");
+        group.MapPost("/", Create).WithName("CreateAccount");
     }
 
     private IResult List()
@@ -36,6 +39,61 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         => _accounts.GetByUsername(username) is { } account
                ? Results.Ok(ToResponse(account))
                : NotFound(username);
+
+    private IResult Create(CreateAccountRequest request)
+    {
+        // Before the write, so an unknown level cannot leave a half-made account behind.
+        if (!TryParseLevel(request.Level, AccountLevelType.Player, out var level))
+        {
+            return InvalidLevel(request.Level);
+        }
+
+        return _accounts.Create(request.Username, request.Password, request.Email, level) switch
+        {
+            AccountCreateResultType.Created => Results.Created(
+                $"/api/v1/admin/accounts/{request.Username}",
+                ToResponse(_accounts.GetByUsername(request.Username)!)
+            ),
+            AccountCreateResultType.UsernameTaken => Results.Problem(
+                $"An account named '{request.Username}' already exists.",
+                statusCode: StatusCodes.Status409Conflict
+            ),
+            AccountCreateResultType.UsernameEmpty => Results.Problem(
+                "Username is required.",
+                statusCode: StatusCodes.Status400BadRequest
+            ),
+            AccountCreateResultType.PasswordEmpty => Results.Problem(
+                "Password is required.",
+                statusCode: StatusCodes.Status400BadRequest
+            ),
+            _ => Results.Problem(
+                "Unknown account creation result.",
+                statusCode: StatusCodes.Status500InternalServerError
+            )
+        };
+    }
+
+    /// <summary>
+    /// Parses a level name, falling back when none was sent. Callers check this before writing anything,
+    /// so a bad level fails the whole request rather than half of it.
+    /// </summary>
+    internal static bool TryParseLevel(string? name, AccountLevelType fallback, out AccountLevelType level)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            level = fallback;
+
+            return true;
+        }
+
+        return Enum.TryParse(name, ignoreCase: true, out level);
+    }
+
+    internal static IResult InvalidLevel(string? name)
+        => Results.Problem(
+            $"'{name}' is not an account level. Valid levels: {string.Join(", ", Enum.GetNames<AccountLevelType>())}.",
+            statusCode: StatusCodes.Status400BadRequest
+        );
 
     /// <summary>
     /// CharacterCount comes from the entity's own id list, which is free. It must not come from

--- a/src/Moongate.Server/Endpoints/AccountEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AccountEndpoints.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Interfaces.Accounts;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>Account administration: the REST twin of Lua's <c>account.*</c> module.</summary>
+public sealed class AccountEndpoints : IApiEndpointRegistration
+{
+    private readonly IAccountService _accounts;
+
+    public AccountEndpoints(IAccountService accounts)
+    {
+        _accounts = accounts;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/admin/accounts")
+                          .WithTags("accounts")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        group.MapGet("/", List).WithName("ListAccounts");
+        group.MapGet("/{username}", Get).WithName("GetAccount");
+    }
+
+    private IResult List()
+        => Results.Ok(_accounts.GetAll().Select(ToResponse));
+
+    private IResult Get(string username)
+        => _accounts.GetByUsername(username) is { } account
+               ? Results.Ok(ToResponse(account))
+               : NotFound(username);
+
+    /// <summary>
+    /// CharacterCount comes from the entity's own id list, which is free. It must not come from
+    /// <c>ICharacterService.GetPlayerCharacters</c>, which scans the account store and the mobile store
+    /// on every call — quadratic over a list, and pointless when the entity already holds the ids.
+    /// </summary>
+    internal static AccountResponse ToResponse(AccountEntity account)
+        => new(
+            account.Username,
+            account.Email,
+            account.AccountLevel.ToString(),
+            account.IsActive,
+            account.MobileIds.Count
+        );
+
+    /// <summary>
+    /// Says which account was not found. Unlike login's flat 401, these routes name the reason: the
+    /// caller already holds a staff token, so it is operational information for someone entitled to it
+    /// rather than an oracle telling an attacker which usernames exist.
+    /// </summary>
+    internal static IResult NotFound(string username)
+        => Results.Problem($"No account named '{username}'.", statusCode: StatusCodes.Status404NotFound);
+}

--- a/src/Moongate.Server/Interfaces/Accounts/IAccountService.cs
+++ b/src/Moongate.Server/Interfaces/Accounts/IAccountService.cs
@@ -27,6 +27,13 @@ public interface IAccountService
     IReadOnlyList<string> GetUsernames();
 
     /// <summary>
+    /// Every account, in one pass over the store. Exists because <see cref="GetByUsername" /> scans:
+    /// building a list from <see cref="GetUsernames" /> plus a lookup per name would scan the store once
+    /// per account.
+    /// </summary>
+    IReadOnlyList<AccountEntity> GetAll();
+
+    /// <summary>
     /// Creates an active account with a hashed password. Refuses a blank username or password, and a
     /// username already taken.
     /// </summary>

--- a/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
+++ b/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
@@ -26,6 +26,7 @@ public class MoongateApiEndpointsPlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
+        container.RegisterApiEndpoint<AccountEndpoints>();
         container.RegisterApiEndpoint<VersionEndpoints>();
         container.RegisterApiEndpoint<AuthEndpoints>();
         container.RegisterApiEndpoint<AdminEndpoints>();

--- a/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
+++ b/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
@@ -1,0 +1,34 @@
+using DryIoc;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Server.Endpoints;
+using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Server;
+
+/// <summary>
+/// Registers Moongate's REST endpoint groups, which depend on Server services. They live here rather
+/// than in Moongate.Http.Plugin because Program.cs adds that plugin, so it cannot reference Server back;
+/// the plugin owns the API's plumbing and the game owns the endpoints that need game services.
+/// </summary>
+public class MoongateApiEndpointsPlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.apiendpoints.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateApiEndpointsPlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate API Endpoints",
+            Description = "Server-side REST endpoint registrations"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        container.RegisterApiEndpoint<VersionEndpoints>();
+        container.RegisterApiEndpoint<AuthEndpoints>();
+        container.RegisterApiEndpoint<AdminEndpoints>();
+        container.RegisterApiEndpoint<PlayerEndpoints>();
+    }
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -22,6 +22,7 @@ using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Network;
 using Moongate.Server.Services.World;
+using Serilog;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;
 using SquidStd.Core.Config;
@@ -37,7 +38,13 @@ const int loginHandoffTtlMs = 30_000;
 
 await ConsoleApp.RunAsync(
     args,
-    async (string rootDirectory = null, bool showHeader = true, string? uoDirectory = null, CancellationToken ct = default)
+    async (
+            string rootDirectory = null,
+            bool showHeader = true,
+            string? uoDirectory = null,
+            bool disableWebPlugin = false,
+            CancellationToken ct = default
+        )
         =>
     {
         rootDirectory ??= Environment.GetEnvironmentVariable("MOONGATE_ROOT");
@@ -93,7 +100,8 @@ await ConsoleApp.RunAsync(
         // Safe with config-first: sections bind eagerly at registration, even after this call.
         stdBootstrap.ConfigureLogging();
 
-        stdBootstrap.UsePlugins(builder =>
+        stdBootstrap.UsePlugins(
+            builder =>
             {
                 builder.FromDirectory("plugins");
                 builder.Add<MoongatePersistencePlugin>();
@@ -102,19 +110,24 @@ await ConsoleApp.RunAsync(
                 builder.Add<MoongateDataLoaderPlugin>();
                 builder.Add<MoongatePacketHandlersPlugin>();
                 builder.Add<MoongateEventSubscribersPlugin>();
-                builder.Add<MoongateHttpPlugin>();
+
+                if (!disableWebPlugin)
+                {
+                    builder.Add<MoongateHttpPlugin>();
+                    builder.Add<MoongateApiEndpointsPlugin>();
+                }
+                else
+                {
+                    Log.Logger.Warning("HTTP is disabled");
+                }
             }
         );
 
-        stdBootstrap.ConfigureServices(container =>
+        stdBootstrap.ConfigureServices(
+            container =>
             {
                 // Binds the SAME cached instance mutated above; the file cannot clobber it.
                 container.RegisterConfigSection<MoongateConfig>("moongate");
-
-                container.RegisterApiEndpoint<VersionEndpoints>();
-                container.RegisterApiEndpoint<AuthEndpoints>();
-                container.RegisterApiEndpoint<AdminEndpoints>();
-                container.RegisterApiEndpoint<PlayerEndpoints>();
 
                 container.Register<IAccountService, AccountService>(Reuse.Singleton);
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);
@@ -163,14 +176,16 @@ await ConsoleApp.RunAsync(
 
                 var eventBus = container.Resolve<IEventBus>();
 
-                eventBus.Subscribe<EngineStartedEvent>((_, _) =>
+                eventBus.Subscribe<EngineStartedEvent>(
+                    (_, _) =>
                     {
                         container.Resolve<TimerAutostartService>().InitDefaultTimers();
 
                         var loop = container.Resolve<IGameLoopContext>();
                         var marker = container.Resolve<ILoopThread>();
 
-                        loop.Post(() =>
+                        loop.Post(
+                            () =>
                             {
                                 marker.Capture();
                                 _ = eventBus.PublishAsync(new WorldReadyEvent());

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -57,6 +57,9 @@ public class AccountService : IAccountService
     public IReadOnlyList<string> GetUsernames()
         => _accountStore.Query().Select(account => account.Username).ToList();
 
+    public IReadOnlyList<AccountEntity> GetAll()
+        => [.. _accountStore.GetAll()];
+
     public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
     {
         if (string.IsNullOrWhiteSpace(username))

--- a/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
@@ -3,7 +3,10 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Moongate.Core.Types;
 using Moongate.Http.Plugin.Data;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Types;
 using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
 
 namespace Moongate.Tests.Http;
 
@@ -237,6 +240,100 @@ public class AccountEndpointsTests
         var account = server.Accounts.GetByUsername("tom")!;
         Assert.True(account.IsActive);
         Assert.Equal(AccountLevelType.Administrator, account.AccountLevel);
+    }
+
+    [Fact]
+    public async Task Delete_KnownAccount_Is204AndRemovesIt()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Null(server.Accounts.GetByUsername("tom"));
+    }
+
+    [Fact]
+    public async Task Delete_RunsOnTheGameLoop()
+    {
+        // Delete checks IsCharacterPlayed and then deletes, and login runs on the loop. Doing the work
+        // anywhere else lets a player log in between the two and lose their character. This pins the
+        // handover, which no status code would reveal.
+        var loop = new StubGameLoopContext();
+        await using var server = await TestApiServer.StartAsync(loop: loop);
+        await AuthenticateAsync(server);
+
+        await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
+
+        Assert.Equal(1, loop.PostCount);
+    }
+
+    [Fact]
+    public async Task Delete_CharacterBeingPlayed_Is409AndKeepsTheAccount()
+    {
+        // Deleting an account whose character is logged in would pull the world out from under them.
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var account = server.Accounts.GetByUsername("tom")!;
+        var mobile = server.Characters.CreateCharacter(account.Id, CharacterPacket());
+        server.Sessions.Played.Add(mobile!.Id);
+
+        var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.NotNull(server.Accounts.GetByUsername("tom"));
+    }
+
+    private static CharacterCreationPacket CharacterPacket()
+        => new(
+            0,
+            "Freydis",
+            0,
+            4,
+            GenderType.Female,
+            RaceType.Elf,
+            45,
+            20,
+            25,
+            [new(1, 50)],
+            0x03EA,
+            0x203C,
+            0x044E,
+            0x2040,
+            0x0450,
+            0,
+            0x0765,
+            0x0766
+        );
+
+    [Fact]
+    public async Task Delete_UnknownAccount_Is404()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await server.Client.DeleteAsync("/api/v1/admin/accounts/nobody")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task Delete_LoopNeverAnswers_Is503()
+    {
+        await using var server = await TestApiServer.StartAsync(
+            loop: new StubGameLoopContext(answers: false),
+            deleteTimeout: TimeSpan.FromMilliseconds(50)
+        );
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        // Still there: a timeout must not read as a delete.
+        Assert.NotNull(server.Accounts.GetByUsername("tom"));
     }
 
     internal static async Task AuthenticateAsync(TestApiServer server)

--- a/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
@@ -85,6 +85,83 @@ public class AccountEndpointsTests
         );
     }
 
+    [Fact]
+    public async Task Create_NewAccount_Is201WithLocation()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret", email = "a@b.c", level = "Player" }
+        );
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("/api/v1/admin/accounts/alice", response.Headers.Location?.ToString());
+        Assert.NotNull(server.Accounts.GetByUsername("alice"));
+    }
+
+    [Fact]
+    public async Task Create_OmittedLevel_DefaultsToPlayer()
+    {
+        // The safe default: an account that gains staff rights by accident is the wrong way to fail.
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret" }
+        );
+
+        Assert.Equal(AccountLevelType.Player, server.Accounts.GetByUsername("alice")!.AccountLevel);
+    }
+
+    [Fact]
+    public async Task Create_TakenUsername_Is409()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username = "tom", password = "secret" }
+        );
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("", "secret")]
+    [InlineData("alice", "")]
+    public async Task Create_EmptyUsernameOrPassword_Is400(string username, string password)
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username, password }
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_UnknownLevel_Is400AndCreatesNothing()
+    {
+        // The level is checked before the write, so a bad request cannot half-apply.
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret", level = "Wizard" }
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Null(server.Accounts.GetByUsername("alice"));
+    }
+
     internal static async Task AuthenticateAsync(TestApiServer server)
     {
         var response = await server.Client.PostAsJsonAsync(

--- a/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
@@ -162,6 +162,83 @@ public class AccountEndpointsTests
         Assert.Null(server.Accounts.GetByUsername("alice"));
     }
 
+    [Fact]
+    public async Task Update_ChangesOnlyTheFieldsSent()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PatchAsJsonAsync(
+            "/api/v1/admin/accounts/tom",
+            new { isActive = false }
+        );
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var account = server.Accounts.GetByUsername("tom")!;
+        Assert.False(account.IsActive);
+        // Untouched: the level was not in the body, which is what makes this a PATCH.
+        Assert.Equal(AccountLevelType.Administrator, account.AccountLevel);
+    }
+
+    [Fact]
+    public async Task Update_ChangesTheLevel()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        await server.Client.PatchAsJsonAsync("/api/v1/admin/accounts/tom", new { level = "GrandMaster" });
+
+        Assert.Equal(AccountLevelType.GrandMaster, server.Accounts.GetByUsername("tom")!.AccountLevel);
+    }
+
+    [Fact]
+    public async Task Update_ChangesThePassword()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        await server.Client.PatchAsJsonAsync("/api/v1/admin/accounts/tom", new { password = "nuova" });
+
+        // Proved through the service rather than by reading a hash back: the new password must
+        // authenticate and the old one must not.
+        Assert.True(server.Accounts.Authenticate("tom", "nuova").Success);
+        Assert.False(server.Accounts.Authenticate("tom", "secret").Success);
+    }
+
+    [Fact]
+    public async Task Update_UnknownAccount_Is404()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PatchAsJsonAsync(
+            "/api/v1/admin/accounts/nobody",
+            new { isActive = false }
+        );
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_UnknownLevel_Is400AndChangesNothing()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.PatchAsJsonAsync(
+            "/api/v1/admin/accounts/tom",
+            new { level = "Wizard", isActive = false }
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        // Nothing applied: the level is validated before any setter runs.
+        var account = server.Accounts.GetByUsername("tom")!;
+        Assert.True(account.IsActive);
+        Assert.Equal(AccountLevelType.Administrator, account.AccountLevel);
+    }
+
     internal static async Task AuthenticateAsync(TestApiServer server)
     {
         var response = await server.Client.PostAsJsonAsync(

--- a/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http;
+
+public class AccountEndpointsTests
+{
+    [Fact]
+    public async Task List_ReportsEveryAccount()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.GetAsync("/api/v1/admin/accounts");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("tom", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Get_KnownAccount_ReportsIt()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        var response = await server.Client.GetAsync("/api/v1/admin/accounts/tom");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("Administrator", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Get_UnknownAccount_Is404()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await server.Client.GetAsync("/api/v1/admin/accounts/nobody")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task Responses_NeverCarryTheSecrets()
+    {
+        // Against the raw JSON, not a deserialized DTO: deserializing into AccountResponse would drop an
+        // extra field silently, which is exactly the leak this guards. AccountEntity holds both.
+        await using var server = await TestApiServer.StartAsync();
+        await AuthenticateAsync(server);
+
+        foreach (var route in new[] { "/api/v1/admin/accounts", "/api/v1/admin/accounts/tom" })
+        {
+            var body = await server.Client.GetStringAsync(route);
+
+            Assert.DoesNotContain("assword", body, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("ctivationToken", body, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task List_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            (await server.Client.GetAsync("/api/v1/admin/accounts")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task List_WithPlayerToken_Is403()
+    {
+        await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
+        await AuthenticateAsync(server);
+
+        Assert.Equal(
+            HttpStatusCode.Forbidden,
+            (await server.Client.GetAsync("/api/v1/admin/accounts")).StatusCode
+        );
+    }
+
+    internal static async Task AuthenticateAsync(TestApiServer server)
+    {
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
+        var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
+
+        server.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+    }
+}

--- a/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
+++ b/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
@@ -38,7 +38,7 @@ public class HttpServerServiceTests
     }
 
     [Fact]
-    public async Task StartAsync_ServesTheOpenApiDocumentAndScalar()
+    public async Task StartAsync_ServesTheOpenApiDocument()
     {
         await using var server = await TestHttpServer.StartAsync();
 
@@ -46,7 +46,31 @@ public class HttpServerServiceTests
             HttpStatusCode.OK,
             (await server.Client.GetAsync(HttpServerService.SwaggerDocumentRoute)).StatusCode
         );
-        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/scalar/v1")).StatusCode);
+    }
+
+    [Fact]
+    public async Task StartAsync_ScalarPointsAtTheDocumentThatIsActuallyServed()
+    {
+        // Asserting that /scalar/v1 answers 200 proves nothing: the page renders whatever happens, so
+        // pointing it at a document nobody serves still yields a 200 — showing an empty reference, which
+        // is exactly the bug this catches. What matters is the document it will go and fetch.
+        //
+        // Scalar's integration script resolves each source against the origin plus the app's base path
+        // (`new URL(source.url, origin + basePath + '/')`), so the route is emitted relative and is
+        // matched here the same way.
+        await using var server = await TestHttpServer.StartAsync();
+
+        var page = await server.Client.GetStringAsync("/scalar/v1");
+
+        Assert.Contains(HttpServerService.SwaggerDocumentRoute.TrimStart('/'), page, StringComparison.Ordinal);
+
+        // Scalar's own default, which nothing here serves: the reference silently renders empty against it.
+        Assert.DoesNotContain("openapi/v1.json", page, StringComparison.Ordinal);
+
+        Assert.Equal(
+            HttpStatusCode.OK,
+            (await server.Client.GetAsync(HttpServerService.SwaggerDocumentRoute)).StatusCode
+        );
     }
 
     [Fact]
@@ -127,6 +151,29 @@ public class HttpServerServiceTests
 
         Assert.Equal(TestHttpServer.SigningKey, server.Container.Resolve<MoongateHttpConfig>().Jwt.SigningKey);
         Assert.Equal(0, configManager.SaveCount);
+    }
+
+    /// <summary>Stands in for any game singleton holding an OS resource, as several really do.</summary>
+    private sealed class DisposableGameSingleton : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+            => Disposed = true;
+    }
+
+    [Fact]
+    public async Task StopAsync_LeavesTheGameContainersSingletonsAlone()
+    {
+        // The web app runs on the game's container, so disposing the WebApplication disposes that
+        // container's singletons — the game's, not the API's. They would go down while the game is still
+        // running, and its own StopAsync would then fail on objects already disposed.
+        var server = await TestHttpServer.StartAsync(container => container.Register<DisposableGameSingleton>(Reuse.Singleton));
+        var singleton = server.Container.Resolve<DisposableGameSingleton>();
+
+        await server.DisposeAsync();
+
+        Assert.False(singleton.Disposed);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/MoongateApiEndpointsPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateApiEndpointsPluginTests.cs
@@ -1,0 +1,34 @@
+using DryIoc;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Server;
+using Moongate.Server.Endpoints;
+
+namespace Moongate.Tests.Http;
+
+public class MoongateApiEndpointsPluginTests
+{
+    [Fact]
+    public void Configure_RegistersEveryEndpointGroupTheApiServes()
+    {
+        // Registrations rather than instances: the groups need game services this bare container has no
+        // reason to hold, and what the plugin is responsible for is the registering.
+        var container = new Container();
+
+        new MoongateApiEndpointsPlugin().Configure(container, new());
+
+        var registered = container.GetServiceRegistrations()
+                                  .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+                                  .Select(registration => registration.ImplementationType)
+                                  .OrderBy(type => type!.Name)
+                                  .ToArray();
+
+        Assert.Equal(
+            [typeof(AdminEndpoints), typeof(AuthEndpoints), typeof(PlayerEndpoints), typeof(VersionEndpoints)],
+            registered
+        );
+    }
+
+    [Fact]
+    public void Metadata_IdentifiesThePlugin()
+        => Assert.Equal("moongate.apiendpoints.plugin", new MoongateApiEndpointsPlugin().Metadata.Id);
+}

--- a/tests/Moongate.Tests/Http/MoongateApiEndpointsPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateApiEndpointsPluginTests.cs
@@ -23,7 +23,13 @@ public class MoongateApiEndpointsPluginTests
                                   .ToArray();
 
         Assert.Equal(
-            [typeof(AdminEndpoints), typeof(AuthEndpoints), typeof(PlayerEndpoints), typeof(VersionEndpoints)],
+            [
+                typeof(AccountEndpoints),
+                typeof(AdminEndpoints),
+                typeof(AuthEndpoints),
+                typeof(PlayerEndpoints),
+                typeof(VersionEndpoints)
+            ],
             registered
         );
     }

--- a/tests/Moongate.Tests/Server/Accounts/AccountServiceGetAllTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/AccountServiceGetAllTests.cs
@@ -1,0 +1,36 @@
+using Moongate.Core.Types;
+using Moongate.Server.Services.Accounts;
+using Moongate.Tests.Support;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Accounts;
+
+public class AccountServiceGetAllTests
+{
+    private static AccountService Build()
+    {
+        var persistence = new FakePersistenceService();
+
+        return new(
+            persistence,
+            CharacterServiceFixture.Create(persistence, new EventBusService()),
+            new StubSessionManager()
+        );
+    }
+
+    [Fact]
+    public void GetAll_ReturnsEveryAccount()
+    {
+        var accounts = Build();
+        accounts.Create("tom", "secret", null, AccountLevelType.Administrator);
+        accounts.Create("alice", "secret", "a@b.c", AccountLevelType.Player);
+
+        var all = accounts.GetAll();
+
+        Assert.Equal(["alice", "tom"], all.Select(account => account.Username).OrderBy(name => name));
+    }
+
+    [Fact]
+    public void GetAll_NoAccounts_IsEmpty()
+        => Assert.Empty(Build().GetAll());
+}

--- a/tests/Moongate.Tests/Support/StubAccountService.cs
+++ b/tests/Moongate.Tests/Support/StubAccountService.cs
@@ -35,6 +35,9 @@ public sealed class StubAccountService : IAccountService
     public IReadOnlyList<string> GetUsernames()
         => throw new NotSupportedException();
 
+    public IReadOnlyList<AccountEntity> GetAll()
+        => throw new NotSupportedException();
+
     public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
         => throw new NotSupportedException();
 

--- a/tests/Moongate.Tests/Support/StubGameLoopContext.cs
+++ b/tests/Moongate.Tests/Support/StubGameLoopContext.cs
@@ -1,0 +1,46 @@
+using Moongate.Core.Interfaces;
+using SquidStd.Core.Interfaces.Threading;
+using SquidStd.Core.Interfaces.Timing;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// A game loop that runs posted work inline, so a test can assert the contract — the work happens on the
+/// loop and the caller waits for it — with no timing to flake on. Built with <c>answers: false</c> it
+/// counts the post and swallows the work, standing in for a loop that has stalled.
+/// </summary>
+public sealed class StubGameLoopContext : IGameLoopContext
+{
+    private readonly bool _answers;
+
+    public StubGameLoopContext(bool answers = true)
+    {
+        _answers = answers;
+    }
+
+    /// <summary>How many times work was handed to the loop.</summary>
+    public int PostCount { get; private set; }
+
+    public IMainThreadDispatcher Dispatcher => throw new NotSupportedException();
+
+    public ITimerService Timers => throw new NotSupportedException();
+
+    public void Post(Action action)
+    {
+        PostCount++;
+
+        if (_answers)
+        {
+            action();
+        }
+    }
+
+    public bool Cancel(string timerId)
+        => throw new NotSupportedException();
+
+    public string Schedule(string name, TimeSpan delay, Action callback)
+        => throw new NotSupportedException();
+
+    public string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null)
+        => throw new NotSupportedException();
+}

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -1,4 +1,5 @@
 using DryIoc;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Types;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces;
@@ -20,27 +21,42 @@ public sealed class TestApiServer : IAsyncDisposable
 {
     private readonly HttpServerService _service;
 
-    private TestApiServer(HttpServerService service, HttpClient client, IAccountService accounts)
+    private TestApiServer(
+        HttpServerService service,
+        HttpClient client,
+        IAccountService accounts,
+        CharacterService characters,
+        StubSessionManager sessions
+    )
     {
         _service = service;
         Client = client;
         Accounts = accounts;
+        Characters = characters;
+        Sessions = sessions;
     }
 
     public HttpClient Client { get; }
 
     public IAccountService Accounts { get; }
 
-    public static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+    /// <summary>Real, over the same fake persistence: a test can give an account a character.</summary>
+    public CharacterService Characters { get; }
+
+    /// <summary>Lets a test declare a character as being played, via <see cref="StubSessionManager.Played" />.</summary>
+    public StubSessionManager Sessions { get; }
+
+    public static async Task<TestApiServer> StartAsync(
+        AccountLevelType level = AccountLevelType.Administrator,
+        IGameLoopContext? loop = null,
+        TimeSpan? deleteTimeout = null
+    )
     {
         var container = new Container();
         var persistence = new FakePersistenceService();
         var sessions = new StubSessionManager();
-        var accounts = new AccountService(
-            persistence,
-            CharacterServiceFixture.Create(persistence, new EventBusService()),
-            sessions
-        );
+        var characters = CharacterServiceFixture.Create(persistence, new EventBusService(), sessions);
+        var accounts = new AccountService(persistence, characters, sessions);
         accounts.Create("tom", "secret", null, level);
 
         var config = new MoongateHttpConfig
@@ -58,7 +74,17 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterInstance<IConfigManagerService>(new StubConfigManagerService());
         container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
 
-        container.RegisterApiEndpointInstance(new AccountEndpoints(accounts));
+        // Inline by default: the delete route's contract is "hand it to the loop and wait", and running
+        // the work inline satisfies it with nothing to flake on.
+        var gameLoop = loop ?? new StubGameLoopContext();
+        container.RegisterInstance(gameLoop);
+
+        container.RegisterApiEndpointInstance(
+            new AccountEndpoints(accounts, gameLoop)
+            {
+                DeleteTimeout = deleteTimeout ?? TimeSpan.FromSeconds(5)
+            }
+        );
         container.RegisterApiEndpointInstance(new VersionEndpoints(moongateConfig));
         container.RegisterApiEndpointInstance(new AuthEndpoints(accounts, container.Resolve<IJwtTokenService>()));
         container.RegisterApiEndpointInstance(new AdminEndpoints(moongateConfig, sessions));
@@ -67,7 +93,13 @@ public sealed class TestApiServer : IAsyncDisposable
         var service = new HttpServerService(container, config);
         await service.StartAsync();
 
-        return new(service, new() { BaseAddress = new($"http://127.0.0.1:{service.BoundPort}") }, accounts);
+        return new(
+            service,
+            new() { BaseAddress = new($"http://127.0.0.1:{service.BoundPort}") },
+            accounts,
+            characters,
+            sessions
+        );
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -58,6 +58,7 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterInstance<IConfigManagerService>(new StubConfigManagerService());
         container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
 
+        container.RegisterApiEndpointInstance(new AccountEndpoints(accounts));
         container.RegisterApiEndpointInstance(new VersionEndpoints(moongateConfig));
         container.RegisterApiEndpointInstance(new AuthEndpoints(accounts, container.Resolve<IJwtTokenService>()));
         container.RegisterApiEndpointInstance(new AdminEndpoints(moongateConfig, sessions));


### PR DESCRIPTION
Full CRUD for accounts under `/api/v1/admin/accounts`, behind the admin policy — the REST twin of Lua's `account.*` module, reaching the same `IAccountService`.

| Method | Route | Returns |
| --- | --- | --- |
| `GET` | `/api/v1/admin/accounts` | every account |
| `GET` | `/api/v1/admin/accounts/{username}` | one, or 404 |
| `POST` | `/api/v1/admin/accounts` | 201 + `Location`, or 400 / 409 |
| `PATCH` | `/api/v1/admin/accounts/{username}` | the updated account, or 400 / 404 |
| `DELETE` | `/api/v1/admin/accounts/{username}` | 204, or 404 / 409 / 503 |

## Decisions worth reviewing

**`AccountResponse` instead of the entity.** `AccountEntity` carries `PasswordHash` and `ActivationToken`; returning it would publish both to every caller, log and proxy cache on the way. The DTO names its fields, so one added to the entity later cannot leak by default. The password is write-only: it enters through `POST`/`PATCH` and appears in no response. The test reads the raw JSON rather than a deserialized DTO, which would drop the extra field silently — the very leak it guards.

**Delete runs on the game loop, and the request waits.** It is the only route that mutates world state: it cascades into the account's characters and everything they carry. It also checks `IsCharacterPlayed` and *then* deletes, and login runs on the loop — so off the loop a player can log in between the two and lose their character from under them. The stores lock internally, so the damage would not be corruption; it would be a silent, permanent loss. A five-second timeout answers **503** rather than hanging the request when the loop has stalled, and the account survives it: a timeout must not read as a delete.

**`GetAll()` is the only new service method,** and it exists for a measured reason: `GetByUsername` is a full scan, so building the list from `GetUsernames` plus a lookup per name would scan once per account — 25M comparisons per request at 5,000 accounts. `characterCount` likewise comes from `account.MobileIds.Count`, which is free, not from `GetPlayerCharacters`, which scans two stores per call.

**The level is validated before any write,** on both `POST` and `PATCH`, so the one input a caller can get wrong fails the whole request instead of leaving a half-made account or a half-applied patch. An omitted level means `Player`: an account that gains staff rights by accident is the wrong way to fail.

**These routes name their failure, unlike login's flat 401.** That looks contradictory and is not: anyone can call login, so distinguishing "no such user" from "wrong password" tells an attacker which usernames exist. Here the caller already holds a staff token, so the reason is operational information for someone entitled to it.

## Verification

- 975/975 tests green; `dotnet docfx` at 0 warnings
- Real boot: the five routes appear in the OpenAPI document, all answer 401 without a token, clean shutdown
- The 409 case is covered end-to-end over HTTP with a real character and a session claiming it, not pushed down to the service
- **Five sabotages, all red:** returning the entity (secret leak), validating the level after the write on `POST` and on `PATCH`, deleting off the loop (two tests red), and removing the played-character guard

## Also included

`c440c6a` was sitting unpushed on the local develop and would otherwise have been stranded: it registers the endpoint groups through `MoongateApiEndpointsPlugin` (they were registered nowhere, so every `/api/v1` route 404'd and Scalar rendered empty), points Scalar at the document actually served, and stops disposing the WebApplication on shutdown — it is built on the game's container, so disposing it took the game's singletons down while the game was still running.

## Out of scope, deliberately

Email cannot be changed (the service has no setter). No self-harm guard: an administrator can demote, deactivate or delete their own account — forbidding it means ruling on cases nobody has decided. No pagination, no rate limiting, no audit trail beyond the existing logs.