### PR TITLE
docs(http): render the endpoint descriptions on the OpenAPI reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,12 @@
         <WarningsAsErrors/>
         <WarningsNotAsErrors/>
         <LangVersion>latest</LangVersion>
+
+        <!-- Every configuration, not just Release: the XML feeds the OpenAPI descriptions, and Scalar is
+             read in dev. Release-only would mean a wrong or missing summary stays invisible until the
+             build that publishes it. -->
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
         <NoWarn>CA1000;CA1036;CA1051;CA1304;CA1305;CA1309;CA1310;CA1512;CA1513;CA1707;CA1711;CA1720;CA1805;CA1806;CA1822;CA1854;CA1859;CA1861;CA1862;CA2201;CA2208;CA2211;</NoWarn>
 
     </PropertyGroup>
@@ -50,7 +56,6 @@
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <!-- Common Package References -->

--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -181,6 +181,13 @@ reading the OpenAPI document published at `/swagger/v1/swagger.json`. There is
 also an unlisted `/health` returning `{"status":"ok"}`, for a load balancer or
 a container probe.
 
+The prose on each route is not written in the reference; it is written in the
+code. Swashbuckle reads the `///` off each handler, so a route's `<summary>`
+becomes its summary and its `<remarks>` becomes its description. The XML those
+are compiled into is produced by `GenerateDocumentationFile`, which is on for
+every configuration precisely so the reference reads the same in development as
+in production.
+
 ## Adding endpoints
 
 An endpoint group implements `IApiEndpointRegistration` and is registered in
@@ -195,7 +202,29 @@ and the route simply 404s, and Scalar shows a reference with nothing in it.
 Groups live in `Moongate.Server`, not in `Moongate.Http.Plugin`: `Program.cs`
 adds that plugin, so it cannot reference the server back. The plugin owns the
 plumbing — config, tokens, the server itself — and the game owns the endpoints
-that need game services.
+that need game services. This is also why the server finds the XML to document
+your routes with by reading the DI registrations: it cannot name the assembly
+your group lives in, so it asks the container which assemblies contributed
+endpoints and looks for their XML beside the binaries.
+
+Map each route to a **method group**, not a lambda:
+
+```csharp
+group.MapGet("/{username}", Get).WithName("GetAccount");
+
+/// <summary>Fetches a single account by username.</summary>
+/// <remarks>Answers 404 when no account carries that username.</remarks>
+private IResult Get(string username) => ...;
+```
+
+A lambda has no method for the `///` to hang off, so the route documents itself
+as blank — the reference still renders, and simply says nothing about it.
+
+Write the `<summary>` and `<remarks>` for whoever is calling the route: what it
+does, what it needs, what the failures mean. Reasoning aimed at whoever
+maintains the handler goes in a plain `//` comment inside the method, which is
+never published. The two registers are easy to mix up, and the cost of mixing
+them up is internal notes appearing in the public reference.
 
 Anything that mutates world state must get onto the game loop first; see
 [Architecture overview](architecture.md). None of the v1 endpoints do.

--- a/src/Moongate.Http.Plugin/Services/HttpServerService.cs
+++ b/src/Moongate.Http.Plugin/Services/HttpServerService.cs
@@ -78,7 +78,15 @@ public sealed class HttpServerService : ISquidStdService
 
         builder.Services.AddProblemDetails();
         builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen();
+        builder.Services.AddSwaggerGen(
+            options =>
+            {
+                foreach (var path in EndpointXmlDocumentationPaths())
+                {
+                    options.IncludeXmlComments(path);
+                }
+            }
+        );
 
         // camelCase over the wire while the DTOs stay PascalCase in C#. ASP.NET already defaults to this,
         // but the wire format is a contract clients are written against: stated here it cannot be changed
@@ -189,6 +197,30 @@ public sealed class HttpServerService : ISquidStdService
 
         _logger.Information("No http.Jwt.SigningKey was configured; minted one and saved it to moongate.yaml");
     }
+
+    /// <summary>
+    /// Finds the XML documentation of every assembly that contributes endpoints, which is what turns their
+    /// <c>///</c> summaries into the descriptions Scalar renders.
+    /// <para>
+    /// Read from the DI registrations rather than a hardcoded list because the endpoints live in
+    /// Moongate.Server while this runs in the plugin, and the dependency points the other way — the plugin
+    /// cannot name the assembly it must document. Registration metadata gives the implementation types
+    /// without resolving them, so nothing is constructed here just to be asked what assembly it came from.
+    /// </para>
+    /// <para>
+    /// A missing file is skipped rather than passed on: Swashbuckle throws on one, and it throws while
+    /// serving the document, so a single absent XML would turn the whole reference into a 500 instead of a
+    /// page with some prose missing.
+    /// </para>
+    /// </summary>
+    private IEnumerable<string> EndpointXmlDocumentationPaths()
+        => _container.GetServiceRegistrations()
+                     .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+                     .Select(registration => registration.ImplementationType?.Assembly)
+                     .Where(assembly => assembly is not null)
+                     .Select(assembly => Path.Combine(AppContext.BaseDirectory, $"{assembly!.GetName().Name}.xml"))
+                     .Distinct()
+                     .Where(File.Exists);
 
     /// <summary>
     /// Asks Kestrel what it actually bound. With a configured port of 0 the OS picks one, and this is the

--- a/src/Moongate.Server/Endpoints/AccountEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AccountEndpoints.cs
@@ -46,23 +46,22 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         group.MapDelete("/{username}", Delete).WithName("DeleteAccount");
     }
 
-    /// <summary>
-    /// The only route that mutates world state: deleting an account cascades into its characters and
-    /// everything they carry.
-    /// <para>
-    /// It also checks <c>IsCharacterPlayed</c> and then deletes, and login runs on the game loop — so off
-    /// the loop a player can log in between the two and lose their character from under them. The stores
-    /// lock internally, so the damage would not be corruption; it would be a silent, permanent loss.
-    /// Handing the work to the loop puts check and act on login's own thread, where they cannot
-    /// interleave.
-    /// </para>
-    /// <para>
-    /// The timeout is why a stalled loop fails the request instead of hanging it forever, and 503 is the
-    /// honest answer: the game loop is not responding.
-    /// </para>
-    /// </summary>
+    /// <summary>Deletes an account, along with its characters and everything they carry.</summary>
+    /// <remarks>
+    /// Permanent, and the only account route that changes the world rather than just the account record.
+    /// An account whose character is currently being played cannot be deleted: the request answers 409
+    /// until that character logs out. A 503 means the game loop did not respond and nothing was deleted.
+    /// </remarks>
     private async Task<IResult> Delete(string username)
     {
+        // Runs on the game loop rather than here. This checks IsCharacterPlayed and then deletes, and
+        // login runs on the loop — so off the loop a player can log in between the two and lose their
+        // character from under them. The stores lock internally, so the damage would not be corruption; it
+        // would be a silent, permanent loss. Handing the work to the loop puts check and act on login's
+        // own thread, where they cannot interleave.
+        //
+        // The timeout is why a stalled loop fails the request instead of hanging it forever, and 503 is
+        // the honest answer: the game loop is not responding.
         var completion = new TaskCompletionSource<AccountDeleteResultType>(
             TaskCreationOptions.RunContinuationsAsynchronously
         );
@@ -104,14 +103,23 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         };
     }
 
+    /// <summary>Lists every account on the shard.</summary>
+    /// <remarks>Passwords are never returned, by any account route.</remarks>
     private IResult List()
         => Results.Ok(_accounts.GetAll().Select(ToResponse));
 
+    /// <summary>Fetches a single account by username.</summary>
+    /// <remarks>Answers 404 when no account carries that username.</remarks>
     private IResult Get(string username)
         => _accounts.GetByUsername(username) is { } account
                ? Results.Ok(ToResponse(account))
                : NotFound(username);
 
+    /// <summary>Creates an account.</summary>
+    /// <remarks>
+    /// Username and password are required, and the username must be free — a taken one answers 409. Level
+    /// is optional and defaults to Player; when sent it must name an account level, case-insensitively.
+    /// </remarks>
     private IResult Create(CreateAccountRequest request)
     {
         // Before the write, so an unknown level cannot leave a half-made account behind.
@@ -145,18 +153,18 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         };
     }
 
-    /// <summary>
-    /// Applies the fields that are present and leaves the rest alone.
-    /// <para>
-    /// Applying several is not atomic: nothing rolls the level back if a later setter fails. Accepted
-    /// rather than solved — the setters fail only when the account is missing, which is ruled out a line
-    /// earlier, so a delete would have to race this patch for the window to open at all, and closing it
-    /// properly needs a transaction the store does not offer. The level, the one input a caller can get
-    /// wrong, is validated before any setter runs.
-    /// </para>
-    /// </summary>
+    /// <summary>Updates an account, changing only the fields that are sent.</summary>
+    /// <remarks>
+    /// Every field is optional; an omitted one is left as it is. Answers 404 for an unknown account, and
+    /// 400 when the level does not name one. Returns the account as it stands after the update.
+    /// </remarks>
     private IResult Update(string username, UpdateAccountRequest request)
     {
+        // Applying several fields is not atomic: nothing rolls the level back if a later setter fails.
+        // Accepted rather than solved — the setters fail only when the account is missing, which is ruled
+        // out a line below, so a delete would have to race this patch for the window to open at all, and
+        // closing it properly needs a transaction the store does not offer. The level, the one input a
+        // caller can get wrong, is validated before any setter runs.
         if (_accounts.GetByUsername(username) is null)
         {
             return NotFound(username);

--- a/src/Moongate.Server/Endpoints/AdminEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AdminEndpoints.cs
@@ -30,11 +30,10 @@ public sealed class AdminEndpoints : IApiEndpointRegistration
               .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
-    /// <summary>
-    /// A snapshot of the shard. <see cref="ISessionManager.Count" /> is backed by a ConcurrentDictionary,
-    /// so it is safe to read from an ASP.NET thread; nothing here touches world state, which is
-    /// single-writer on the game loop.
-    /// </summary>
+    /// <summary>Reports the shard's name, build and how many sessions are connected.</summary>
+    /// <remarks>A snapshot taken when the request is served, not a live figure.</remarks>
+    // ISessionManager.Count is backed by a ConcurrentDictionary, so it is safe to read from an ASP.NET
+    // thread; nothing here touches world state, which is single-writer on the game loop.
     private IResult Status()
         => Results.Ok(
             new AdminStatusResponse(

--- a/src/Moongate.Server/Endpoints/AuthEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/AuthEndpoints.cs
@@ -29,6 +29,12 @@ public sealed class AuthEndpoints : IApiEndpointRegistration
               .AllowAnonymous();
     }
 
+    /// <summary>Trades account credentials for a bearer token.</summary>
+    /// <remarks>
+    /// The token carries the account's username and level, and every other route reads authorisation from
+    /// it. Send it as <c>Authorization: Bearer &lt;token&gt;</c>. Any failure answers 401 without saying
+    /// which part was wrong.
+    /// </remarks>
     private IResult Login(LoginRequest request)
     {
         var result = _accounts.Authenticate(request.Username, request.Password);

--- a/src/Moongate.Server/Endpoints/PlayerEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/PlayerEndpoints.cs
@@ -19,11 +19,13 @@ public sealed class PlayerEndpoints : IApiEndpointRegistration
               .RequireAuthorization(HttpServerService.PlayerPolicy);
     }
 
-    /// <summary>
-    /// Reports only what the token already carries. It deliberately does not list the account's
-    /// characters: that would read the mobile store, which is single-writer on the game loop, and drag
-    /// loop affinity into a probe endpoint.
-    /// </summary>
+    /// <summary>Reports the account the bearer token belongs to.</summary>
+    /// <remarks>
+    /// Username and level, read straight from the token — useful for confirming a token is still valid
+    /// and what it grants. It does not list the account's characters.
+    /// </remarks>
+    // Deliberately no character list: that would read the mobile store, which is single-writer on the game
+    // loop, and drag loop affinity into a probe endpoint.
     private static IResult Me(ClaimsPrincipal user)
         => Results.Ok(
             new PlayerMeResponse(

--- a/src/Moongate.Server/Endpoints/VersionEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/VersionEndpoints.cs
@@ -23,14 +23,20 @@ public sealed class VersionEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
     {
-        routes.MapGet(
-                  "/api/v1/version",
-                  () => Results.Ok(
-                      new VersionResponse(_config.ShardName, VersionUtils.GetVersion(typeof(VersionEndpoints).Assembly))
-                  )
-              )
+        // A method group rather than a lambda: Swashbuckle reads the /// off the handler's method, and a
+        // lambda has no method to read it from — the route would document itself as blank.
+        routes.MapGet("/api/v1/version", Version)
               .WithName("GetVersion")
               .WithTags("version")
               .AllowAnonymous();
     }
+
+    /// <summary>Reports the shard's name and build.</summary>
+    /// <remarks>
+    /// Open without a token, so a launcher or the website can check compatibility before anyone logs in.
+    /// </remarks>
+    private IResult Version()
+        => Results.Ok(
+            new VersionResponse(_config.ShardName, VersionUtils.GetVersion(typeof(VersionEndpoints).Assembly))
+        );
 }

--- a/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
+++ b/tests/Moongate.Tests/Http/HttpServerServiceTests.cs
@@ -19,6 +19,25 @@ public class HttpServerServiceTests
             => routes.MapGet("/probe", () => Results.Ok("mapped"));
     }
 
+    /// <summary>
+    /// Documented with a method group rather than a lambda on purpose: that is the shape the real endpoint
+    /// groups use, and the only shape whose <c>///</c> Swashbuckle reads.
+    /// </summary>
+    private sealed class DocumentedProbeEndpoints : IApiEndpointRegistration
+    {
+        internal const string Summary = "Documented probe summary.";
+
+        internal const string Remarks = "Documented probe remarks.";
+
+        public void Register(IEndpointRouteBuilder routes)
+            => routes.MapGet("/documented-probe", Handle);
+
+        /// <summary>Documented probe summary.</summary>
+        /// <remarks>Documented probe remarks.</remarks>
+        private static IResult Handle()
+            => Results.Ok("documented");
+    }
+
     [Fact]
     public async Task StartAsync_MapsRegisteredEndpointGroups()
     {
@@ -71,6 +90,22 @@ public class HttpServerServiceTests
             HttpStatusCode.OK,
             (await server.Client.GetAsync(HttpServerService.SwaggerDocumentRoute)).StatusCode
         );
+    }
+
+    [Fact]
+    public async Task StartAsync_PutsEndpointXmlCommentsIntoTheDocument()
+    {
+        // The whole point of the /// on the endpoint handlers: without the XML wired in, the document
+        // still serves and Scalar still renders — just with every description blank. Nothing else here
+        // would notice, which is why this asserts on the prose rather than on a 200.
+        await using var server = await TestHttpServer.StartAsync(
+            container => container.RegisterApiEndpointInstance(new DocumentedProbeEndpoints())
+        );
+
+        var document = await server.Client.GetStringAsync(HttpServerService.SwaggerDocumentRoute);
+
+        Assert.Contains(DocumentedProbeEndpoints.Summary, document, StringComparison.Ordinal);
+        Assert.Contains(DocumentedProbeEndpoints.Remarks, document, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
The REST reference listed every route with no prose at all. `AddSwaggerGen()` was bare, so the `///` on the endpoints reached the compiler and stopped there.

## What changed

**The XML now feeds the document.** `AddSwaggerGen` includes the XML of every assembly that contributes endpoints. The paths come from the DI registrations rather than a hardcoded list: the endpoints live in `Moongate.Server` while the wiring runs in `Moongate.Http.Plugin`, and the dependency points the other way — the plugin cannot name the assembly it has to document. `GetServiceRegistrations()` yields the implementation types without resolving them, so nothing is constructed just to be asked where it came from.

**`GenerateDocumentationFile` now applies to every configuration.** It was set only under Release, so a Debug build produced no XML at all — meaning the reference developers actually read was the one guaranteed to have nothing to read. Checked on a full rebuild: no new warnings, CS1591 included.

**A missing XML file is skipped rather than passed on.** `IncludeXmlComments` throws *while serving the document*, so one absent file would turn the whole reference into a 500 instead of a page with some prose missing.

**`/api/v1/version` moved from a lambda to a method group.** Swashbuckle reads the `///` off the handler's method; a lambda has none, so the route documented itself as blank.

## The part that matters most: two registers

The `///` already on the handlers explained the implementation to whoever maintains it — the game-loop race behind the delete route, the loop affinity deliberately kept out of `/player/me`. Published verbatim, that reasoning would have become the public description of those routes. The summaries now address the caller: what the route does, what it needs, what each failure means. The rationale moved into `//` comments in the method bodies, which are never published.

## Verification

Before any wiring, a throwaway probe settled the open question: Swashbuckle 10.2.3 reads XML from method groups but never from lambdas. Then the real document, with every real endpoint mounted: **9 routes out of 9 carry a summary and a description, none blank.**

The guard test was confirmed red with the wiring removed — worth stating, because without the XML the document still serves and Scalar still renders, just with every description blank, and nothing else in the suite would notice.

Suite 976/976. DocFX 0 warnings.

## Note for reviewers

The docs go live only at the next `develop` → `main`; `docs/under-the-hood/rest-api.md` now says where a route's prose is written, why the handler must be a method group, and which register belongs in `///` versus `//`.
