### PR TITLE
feat(http): shared paging and search contract for listing routes

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -210,6 +210,32 @@ item, since two requests for *different* items corrupt that state exactly as two
 for the same one would. Cache hits skip the gate entirely. Do not call `Art` from
 a request thread without going through that service.
 
+## Paged listings
+
+Listing routes share one contract, in `PageRequest` and `PagedResponse`:
+
+| Parameter | Default | Rules |
+| --- | --- | --- |
+| `page` | 1 | 1-based. Below 1 is a 400. |
+| `pageSize` | 25 | 1 to 100. Outside that is a 400. |
+| `search` | none | Free text. Blank means no filter. |
+
+The response carries `items`, `total`, `page`, `pageSize` and `totalPages`, where
+`total` counts everything the search matched and not just this page.
+
+Out-of-range values are rejected rather than corrected. A caller asking for page
+0, or for 5000 rows, has a bug: serving page 1 or 100 rows hides it, and in the
+second case leaves them believing they read everything they asked for.
+
+An empty page is a 200 with `total: 0`, never a 404. The query ran and matched
+nothing, which is a fact rather than a failure.
+
+Under it, `IEntityStore.QueryPaged` filters and orders inside the store's lock and
+clones only the page. Do not page over `GetAll()` or `Query()` — both deep-clone
+the entire store on every call, so paging over them costs the whole bucket per
+page. `QueryPaged` requires its sort key explicitly, because paging an unordered
+bucket lets a page repeat or drop a row with nothing in the response admitting it.
+
 ## Browsing the API
 
 [Scalar](https://scalar.com) serves an interactive reference at `/scalar/v1`,

--- a/src/Moongate.Core/Moongate.Core.csproj
+++ b/src/Moongate.Core/Moongate.Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Core" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.37.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Http.Plugin/Data/PageRequest.cs
+++ b/src/Moongate.Http.Plugin/Data/PageRequest.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>
+/// The paging and search arguments every listing route accepts, parsed and validated in one place so each
+/// route does not invent its own rules.
+/// </summary>
+public sealed class PageRequest
+{
+    /// <summary>What a caller gets without asking. Big enough to be useful, small enough to be cheap.</summary>
+    public const int DefaultPageSize = 25;
+
+    /// <summary>
+    /// The ceiling on one page. Asking for more is an error rather than a capped page: a caller that
+    /// requested 5000 and silently received 100 believes it has read everything.
+    /// </summary>
+    public const int MaxPageSize = 100;
+
+    private PageRequest(int page, int pageSize, string? search)
+    {
+        Page = page;
+        PageSize = pageSize;
+        Search = search;
+    }
+
+    /// <summary>1-based, as it appears on the wire.</summary>
+    public int Page { get; }
+
+    public int PageSize { get; }
+
+    /// <summary>The trimmed search text, or null when there is nothing to filter on.</summary>
+    public string? Search { get; }
+
+    /// <summary>
+    /// The 0-based offset for the store. The one place the wire's 1-based page becomes an offset: doing it
+    /// per route is how a page quietly repeats or drops a row.
+    /// </summary>
+    public int Skip
+        => (Page - 1) * PageSize;
+
+    /// <summary>
+    /// Parses the raw query values. Returns false with a caller-facing reason rather than correcting
+    /// anything: an out-of-range page or size is a bug in the caller, and clamping it hides that bug behind
+    /// a plausible-looking response.
+    /// </summary>
+    public static bool TryParse(
+        string? page,
+        string? pageSize,
+        string? search,
+        out PageRequest request,
+        out string? error
+    )
+    {
+        request = null!;
+        error = null;
+
+        var pageNumber = 1;
+
+        if (!string.IsNullOrWhiteSpace(page)
+            && (!int.TryParse(page, NumberStyles.Integer, CultureInfo.InvariantCulture, out pageNumber)
+                || pageNumber < 1))
+        {
+            error = $"'{page}' is not a page. Expected a whole number from 1 up.";
+
+            return false;
+        }
+
+        var size = DefaultPageSize;
+
+        if (!string.IsNullOrWhiteSpace(pageSize)
+            && (!int.TryParse(pageSize, NumberStyles.Integer, CultureInfo.InvariantCulture, out size)
+                || size < 1
+                || size > MaxPageSize))
+        {
+            error = $"'{pageSize}' is not a page size. Expected a whole number from 1 to {MaxPageSize}.";
+
+            return false;
+        }
+
+        // Blank and absent must mean the same thing, or "?search=" filters differently from no search.
+        var trimmed = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+
+        request = new(pageNumber, size, trimmed);
+
+        return true;
+    }
+}

--- a/src/Moongate.Http.Plugin/Data/PagedResponse.cs
+++ b/src/Moongate.Http.Plugin/Data/PagedResponse.cs
@@ -1,0 +1,23 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>One page of results, and what a caller needs to walk the rest.</summary>
+/// <param name="Items">The results on this page.</param>
+/// <param name="Total">How many results matched in total, before paging.</param>
+/// <param name="Page">The 1-based page this is.</param>
+/// <param name="PageSize">The page size used. The last page may hold fewer items.</param>
+/// <param name="TotalPages">How many pages exist at this page size. 0 when nothing matched.</param>
+public record PagedResponse<T>(IReadOnlyList<T> Items, int Total, int Page, int PageSize, int TotalPages)
+{
+    /// <summary>
+    /// Wraps a page in the request that asked for it. TotalPages rounds up: 51 results at 25 a page is
+    /// three pages, and rounding down would hide the last one from any caller that trusts the count.
+    /// </summary>
+    public static PagedResponse<T> From(IReadOnlyList<T> items, int total, PageRequest request)
+        => new(
+            items,
+            total,
+            request.Page,
+            request.PageSize,
+            (int)Math.Ceiling(total / (double)request.PageSize)
+        );
+}

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -35,8 +35,8 @@
         -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.13"/>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Network/Moongate.Network.csproj
+++ b/src/Moongate.Network/Moongate.Network.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Network" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Network" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Persistence/Moongate.Persistence.csproj
+++ b/src/Moongate.Persistence/Moongate.Persistence.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Persistence" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Persistence" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.37.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -26,11 +26,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Core" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Plugin" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.36.0"/>
-        <PackageReference Include="SquidStd.Services.Core" Version="0.36.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Services.Core" Version="0.37.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Moongate.Tests/Http/PageRequestTests.cs
+++ b/tests/Moongate.Tests/Http/PageRequestTests.cs
@@ -1,0 +1,112 @@
+using Moongate.Http.Plugin.Data;
+
+namespace Moongate.Tests.Http;
+
+public class PageRequestTests
+{
+    [Fact]
+    public void TryParse_NothingSupplied_UsesTheDefaults()
+    {
+        Assert.True(PageRequest.TryParse(null, null, null, out var request, out var error));
+
+        Assert.Null(error);
+        Assert.Equal(1, request.Page);
+        Assert.Equal(PageRequest.DefaultPageSize, request.PageSize);
+        Assert.Null(request.Search);
+    }
+
+    [Fact]
+    public void TryParse_FirstPage_SkipsNothing()
+    {
+        Assert.True(PageRequest.TryParse("1", "25", null, out var request, out _));
+
+        Assert.Equal(0, request.Skip);
+    }
+
+    [Fact]
+    public void TryParse_Skip_IsOneBasedPageTurnedIntoAnOffset()
+    {
+        // The single place page-to-offset happens. Mixing 1-based and 0-based across layers is the classic
+        // off-by-one, and it shows up as a quietly missing or repeated row, not as an error.
+        Assert.True(PageRequest.TryParse("3", "25", null, out var request, out _));
+
+        Assert.Equal(50, request.Skip);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("abc")]
+    public void TryParse_BadPage_IsRejectedRatherThanClamped(string page)
+    {
+        // Serving page 1 to someone who asked for page 0 hides their bug instead of reporting it.
+        Assert.False(PageRequest.TryParse(page, null, null, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-5")]
+    [InlineData("101")]
+    [InlineData("5000")]
+    [InlineData("abc")]
+    public void TryParse_BadPageSize_IsRejectedRatherThanClamped(string pageSize)
+    {
+        // Silently capping 5000 to 100 leaves the caller believing it read everything.
+        Assert.False(PageRequest.TryParse(null, pageSize, null, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParse_MaxPageSize_IsAllowed()
+    {
+        Assert.True(
+            PageRequest.TryParse(null, PageRequest.MaxPageSize.ToString(), null, out var request, out _)
+        );
+
+        Assert.Equal(PageRequest.MaxPageSize, request.PageSize);
+    }
+
+    [Fact]
+    public void TryParse_Search_IsTrimmed()
+    {
+        Assert.True(PageRequest.TryParse(null, null, "  tom  ", out var request, out _));
+
+        Assert.Equal("tom", request.Search);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryParse_BlankSearch_MeansNoFilter(string search)
+    {
+        // Null and blank must mean the same thing, or "?search=" behaves differently from omitting it.
+        Assert.True(PageRequest.TryParse(null, null, search, out var request, out _));
+
+        Assert.Null(request.Search);
+    }
+
+    [Fact]
+    public void From_ComputesTheTotalPages()
+    {
+        PageRequest.TryParse("1", "25", null, out var request, out _);
+
+        var response = PagedResponse<string>.From(["a"], 51, request);
+
+        Assert.Equal(3, response.TotalPages); // 51 over 25 is three pages, not two
+        Assert.Equal(51, response.Total);
+        Assert.Equal(1, response.Page);
+        Assert.Equal(25, response.PageSize);
+    }
+
+    [Fact]
+    public void From_NoResults_IsZeroPages()
+    {
+        PageRequest.TryParse("1", "25", null, out var request, out _);
+
+        var response = PagedResponse<string>.From([], 0, request);
+
+        Assert.Equal(0, response.TotalPages);
+        Assert.Empty(response.Items);
+    }
+}

--- a/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
+++ b/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
@@ -1,5 +1,6 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Interfaces;
+using SquidStd.Persistence.Abstractions.Data;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.Tests.Support;
@@ -36,6 +37,31 @@ public sealed class InMemoryEntityStore<TEntity> : IEntityStore<TEntity, Serial>
 
     public IQueryable<TEntity> Query()
         => _items.Values.AsQueryable();
+
+    /// <summary>
+    /// Mirrors the real store's ordering, ties included: equal sort keys break on the entity's serial, so
+    /// a test cannot pass against a page order production would not produce. Unlike the real store this
+    /// hands back live references rather than clones — the simplification the rest of this double already
+    /// makes.
+    /// </summary>
+    public PagedResult<TEntity> QueryPaged<TOrder>(
+        Func<TEntity, bool>? filter,
+        Func<TEntity, TOrder> orderBy,
+        int skip,
+        int take,
+        bool descending = false
+    )
+    {
+        var matched = filter is null ? _items.Values.ToList() : _items.Values.Where(filter).ToList();
+
+        var ordered = descending
+                          ? matched.OrderByDescending(orderBy).ThenByDescending(entity => entity.Id)
+                          : matched.OrderBy(orderBy).ThenBy(entity => entity.Id);
+
+        IReadOnlyList<TEntity> page = [.. ordered.Skip(skip).Take(take)];
+
+        return new(page, matched.Count, skip, take);
+    }
 
     public ValueTask<bool> RemoveAsync(Serial id, CancellationToken cancellationToken = default)
         => new(_items.Remove(id));


### PR DESCRIPTION
The plumbing every paged CRUD will share, written once. No route uses it yet — the character endpoints are the first consumer, in the next PR.

## What changed

**SquidStd 0.37.0.** Brings `IEntityStore.QueryPaged`, which pages under the store's lock and clones only the returned page. All 16 references across the 10 SquidStd packages move together — mixed versions of sibling packages resolve unpredictably and fail without naming the cause. Each package was checked as published at 0.37.0 before the bump.

**`PagedResponse<T>` and `PageRequest`.** One envelope and one binder, so each listing route does not invent its own rules.

## Decisions worth reviewing

**Out-of-range values are 400, not a silent clamp.** A caller asking for page 0, or 5000 rows, has a bug. Serving page 1 or capping to 100 hides it — and the second case leaves them believing they read everything they asked for.

**`PageRequest.Skip` is the only place 1-based becomes 0-based.** The wire is 1-based, the store is 0-based, and doing that conversion per route is how a page quietly repeats or drops a row.

**`TotalPages` rounds up.** 51 results at 25 a page is three pages; rounding down would hide the last one from any caller that trusts the count.

## The interface break landed on us

`QueryPaged` is a new member on `IEntityStore`. The SquidStd PR named a downstream test double as the only plausible casualty — and it turned out to be ours: `InMemoryEntityStore`. It now implements `QueryPaged`, mirroring the real store's ordering **including the tiebreak on serial**, so a test cannot pass against a page order production would not produce. It hands back live references rather than clones, which is the simplification the rest of that double already makes.

## Verification

1014 tests (997 on develop plus 17 here), 0 failures. DocFX 0 warnings.
