### PR TITLE
feat(http): serve item art as PNG over the REST API

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -109,6 +109,9 @@ good token that is simply not staff.
 | `POST`   | `/api/v1/admin/accounts`             | `admin`  | 201 and a `Location`, or 400 / 409 |
 | `PATCH`  | `/api/v1/admin/accounts/{username}`  | `admin`  | the updated account, or 400 / 404  |
 | `DELETE` | `/api/v1/admin/accounts/{username}`  | `admin`  | 204, or 404 / 409 / 503            |
+| `GET`    | `/api/v1/images/items/{id}.png`      | none     | item art as PNG, or 400 / 404 / 503 |
+| `POST`   | `/api/v1/admin/images/items`         | `admin`  | 202, or 409 / 503                  |
+| `GET`    | `/api/v1/admin/images/items`         | `admin`  | export progress                    |
 
 `/api/v1/version` is deliberately unauthenticated: a launcher or the website
 checks compatibility with it, and it reveals nothing an operator would want
@@ -174,6 +177,39 @@ and lose their character from under them.
 - **503** — the game loop did not answer within five seconds. Nothing is
   deleted; the shard is unwell and the log says so.
 
+## Item images
+
+`GET /api/v1/images/items/0x1234.png` returns an item's art as a PNG, and is
+open without a token: the art is client data every player already has on disk.
+The id is hex with or without the `0x` prefix — a bare `1234.png` is the same
+item, not item 4660. Add `?hue=0x21` for a coloured variant; the range is 0 to
+3000, and 0, or omitting it, gives the raw art.
+
+The hue range is checked here rather than left to Ultima because `Hues.GetHue`
+never fails: it masks the index and falls back to hue 0, so an out-of-range hue
+would answer 200 with the wrong image instead of an error.
+
+Images are decoded on first request and cached under `cache/images/items` in the
+runtime root, so the first call for an item is slower than every call after it.
+The directory is registered through `DirectoriesConfig` and needs no ignore rule
+of its own: the whole runtime root is already outside git.
+
+`POST /api/v1/admin/images/items` warms the cache for every item at once. It is
+staff-only, answers 202, and works in the background; `GET` on the same route
+reports progress, and a second `POST` while one runs answers 409. It generates
+unhued art only — hued variants are left to the public route, since multiplying
+every item by 3000 hues is not a cache but a disk filler. Progress lives in
+memory and does not survive a restart, which is what a cache warm should do: the
+lazy path is always the fallback.
+
+One thing to know before adding any route that reads the client files:
+`Moongate.Ultima`'s `Art` holds no locks, and shares an LRU bitmap cache, plain
+dictionaries and a static scratch buffer across calls. `ItemImageService`
+funnels every decode through a single gate for that reason — not one gate per
+item, since two requests for *different* items corrupt that state exactly as two
+for the same one would. Cache hits skip the gate entirely. Do not call `Art` from
+a request thread without going through that service.
+
 ## Browsing the API
 
 [Scalar](https://scalar.com) serves an interactive reference at `/scalar/v1`,
@@ -199,13 +235,25 @@ plugin too.
 A group that is never registered is not a startup error: the server comes up
 and the route simply 404s, and Scalar shows a reference with nothing in it.
 
-Groups live in `Moongate.Server`, not in `Moongate.Http.Plugin`: `Program.cs`
-adds that plugin, so it cannot reference the server back. The plugin owns the
-plumbing — config, tokens, the server itself — and the game owns the endpoints
-that need game services. This is also why the server finds the XML to document
-your routes with by reading the DI registrations: it cannot name the assembly
-your group lives in, so it asks the container which assemblies contributed
-endpoints and looks for their XML beside the binaries.
+Where a group lives depends on what it needs. Groups that need game services
+live in `Moongate.Server` and are registered in `MoongateApiEndpointsPlugin`:
+`Program.cs` adds the HTTP plugin, so the plugin cannot reference the server
+back. The plugin owns the plumbing — config, tokens, the server itself — and the
+game owns the endpoints that reach into it.
+
+Groups that need no game service live in `Moongate.Http.Plugin` and are
+registered in `MoongateHttpPlugin`. The item image routes are the case in point:
+they read the UO client files through `Moongate.Ultima` and write to disk, and
+touch nothing the game owns. `Moongate.Ultima` references no Moongate project,
+so the plugin may reference it without a cycle.
+
+The rule is about the dependency, not the address: if your group needs a game
+service, it goes in the server, because that is the only place that can see one.
+
+This is also why the server finds the XML to document your routes with by
+reading the DI registrations: it cannot name the assembly your group lives in,
+so it asks the container which assemblies contributed endpoints and looks for
+their XML beside the binaries.
 
 Map each route to a **method group**, not a lambda:
 

--- a/src/Moongate.Http.Plugin/Data/ItemImageExportStatus.cs
+++ b/src/Moongate.Http.Plugin/Data/ItemImageExportStatus.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>How far the bulk item-image export has got.</summary>
+/// <param name="State">Idle, Running, Completed or Failed.</param>
+/// <param name="Done">Items exported so far.</param>
+/// <param name="Total">Items with art to export. 0 until the export has counted them.</param>
+/// <param name="Failed">Items whose art could not be written. The reasons are in the log.</param>
+/// <param name="StartedAt">When the current or last export started; null if none ever has.</param>
+public record ItemImageExportStatus(string State, int Done, int Total, int Failed, DateTimeOffset? StartedAt);

--- a/src/Moongate.Http.Plugin/Endpoints/ItemImageAdminEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/ItemImageAdminEndpoints.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+
+namespace Moongate.Http.Plugin.Endpoints;
+
+/// <summary>Staff-only control of the item image cache.</summary>
+public sealed class ItemImageAdminEndpoints : IApiEndpointRegistration
+{
+    private readonly IItemImageExportJob _export;
+    private readonly IItemImageService _images;
+
+    public ItemImageAdminEndpoints(IItemImageExportJob export, IItemImageService images)
+    {
+        _export = export;
+        _images = images;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/admin/images/items")
+                          .WithTags("images")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        group.MapPost("/", Start).WithName("StartItemImageExport");
+        group.MapGet("/", GetStatus).WithName("GetItemImageExportStatus");
+    }
+
+    /// <summary>Generates every item's art into the cache.</summary>
+    /// <remarks>
+    /// Answers 202 and works in the background; poll this same route with GET for progress. Only one
+    /// export runs at a time, so a second request while one is going answers 409. Unhued art only — hued
+    /// variants are generated on demand by the public image route. Progress is kept in memory and does
+    /// not survive a restart.
+    /// </remarks>
+    private IResult Start()
+    {
+        if (!_images.IsReady)
+        {
+            return Results.Problem(
+                "The UO client files are not loaded; there is no art to export.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        if (!_export.TryStart())
+        {
+            return Results.Problem(
+                "An item image export is already running.",
+                statusCode: StatusCodes.Status409Conflict
+            );
+        }
+
+        return Results.Accepted("/api/v1/admin/images/items", _export.Status);
+    }
+
+    /// <summary>Reports how far the item image export has got.</summary>
+    /// <remarks>
+    /// State is Idle before any export has run, then Running, and finally Completed or Failed. Failed
+    /// counts items whose art could not be written; the reasons are in the server log.
+    /// </remarks>
+    private IResult GetStatus()
+        => Results.Ok(_export.Status);
+}

--- a/src/Moongate.Http.Plugin/Endpoints/ItemImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/ItemImageEndpoints.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+
+namespace Moongate.Http.Plugin.Endpoints;
+
+/// <summary>Item art as PNG, straight from the UO client files.</summary>
+public sealed class ItemImageEndpoints : IApiEndpointRegistration
+{
+    /// <summary>Hues.GetHue indexes 0..2999 once the client's 1-based hue is undone; 0 means unhued.</summary>
+    private const uint MaxHue = 3000;
+
+    private readonly IItemImageService _images;
+
+    public ItemImageEndpoints(IItemImageService images)
+    {
+        _images = images;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
+        // has none — the route would document itself blank.
+        routes.MapGet("/api/v1/images/items/{id}.png", Get)
+              .WithName("GetItemImage")
+              .WithTags("images")
+              .AllowAnonymous();
+    }
+
+    /// <summary>Item art as a PNG, optionally hued.</summary>
+    /// <remarks>
+    /// Open without a token: the art is client data every player already has on disk. The id is hex, with
+    /// or without the 0x prefix — 0x1234.png and 1234.png are the same item. Pass hue for a coloured
+    /// variant; 0, or omitting it, gives the raw art, and the range is 0 to 3000. Images are decoded on
+    /// first request and cached, so the first call for an item is slower than every call after it.
+    /// </remarks>
+    private async Task<IResult> Get(string id, string? hue, CancellationToken cancellationToken)
+    {
+        if (!TryParseHex(id, out var itemId))
+        {
+            return Results.Problem(
+                $"'{id}' is not an item id. Expected hex, such as 0x1234.",
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+
+        if (!TryParseHue(hue, out var hueValue))
+        {
+            return Results.Problem(
+                $"'{hue}' is not a hue. Expected hex from 0 to {MaxHue}, where 0 is unhued.",
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+
+        // Checked before the lookup, because a missing image and missing client files are indistinguishable
+        // afterwards: a shard with a wrong UltimaDirectory would answer 404, telling the operator this item
+        // does not exist when the truth is that none of them do.
+        if (!_images.IsReady)
+        {
+            return Results.Problem(
+                "The UO client files are not loaded; no item art can be served.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        var path = await _images.GetOrCreateAsync(itemId, hueValue, cancellationToken);
+
+        return path is null
+                   ? Results.Problem(
+                       $"No art for item 0x{itemId:x4}.",
+                       statusCode: StatusCodes.Status404NotFound
+                   )
+                   : Results.File(path, "image/png");
+    }
+
+    /// <summary>
+    /// Hex, with or without the prefix. A bare "1234" is hex too: the route is documented as 0xITEM_ID,
+    /// and reading it as decimal would quietly serve 0x4D2 to someone who meant 0x1234.
+    /// </summary>
+    internal static bool TryParseHex(string? value, out uint parsed)
+    {
+        parsed = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var digits = value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? value[2..] : value;
+
+        return uint.TryParse(digits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out parsed);
+    }
+
+    /// <summary>
+    /// An absent hue is unhued. The range is checked here because Hues.GetHue never fails — it masks the
+    /// index and falls back to hue 0 — so an out-of-range value would serve a wrong image, not an error.
+    /// </summary>
+    internal static bool TryParseHue(string? value, out ushort hue)
+    {
+        hue = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (!TryParseHex(value, out var parsed) || parsed > MaxHue)
+        {
+            return false;
+        }
+
+        hue = (ushort)parsed;
+
+        return true;
+    }
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IItemImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IItemImageExportJob.cs
@@ -1,0 +1,13 @@
+using Moongate.Http.Plugin.Data;
+
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>Fills the item image cache in the background, one export at a time.</summary>
+public interface IItemImageExportJob
+{
+    /// <summary>How far the current or last export has got.</summary>
+    ItemImageExportStatus Status { get; }
+
+    /// <summary>Starts an export. False when one is already running.</summary>
+    bool TryStart();
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IItemImageService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IItemImageService.cs
@@ -1,0 +1,22 @@
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>
+/// Item art as PNG files, decoded from the UO client files on first request and cached on disk.
+/// </summary>
+public interface IItemImageService
+{
+    /// <summary>
+    /// False when the UO client files are not loaded, and no image can be produced at all. Keeps two
+    /// different failures apart: an item that has no art, and a shard whose UltimaDirectory is wrong.
+    /// </summary>
+    bool IsReady { get; }
+
+    /// <summary>
+    /// The path of the cached PNG for this item and hue, decoding and caching it on first request. Null
+    /// when the item has no art.
+    /// </summary>
+    Task<string?> GetOrCreateAsync(uint itemId, ushort hue, CancellationToken cancellationToken = default);
+
+    /// <summary>Every item id the client files hold static art for.</summary>
+    Task<IReadOnlyList<uint>> GetArtItemIdsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -12,6 +12,14 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Moongate.Core\Moongate.Core.csproj"/>
+        <!--
+            Moongate.Ultima is standalone: it references no Moongate project, so the plugin may reference it
+            without a cycle. This is what lets the image endpoints live here rather than in Moongate.Server,
+            which the plugin cannot reference — Program.cs adds this plugin, so the dependency runs the other
+            way. The client files reach us through Ultima's process-wide statics, which the server has already
+            initialised by the time a request arrives.
+        -->
+        <ProjectReference Include="..\Moongate.Ultima\Moongate.Ultima.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -40,10 +40,12 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // nothing.
         container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
         container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+        container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
 
         // These endpoints live here rather than in Moongate.Server because they need no game service at
         // all — only the client files and the filesystem.
         container.RegisterApiEndpoint<ItemImageEndpoints>();
+        container.RegisterApiEndpoint<ItemImageAdminEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -2,6 +2,8 @@ using DryIoc;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
+using Moongate.Ultima.Catalog;
+using Moongate.Ultima.Interfaces;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;
 using SquidStd.Core.Utils;
@@ -30,6 +32,11 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterConfigSection<MoongateHttpConfig>("http");
 
         container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
+
+        // The catalog reads the UO client files through Moongate.Ultima's process-wide statics, which
+        // FilesLoaderService initialises at startup. It carries no state of its own, so a singleton costs
+        // nothing.
+        container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -1,5 +1,7 @@
 using DryIoc;
 using Moongate.Http.Plugin.Data.Config;
+using Moongate.Http.Plugin.Endpoints;
+using Moongate.Http.Plugin.Extensions;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
 using Moongate.Ultima.Catalog;
@@ -37,6 +39,11 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // FilesLoaderService initialises at startup. It carries no state of its own, so a singleton costs
         // nothing.
         container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+        container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+
+        // These endpoints live here rather than in Moongate.Server because they need no game service at
+        // all — only the client files and the filesystem.
+        container.RegisterApiEndpoint<ItemImageEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/src/Moongate.Http.Plugin/Services/ItemImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Services/ItemImageExportJob.cs
@@ -1,0 +1,120 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Types;
+using Serilog;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// Warms the item image cache by walking every item id that has art. It goes through
+/// <see cref="IItemImageService" /> like any request, so it takes the same gate per item and interleaves
+/// with live traffic rather than blocking it for the length of the run.
+/// </summary>
+public sealed class ItemImageExportJob : IItemImageExportJob
+{
+    private readonly ILogger _logger = Log.ForContext<ItemImageExportJob>();
+    private readonly IItemImageService _images;
+    private readonly object _sync = new();
+
+    private ItemImageExportStateType _state = ItemImageExportStateType.Idle;
+    private int _done;
+    private int _total;
+    private int _failed;
+    private DateTimeOffset? _startedAt;
+
+    public ItemImageExportJob(IItemImageService images)
+    {
+        _images = images;
+    }
+
+    public ItemImageExportStatus Status
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return new(_state.ToString(), _done, _total, _failed, _startedAt);
+            }
+        }
+    }
+
+    public bool TryStart()
+    {
+        lock (_sync)
+        {
+            if (_state == ItemImageExportStateType.Running)
+            {
+                return false;
+            }
+
+            _state = ItemImageExportStateType.Running;
+            _done = 0;
+            _total = 0;
+            _failed = 0;
+            _startedAt = DateTimeOffset.UtcNow;
+        }
+
+        // Deliberately not awaited: the route answers 202 and the caller polls. The task owns its own
+        // failures — RunAsync catches everything and records it in the state, so nothing is left to an
+        // unobserved exception.
+        _ = Task.Run(RunAsync);
+
+        return true;
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            var ids = await _images.GetArtItemIdsAsync();
+
+            lock (_sync)
+            {
+                _total = ids.Count;
+            }
+
+            foreach (var id in ids)
+            {
+                try
+                {
+                    await _images.GetOrCreateAsync(id, 0);
+
+                    lock (_sync)
+                    {
+                        _done++;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    // One unreadable tile must not end the run: the point is to warm what can be warmed.
+                    _logger.Warning(exception, "Could not export art for item 0x{ItemId:x4}", id);
+
+                    lock (_sync)
+                    {
+                        _failed++;
+                    }
+                }
+            }
+
+            lock (_sync)
+            {
+                _state = ItemImageExportStateType.Completed;
+            }
+
+            _logger.Information(
+                "Item image export finished: {Done} exported, {Failed} failed",
+                _done,
+                _failed
+            );
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Item image export stopped early");
+
+            lock (_sync)
+            {
+                _state = ItemImageExportStateType.Failed;
+            }
+        }
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/ItemImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/ItemImageService.cs
@@ -1,0 +1,142 @@
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Ultima.Graphics;
+using Moongate.Ultima.Interfaces;
+using Moongate.Ultima.Tiles;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// Caches item art as PNG files on disk. The decode itself belongs to <see cref="IItemCatalog" />; what
+/// this adds is the cache, and the serialisation that makes it safe to call from a web server at all.
+/// </summary>
+public sealed class ItemImageService : IItemImageService, IDisposable
+{
+    /// <summary>
+    /// Under the runtime root, which .gitignore already excludes wholesale — so the cache needs no ignore
+    /// rule of its own. RegisterDirectory creates the whole tree.
+    /// </summary>
+    private const string CacheDirectory = "cache/images/items";
+
+    private readonly IItemCatalog _catalog;
+    private readonly string _cachePath;
+
+    // One gate for every decode, not one per item. What it protects is Art's process-wide state — an LRU
+    // bitmap cache, plain Dictionary fields and a shared static scratch buffer — so two requests for
+    // different items corrupt each other exactly as two for the same item would. Art.cs holds no lock of
+    // its own, and nothing else in the server calls it, so this is the only thing standing between a
+    // concurrent request and that state.
+    private readonly SemaphoreSlim _decodeGate = new(1, 1);
+
+    public ItemImageService(IItemCatalog catalog, DirectoriesConfig directories)
+    {
+        _catalog = catalog;
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+    }
+
+    public bool IsReady
+        => TileData.ItemTable is not null;
+
+    public async Task<string?> GetOrCreateAsync(
+        uint itemId,
+        ushort hue,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var path = Path.Combine(_cachePath, FileName(itemId, hue));
+
+        // The hit path takes no lock and never touches Art: concurrent readers of a finished file are the
+        // OS's problem, not ours. This is what keeps the gate off the common case.
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        await _decodeGate.WaitAsync(cancellationToken);
+
+        try
+        {
+            // Another request may have produced it while this one waited on the gate.
+            if (File.Exists(path))
+            {
+                return path;
+            }
+
+            using var png = _catalog.GetItemImage(itemId, hue);
+
+            if (png is null)
+            {
+                return null;
+            }
+
+            await WriteAtomicallyAsync(path, png, cancellationToken);
+
+            return path;
+        }
+        finally
+        {
+            _decodeGate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<uint>> GetArtItemIdsAsync(CancellationToken cancellationToken = default)
+    {
+        await _decodeGate.WaitAsync(cancellationToken);
+
+        try
+        {
+            var ids = new List<uint>();
+            var max = Art.GetMaxItemId();
+
+            for (var id = 0; id <= max; id++)
+            {
+                if (Art.IsValidStatic(id))
+                {
+                    ids.Add((uint)id);
+                }
+            }
+
+            return ids;
+        }
+        finally
+        {
+            _decodeGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Lowercase hex, zero-padded, so names sort and cannot collide. The hue goes in the name rather than
+    /// a subdirectory: one flat directory keeps the hit path a single File.Exists.
+    /// </summary>
+    internal static string FileName(uint itemId, ushort hue)
+        => hue == 0 ? $"0x{itemId:x4}.png" : $"0x{itemId:x4}_0x{hue:x4}.png";
+
+    /// <summary>
+    /// Writes to a temporary file in the same directory, then moves it into place. A reader must never be
+    /// handed a half-written PNG, and a move within one directory is atomic on Linux and Windows alike —
+    /// writing straight to the final path would not be.
+    /// </summary>
+    private static async Task WriteAtomicallyAsync(string path, Stream png, CancellationToken cancellationToken)
+    {
+        var temporary = $"{path}.{Guid.NewGuid():N}.tmp";
+
+        try
+        {
+            await using (var file = File.Create(temporary))
+            {
+                await png.CopyToAsync(file, cancellationToken);
+            }
+
+            File.Move(temporary, path, true);
+        }
+        catch
+        {
+            File.Delete(temporary);
+
+            throw;
+        }
+    }
+
+    public void Dispose()
+        => _decodeGate.Dispose();
+}

--- a/src/Moongate.Http.Plugin/Types/ItemImageExportStateType.cs
+++ b/src/Moongate.Http.Plugin/Types/ItemImageExportStateType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Http.Plugin.Types;
+
+/// <summary>Where a bulk item-image export stands.</summary>
+public enum ItemImageExportStateType
+{
+    /// <summary>No export has run since the server started.</summary>
+    Idle,
+
+    /// <summary>An export is working through the item ids.</summary>
+    Running,
+
+    /// <summary>The last export finished; Failed says whether every item made it.</summary>
+    Completed,
+
+    /// <summary>The last export stopped early. The reason is in the log.</summary>
+    Failed
+}

--- a/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AccountEndpointsTests.cs
@@ -16,7 +16,7 @@ public class AccountEndpointsTests
     public async Task List_ReportsEveryAccount()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.GetAsync("/api/v1/admin/accounts");
 
@@ -28,7 +28,7 @@ public class AccountEndpointsTests
     public async Task Get_KnownAccount_ReportsIt()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.GetAsync("/api/v1/admin/accounts/tom");
 
@@ -40,7 +40,7 @@ public class AccountEndpointsTests
     public async Task Get_UnknownAccount_Is404()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         Assert.Equal(
             HttpStatusCode.NotFound,
@@ -54,7 +54,7 @@ public class AccountEndpointsTests
         // Against the raw JSON, not a deserialized DTO: deserializing into AccountResponse would drop an
         // extra field silently, which is exactly the leak this guards. AccountEntity holds both.
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         foreach (var route in new[] { "/api/v1/admin/accounts", "/api/v1/admin/accounts/tom" })
         {
@@ -80,7 +80,7 @@ public class AccountEndpointsTests
     public async Task List_WithPlayerToken_Is403()
     {
         await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         Assert.Equal(
             HttpStatusCode.Forbidden,
@@ -92,7 +92,7 @@ public class AccountEndpointsTests
     public async Task Create_NewAccount_Is201WithLocation()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/admin/accounts",
@@ -109,7 +109,7 @@ public class AccountEndpointsTests
     {
         // The safe default: an account that gains staff rights by accident is the wrong way to fail.
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         await server.Client.PostAsJsonAsync(
             "/api/v1/admin/accounts",
@@ -123,7 +123,7 @@ public class AccountEndpointsTests
     public async Task Create_TakenUsername_Is409()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/admin/accounts",
@@ -139,7 +139,7 @@ public class AccountEndpointsTests
     public async Task Create_EmptyUsernameOrPassword_Is400(string username, string password)
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/admin/accounts",
@@ -154,7 +154,7 @@ public class AccountEndpointsTests
     {
         // The level is checked before the write, so a bad request cannot half-apply.
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/admin/accounts",
@@ -169,7 +169,7 @@ public class AccountEndpointsTests
     public async Task Update_ChangesOnlyTheFieldsSent()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
             "/api/v1/admin/accounts/tom",
@@ -188,7 +188,7 @@ public class AccountEndpointsTests
     public async Task Update_ChangesTheLevel()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         await server.Client.PatchAsJsonAsync("/api/v1/admin/accounts/tom", new { level = "GrandMaster" });
 
@@ -199,7 +199,7 @@ public class AccountEndpointsTests
     public async Task Update_ChangesThePassword()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         await server.Client.PatchAsJsonAsync("/api/v1/admin/accounts/tom", new { password = "nuova" });
 
@@ -213,7 +213,7 @@ public class AccountEndpointsTests
     public async Task Update_UnknownAccount_Is404()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
             "/api/v1/admin/accounts/nobody",
@@ -227,7 +227,7 @@ public class AccountEndpointsTests
     public async Task Update_UnknownLevel_Is400AndChangesNothing()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
             "/api/v1/admin/accounts/tom",
@@ -246,7 +246,7 @@ public class AccountEndpointsTests
     public async Task Delete_KnownAccount_Is204AndRemovesIt()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
 
@@ -262,7 +262,7 @@ public class AccountEndpointsTests
         // handover, which no status code would reveal.
         var loop = new StubGameLoopContext();
         await using var server = await TestApiServer.StartAsync(loop: loop);
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
 
@@ -274,7 +274,7 @@ public class AccountEndpointsTests
     {
         // Deleting an account whose character is logged in would pull the world out from under them.
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var account = server.Accounts.GetByUsername("tom")!;
         var mobile = server.Characters.CreateCharacter(account.Id, CharacterPacket());
@@ -312,7 +312,7 @@ public class AccountEndpointsTests
     public async Task Delete_UnknownAccount_Is404()
     {
         await using var server = await TestApiServer.StartAsync();
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         Assert.Equal(
             HttpStatusCode.NotFound,
@@ -327,23 +327,12 @@ public class AccountEndpointsTests
             loop: new StubGameLoopContext(answers: false),
             deleteTimeout: TimeSpan.FromMilliseconds(50)
         );
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
         // Still there: a timeout must not read as a delete.
         Assert.NotNull(server.Accounts.GetByUsername("tom"));
-    }
-
-    internal static async Task AuthenticateAsync(TestApiServer server)
-    {
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "secret" }
-        );
-        var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
-
-        server.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
     }
 }

--- a/tests/Moongate.Tests/Http/AdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/AdminEndpointsTests.cs
@@ -23,7 +23,7 @@ public class AdminEndpointsTests
     public async Task AdminStatus_WithStaffToken_Is200(AccountLevelType level)
     {
         await using var server = await TestApiServer.StartAsync(level);
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
     }
@@ -34,7 +34,7 @@ public class AdminEndpointsTests
         // The test that proves the admin/player split exists rather than being asserted: a valid token
         // that is simply not staff enough.
         await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
     }
@@ -43,7 +43,7 @@ public class AdminEndpointsTests
     public async Task PlayerMe_WithAnyToken_ReportsTheAccount()
     {
         await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
-        await AuthenticateAsync(server);
+        await server.AuthenticateAsync();
 
         var response = await server.Client.GetAsync("/api/v1/player/me");
 
@@ -60,16 +60,5 @@ public class AdminEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync("/api/v1/player/me")).StatusCode);
-    }
-
-    private static async Task AuthenticateAsync(TestApiServer server)
-    {
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "secret" }
-        );
-        var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
-
-        server.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
     }
 }

--- a/tests/Moongate.Tests/Http/ItemImageAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageAdminEndpointsTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Endpoints;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Http.Plugin.Types;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Catalog;
+using Moongate.Ultima.Interfaces;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class ItemImageAdminEndpointsTests
+{
+    private static async Task<TestApiServer> StartAsync(ItemImageFixture fixture)
+        => await TestApiServer.StartAsync(
+            configure: container =>
+            {
+                container.RegisterInstance(fixture.Directories);
+                container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+                container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new ItemImageAdminEndpoints(
+                        container.Resolve<IItemImageExportJob>(),
+                        container.Resolve<IItemImageService>()
+                    )
+                );
+            }
+        );
+
+    [Fact]
+    public async Task Post_WithoutAToken_IsUnauthorized()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.PostAsync("/api/v1/admin/images/items", null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_AsStaff_IsAccepted()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.PostAsync("/api/v1/admin/images/items", null);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsStaff_ReportsTheState()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+        await server.AuthenticateAsync();
+
+        var status = await server.Client.GetFromJsonAsync<ItemImageExportStatus>("/api/v1/admin/images/items");
+
+        Assert.NotNull(status);
+        Assert.Equal(nameof(ItemImageExportStateType.Idle), status.State);
+    }
+}

--- a/tests/Moongate.Tests/Http/ItemImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageEndpointsTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using DryIoc;
+using Moongate.Http.Plugin.Endpoints;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Catalog;
+using Moongate.Ultima.Interfaces;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class ItemImageEndpointsTests
+{
+    private static async Task<TestHttpServer> StartAsync(ItemImageFixture fixture)
+        => await TestHttpServer.StartAsync(
+            container =>
+            {
+                container.RegisterInstance(fixture.Directories);
+                container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new ItemImageEndpoints(container.Resolve<IItemImageService>())
+                );
+            }
+        );
+
+    [Fact]
+    public async Task Get_KnownItem_ReturnsADecodablePng()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync($"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+
+        using var image = Image.Load<Bgra32>(await response.Content.ReadAsByteArrayAsync());
+
+        Assert.Equal(2, image.Width);
+    }
+
+    [Fact]
+    public async Task Get_NoToken_StillServesTheImage()
+    {
+        // Anonymous on purpose: the art is client data every player already has on disk.
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync($"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_IdWithoutThePrefix_IsReadAsHex()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync($"/api/v1/images/items/{ItemImageFixture.ItemId:x4}.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_Hued_ReturnsDifferentPixelsFromThePlainArt()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var plain = await server.Client.GetByteArrayAsync(
+            $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png"
+        );
+        var hued = await server.Client.GetByteArrayAsync(
+            $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x{ItemImageFixture.Hue:x4}"
+        );
+
+        using var plainImage = Image.Load<Bgra32>(plain);
+        using var huedImage = Image.Load<Bgra32>(hued);
+
+        Assert.NotEqual(plainImage[0, 0], huedImage[0, 0]);
+    }
+
+    [Fact]
+    public async Task Get_ItemWithoutArt_IsNotFound()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync(
+            $"/api/v1/images/items/0x{ItemImageFixture.MissingArtItemId:x4}.png"
+        );
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_MalformedId_IsBadRequest()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync("/api/v1/images/items/zzzz.png");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_HueOutOfRange_IsBadRequest()
+    {
+        // Hues.GetHue never fails: it masks the index and falls back to hue 0. Without this check the
+        // request would answer 200 with the wrong image.
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync(
+            $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x9999"
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/tests/Moongate.Tests/Http/ItemImageExportJobTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageExportJobTests.cs
@@ -1,0 +1,86 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Services;
+using Moongate.Http.Plugin.Types;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Catalog;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class ItemImageExportJobTests
+{
+    private static async Task<ItemImageExportStatus> WaitForCompletionAsync(ItemImageExportJob job)
+    {
+        // Polls rather than sleeping a fixed span: the export is a background task, and a fixed wait would
+        // either flake on a loaded machine or waste the difference on a fast one.
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var status = job.Status;
+
+            if (status.State != nameof(ItemImageExportStateType.Running))
+            {
+                return status;
+            }
+
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException($"The export never left Running. Last status: {job.Status}.");
+    }
+
+    [Fact]
+    public async Task TryStart_ExportsEveryItemThatHasArt()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var job = new ItemImageExportJob(service);
+
+        Assert.True(job.TryStart());
+
+        var status = await WaitForCompletionAsync(job);
+
+        Assert.Equal(nameof(ItemImageExportStateType.Completed), status.State);
+        Assert.Equal(0, status.Failed);
+        Assert.Equal(status.Total, status.Done);
+        Assert.True(status.Done > 0);
+
+        // Asserts on the files rather than on the cache's naming, which is the service's own business:
+        // what the export promises is that every item it counted ended up on disk.
+        var written = Directory.GetFiles(fixture.Directories.GetPath("cache/images/items"), "*.png");
+
+        Assert.Equal(status.Done, written.Length);
+    }
+
+    [Fact]
+    public async Task TryStart_WhileRunning_IsRefused()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var job = new ItemImageExportJob(service);
+
+        Assert.True(job.TryStart());
+
+        // Either the second start is refused, or the first finished before this line ran. Asserting only
+        // the refusal would flake on a fast machine, so this accepts both and checks the state matches.
+        var refused = !job.TryStart();
+        var status = await WaitForCompletionAsync(job);
+
+        Assert.True(refused || status.State == nameof(ItemImageExportStateType.Completed));
+    }
+
+    [Fact]
+    public void Status_BeforeAnyExport_IsIdle()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var job = new ItemImageExportJob(service);
+
+        var status = job.Status;
+
+        Assert.Equal(nameof(ItemImageExportStateType.Idle), status.State);
+        Assert.Null(status.StartedAt);
+        Assert.Equal(0, status.Done);
+    }
+}

--- a/tests/Moongate.Tests/Http/ItemImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageServiceTests.cs
@@ -1,0 +1,118 @@
+using Moongate.Http.Plugin.Services;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Catalog;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class ItemImageServiceTests
+{
+    [Fact]
+    public async Task GetOrCreateAsync_FirstCall_WritesADecodablePng()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        var path = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
+
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path));
+
+        using var image = await Image.LoadAsync<Bgra32>(path);
+
+        Assert.Equal(2, image.Width);
+        Assert.Equal(2, image.Height);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_SecondCall_ServesTheCachedFileWithoutRewritingIt()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        var first = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
+
+        // Backdate the file, then check the timestamp survives. Asserting on the file rather than on a mock
+        // keeps the test honest about what the cache is for: not decoding through Art twice.
+        var marker = DateTime.UtcNow.AddDays(-1);
+        File.SetLastWriteTimeUtc(first!, marker);
+
+        var second = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
+
+        Assert.Equal(first, second);
+        Assert.Equal(marker, File.GetLastWriteTimeUtc(second!), TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_MissingArt_ReturnsNull()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        Assert.Null(await service.GetOrCreateAsync(ItemImageFixture.MissingArtItemId, 0));
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_Hued_GetsItsOwnFileWithDifferentPixels()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        var plain = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
+        var hued = await service.GetOrCreateAsync(ItemImageFixture.ItemId, ItemImageFixture.Hue);
+
+        Assert.NotEqual(plain, hued);
+
+        using var plainImage = await Image.LoadAsync<Bgra32>(plain!);
+        using var huedImage = await Image.LoadAsync<Bgra32>(hued!);
+
+        Assert.NotEqual(plainImage[0, 0], huedImage[0, 0]);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ConcurrentCallers_AllGetTheirOwnValidPng()
+    {
+        // The reason the gate exists: Art holds no lock, and shares an LRU cache, non-concurrent
+        // dictionaries and a static scratch buffer across calls. Parallel decodes are what corrupt it.
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        var hues = Enumerable.Range(1, 16).Select(hue => (ushort)hue).ToArray();
+
+        var paths = await Task.WhenAll(
+            hues.Select(hue => service.GetOrCreateAsync(ItemImageFixture.ItemId, hue))
+        );
+
+        Assert.Equal(hues.Length, paths.Distinct().Count());
+
+        foreach (var path in paths)
+        {
+            using var image = await Image.LoadAsync<Bgra32>(path!);
+
+            Assert.Equal(2, image.Width);
+        }
+    }
+
+    [Fact]
+    public async Task GetArtItemIdsAsync_ReturnsOnlyIdsThatHaveArt()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        var ids = await service.GetArtItemIdsAsync();
+
+        Assert.Contains((uint)ItemImageFixture.ItemId, ids);
+        Assert.DoesNotContain((uint)ItemImageFixture.MissingArtItemId, ids);
+    }
+
+    [Fact]
+    public void IsReady_TrueOnceTheClientFilesAreLoaded()
+    {
+        using var fixture = ItemImageFixture.Create();
+        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+
+        Assert.True(service.IsReady);
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -3,6 +3,8 @@ using Moongate.Http.Plugin;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
+using Moongate.Ultima.Catalog;
+using Moongate.Ultima.Interfaces;
 
 namespace Moongate.Tests.Http;
 
@@ -27,6 +29,10 @@ public class MoongateHttpPluginTests
     [Fact]
     public void Configure_RegistersTheServerThatRunsTheApi()
         => Assert.NotNull(Configured().Resolve<HttpServerService>());
+
+    [Fact]
+    public void Configure_RegistersTheItemCatalog()
+        => Assert.IsType<ItemCatalog>(Configured().Resolve<IItemCatalog>());
 
     [Fact]
     public void Metadata_IdentifiesThePlugin()

--- a/tests/Moongate.Tests/Support/ItemImageFixture.cs
+++ b/tests/Moongate.Tests/Support/ItemImageFixture.cs
@@ -1,0 +1,85 @@
+using Moongate.Ultima.Graphics;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// A synthetic UO client directory holding one item's art, plus a throwaway runtime root for the image
+/// cache. Building it mutates Moongate.Ultima's process-wide statics, so every test using it must sit in
+/// the "UltimaClientData" collection.
+/// </summary>
+public sealed class ItemImageFixture : IDisposable
+{
+    /// <summary>The only id with art. Any other id exercises the missing-art path.</summary>
+    public const int ItemId = 0x10;
+
+    /// <summary>An id the art file does not cover, for the 404 path.</summary>
+    public const int MissingArtItemId = 0x20;
+
+    /// <summary>
+    /// The one hue the synthetic hues.mul actually colours. Hues.Initialize fills every remaining index up
+    /// to 3000 with a default, so higher hues are valid but paint nothing.
+    /// </summary>
+    public const ushort Hue = 1;
+
+    private readonly string _clientDirectory;
+
+    private ItemImageFixture(string clientDirectory, string root, DirectoriesConfig directories)
+    {
+        _clientDirectory = clientDirectory;
+        Root = root;
+        Directories = directories;
+    }
+
+    public string Root { get; }
+
+    public DirectoriesConfig Directories { get; }
+
+    public static ItemImageFixture Create()
+    {
+        var tileData = UltimaFixtures.BuildTileData();
+
+        UltimaFixtures.SetItem(
+            tileData,
+            ItemId,
+            (uint)(TileFlagType.Wearable | TileFlagType.PartialHue),
+            4,
+            "test tunic"
+        );
+
+        var (artIndex, art) = UltimaFixtures.BuildStaticArt(ItemId, 2, 2, 0xFFFF); // white -> gray, hueable
+        var hues = UltimaFixtures.BuildHues("Red", 0x7C00, 0, 0);
+
+        var clientDirectory = UltimaFixtures.CreateClientDirectory(
+            ("tiledata.mul", tileData),
+            ("artidx.mul", artIndex),
+            ("art.mul", art),
+            ("hues.mul", hues)
+        );
+
+        Files.SetDirectory(clientDirectory);
+        Art.Reload();
+        TileData.Initialize();
+        Hues.Initialize();
+
+        var root = Path.Combine(Path.GetTempPath(), $"mg_images_{Guid.NewGuid():N}");
+
+        return new(clientDirectory, root, new(root, []));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_clientDirectory))
+        {
+            Directory.Delete(_clientDirectory, true);
+        }
+
+        if (Directory.Exists(Root))
+        {
+            Directory.Delete(Root, true);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -1,6 +1,9 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using DryIoc;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces;
 using Moongate.Http.Plugin.Services;
@@ -46,10 +49,27 @@ public sealed class TestApiServer : IAsyncDisposable
     /// <summary>Lets a test declare a character as being played, via <see cref="StubSessionManager.Played" />.</summary>
     public StubSessionManager Sessions { get; }
 
+    /// <summary>
+    /// Logs in as the account this fixture seeded and keeps the token on the client, so later requests
+    /// carry it. Lives here rather than in each test class because the fixture is what knows the
+    /// credentials it created.
+    /// </summary>
+    public async Task AuthenticateAsync()
+    {
+        var response = await Client.PostAsJsonAsync(
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
+        var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
+
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token!.Token);
+    }
+
     public static async Task<TestApiServer> StartAsync(
         AccountLevelType level = AccountLevelType.Administrator,
         IGameLoopContext? loop = null,
-        TimeSpan? deleteTimeout = null
+        TimeSpan? deleteTimeout = null,
+        Action<IContainer>? configure = null
     )
     {
         var container = new Container();
@@ -89,6 +109,9 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterApiEndpointInstance(new AuthEndpoints(accounts, container.Resolve<IJwtTokenService>()));
         container.RegisterApiEndpointInstance(new AdminEndpoints(moongateConfig, sessions));
         container.RegisterApiEndpointInstance(new PlayerEndpoints());
+
+        // Lets a test add endpoint groups this fixture cannot know about — the ones the HTTP plugin owns.
+        configure?.Invoke(container);
 
         var service = new HttpServerService(container, config);
         await service.StartAsync();


### PR DESCRIPTION
Item art as PNG at `GET /api/v1/images/items/0x1234.png`, decoded from the UO client files on first request and cached on disk, plus a staff-only route that warms the lot.

## What changed

**The decode already existed.** `ItemCatalog.GetItemImage(itemId, hue)` in `Moongate.Ultima` already did art lookup, hue application with the `PartialHue` tile flag, the `hue - 1` off-by-one and PNG encoding — and was registered nowhere, reachable only from tests. This consumes it rather than writing a second decoder.

**The plugin now references `Moongate.Ultima`.** It is standalone (no `ProjectReference` of its own), so there is no cycle. This is what lets these endpoints live in `Moongate.Http.Plugin`, which cannot reference `Moongate.Server`: they need no game service, only the client files and the filesystem. `UltimaDirectory` living in `Moongate.Server` does not matter — `Files`/`Art` are process-wide statics the server initialises at startup.

**The cache.** `moongate_root/cache/images/items`, registered through `DirectoriesConfig`. It needs no `.gitignore` entry: `/moongate_root/` is already ignored wholesale.

## The part worth reviewing: `Art` is not thread-safe

`Moongate.Ultima`'s `Art` holds **zero locks** and shares an LRU bitmap cache, plain `Dictionary` fields and a `static byte[]` scratch buffer across calls. Nothing in the server calls `Art` today — only a test — so a REST endpoint would have been its first concurrent caller.

`ItemImageService` therefore funnels every decode through a **single** `SemaphoreSlim`, not one per item: two requests for *different* items corrupt that shared state exactly as two for the same one would. Cache hits skip the gate entirely and never reach `Art`, so the cost is only on a miss. Writes go through a temp file and a move, so a reader is never handed a half-written PNG.

The alternative — putting locks inside `Art` — is a different job on a library that is deliberately standalone, and is not attempted here.

## Behaviour worth knowing

- Ids and hues parse as **hex**, with or without `0x`. A bare `1234.png` is item 0x1234, not 4660: the route is documented as `0xITEM_ID` and reading it as decimal would quietly serve the wrong item.
- The hue range (0–3000) is validated in the endpoint because `Hues.GetHue` **never fails** — it masks the index and falls back to hue 0, so an out-of-range hue would answer 200 with a *wrong image* rather than an error.
- Readiness is checked before the lookup: a shard with a wrong `UltimaDirectory` answers 503, not 404. A 404 would claim the item does not exist when the truth is that none of them do.

## Verification

997/997 tests (976 on develop plus 21 here). DocFX 0 warnings.

The three new routes were checked **on the served OpenAPI document**, not only through tests: all three carry a summary and a description.

## Also in here

- `docs/under-the-hood/rest-api.md`: the rule that endpoint groups live in `Moongate.Server` was flatly stated and these routes contradict it. It is now about the dependency, not the address — groups needing game services live in the server, groups needing only the plugin's plumbing or the client files live in the plugin.
- `AuthenticateAsync` was copied verbatim into two test classes and this change wanted a third, so it moved onto `TestApiServer` (23 call sites). The existing suites were run before anything new was added, to prove the move changed nothing.
