### PR TITLE
feat(http): character endpoints for players and staff

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -109,6 +109,8 @@ good token that is simply not staff.
 | `POST`   | `/api/v1/admin/accounts`             | `admin`  | 201 and a `Location`, or 400 / 409 |
 | `PATCH`  | `/api/v1/admin/accounts/{username}`  | `admin`  | the updated account, or 400 / 404  |
 | `DELETE` | `/api/v1/admin/accounts/{username}`  | `admin`  | 204, or 404 / 409 / 503            |
+| `GET`    | `/api/v1/player/me/characters`       | `player` | the caller's own characters        |
+| `GET`    | `/api/v1/admin/characters`           | `admin`  | every character, paged             |
 | `GET`    | `/api/v1/images/items/{id}.png`      | none     | item art as PNG, or 400 / 404 / 503 |
 | `POST`   | `/api/v1/admin/images/items`         | `admin`  | 202, or 409 / 503                  |
 | `GET`    | `/api/v1/admin/images/items`         | `admin`  | export progress                    |
@@ -176,6 +178,36 @@ and lose their character from under them.
 - **409** — a character on the account is being played. Nothing is deleted.
 - **503** — the game loop did not answer within five seconds. Nothing is
   deleted; the shard is unwell and the log says so.
+
+## Characters
+
+`GET /api/v1/player/me/characters` reports the caller's own characters — stats,
+appearance and where they stand. The account comes from the token, never from the
+request: an id a caller could supply would let anyone list anyone's characters by
+changing a number. It is not paged, because an account holds a handful of
+characters and a page envelope around five rows is ceremony.
+
+`GET /api/v1/admin/characters` is the staff view of every character, paged and
+searchable. `search` is free text matched against both the character's name and
+the owning account's username, so "find me so-and-so's character" is one query.
+
+Nothing on a mobile marks it as a player character: the only link is the owning
+account's `MobileIds`. The admin route therefore reads the accounts first, which
+it must do anyway to name each character's owner, and uses that to tell characters
+from the NPCs sharing the mobile store.
+
+Neither route returns `MobileEntity`. It carries `BrainScriptId`, `LootTableId`
+and `BackpackId`, and a field added to it later would publish itself; the DTO
+names its fields for the same reason `AccountResponse` does.
+
+There is no fame or karma. `ITitleService` takes both, but nothing stores them on
+the entity yet, and a field pinned at 0 in this reference would be worse than an
+absent one. They arrive with the system that moves them.
+
+One detail worth copying if you add a route that reads the caller's identity: the
+account id is read from `NameIdentifier` before `sub`. `JwtTokenService` writes it
+into `sub`, but JwtBearer's inbound claim mapping is on by default and renames it
+before the principal reaches the route — reading only `sub` 401s every request.
 
 ## Item images
 

--- a/src/Moongate.Server/Data/Api/CharacterResponse.cs
+++ b/src/Moongate.Server/Data/Api/CharacterResponse.cs
@@ -1,0 +1,70 @@
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Server.Data.Api;
+
+/// <summary>
+/// A character as the API reports it. Deliberately not <c>MobileEntity</c>, which carries BrainScriptId,
+/// LootTableId and BackpackId: returning the entity would publish the shard's internals to every caller,
+/// and a field added to the entity later would publish itself. Naming the fields here means that cannot
+/// happen by default — the same reason <see cref="AccountResponse" /> exists rather than returning
+/// AccountEntity with its PasswordHash.
+/// </summary>
+/// <param name="Serial">The character's serial, as <c>0x40000001</c>.</param>
+/// <param name="AccountUsername">The owning account. Null on the player's own route, where it is the caller.</param>
+public sealed record CharacterResponse(
+    string Serial,
+    string Name,
+    string? AccountUsername,
+    string Race,
+    string Gender,
+    int Body,
+    int Strength,
+    int Dexterity,
+    int Intelligence,
+    int Hits,
+    int HitsMax,
+    int Stamina,
+    int StaminaMax,
+    int Mana,
+    int ManaMax,
+    int Kills,
+    int SkinHue,
+    int HairStyle,
+    int HairHue,
+    int MapId,
+    int X,
+    int Y,
+    int Z
+)
+{
+    /// <summary>
+    /// Projects a mobile. Pass <paramref name="accountUsername" /> as null on the player's own route:
+    /// telling callers who they are is noise, and the admin route is the one that needs the owner.
+    /// </summary>
+    public static CharacterResponse From(MobileEntity mobile, string? accountUsername)
+        => new(
+            mobile.Id.ToString(),
+            mobile.Name,
+            accountUsername,
+            mobile.Race.ToString(),
+            mobile.Gender.ToString(),
+            mobile.Body,
+            mobile.Strength,
+            mobile.Dexterity,
+            mobile.Intelligence,
+            mobile.Hits,
+            mobile.HitsMax,
+            mobile.Stamina,
+            mobile.StaminaMax,
+            mobile.Mana,
+            mobile.ManaMax,
+            mobile.Kills,
+            mobile.SkinHue.Value,
+            mobile.HairStyle,
+            mobile.HairHue.Value,
+            mobile.MapId,
+            mobile.Position.X,
+            mobile.Position.Y,
+            mobile.Position.Z
+        );
+}

--- a/src/Moongate.Server/Data/Internal/OwnedCharacter.cs
+++ b/src/Moongate.Server/Data/Internal/OwnedCharacter.cs
@@ -1,0 +1,6 @@
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Server.Data.Internal;
+
+/// <summary>A character paired with the account that owns it, on the way to the API.</summary>
+public sealed record OwnedCharacter(MobileEntity Mobile, string AccountUsername);

--- a/src/Moongate.Server/Endpoints/CharacterAdminEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/CharacterAdminEndpoints.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Interfaces.Accounts;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>Staff-only views over every character on the shard.</summary>
+public sealed class CharacterAdminEndpoints : IApiEndpointRegistration
+{
+    private readonly ICharacterQueryService _characters;
+
+    public CharacterAdminEndpoints(ICharacterQueryService characters)
+    {
+        _characters = characters;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/admin/characters", List)
+              .WithName("ListCharacters")
+              .WithTags("characters")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>Every player character on the shard, paged.</summary>
+    /// <remarks>
+    /// Ordered by character name. Pass search to filter: it is free text, case-insensitive, and matches
+    /// either the character's name or the owning account's username, so "find me so-and-so's character" is
+    /// one query. Page is 1-based and defaults to 1; pageSize defaults to 25 and cannot exceed 100. NPCs
+    /// are not characters and never appear. A search matching nothing is an empty page, not an error.
+    /// </remarks>
+    private IResult List(string? page, string? pageSize, string? search)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var found = _characters.Search(request.Search, request.Skip, request.PageSize);
+
+        IReadOnlyList<CharacterResponse> items =
+            [.. found.Items.Select(owned => CharacterResponse.From(owned.Mobile, owned.AccountUsername))];
+
+        return Results.Ok(PagedResponse<CharacterResponse>.From(items, found.Total, request));
+    }
+}

--- a/src/Moongate.Server/Endpoints/CharacterEndpoints.cs
+++ b/src/Moongate.Server/Endpoints/CharacterEndpoints.cs
@@ -1,0 +1,91 @@
+using System.Globalization;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Interfaces.Accounts;
+
+namespace Moongate.Server.Endpoints;
+
+/// <summary>What an authenticated account may ask about its own characters.</summary>
+public sealed class CharacterEndpoints : IApiEndpointRegistration
+{
+    private readonly IAccountService _accounts;
+    private readonly ICharacterService _characters;
+
+    public CharacterEndpoints(IAccountService accounts, ICharacterService characters)
+    {
+        _accounts = accounts;
+        _characters = characters;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
+        // has none — the route would document itself blank.
+        routes.MapGet("/api/v1/player/me/characters", GetMine)
+              .WithName("GetMyCharacters")
+              .WithTags("player")
+              .RequireAuthorization(HttpServerService.PlayerPolicy);
+    }
+
+    /// <summary>The caller's own characters.</summary>
+    /// <remarks>
+    /// Reports every character on the account the bearer token belongs to, with its stats, appearance and
+    /// where it stands. Never another account's. The owner field is null here: the caller is the owner. An
+    /// account with no characters gets an empty list, not an error.
+    /// </remarks>
+    private IResult GetMine(ClaimsPrincipal user)
+    {
+        // The account comes from the token, never from the query string: reading an id the caller supplied
+        // would let anyone list anyone's characters by changing a number.
+        if (!TryReadAccountId(user, out var accountId))
+        {
+            return Results.Problem(
+                "The token carries no account id.",
+                statusCode: StatusCodes.Status401Unauthorized
+            );
+        }
+
+        if (_accounts.GetById(accountId) is null)
+        {
+            return Results.Problem(
+                "The account this token belongs to no longer exists.",
+                statusCode: StatusCodes.Status404NotFound
+            );
+        }
+
+        return Results.Ok(
+            _characters.GetPlayerCharacters(accountId)
+                       .Select(mobile => CharacterResponse.From(mobile, null))
+        );
+    }
+
+    /// <summary>
+    /// Reads the account id the token was issued with. JwtTokenService writes it into <c>sub</c>, but
+    /// JwtBearer's inbound claim mapping is on by default and renames <c>sub</c> to NameIdentifier before
+    /// the principal reaches here — so the mapped name is tried first and the raw one second, and the
+    /// route survives that setting being changed either way.
+    /// </summary>
+    internal static bool TryReadAccountId(ClaimsPrincipal user, out Serial accountId)
+    {
+        accountId = default;
+
+        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier)
+                  ?? user.FindFirstValue(JwtRegisteredClaimNames.Sub);
+
+        if (!uint.TryParse(sub, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return false;
+        }
+
+        accountId = new(value);
+
+        return true;
+    }
+}

--- a/src/Moongate.Server/Interfaces/Accounts/IAccountService.cs
+++ b/src/Moongate.Server/Interfaces/Accounts/IAccountService.cs
@@ -23,6 +23,13 @@ public interface IAccountService
     /// <summary>Returns the account with that username, or null when none has it.</summary>
     AccountEntity? GetByUsername(string username);
 
+    /// <summary>
+    /// Returns the account with that id, or null when none has it. A direct key lookup, unlike
+    /// <see cref="GetByUsername" /> which scans and clones the whole store — worth having because the
+    /// bearer token carries the account id, so a route already knows it and need not search by name.
+    /// </summary>
+    AccountEntity? GetById(Serial accountId);
+
     /// <summary>Returns every account's username, in store order.</summary>
     IReadOnlyList<string> GetUsernames();
 

--- a/src/Moongate.Server/Interfaces/Accounts/ICharacterQueryService.cs
+++ b/src/Moongate.Server/Interfaces/Accounts/ICharacterQueryService.cs
@@ -1,0 +1,17 @@
+using Moongate.Server.Data.Internal;
+using SquidStd.Persistence.Abstractions.Data;
+
+namespace Moongate.Server.Interfaces.Accounts;
+
+/// <summary>Read-only, paged views over every player character. Exists for the admin API.</summary>
+public interface ICharacterQueryService
+{
+    /// <summary>
+    /// One page of player characters with their owners, ordered by character name, filtered by a free-text
+    /// match on the character's name or the owning account's username. NPCs are excluded.
+    /// </summary>
+    /// <param name="search">Case-insensitive substring, or null for everything.</param>
+    /// <param name="skip">Characters to skip. Past the end yields an empty page and the true total.</param>
+    /// <param name="take">Page size.</param>
+    PagedResult<OwnedCharacter> Search(string? search, int skip, int take);
+}

--- a/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
+++ b/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
@@ -32,5 +32,6 @@ public class MoongateApiEndpointsPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<AdminEndpoints>();
         container.RegisterApiEndpoint<PlayerEndpoints>();
         container.RegisterApiEndpoint<CharacterEndpoints>();
+        container.RegisterApiEndpoint<CharacterAdminEndpoints>();
     }
 }

--- a/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
+++ b/src/Moongate.Server/MoongateApiEndpointsPlugin.cs
@@ -31,5 +31,6 @@ public class MoongateApiEndpointsPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<AuthEndpoints>();
         container.RegisterApiEndpoint<AdminEndpoints>();
         container.RegisterApiEndpoint<PlayerEndpoints>();
+        container.RegisterApiEndpoint<CharacterEndpoints>();
     }
 }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -131,6 +131,7 @@ await ConsoleApp.RunAsync(
 
                 container.Register<IAccountService, AccountService>(Reuse.Singleton);
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);
+                container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
                 container.Register<IMobileFactoryService, MobileFactoryService>(Reuse.Singleton);
 
                 container.RegisterInstance(Random.Shared);

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -54,6 +54,9 @@ public class AccountService : IAccountService
     public AccountEntity? GetByUsername(string username)
         => _accountStore.Query().FirstOrDefault(account => account.Username == username);
 
+    public AccountEntity? GetById(Serial accountId)
+        => _accountStore.GetById(accountId);
+
     public IReadOnlyList<string> GetUsernames()
         => _accountStore.Query().Select(account => account.Username).ToList();
 

--- a/src/Moongate.Server/Services/Accounts/CharacterQueryService.cs
+++ b/src/Moongate.Server/Services/Accounts/CharacterQueryService.cs
@@ -1,0 +1,65 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Data.Internal;
+using Moongate.Server.Interfaces.Accounts;
+using SquidStd.Persistence.Abstractions.Data;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Services.Accounts;
+
+/// <summary>
+/// Pages player characters out of the mobile store. Nothing on a mobile says it is a player character —
+/// the only link is the owning account's id list — so the accounts are read first, both to know which
+/// mobiles to keep and to name each character's owner.
+/// </summary>
+public sealed class CharacterQueryService : ICharacterQueryService
+{
+    private readonly IAccountService _accounts;
+    private readonly IEntityStore<MobileEntity, Serial> _mobileStore;
+
+    public CharacterQueryService(IAccountService accounts, IPersistenceService persistenceService)
+    {
+        _accounts = accounts;
+        _mobileStore = persistenceService.GetStore<MobileEntity, Serial>();
+    }
+
+    public PagedResult<OwnedCharacter> Search(string? search, int skip, int take)
+    {
+        // One pass over the accounts, needed either way: it is what tells a character from an NPC, and the
+        // admin list has to name each character's owner regardless. Accounts are few and small next to the
+        // mobile store, which holds every NPC on the shard.
+        var owners = new Dictionary<Serial, string>();
+
+        foreach (var account in _accounts.GetAll())
+        {
+            foreach (var mobileId in account.MobileIds)
+            {
+                owners[mobileId] = account.Username;
+            }
+        }
+
+        // QueryPaged filters the live entities under the store's lock and clones only the page. Filtering
+        // over GetAll() or Query() instead would deep-clone every mobile on the shard first, which is the
+        // cost this exists to avoid.
+        var page = _mobileStore.QueryPaged(
+            mobile => owners.TryGetValue(mobile.Id, out var username) && Matches(mobile, username, search),
+            mobile => mobile.Name,
+            skip,
+            take
+        );
+
+        IReadOnlyList<OwnedCharacter> items =
+            [.. page.Items.Select(mobile => new OwnedCharacter(mobile, owners[mobile.Id]))];
+
+        return new(items, page.Total, page.Skip, page.Take);
+    }
+
+    /// <summary>
+    /// One box, matched against the character's name and its owner's username: the staff question is "find
+    /// me so-and-so's character", and which of the two names they typed is not worth asking.
+    /// </summary>
+    private static bool Matches(MobileEntity mobile, string username, string? search)
+        => string.IsNullOrEmpty(search)
+           || mobile.Name.Contains(search, StringComparison.OrdinalIgnoreCase)
+           || username.Contains(search, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Moongate.Server/Services/Accounts/CharacterService.cs
+++ b/src/Moongate.Server/Services/Accounts/CharacterService.cs
@@ -164,7 +164,11 @@ public class CharacterService : ICharacterService
 
     public IReadOnlyCollection<MobileEntity> GetPlayerCharacters(Serial accountId)
     {
-        var account = _accountStore.Query().FirstOrDefault(a => a.Id == accountId);
+        // Reads the account's own id list rather than filtering the mobile store by it. The store's Query()
+        // deep-clones every entity it holds before any Where runs, so the old shape cloned every account
+        // and every mobile — NPCs included — to return a handful of characters. GetById is a dictionary
+        // lookup and one clone, and an account holds at most a few characters.
+        var account = _accountStore.GetById(accountId);
 
         if (account == null)
         {
@@ -173,7 +177,19 @@ public class CharacterService : ICharacterService
             return [];
         }
 
-        return [.. _mobileStore.Query().Where(mobile => account.MobileIds.Contains(mobile.Id))];
+        var characters = new List<MobileEntity>(account.MobileIds.Count);
+
+        foreach (var id in account.MobileIds)
+        {
+            // A dangling id is not a failure worth refusing the whole list for: the character is gone and
+            // the account's list has not caught up. Skipping is what the old filter did implicitly.
+            if (_mobileStore.GetById(id) is { } mobile)
+            {
+                characters.Add(mobile);
+            }
+        }
+
+        return characters;
     }
 
     // Depth-first so a container's contents are gone before the container itself.

--- a/tests/Moongate.Tests/Http/CharacterAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/CharacterAdminEndpointsTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Data.Api;
+using Moongate.Server.Endpoints;
+using Moongate.Server.Interfaces.Accounts;
+using Moongate.Server.Services.Accounts;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http;
+
+public class CharacterAdminEndpointsTests
+{
+    private const string Route = "/api/v1/admin/characters";
+
+    private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+        => await TestApiServer.StartAsync(
+            level,
+            configure: container =>
+            {
+                container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new CharacterAdminEndpoints(container.Resolve<ICharacterQueryService>())
+                );
+            }
+        );
+
+    [Fact]
+    public async Task List_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsStaff_ReturnsEveryCharacterWithItsOwner()
+    {
+        await using var server = await StartAsync();
+        server.Characters.CreateCharacter(server.Accounts.GetByUsername("tom")!.Id, Packet("Freydis"));
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+        server.Characters.CreateCharacter(server.Accounts.GetByUsername("alice")!.Id, Packet("Aramis"));
+
+        // Every NPC on a real shard looks like this: a mobile no account lists. It is not a character.
+        await server.Persistence.Store<MobileEntity>().UpsertAsync(new() { Name = "a wandering healer" });
+
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<CharacterResponse>>(Route);
+
+        Assert.Equal(2, page!.Total);
+        Assert.All(page.Items, character => Assert.NotNull(character.AccountUsername));
+        Assert.Contains(page.Items, character => character.AccountUsername == "alice");
+    }
+
+    [Fact]
+    public async Task List_NoMatches_IsAnEmptyPageNotANotFound()
+    {
+        // The query ran and matched nothing. That is a fact, not a failure.
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync($"{Route}?search=nobody");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.Content.ReadFromJsonAsync<PagedResponse<CharacterResponse>>();
+
+        Assert.Equal(0, page!.Total);
+        Assert.Empty(page.Items);
+    }
+
+    [Fact]
+    public async Task List_SearchMatchesTheCharacterName()
+    {
+        await using var server = await StartAsync();
+        var tom = server.Accounts.GetByUsername("tom")!.Id;
+        server.Characters.CreateCharacter(tom, Packet("Aramis"));
+        server.Characters.CreateCharacter(tom, Packet("Bors"));
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<CharacterResponse>>($"{Route}?search=ara");
+
+        Assert.Equal("Aramis", Assert.Single(page!.Items).Name);
+    }
+
+    [Fact]
+    public async Task List_SearchMatchesTheOwningUsername()
+    {
+        // The staff question is "find me so-and-so's character", so one box searches both.
+        await using var server = await StartAsync();
+        server.Characters.CreateCharacter(server.Accounts.GetByUsername("tom")!.Id, Packet("Aramis"));
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+        server.Characters.CreateCharacter(server.Accounts.GetByUsername("alice")!.Id, Packet("Bors"));
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<CharacterResponse>>($"{Route}?search=alice");
+
+        Assert.Equal("Bors", Assert.Single(page!.Items).Name);
+    }
+
+    [Fact]
+    public async Task List_Pages()
+    {
+        await using var server = await StartAsync();
+        var tom = server.Accounts.GetByUsername("tom")!.Id;
+        server.Characters.CreateCharacter(tom, Packet("Aramis"));
+        server.Characters.CreateCharacter(tom, Packet("Bors"));
+        server.Characters.CreateCharacter(tom, Packet("Cedric"));
+        await server.AuthenticateAsync();
+
+        var first = await server.Client.GetFromJsonAsync<PagedResponse<CharacterResponse>>(
+            $"{Route}?page=1&pageSize=2"
+        );
+        var second = await server.Client.GetFromJsonAsync<PagedResponse<CharacterResponse>>(
+            $"{Route}?page=2&pageSize=2"
+        );
+
+        Assert.Equal(2, first!.Items.Count);
+        Assert.Single(second!.Items);
+        Assert.Equal(3, first.Total);
+        Assert.Equal(2, first.TotalPages);
+
+        // Pages must not overlap, which is what the ordering key is for.
+        Assert.Empty(first.Items.Select(c => c.Serial).Intersect(second.Items.Select(c => c.Serial)));
+    }
+
+    [Theory]
+    [InlineData("?page=0")]
+    [InlineData("?pageSize=5000")]
+    public async Task List_OutOfRangePaging_IsBadRequest(string query)
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync($"{Route}{query}")).StatusCode);
+    }
+
+    private static CharacterCreationPacket Packet(string name)
+        => new(
+            0,
+            name,
+            0,
+            4,
+            GenderType.Female,
+            RaceType.Elf,
+            45,
+            20,
+            25,
+            [new(1, 50)],
+            0x03EA,
+            0x203C,
+            0x044E,
+            0x2040,
+            0x0450,
+            0,
+            0x0765,
+            0x0766
+        );
+}

--- a/tests/Moongate.Tests/Http/CharacterEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/CharacterEndpointsTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Http.Json;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Types;
+using Moongate.Server.Data.Api;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http;
+
+public class CharacterEndpointsTests
+{
+    private const string Route = "/api/v1/player/me/characters";
+
+    [Fact]
+    public async Task GetMyCharacters_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMyCharacters_NoCharacters_IsAnEmptyList()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var characters = await server.Client.GetFromJsonAsync<List<CharacterResponse>>(Route);
+
+        Assert.NotNull(characters);
+        Assert.Empty(characters);
+    }
+
+    [Fact]
+    public async Task GetMyCharacters_ReturnsTheCallersCharacters()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        var mine = server.Characters.CreateCharacter(server.Accounts.GetByUsername("tom")!.Id, Packet("Freydis"));
+        await server.AuthenticateAsync();
+
+        var characters = await server.Client.GetFromJsonAsync<List<CharacterResponse>>(Route);
+
+        var only = Assert.Single(characters!);
+        Assert.Equal(mine.Id.ToString(), only.Serial);
+        Assert.Equal("Freydis", only.Name);
+
+        // The caller already knows who they are; naming the owner back at them is noise.
+        Assert.Null(only.AccountUsername);
+    }
+
+    [Fact]
+    public async Task GetMyCharacters_NeverReturnsAnotherAccountsCharacters()
+    {
+        // The one defect here that would be a security bug rather than an inconvenience.
+        await using var server = await TestApiServer.StartAsync();
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+        server.Characters.CreateCharacter(server.Accounts.GetByUsername("alice")!.Id, Packet("Aramis"));
+        await server.AuthenticateAsync();
+
+        var characters = await server.Client.GetFromJsonAsync<List<CharacterResponse>>(Route);
+
+        Assert.Empty(characters!);
+    }
+
+    [Fact]
+    public async Task GetMyCharacters_IgnoresMobilesOwnedByNobody()
+    {
+        // Every NPC on a real shard looks like this in the store: a mobile no account lists.
+        await using var server = await TestApiServer.StartAsync();
+        await server.Persistence.Store<Moongate.Persistence.Entities.MobileEntity>()
+                    .UpsertAsync(new() { Name = "a wandering healer" });
+        await server.AuthenticateAsync();
+
+        var characters = await server.Client.GetFromJsonAsync<List<CharacterResponse>>(Route);
+
+        Assert.Empty(characters!);
+    }
+
+    private static CharacterCreationPacket Packet(string name)
+        => new(
+            0,
+            name,
+            0,
+            4,
+            GenderType.Female,
+            RaceType.Elf,
+            45,
+            20,
+            25,
+            [new(1, 50)],
+            0x03EA,
+            0x203C,
+            0x044E,
+            0x2040,
+            0x0450,
+            0,
+            0x0765,
+            0x0766
+        );
+}

--- a/tests/Moongate.Tests/Http/MoongateApiEndpointsPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateApiEndpointsPluginTests.cs
@@ -27,6 +27,8 @@ public class MoongateApiEndpointsPluginTests
                 typeof(AccountEndpoints),
                 typeof(AdminEndpoints),
                 typeof(AuthEndpoints),
+                typeof(CharacterAdminEndpoints),
+                typeof(CharacterEndpoints),
                 typeof(PlayerEndpoints),
                 typeof(VersionEndpoints)
             ],

--- a/tests/Moongate.Tests/Server/Accounts/AccountServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/AccountServiceTests.cs
@@ -225,6 +225,28 @@ public class AccountServiceTests
         Assert.NotNull(persistence.Store<MobileEntity>().GetById(other.Id));
     }
 
+    [Fact]
+    public void GetById_KnownAccount_ReturnsIt()
+    {
+        // The JWT carries the account id in Sub, so a route holding a token can look the account up
+        // directly. GetByUsername answers the same question by scanning and deep-cloning every account.
+        var persistence = new FakePersistenceService();
+        var service = Service(persistence);
+        service.Create("tom", "secret", null, AccountLevelType.Player);
+        var created = service.GetByUsername("tom");
+
+        var fetched = service.GetById(created!.Id);
+
+        Assert.NotNull(fetched);
+        Assert.Equal("tom", fetched!.Username);
+    }
+
+    [Fact]
+    public void GetById_UnknownAccount_ReturnsNull()
+    {
+        Assert.Null(Service(new FakePersistenceService()).GetById(new Serial(0xDEADBEEF)));
+    }
+
     private static AccountService Service(
         FakePersistenceService persistence, ICharacterService? characters = null, ISessionManager? sessions = null
     )

--- a/tests/Moongate.Tests/Server/CharacterServiceTests.cs
+++ b/tests/Moongate.Tests/Server/CharacterServiceTests.cs
@@ -323,6 +323,36 @@ public class CharacterServiceTests
     }
 
 
+    [Fact]
+    public async Task GetPlayerCharacters_ReturnsOnlyTheAccountsOwnCharacters()
+    {
+        // Characterises the behaviour before the read path is rewritten: the account's own characters, and
+        // nothing else — not another account's, and not a mobile belonging to nobody, which is what every
+        // NPC on a real shard looks like in this store.
+        var persistence = new FakePersistenceService();
+        var mine = (Serial)5;
+        var theirs = (Serial)6;
+        await persistence.Store<AccountEntity>().UpsertAsync(new() { Id = mine, Username = "bob" });
+        await persistence.Store<AccountEntity>().UpsertAsync(new() { Id = theirs, Username = "alice" });
+
+        var service = Service(persistence, new());
+        var myCharacter = service.CreateCharacter(mine, Packet());
+        service.CreateCharacter(theirs, Packet());
+        await persistence.Store<MobileEntity>().UpsertAsync(new() { Name = "a wandering healer" });
+
+        var characters = service.GetPlayerCharacters(mine);
+
+        Assert.Equal(myCharacter.Id, Assert.Single(characters).Id);
+    }
+
+    [Fact]
+    public void GetPlayerCharacters_UnknownAccount_IsEmpty()
+    {
+        var service = Service(new FakePersistenceService(), new());
+
+        Assert.Empty(service.GetPlayerCharacters(new Serial(0xDEADBEEF)));
+    }
+
     private static CharacterCreationPacket Packet()
         => new(
             0,

--- a/tests/Moongate.Tests/Support/StubAccountService.cs
+++ b/tests/Moongate.Tests/Support/StubAccountService.cs
@@ -32,6 +32,9 @@ public sealed class StubAccountService : IAccountService
     public AccountEntity? GetByUsername(string username)
         => throw new NotSupportedException();
 
+    public AccountEntity? GetById(Serial accountId)
+        => throw new NotSupportedException();
+
     public IReadOnlyList<string> GetUsernames()
         => throw new NotSupportedException();
 

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -29,7 +29,8 @@ public sealed class TestApiServer : IAsyncDisposable
         HttpClient client,
         IAccountService accounts,
         CharacterService characters,
-        StubSessionManager sessions
+        StubSessionManager sessions,
+        FakePersistenceService persistence
     )
     {
         _service = service;
@@ -37,6 +38,7 @@ public sealed class TestApiServer : IAsyncDisposable
         Accounts = accounts;
         Characters = characters;
         Sessions = sessions;
+        Persistence = persistence;
     }
 
     public HttpClient Client { get; }
@@ -45,6 +47,12 @@ public sealed class TestApiServer : IAsyncDisposable
 
     /// <summary>Real, over the same fake persistence: a test can give an account a character.</summary>
     public CharacterService Characters { get; }
+
+    /// <summary>
+    /// The store behind the services, for the things no service creates: a mobile owned by no account is
+    /// what every NPC on a real shard looks like here, and there is no other way to seed one.
+    /// </summary>
+    public FakePersistenceService Persistence { get; }
 
     /// <summary>Lets a test declare a character as being played, via <see cref="StubSessionManager.Played" />.</summary>
     public StubSessionManager Sessions { get; }
@@ -109,6 +117,7 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterApiEndpointInstance(new AuthEndpoints(accounts, container.Resolve<IJwtTokenService>()));
         container.RegisterApiEndpointInstance(new AdminEndpoints(moongateConfig, sessions));
         container.RegisterApiEndpointInstance(new PlayerEndpoints());
+        container.RegisterApiEndpointInstance(new CharacterEndpoints(accounts, characters));
 
         // Lets a test add endpoint groups this fixture cannot know about — the ones the HTTP plugin owns.
         configure?.Invoke(container);
@@ -121,7 +130,8 @@ public sealed class TestApiServer : IAsyncDisposable
             new() { BaseAddress = new($"http://127.0.0.1:{service.BoundPort}") },
             accounts,
             characters,
-            sessions
+            sessions,
+            persistence
         );
     }
 

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -12,6 +12,7 @@ using Moongate.Server.Endpoints;
 using Moongate.Server.Interfaces.Accounts;
 using Moongate.Server.Services.Accounts;
 using SquidStd.Core.Interfaces.Config;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Support;
@@ -99,6 +100,10 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterInstance(TimeProvider.System);
         container.RegisterInstance(moongateConfig);
         container.RegisterInstance<IAccountService>(accounts);
+
+        // Mirrors production, where the persistence plugin registers it: a service resolved from this
+        // container can ask for a store, exactly as it does on a real shard.
+        container.RegisterInstance<IPersistenceService>(persistence);
         container.RegisterInstance<IConfigManagerService>(new StubConfigManagerService());
         container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
 


### PR DESCRIPTION
Two routes: a player lists their own characters, staff list every character paged and searchable. Data only — no images.

## The routes

`GET /api/v1/player/me/characters` — the caller's own. Not paged: an account holds a handful of characters, and a page envelope around five rows is ceremony.

`GET /api/v1/admin/characters?page=1&pageSize=25&search=tom` — every character, with its owner. `search` is one box matched against **both** the character's name and the owning username, because the staff question is "find me so-and-so's character" and which of the two they typed is not worth asking.

Both live in `Moongate.Server`, not the HTTP plugin: they need game services, which the plugin cannot reach. That is the rule as amended in the image PR — about the dependency, not the address.

## Two traps found while building this

**`sub` is not `sub` by the time it reaches the route.** `JwtTokenService` writes the account id into `sub`, but JwtBearer's inbound claim mapping is on by default and renames it to `NameIdentifier`. Reading only `sub` — as the plan said — would have 401'd every request. The code reads the mapped name first and the raw one second, so it survives that setting changing either way.

**Nothing marks a mobile as a player character.** No flag, no `AccountId` — the only link is the owning account's `MobileIds`, and the mobile store holds every NPC alongside. So the admin route reads the accounts first, which it must do anyway to name each owner, and uses that to tell characters from NPCs. A test asserts a mobile owned by nobody never appears.

## A fix that came free

`CharacterService.GetPlayerCharacters` filtered the mobile store by the account's id list. `Query()` deep-clones **every entity it holds** before any `Where` runs — so this cloned every account *and* every mobile, NPCs included, to return a handful of characters, on every call. It now reads the id list and does one dictionary lookup per character.

Behaviour is unchanged: the two new tests were run against the **old** body first, to prove the rewrite only changed the cost. Character select and every other caller get the fix for free.

`IAccountService.GetById` is new for the same reason — the token already carries the id, and `GetByUsername` scans and clones the whole store to answer the same question.

## Not in here, deliberately

**No fame or karma.** `ITitleService.GetTitle(name, fame, karma, female)` exists and takes both, but `MobileEntity` carries neither. A field pinned at 0 in the API reference is worse than an absent one; they arrive with the system that moves them.

Neither route returns `MobileEntity` — it carries `BrainScriptId`, `LootTableId` and `BackpackId`, and a field added later would publish itself.

## Verification

1032 tests, 0 failures. DocFX 0 warnings. Both routes checked **on the served OpenAPI document**, not only through tests: each carries a summary and a description.

The test that matters most is the cross-account one: a player must never see another account's characters. That is the only defect here that would be a security bug rather than an inconvenience.
