### PR TITLE
feat(http): serve UO map facets as tiles and whole images

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -114,6 +114,11 @@ good token that is simply not staff.
 | `GET`    | `/api/v1/images/items/{id}.png`      | none     | item art as PNG, or 400 / 404 / 503 |
 | `POST`   | `/api/v1/admin/images/items`         | `admin`  | 202, or 409 / 503                  |
 | `GET`    | `/api/v1/admin/images/items`         | `admin`  | export progress                    |
+| `GET`    | `/api/v1/images/maps`                | none     | the facets and their tile grids    |
+| `GET`    | `/api/v1/images/maps/{map}/full.png` | none     | a whole facet as one PNG           |
+| `GET`    | `/api/v1/images/maps/{map}/{z}/{x}/{y}.png` | none | one map tile                  |
+| `POST`   | `/api/v1/admin/images/maps`          | `admin`  | 202, or 409 / 503                  |
+| `GET`    | `/api/v1/admin/images/maps`          | `admin`  | pre-warm progress                  |
 
 `/api/v1/version` is deliberately unauthenticated: a launcher or the website
 checks compatibility with it, and it reveals nothing an operator would want
@@ -267,6 +272,58 @@ clones only the page. Do not page over `GetAll()` or `Query()` — both deep-clo
 the entire store on every call, so paging over them costs the whole bucket per
 page. `QueryPaged` requires its sort key explicitly, because paging an unordered
 bucket lets a page repeat or drop a row with nothing in the response admitting it.
+
+## Map images
+
+`GET /api/v1/images/maps/{map}/{z}/{x}/{y}.png` serves a facet as 256×256 slippy-map
+tiles, open without a token: like the item art, it is client data every player
+already has. Facets are named, case-insensitively — `felucca`, `trammel`,
+`ilshenar`, `malas`, `tokuno`, `termur`.
+
+Zoom counts **up to detail**: `0` is the whole facet in a single tile, and `maxZoom`
+is one pixel per map tile. `maxZoom` differs per facet — it is
+`ceil(log2(longest side / 256))`, so Felucca's is 5 — and it depends on the shard's
+own client files. Read `GET /api/v1/images/maps` and configure the viewer from what
+it reports rather than hardcoding it.
+
+`GET /api/v1/images/maps/{map}/full.png` is the whole facet in one image, for
+downloading or printing rather than browsing.
+
+`POST /api/v1/admin/images/maps` builds every tile and whole-facet image ahead of
+time; `GET` on the same route reports progress. Staff-only. Run it before anyone
+opens a viewer: the first request at a low zoom otherwise builds every tile beneath
+it.
+
+### How a tile is built, and why
+
+A tile at native zoom is one `Map.GetImage` of exactly **32 blocks** — which is why
+256 was chosen: a block is 8×8 tiles, so a native tile is a whole number of blocks
+and never straddles one. Every zoom below is composed by halving its four children,
+recursively, each cached on the way down.
+
+The alternative — rendering a low zoom directly — means a facet-sized bitmap:
+6144×4096 for Felucca, roughly 100 MB. Composing from children never holds more than
+a few 256×256 images. `full.png` pays that cost once, unavoidably, because the
+output *is* that image; the pre-warm exists so nobody meets it on a request.
+
+**Fewer than four children is normal.** Grids do not double cleanly — each level's
+size is its own `ceil` — so Felucca's z1 is 2×1 and its z0 tile asks for two children
+that do not exist. A missing child leaves its quadrant transparent.
+
+### The rule that matters
+
+**Nothing may touch `Art`, `Map`, `RadarCol` or `TileData` outside
+`IUltimaReadGate.ReadAsync`.**
+
+`Map.cs` holds 18 locks of its own, which makes it look safe. It is not: it calls
+`Art.IsValidStatic`, which reads a shared LRU cache, moves a **shared file-index
+stream position** and writes a **shared static scratch buffer** — and `Art` holds no
+locks at all. `RadarCol` holds none either. So map rendering and item art decoding
+corrupt each other unless they queue behind the same gate, and it must be *one*
+gate: a service with its own semaphore is exactly as broken as one with none.
+
+None of this is visible from those types' signatures, which is why it is written
+down here.
 
 ## Browsing the API
 

--- a/src/Moongate.Http.Plugin/Data/MapFacetInfo.cs
+++ b/src/Moongate.Http.Plugin/Data/MapFacetInfo.cs
@@ -1,0 +1,19 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>A map facet as the API describes it, so a viewer can configure itself rather than guess.</summary>
+/// <param name="Name">The facet's name, as used in the tile route.</param>
+/// <param name="Width">Facet width in map tiles, which is its width in pixels at native zoom.</param>
+/// <param name="Height">Facet height in map tiles.</param>
+/// <param name="MaxZoom">The deepest zoom, where one pixel is one map tile. Zoom 0 is always one tile.</param>
+/// <param name="TileSize">Tile edge in pixels.</param>
+/// <param name="TilesAcross">Tiles across the grid at <paramref name="MaxZoom" />.</param>
+/// <param name="TilesDown">Tiles down the grid at <paramref name="MaxZoom" />.</param>
+public sealed record MapFacetInfo(
+    string Name,
+    int Width,
+    int Height,
+    int MaxZoom,
+    int TileSize,
+    int TilesAcross,
+    int TilesDown
+);

--- a/src/Moongate.Http.Plugin/Data/MapImageExportStatus.cs
+++ b/src/Moongate.Http.Plugin/Data/MapImageExportStatus.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>How far the map image pre-warm has got.</summary>
+/// <param name="State">Idle, Running, Completed or Failed.</param>
+/// <param name="Done">Tiles and whole-facet images produced so far.</param>
+/// <param name="Total">How many there are to produce. 0 until the pre-warm has counted them.</param>
+/// <param name="Failed">How many could not be produced. The reasons are in the log.</param>
+/// <param name="StartedAt">When the current or last pre-warm started; null if none ever has.</param>
+public record MapImageExportStatus(string State, int Done, int Total, int Failed, DateTimeOffset? StartedAt);

--- a/src/Moongate.Http.Plugin/Data/MapTileGeometry.cs
+++ b/src/Moongate.Http.Plugin/Data/MapTileGeometry.cs
@@ -1,0 +1,51 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>
+/// The arithmetic of the map tile pyramid. Pure: it reads no files and touches no Ultima state, which is
+/// why it can be proven on its own rather than inferred from a rendered image.
+/// </summary>
+public static class MapTileGeometry
+{
+    /// <summary>
+    /// 256 pixels a side. Chosen because it is exactly <see cref="BlocksPerTile" /> map blocks: a native
+    /// tile is a whole number of blocks, so GetImage never gets a fraction and tiles never straddle one.
+    /// </summary>
+    public const int TileSize = 256;
+
+    /// <summary>Map blocks in one native tile. A block is 8×8 tiles and renders 8×8 pixels.</summary>
+    public const int BlocksPerTile = TileSize / 8;
+
+    /// <summary>
+    /// The zoom at which one pixel is one map tile — and therefore the number of halvings needed for the
+    /// whole facet to fit a single tile at zoom 0.
+    /// </summary>
+    public static int MaxZoom(int width, int height)
+    {
+        var longest = Math.Max(width, height);
+
+        if (longest <= TileSize)
+        {
+            return 0;
+        }
+
+        return (int)Math.Ceiling(Math.Log2(longest / (double)TileSize));
+    }
+
+    /// <summary>Map tiles per pixel at this zoom. 1 at native, doubling with every step down.</summary>
+    public static int Scale(int zoom, int maxZoom)
+        => 1 << (maxZoom - zoom);
+
+    /// <summary>
+    /// Tiles across the grid at this zoom. Rounded up: the last tile is usually partial, and rounding down
+    /// would drop the map's right edge with nothing saying so.
+    /// </summary>
+    public static int TilesAcross(int width, int zoom, int maxZoom)
+        => Count(width, zoom, maxZoom);
+
+    /// <summary>Tiles down the grid at this zoom. Rounded up, for the same reason as across.</summary>
+    public static int TilesDown(int height, int zoom, int maxZoom)
+        => Count(height, zoom, maxZoom);
+
+    private static int Count(int extent, int zoom, int maxZoom)
+        => (int)Math.Ceiling(extent / (double)(TileSize * Scale(zoom, maxZoom)));
+}

--- a/src/Moongate.Http.Plugin/Endpoints/MapImageAdminEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/MapImageAdminEndpoints.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+
+namespace Moongate.Http.Plugin.Endpoints;
+
+/// <summary>Staff-only control of the map image cache.</summary>
+public sealed class MapImageAdminEndpoints : IApiEndpointRegistration
+{
+    private readonly IMapImageExportJob _export;
+    private readonly IMapImageService _maps;
+
+    public MapImageAdminEndpoints(IMapImageExportJob export, IMapImageService maps)
+    {
+        _export = export;
+        _maps = maps;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/v1/admin/images/maps")
+                          .WithTags("images")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        group.MapPost("/", Start).WithName("StartMapImageExport");
+        group.MapGet("/", GetStatus).WithName("GetMapImageExportStatus");
+    }
+
+    /// <summary>Builds every map tile and whole-facet image into the cache.</summary>
+    /// <remarks>
+    /// Answers 202 and works in the background; poll this same route with GET for progress. Only one runs
+    /// at a time, so a second request while one is going answers 409. Worth running before anyone opens a
+    /// viewer: the first request at a low zoom otherwise builds every tile beneath it, and the first
+    /// request for a whole facet renders a facet-sized image. Progress is kept in memory and does not
+    /// survive a restart.
+    /// </remarks>
+    private IResult Start()
+    {
+        if (!_maps.IsReady)
+        {
+            return Results.Problem(
+                "The UO client files are not loaded; there are no maps to export.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        if (!_export.TryStart())
+        {
+            return Results.Problem(
+                "A map image export is already running.",
+                statusCode: StatusCodes.Status409Conflict
+            );
+        }
+
+        return Results.Accepted("/api/v1/admin/images/maps", _export.Status);
+    }
+
+    /// <summary>Reports how far the map image export has got.</summary>
+    /// <remarks>
+    /// State is Idle before any export has run, then Running, and finally Completed or Failed. Failed counts
+    /// images that could not be produced; the reasons are in the server log.
+    /// </remarks>
+    private IResult GetStatus()
+        => Results.Ok(_export.Status);
+}

--- a/src/Moongate.Http.Plugin/Endpoints/MapImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/MapImageEndpoints.cs
@@ -1,0 +1,174 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Http.Plugin.Endpoints;
+
+/// <summary>UO map facets as tiles and as whole images.</summary>
+public sealed class MapImageEndpoints : IApiEndpointRegistration
+{
+    private readonly IMapImageService _maps;
+    private readonly IUltimaMapProvider _provider;
+
+    public MapImageEndpoints(IMapImageService maps, IUltimaMapProvider provider)
+    {
+        _maps = maps;
+        _provider = provider;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        // Method groups, not lambdas: Swashbuckle reads the /// off the handler's method, and a lambda has
+        // none — the route would document itself blank.
+        routes.MapGet("/api/v1/images/maps", List)
+              .WithName("ListMaps")
+              .WithTags("images")
+              .AllowAnonymous();
+
+        // Before the tile route, so "full" is never read as a zoom.
+        routes.MapGet("/api/v1/images/maps/{map}/full.png", GetFull)
+              .WithName("GetFullMapImage")
+              .WithTags("images")
+              .AllowAnonymous();
+
+        routes.MapGet("/api/v1/images/maps/{map}/{z}/{x}/{y}.png", GetTile)
+              .WithName("GetMapTile")
+              .WithTags("images")
+              .AllowAnonymous();
+    }
+
+    /// <summary>The facets this shard serves, and the shape of each one's tile grid.</summary>
+    /// <remarks>
+    /// Open without a token. Read this before requesting tiles: the facets' sizes come from the shard's own
+    /// client files, so maxZoom and the grid differ between shards and must not be hardcoded.
+    /// </remarks>
+    private IResult List()
+    {
+        if (!_maps.IsReady)
+        {
+            return NotLoaded();
+        }
+
+        return Results.Ok(
+            _provider.Facets
+                     .Select(facet => (Facet: facet, Map: _provider.Get(facet)))
+                     .Where(entry => entry.Map is not null)
+                     .Select(
+                         entry =>
+                         {
+                             var maxZoom = _maps.MaxZoomFor(entry.Facet);
+
+                             return new MapFacetInfo(
+                                 entry.Facet.ToString(),
+                                 entry.Map!.Width,
+                                 entry.Map.Height,
+                                 maxZoom,
+                                 MapTileGeometry.TileSize,
+                                 MapTileGeometry.TilesAcross(entry.Map.Width, maxZoom, maxZoom),
+                                 MapTileGeometry.TilesDown(entry.Map.Height, maxZoom, maxZoom)
+                             );
+                         }
+                     )
+        );
+    }
+
+    /// <summary>One map tile.</summary>
+    /// <remarks>
+    /// Open without a token: map data is client data every player already has on disk. The facet is named,
+    /// case-insensitively — felucca, trammel, ilshenar, malas, tokuno, termur. Zoom counts up to detail: 0
+    /// is the whole facet in one tile, and maxZoom — which GET /api/v1/images/maps reports per facet — is
+    /// one pixel per map tile. Tiles are 256×256. A tile at the facet's edge is padded transparent. Tiles
+    /// are rendered on first request and cached, so the first call at a low zoom builds everything beneath
+    /// it and is slow; the staff pre-warm exists to do that in advance.
+    /// </remarks>
+    private async Task<IResult> GetTile(string map, string z, int x, int y, CancellationToken cancellationToken)
+    {
+        if (!TryParseFacet(map, out var facet))
+        {
+            return InvalidFacet(map);
+        }
+
+        if (!_maps.IsReady)
+        {
+            return NotLoaded();
+        }
+
+        if (!int.TryParse(z, out var zoom))
+        {
+            // "full" reaching here means the caller wrote the whole-facet route wrong; the tile route
+            // saying "not a zoom" would be true and useless.
+            return Results.Problem(
+                z.Equals("full", StringComparison.OrdinalIgnoreCase)
+                    ? $"For the whole facet use /api/v1/images/maps/{map}/full.png."
+                    : $"'{z}' is not a zoom. Expected a whole number from 0 to {_maps.MaxZoomFor(facet)}.",
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+
+        var maxZoom = _maps.MaxZoomFor(facet);
+
+        if (zoom < 0 || zoom > maxZoom)
+        {
+            return Results.Problem(
+                $"Zoom {zoom} is outside 0 to {maxZoom} for {facet}.",
+                statusCode: StatusCodes.Status400BadRequest
+            );
+        }
+
+        var path = await _maps.GetTileAsync(facet, zoom, x, y, cancellationToken);
+
+        return path is null
+                   ? Results.Problem(
+                       $"No tile {x},{y} at zoom {zoom} for {facet}.",
+                       statusCode: StatusCodes.Status404NotFound
+                   )
+                   : Results.File(path, "image/png");
+    }
+
+    /// <summary>A whole facet as one PNG.</summary>
+    /// <remarks>
+    /// Open without a token. The entire facet at one pixel per map tile — 6144×4096 for Felucca — for
+    /// downloading or printing rather than browsing; use the tiles for a viewer. It is generated once and
+    /// cached, and the first request is slow and memory-hungry if the staff pre-warm has not run.
+    /// </remarks>
+    private async Task<IResult> GetFull(string map, CancellationToken cancellationToken)
+    {
+        if (!TryParseFacet(map, out var facet))
+        {
+            return InvalidFacet(map);
+        }
+
+        if (!_maps.IsReady)
+        {
+            return NotLoaded();
+        }
+
+        var path = await _maps.GetFullAsync(facet, cancellationToken);
+
+        return path is null
+                   ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.File(path, "image/png");
+    }
+
+    /// <summary>
+    /// Enum.TryParse accepts numeric strings, so "99" would parse into an undefined MapType and reach the
+    /// provider as a facet nobody has. Enum.IsDefined is what stops it.
+    /// </summary>
+    private static bool TryParseFacet(string name, out MapType facet)
+        => Enum.TryParse(name, true, out facet) && Enum.IsDefined(facet);
+
+    private static IResult InvalidFacet(string name)
+        => Results.Problem(
+            $"'{name}' is not a map. Valid maps: {string.Join(", ", Enum.GetNames<MapType>())}.",
+            statusCode: StatusCodes.Status400BadRequest
+        );
+
+    private static IResult NotLoaded()
+        => Results.Problem(
+            "The UO client files are not loaded; no maps can be served.",
+            statusCode: StatusCodes.Status503ServiceUnavailable
+        );
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IMapImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IMapImageExportJob.cs
@@ -1,0 +1,13 @@
+using Moongate.Http.Plugin.Data;
+
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>Builds every map tile and whole-facet image in the background, one run at a time.</summary>
+public interface IMapImageExportJob
+{
+    /// <summary>How far the current or last pre-warm has got.</summary>
+    MapImageExportStatus Status { get; }
+
+    /// <summary>Starts a pre-warm. False when one is already running.</summary>
+    bool TryStart();
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IMapImageService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IMapImageService.cs
@@ -1,0 +1,31 @@
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>Map facets as slippy-map tiles and as one whole-facet image, cached on disk.</summary>
+public interface IMapImageService
+{
+    /// <summary>
+    /// False when the UO client files are not loaded and nothing can be rendered. Keeps a shard with a
+    /// wrong UltimaDirectory apart from a tile that is simply outside the grid.
+    /// </summary>
+    bool IsReady { get; }
+
+    /// <summary>
+    /// The zoom at which one pixel is one map tile for this facet, and so the deepest zoom it serves. Zoom
+    /// 0 is always a single tile holding the whole facet. -1 when the facet is not served.
+    /// </summary>
+    int MaxZoomFor(MapType facet);
+
+    /// <summary>
+    /// The path of the cached tile, building it — and, below native zoom, its children — on first request.
+    /// Null when the facet is not served or the tile is outside that zoom's grid.
+    /// </summary>
+    Task<string?> GetTileAsync(MapType facet, int zoom, int x, int y, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The path of the cached whole-facet image, rendering it on first request. Null when the facet is not
+    /// served. This one is expensive — a facet-sized bitmap — which is what the pre-warm is for.
+    /// </summary>
+    Task<string?> GetFullAsync(MapType facet, CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IUltimaMapProvider.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IUltimaMapProvider.cs
@@ -1,0 +1,18 @@
+using Moongate.Ultima.Maps;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>
+/// The facets the shard's client files describe. Exists as an interface because Ultima's facets are static
+/// fields with hardcoded sizes — Felucca is 6144×4096 — and a test that had to render one would be
+/// rendering 384 native tiles to prove a pyramid composes.
+/// </summary>
+public interface IUltimaMapProvider
+{
+    /// <summary>Every facet the API serves.</summary>
+    IReadOnlyList<MapType> Facets { get; }
+
+    /// <summary>The facet's map, or null when it is not one this provider serves.</summary>
+    Map? Get(MapType facet);
+}

--- a/src/Moongate.Http.Plugin/Interfaces/IUltimaReadGate.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/IUltimaReadGate.cs
@@ -1,0 +1,20 @@
+namespace Moongate.Http.Plugin.Interfaces;
+
+/// <summary>
+/// Serialises every read of Moongate.Ultima's process-wide statics.
+/// <para>
+/// One gate for the whole library, not one per caller. Art holds no lock of its own and shares an LRU
+/// cache, a file-index stream position and a static scratch buffer across calls; Map locks its own block
+/// cache but descends into Art regardless, and RadarCol and TileData are equally unguarded. Two callers
+/// holding separate gates corrupt that state exactly as two holding none.
+/// </para>
+/// </summary>
+public interface IUltimaReadGate
+{
+    /// <summary>
+    /// Runs a read against the client files, serialised against every other reader. The delegate holds the
+    /// gate for its whole duration, so it must be a read of the client files and nothing else: no other
+    /// I/O, no waiting on anything, no calls back into a service that takes this gate again.
+    /// </summary>
+    Task<T> ReadAsync<T>(Func<T> read, CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -20,6 +20,12 @@
             initialised by the time a request arrives.
         -->
         <ProjectReference Include="..\Moongate.Ultima\Moongate.Ultima.csproj"/>
+        <!--
+            For MapType, so the map routes name facets the way the rest of the project does rather than
+            inventing a second vocabulary. Moongate.UO.Data references only Moongate.Core and
+            Moongate.Ultima — the two this plugin already has — so this adds no cycle.
+        -->
+        <ProjectReference Include="..\Moongate.UO.Data\Moongate.UO.Data.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -42,6 +42,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // One gate over Ultima's statics for every reader. Map rendering descends into Art too, and a
         // second gate would be no gate at all.
         container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+        container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
         container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
         container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
 

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -44,6 +44,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
         container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
         container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+        container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
         container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
 
         // These endpoints live here rather than in Moongate.Server because they need no game service at

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -50,6 +50,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // These endpoints live here rather than in Moongate.Server because they need no game service at
         // all — only the client files and the filesystem.
         container.RegisterApiEndpoint<ItemImageEndpoints>();
+        container.RegisterApiEndpoint<MapImageEndpoints>();
         container.RegisterApiEndpoint<ItemImageAdminEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -50,7 +50,9 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // These endpoints live here rather than in Moongate.Server because they need no game service at
         // all — only the client files and the filesystem.
         container.RegisterApiEndpoint<ItemImageEndpoints>();
+        container.Register<IMapImageExportJob, MapImageExportJob>(Reuse.Singleton);
         container.RegisterApiEndpoint<MapImageEndpoints>();
+        container.RegisterApiEndpoint<MapImageAdminEndpoints>();
         container.RegisterApiEndpoint<ItemImageAdminEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -39,6 +39,9 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // FilesLoaderService initialises at startup. It carries no state of its own, so a singleton costs
         // nothing.
         container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+        // One gate over Ultima's statics for every reader. Map rendering descends into Art too, and a
+        // second gate would be no gate at all.
+        container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
         container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
         container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
 

--- a/src/Moongate.Http.Plugin/Services/ItemImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/ItemImageService.cs
@@ -10,7 +10,7 @@ namespace Moongate.Http.Plugin.Services;
 /// Caches item art as PNG files on disk. The decode itself belongs to <see cref="IItemCatalog" />; what
 /// this adds is the cache, and the serialisation that makes it safe to call from a web server at all.
 /// </summary>
-public sealed class ItemImageService : IItemImageService, IDisposable
+public sealed class ItemImageService : IItemImageService
 {
     /// <summary>
     /// Under the runtime root, which .gitignore already excludes wholesale — so the cache needs no ignore
@@ -19,18 +19,13 @@ public sealed class ItemImageService : IItemImageService, IDisposable
     private const string CacheDirectory = "cache/images/items";
 
     private readonly IItemCatalog _catalog;
+    private readonly IUltimaReadGate _gate;
     private readonly string _cachePath;
 
-    // One gate for every decode, not one per item. What it protects is Art's process-wide state — an LRU
-    // bitmap cache, plain Dictionary fields and a shared static scratch buffer — so two requests for
-    // different items corrupt each other exactly as two for the same item would. Art.cs holds no lock of
-    // its own, and nothing else in the server calls it, so this is the only thing standing between a
-    // concurrent request and that state.
-    private readonly SemaphoreSlim _decodeGate = new(1, 1);
-
-    public ItemImageService(IItemCatalog catalog, DirectoriesConfig directories)
+    public ItemImageService(IItemCatalog catalog, DirectoriesConfig directories, IUltimaReadGate gate)
     {
         _catalog = catalog;
+        _gate = gate;
         _cachePath = directories.RegisterDirectory(CacheDirectory);
     }
 
@@ -52,57 +47,47 @@ public sealed class ItemImageService : IItemImageService, IDisposable
             return path;
         }
 
-        await _decodeGate.WaitAsync(cancellationToken);
+        // Re-checked inside the gate, because another request may have produced it while this one waited.
+        // The decode is all that needs the gate — the write is ordinary file I/O and is done outside it.
+        var png = await _gate.ReadAsync(
+            () => File.Exists(path) ? null : _catalog.GetItemImage(itemId, hue),
+            cancellationToken
+        );
 
-        try
+        // Null means two different things here: another request won the race, or the item has no art.
+        // The file is what tells them apart — returning null blindly would turn a cache race into a 404.
+        if (png is null)
         {
-            // Another request may have produced it while this one waited on the gate.
-            if (File.Exists(path))
-            {
-                return path;
-            }
+            return File.Exists(path) ? path : null;
+        }
 
-            using var png = _catalog.GetItemImage(itemId, hue);
-
-            if (png is null)
-            {
-                return null;
-            }
-
+        using (png)
+        {
             await WriteAtomicallyAsync(path, png, cancellationToken);
+        }
 
-            return path;
-        }
-        finally
-        {
-            _decodeGate.Release();
-        }
+        return path;
     }
 
     public async Task<IReadOnlyList<uint>> GetArtItemIdsAsync(CancellationToken cancellationToken = default)
-    {
-        await _decodeGate.WaitAsync(cancellationToken);
-
-        try
-        {
-            var ids = new List<uint>();
-            var max = Art.GetMaxItemId();
-
-            for (var id = 0; id <= max; id++)
+        => await _gate.ReadAsync(
+            () =>
             {
-                if (Art.IsValidStatic(id))
-                {
-                    ids.Add((uint)id);
-                }
-            }
+                var ids = new List<uint>();
+                var max = Art.GetMaxItemId();
 
-            return ids;
-        }
-        finally
-        {
-            _decodeGate.Release();
-        }
-    }
+                for (var id = 0; id <= max; id++)
+                {
+                    if (Art.IsValidStatic(id))
+                    {
+                        ids.Add((uint)id);
+                    }
+                }
+
+                return (IReadOnlyList<uint>)ids;
+            },
+            cancellationToken
+        );
 
     /// <summary>
     /// Lowercase hex, zero-padded, so names sort and cannot collide. The hue goes in the name rather than
@@ -136,7 +121,4 @@ public sealed class ItemImageService : IItemImageService, IDisposable
             throw;
         }
     }
-
-    public void Dispose()
-        => _decodeGate.Dispose();
 }

--- a/src/Moongate.Http.Plugin/Services/MapImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Services/MapImageExportJob.cs
@@ -1,0 +1,165 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Types;
+using Moongate.UO.Data.Types;
+using Serilog;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// Builds every facet's tiles and whole-facet image ahead of anyone asking. It goes through
+/// <see cref="IMapImageService" /> like any request, so it takes the same gate per tile and interleaves
+/// with live traffic rather than holding Ultima for the length of the run.
+/// </summary>
+public sealed class MapImageExportJob : IMapImageExportJob
+{
+    /// <summary>Stands for the facet's whole image in the plan, which has no zoom of its own.</summary>
+    private const int FullImageZoom = -1;
+
+    private readonly ILogger _logger = Log.ForContext<MapImageExportJob>();
+    private readonly IMapImageService _maps;
+    private readonly IUltimaMapProvider _provider;
+    private readonly object _sync = new();
+
+    private MapImageExportStateType _state = MapImageExportStateType.Idle;
+    private int _done;
+    private int _total;
+    private int _failed;
+    private DateTimeOffset? _startedAt;
+
+    public MapImageExportJob(IMapImageService maps, IUltimaMapProvider provider)
+    {
+        _maps = maps;
+        _provider = provider;
+    }
+
+    public MapImageExportStatus Status
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return new(_state.ToString(), _done, _total, _failed, _startedAt);
+            }
+        }
+    }
+
+    public bool TryStart()
+    {
+        lock (_sync)
+        {
+            if (_state == MapImageExportStateType.Running)
+            {
+                return false;
+            }
+
+            _state = MapImageExportStateType.Running;
+            _done = 0;
+            _total = 0;
+            _failed = 0;
+            _startedAt = DateTimeOffset.UtcNow;
+        }
+
+        // Deliberately not awaited: the route answers 202 and the caller polls. RunAsync catches everything
+        // and records it in the state, so nothing is left to an unobserved exception.
+        _ = Task.Run(RunAsync);
+
+        return true;
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            var work = Plan();
+
+            lock (_sync)
+            {
+                _total = work.Count;
+            }
+
+            foreach (var (facet, zoom, x, y) in work)
+            {
+                try
+                {
+                    if (zoom == FullImageZoom)
+                    {
+                        await _maps.GetFullAsync(facet);
+                    }
+                    else
+                    {
+                        await _maps.GetTileAsync(facet, zoom, x, y);
+                    }
+
+                    lock (_sync)
+                    {
+                        _done++;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    // One unreadable tile must not end the run: the point is to warm what can be warmed.
+                    _logger.Warning(exception, "Could not export {Facet} z{Zoom} {X},{Y}", facet, zoom, x, y);
+
+                    lock (_sync)
+                    {
+                        _failed++;
+                    }
+                }
+            }
+
+            lock (_sync)
+            {
+                _state = MapImageExportStateType.Completed;
+            }
+
+            _logger.Information("Map image export finished: {Done} produced, {Failed} failed", _done, _failed);
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Map image export stopped early");
+
+            lock (_sync)
+            {
+                _state = MapImageExportStateType.Failed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every tile, deepest zoom first, then the whole-facet image. Bottom-up on purpose: each level
+    /// composes from children already on disk, so nothing recurses and no tile is built twice.
+    /// </summary>
+    private List<(MapType Facet, int Zoom, int X, int Y)> Plan()
+    {
+        var work = new List<(MapType, int, int, int)>();
+
+        foreach (var facet in _provider.Facets)
+        {
+            if (_provider.Get(facet) is not { } map)
+            {
+                continue;
+            }
+
+            var maxZoom = _maps.MaxZoomFor(facet);
+
+            for (var zoom = maxZoom; zoom >= 0; zoom--)
+            {
+                var across = MapTileGeometry.TilesAcross(map.Width, zoom, maxZoom);
+                var down = MapTileGeometry.TilesDown(map.Height, zoom, maxZoom);
+
+                for (var x = 0; x < across; x++)
+                {
+                    for (var y = 0; y < down; y++)
+                    {
+                        work.Add((facet, zoom, x, y));
+                    }
+                }
+            }
+
+            work.Add((facet, FullImageZoom, 0, 0));
+        }
+
+        return work;
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/MapImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/MapImageService.cs
@@ -1,0 +1,246 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Ultima.Tiles;
+using Moongate.UO.Data.Types;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SquidStd.Core.Directories;
+using UltimaMap = Moongate.Ultima.Maps.Map;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// Renders map facets into cached PNG tiles. The pyramid is built from the bottom: a native tile is one
+/// GetImage of exactly 32 blocks, and every zoom below it is composed by halving its four children. The
+/// alternative — rendering a low zoom directly — means a facet-sized bitmap, about 100 MB for Felucca,
+/// inside a request.
+/// </summary>
+public sealed class MapImageService : IMapImageService
+{
+    private const string CacheDirectory = "cache/images/maps";
+
+    private readonly IUltimaMapProvider _maps;
+    private readonly IUltimaReadGate _gate;
+    private readonly string _cachePath;
+
+    public MapImageService(IUltimaMapProvider maps, DirectoriesConfig directories, IUltimaReadGate gate)
+    {
+        _maps = maps;
+        _gate = gate;
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+    }
+
+    public bool IsReady
+        => TileData.ItemTable is not null;
+
+    public int MaxZoomFor(MapType facet)
+        => _maps.Get(facet) is { } map ? MapTileGeometry.MaxZoom(map.Width, map.Height) : -1;
+
+    public async Task<string?> GetTileAsync(
+        MapType facet,
+        int zoom,
+        int x,
+        int y,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (_maps.Get(facet) is not { } map)
+        {
+            return null;
+        }
+
+        var maxZoom = MapTileGeometry.MaxZoom(map.Width, map.Height);
+
+        if (zoom < 0 || zoom > maxZoom || !InGrid(map, zoom, maxZoom, x, y))
+        {
+            return null;
+        }
+
+        var path = TilePath(facet, zoom, x, y);
+
+        // The hit path touches neither the gate nor Ultima. Everything below is the miss.
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        using var tile = zoom == maxZoom
+                             ? await RenderNativeAsync(map, x, y, cancellationToken)
+                             : await ComposeAsync(facet, zoom, x, y, cancellationToken);
+
+        await WriteAtomicallyAsync(path, tile, cancellationToken);
+
+        return path;
+    }
+
+    public async Task<string?> GetFullAsync(MapType facet, CancellationToken cancellationToken = default)
+    {
+        if (_maps.Get(facet) is not { } map)
+        {
+            return null;
+        }
+
+        var path = Path.Combine(FacetDirectory(facet), "full.png");
+
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        // A facet-sized bitmap, unavoidably: the output is that image. The gate makes concurrent first
+        // requests queue rather than each allocating their own, and the re-check means only the first pays.
+        using var image = await _gate.ReadAsync(
+            () =>
+            {
+                if (File.Exists(path))
+                {
+                    return null;
+                }
+
+                using var bitmap = map.GetImage(0, 0, Blocks(map.Width), Blocks(map.Height), true);
+
+                return bitmap.ToImage();
+            },
+            cancellationToken
+        );
+
+        if (image is null)
+        {
+            return File.Exists(path) ? path : null;
+        }
+
+        // GetImage rounds up to whole blocks, so trim back to the facet's real extent.
+        if (image.Width != map.Width || image.Height != map.Height)
+        {
+            image.Mutate(context => context.Crop(new(0, 0, map.Width, map.Height)));
+        }
+
+        await WriteAtomicallyAsync(path, image, cancellationToken);
+
+        return path;
+    }
+
+    /// <summary>
+    /// One GetImage of exactly 32 blocks, clipped at the facet's edge. The remainder of an edge tile is
+    /// left transparent: the grid rounds up, so the last tile is usually partial, and a viewer clips it.
+    /// </summary>
+    private async Task<Image<Bgra32>> RenderNativeAsync(
+        UltimaMap map,
+        int x,
+        int y,
+        CancellationToken cancellationToken
+    )
+    {
+        var blockX = x * MapTileGeometry.BlocksPerTile;
+        var blockY = y * MapTileGeometry.BlocksPerTile;
+        var width = Math.Min(MapTileGeometry.BlocksPerTile, Blocks(map.Width) - blockX);
+        var height = Math.Min(MapTileGeometry.BlocksPerTile, Blocks(map.Height) - blockY);
+
+        var rendered = await _gate.ReadAsync(
+            () =>
+            {
+                using var bitmap = map.GetImage(blockX, blockY, width, height, true);
+
+                return bitmap.ToImage();
+            },
+            cancellationToken
+        );
+
+        if (rendered.Width == MapTileGeometry.TileSize && rendered.Height == MapTileGeometry.TileSize)
+        {
+            return rendered;
+        }
+
+        using (rendered)
+        {
+            var tile = new Image<Bgra32>(MapTileGeometry.TileSize, MapTileGeometry.TileSize);
+            tile.Mutate(context => context.DrawImage(rendered, new Point(0, 0), 1f));
+
+            return tile;
+        }
+    }
+
+    /// <summary>
+    /// Halves the four children into one tile. Fewer than four is normal: the grids do not double cleanly,
+    /// because each level's size is its own ceil — Felucca's z1 is 2×1, so its z0 tile asks for two
+    /// children that do not exist. A missing child leaves its quadrant transparent; treating it as a
+    /// failure would make zoom 0 unreachable on every non-square facet, which is all of them.
+    /// </summary>
+    private async Task<Image<Bgra32>> ComposeAsync(
+        MapType facet,
+        int zoom,
+        int x,
+        int y,
+        CancellationToken cancellationToken
+    )
+    {
+        var tile = new Image<Bgra32>(MapTileGeometry.TileSize, MapTileGeometry.TileSize);
+        var half = MapTileGeometry.TileSize / 2;
+
+        foreach (var (dx, dy) in new[] { (0, 0), (1, 0), (0, 1), (1, 1) })
+        {
+            var childPath = await GetTileAsync(facet, zoom + 1, x * 2 + dx, y * 2 + dy, cancellationToken);
+
+            if (childPath is null)
+            {
+                continue;
+            }
+
+            using var child = await Image.LoadAsync<Bgra32>(childPath, cancellationToken);
+            child.Mutate(context => context.Resize(half, half));
+            tile.Mutate(context => context.DrawImage(child, new Point(dx * half, dy * half), 1f));
+        }
+
+        return tile;
+    }
+
+    private static bool InGrid(UltimaMap map, int zoom, int maxZoom, int x, int y)
+        => x >= 0
+           && y >= 0
+           && x < MapTileGeometry.TilesAcross(map.Width, zoom, maxZoom)
+           && y < MapTileGeometry.TilesDown(map.Height, zoom, maxZoom);
+
+    /// <summary>Map extent in whole 8×8 blocks, rounded up: a partial block still holds tiles.</summary>
+    private static int Blocks(int extent)
+        => (extent + 7) / 8;
+
+    private string FacetDirectory(MapType facet)
+        => Directory.CreateDirectory(Path.Combine(_cachePath, facet.ToString().ToLowerInvariant())).FullName;
+
+    private string TilePath(MapType facet, int zoom, int x, int y)
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(FacetDirectory(facet), zoom.ToString(), x.ToString())
+        );
+
+        return Path.Combine(directory.FullName, $"{y}.png");
+    }
+
+    /// <summary>
+    /// Writes through a temporary file in the same directory, then moves it into place. A reader must never
+    /// be handed a half-written PNG, and a move within one directory is atomic on Linux and Windows alike —
+    /// writing straight to the final path would not be.
+    /// </summary>
+    private static async Task WriteAtomicallyAsync(
+        string path,
+        Image<Bgra32> image,
+        CancellationToken cancellationToken
+    )
+    {
+        var temporary = $"{path}.{Guid.NewGuid():N}.tmp";
+
+        try
+        {
+            await image.SaveAsPngAsync(temporary, cancellationToken);
+
+            File.Move(temporary, path, true);
+        }
+        catch
+        {
+            File.Delete(temporary);
+
+            throw;
+        }
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/UltimaMapProvider.cs
+++ b/src/Moongate.Http.Plugin/Services/UltimaMapProvider.cs
@@ -1,0 +1,35 @@
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Ultima.Maps;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// Ultima's own facets, by <see cref="MapType" />. The sizes are Ultima's, not MapDefinitions': Ultima
+/// hardcodes Felucca at 6144×4096 while MapDefinitions says 7168, and the renderer can only draw what
+/// Ultima's Map object describes. On a shard with post-ML client files this renders the older extent.
+/// </summary>
+public sealed class UltimaMapProvider : IUltimaMapProvider
+{
+    public IReadOnlyList<MapType> Facets { get; } =
+    [
+        MapType.Felucca,
+        MapType.Trammel,
+        MapType.Ilshenar,
+        MapType.Malas,
+        MapType.Tokuno,
+        MapType.TerMur
+    ];
+
+    public Map? Get(MapType facet)
+        => facet switch
+        {
+            MapType.Felucca => Map.Felucca,
+            MapType.Trammel => Map.Trammel,
+            MapType.Ilshenar => Map.Ilshenar,
+            MapType.Malas    => Map.Malas,
+            MapType.Tokuno   => Map.Tokuno,
+            MapType.TerMur   => Map.TerMur,
+            _                => null
+        };
+}

--- a/src/Moongate.Http.Plugin/Services/UltimaReadGate.cs
+++ b/src/Moongate.Http.Plugin/Services/UltimaReadGate.cs
@@ -1,0 +1,29 @@
+using Moongate.Http.Plugin.Interfaces;
+
+namespace Moongate.Http.Plugin.Services;
+
+/// <summary>
+/// The process-wide gate over Moongate.Ultima's statics. Registered as a singleton, which is the only
+/// registration that makes sense: a second instance is a second gate, and a second gate is no gate.
+/// </summary>
+public sealed class UltimaReadGate : IUltimaReadGate, IDisposable
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public async Task<T> ReadAsync<T>(Func<T> read, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+
+        try
+        {
+            return read();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Dispose()
+        => _gate.Dispose();
+}

--- a/src/Moongate.Http.Plugin/Types/MapImageExportStateType.cs
+++ b/src/Moongate.Http.Plugin/Types/MapImageExportStateType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Http.Plugin.Types;
+
+/// <summary>Where a map image pre-warm stands.</summary>
+public enum MapImageExportStateType
+{
+    /// <summary>No pre-warm has run since the server started.</summary>
+    Idle,
+
+    /// <summary>A pre-warm is working through the facets.</summary>
+    Running,
+
+    /// <summary>The last pre-warm finished; Failed says whether every tile made it.</summary>
+    Completed,
+
+    /// <summary>The last pre-warm stopped early. The reason is in the log.</summary>
+    Failed
+}

--- a/tests/Moongate.Tests/Http/ItemImageAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageAdminEndpointsTests.cs
@@ -21,6 +21,7 @@ public class ItemImageAdminEndpointsTests
             {
                 container.RegisterInstance(fixture.Directories);
                 container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
                 container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
                 container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
                 container.RegisterApiEndpointInstance(

--- a/tests/Moongate.Tests/Http/ItemImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageEndpointsTests.cs
@@ -20,6 +20,7 @@ public class ItemImageEndpointsTests
             {
                 container.RegisterInstance(fixture.Directories);
                 container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
                 container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
                 container.RegisterApiEndpointInstance(
                     new ItemImageEndpoints(container.Resolve<IItemImageService>())

--- a/tests/Moongate.Tests/Http/ItemImageExportJobTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageExportJobTests.cs
@@ -34,7 +34,7 @@ public class ItemImageExportJobTests
     public async Task TryStart_ExportsEveryItemThatHasArt()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
         var job = new ItemImageExportJob(service);
 
         Assert.True(job.TryStart());
@@ -57,7 +57,7 @@ public class ItemImageExportJobTests
     public async Task TryStart_WhileRunning_IsRefused()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
         var job = new ItemImageExportJob(service);
 
         Assert.True(job.TryStart());
@@ -74,7 +74,7 @@ public class ItemImageExportJobTests
     public void Status_BeforeAnyExport_IsIdle()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
         var job = new ItemImageExportJob(service);
 
         var status = job.Status;

--- a/tests/Moongate.Tests/Http/ItemImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/ItemImageServiceTests.cs
@@ -13,7 +13,7 @@ public class ItemImageServiceTests
     public async Task GetOrCreateAsync_FirstCall_WritesADecodablePng()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         var path = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
 
@@ -30,7 +30,7 @@ public class ItemImageServiceTests
     public async Task GetOrCreateAsync_SecondCall_ServesTheCachedFileWithoutRewritingIt()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         var first = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
 
@@ -49,7 +49,7 @@ public class ItemImageServiceTests
     public async Task GetOrCreateAsync_MissingArt_ReturnsNull()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         Assert.Null(await service.GetOrCreateAsync(ItemImageFixture.MissingArtItemId, 0));
     }
@@ -58,7 +58,7 @@ public class ItemImageServiceTests
     public async Task GetOrCreateAsync_Hued_GetsItsOwnFileWithDifferentPixels()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         var plain = await service.GetOrCreateAsync(ItemImageFixture.ItemId, 0);
         var hued = await service.GetOrCreateAsync(ItemImageFixture.ItemId, ItemImageFixture.Hue);
@@ -77,7 +77,7 @@ public class ItemImageServiceTests
         // The reason the gate exists: Art holds no lock, and shares an LRU cache, non-concurrent
         // dictionaries and a static scratch buffer across calls. Parallel decodes are what corrupt it.
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         var hues = Enumerable.Range(1, 16).Select(hue => (ushort)hue).ToArray();
 
@@ -99,7 +99,7 @@ public class ItemImageServiceTests
     public async Task GetArtItemIdsAsync_ReturnsOnlyIdsThatHaveArt()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         var ids = await service.GetArtItemIdsAsync();
 
@@ -111,7 +111,7 @@ public class ItemImageServiceTests
     public void IsReady_TrueOnceTheClientFilesAreLoaded()
     {
         using var fixture = ItemImageFixture.Create();
-        using var service = new ItemImageService(new ItemCatalog(), fixture.Directories);
+        var service = new ItemImageService(new ItemCatalog(), fixture.Directories, new UltimaReadGate());
 
         Assert.True(service.IsReady);
     }

--- a/tests/Moongate.Tests/Http/MapImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/MapImageEndpointsTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Endpoints;
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Http.Plugin.Services;
+using Moongate.Tests.Support;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class MapImageEndpointsTests
+{
+    private static async Task<TestHttpServer> StartAsync(MapImageFixture fixture)
+        => await TestHttpServer.StartAsync(
+            container =>
+            {
+                container.RegisterInstance(fixture.Directories);
+                container.RegisterInstance(fixture.Provider);
+                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new MapImageEndpoints(
+                        container.Resolve<IMapImageService>(),
+                        container.Resolve<IUltimaMapProvider>()
+                    )
+                );
+            }
+        );
+
+    [Fact]
+    public async Task GetTile_NoToken_StillServesIt()
+    {
+        // Anonymous on purpose: map data is client data every player already has on disk.
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync("/api/v1/images/maps/felucca/0/0/0.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+
+        using var image = Image.Load<Bgra32>(await response.Content.ReadAsByteArrayAsync());
+
+        Assert.Equal(MapTileGeometry.TileSize, image.Width);
+    }
+
+    [Fact]
+    public async Task GetTile_FacetNameIsCaseInsensitive()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        Assert.Equal(
+            HttpStatusCode.OK,
+            (await server.Client.GetAsync("/api/v1/images/maps/FELUCCA/0/0/0.png")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task GetTile_UnknownFacet_IsBadRequest()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            (await server.Client.GetAsync("/api/v1/images/maps/atlantis/0/0/0.png")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task GetTile_ZoomBeyondNative_IsBadRequest()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            (await server.Client.GetAsync("/api/v1/images/maps/felucca/99/0/0.png")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task GetTile_OutsideTheGrid_IsNotFound()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await server.Client.GetAsync("/api/v1/images/maps/felucca/0/9/9.png")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task GetFull_ReturnsTheWholeFacet()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync("/api/v1/images/maps/felucca/full.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var image = Image.Load<Bgra32>(await response.Content.ReadAsByteArrayAsync());
+
+        Assert.Equal(MapImageFixture.MapWidth, image.Width);
+        Assert.Equal(MapImageFixture.MapHeight, image.Height);
+    }
+
+    [Fact]
+    public async Task List_DescribesEachFacetSoAViewerNeedNotHardcodeIt()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var facets = await server.Client.GetFromJsonAsync<List<MapFacetInfo>>("/api/v1/images/maps");
+
+        var only = Assert.Single(facets!);
+
+        Assert.Equal("Felucca", only.Name);
+        Assert.Equal(MapImageFixture.MapWidth, only.Width);
+        Assert.Equal(MapTileGeometry.MaxZoom(MapImageFixture.MapWidth, MapImageFixture.MapHeight), only.MaxZoom);
+        Assert.Equal(MapTileGeometry.TileSize, only.TileSize);
+    }
+}

--- a/tests/Moongate.Tests/Http/MapImageExportJobTests.cs
+++ b/tests/Moongate.Tests/Http/MapImageExportJobTests.cs
@@ -1,0 +1,97 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Services;
+using Moongate.Http.Plugin.Types;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class MapImageExportJobTests
+{
+    private static MapImageExportJob Job(MapImageFixture fixture, out MapImageService service)
+    {
+        service = new(fixture.Provider, fixture.Directories, new UltimaReadGate());
+
+        return new(service, fixture.Provider);
+    }
+
+    private static async Task<MapImageExportStatus> WaitForCompletionAsync(MapImageExportJob job)
+    {
+        // Polls rather than sleeping a fixed span: the export is a background task, and a fixed wait would
+        // either flake on a loaded machine or waste the difference on a fast one.
+        var deadline = DateTime.UtcNow.AddSeconds(60);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var status = job.Status;
+
+            if (status.State != nameof(MapImageExportStateType.Running))
+            {
+                return status;
+            }
+
+            await Task.Delay(50);
+        }
+
+        throw new TimeoutException($"The export never left Running. Last status: {job.Status}.");
+    }
+
+    [Fact]
+    public async Task TryStart_FillsThePyramidAndTheFullImage()
+    {
+        using var fixture = MapImageFixture.Create();
+        var job = Job(fixture, out var service);
+
+        Assert.True(job.TryStart());
+
+        var status = await WaitForCompletionAsync(job);
+
+        Assert.Equal(nameof(MapImageExportStateType.Completed), status.State);
+        Assert.Equal(0, status.Failed);
+        Assert.Equal(status.Total, status.Done);
+
+        // Every zoom is on disk, and so is the whole-facet image — the one nobody should meet unwarmed.
+        var root = fixture.Directories.GetPath("cache/images/maps");
+        var maxZoom = service.MaxZoomFor(MapType.Felucca);
+
+        for (var zoom = 0; zoom <= maxZoom; zoom++)
+        {
+            Assert.True(
+                Directory.Exists(Path.Combine(root, "felucca", zoom.ToString())),
+                $"zoom {zoom} was not exported"
+            );
+        }
+
+        Assert.True(File.Exists(Path.Combine(root, "felucca", "full.png")));
+    }
+
+    [Fact]
+    public async Task TryStart_WhileRunning_IsRefused()
+    {
+        using var fixture = MapImageFixture.Create();
+        var job = Job(fixture, out _);
+
+        Assert.True(job.TryStart());
+
+        // Either the second start is refused, or the first finished before this line ran. Asserting only
+        // the refusal would flake on a fast machine, so this accepts both and checks the state matches.
+        var refused = !job.TryStart();
+        var status = await WaitForCompletionAsync(job);
+
+        Assert.True(refused || status.State == nameof(MapImageExportStateType.Completed));
+    }
+
+    [Fact]
+    public void Status_BeforeAnyExport_IsIdle()
+    {
+        using var fixture = MapImageFixture.Create();
+        var job = Job(fixture, out _);
+
+        var status = job.Status;
+
+        Assert.Equal(nameof(MapImageExportStateType.Idle), status.State);
+        Assert.Null(status.StartedAt);
+        Assert.Equal(0, status.Done);
+    }
+}

--- a/tests/Moongate.Tests/Http/MapImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/MapImageServiceTests.cs
@@ -1,0 +1,164 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Services;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Moongate.Tests.Http;
+
+[Collection("UltimaClientData")]
+public class MapImageServiceTests
+{
+    private static MapImageService Service(MapImageFixture fixture)
+        => new(fixture.Provider, fixture.Directories, new UltimaReadGate());
+
+    [Fact]
+    public void MaxZoomFor_FollowsTheGeometry()
+    {
+        using var fixture = MapImageFixture.Create();
+
+        Assert.Equal(
+            MapTileGeometry.MaxZoom(MapImageFixture.MapWidth, MapImageFixture.MapHeight),
+            Service(fixture).MaxZoomFor(MapType.Felucca)
+        );
+    }
+
+    [Fact]
+    public async Task GetTileAsync_Native_RendersA256Tile()
+    {
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+
+        var path = await service.GetTileAsync(MapType.Felucca, service.MaxZoomFor(MapType.Felucca), 0, 0);
+
+        Assert.NotNull(path);
+
+        using var image = await Image.LoadAsync<Bgra32>(path!);
+
+        Assert.Equal(MapTileGeometry.TileSize, image.Width);
+        Assert.Equal(MapTileGeometry.TileSize, image.Height);
+    }
+
+    [Fact]
+    public async Task GetTileAsync_SecondCall_ServesTheCachedFileWithoutRerendering()
+    {
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+        var zoom = service.MaxZoomFor(MapType.Felucca);
+
+        var first = await service.GetTileAsync(MapType.Felucca, zoom, 0, 0);
+        var marker = DateTime.UtcNow.AddDays(-1);
+        File.SetLastWriteTimeUtc(first!, marker);
+
+        var second = await service.GetTileAsync(MapType.Felucca, zoom, 0, 0);
+
+        Assert.Equal(first, second);
+        Assert.Equal(marker, File.GetLastWriteTimeUtc(second!), TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetTileAsync_ZoomZero_ComposesFromChildrenIncludingTheOnesThatDoNotExist()
+    {
+        // The case that matters. This facet's z1 grid is 2x1, so the single z0 tile asks for (0,1) and
+        // (1,1), which are outside their own level's grid. A composer that treats a missing child as a
+        // failure makes z0 unreachable on every non-square facet — which is all of them.
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+
+        var path = await service.GetTileAsync(MapType.Felucca, 0, 0, 0);
+
+        Assert.NotNull(path);
+
+        using var image = await Image.LoadAsync<Bgra32>(path!);
+
+        Assert.Equal(MapTileGeometry.TileSize, image.Width);
+    }
+
+    [Fact]
+    public async Task GetTileAsync_ZoomZero_LeavesItsChildrenCachedOnTheWay()
+    {
+        // Proof the pyramid is built bottom-up out of cached tiles rather than by rendering the whole
+        // facet into one bitmap, which for Felucca would be about 100 MB.
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+
+        await service.GetTileAsync(MapType.Felucca, 0, 0, 0);
+
+        var native = service.MaxZoomFor(MapType.Felucca);
+        var root = fixture.Directories.GetPath("cache/images/maps");
+
+        Assert.True(Directory.Exists(Path.Combine(root, "felucca", native.ToString())), "no native tiles cached");
+        Assert.True(Directory.Exists(Path.Combine(root, "felucca", "0")), "no zoom 0 tile cached");
+    }
+
+    [Fact]
+    public async Task GetTileAsync_OutsideTheGrid_ReturnsNull()
+    {
+        using var fixture = MapImageFixture.Create();
+
+        Assert.Null(await Service(fixture).GetTileAsync(MapType.Felucca, 0, 99, 99));
+    }
+
+    [Fact]
+    public async Task GetTileAsync_UnknownFacet_ReturnsNull()
+    {
+        using var fixture = MapImageFixture.Create();
+
+        Assert.Null(await Service(fixture).GetTileAsync(MapType.Malas, 0, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetFullAsync_IsTheWholeFacet()
+    {
+        using var fixture = MapImageFixture.Create();
+
+        var path = await Service(fixture).GetFullAsync(MapType.Felucca);
+
+        Assert.NotNull(path);
+
+        using var image = await Image.LoadAsync<Bgra32>(path!);
+
+        Assert.Equal(MapImageFixture.MapWidth, image.Width);
+        Assert.Equal(MapImageFixture.MapHeight, image.Height);
+    }
+
+    [Fact]
+    public async Task GetFullAsync_SecondCall_ServesTheCachedFile()
+    {
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+
+        var first = await service.GetFullAsync(MapType.Felucca);
+        var marker = DateTime.UtcNow.AddDays(-1);
+        File.SetLastWriteTimeUtc(first!, marker);
+
+        var second = await service.GetFullAsync(MapType.Felucca);
+
+        Assert.Equal(marker, File.GetLastWriteTimeUtc(second!), TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetTileAsync_ConcurrentCallers_AllSucceed()
+    {
+        // Map.GetImage descends into Art, which holds no lock and shares a scratch buffer and a file
+        // stream position. Without the gate these corrupt each other.
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+        var zoom = service.MaxZoomFor(MapType.Felucca);
+
+        var paths = await Task.WhenAll(
+            Enumerable.Range(0, 4).Select(x => service.GetTileAsync(MapType.Felucca, zoom, x, 0))
+        );
+
+        Assert.All(paths, path => Assert.True(File.Exists(path)));
+    }
+
+    [Fact]
+    public void IsReady_TrueOnceTheClientFilesAreLoaded()
+    {
+        using var fixture = MapImageFixture.Create();
+
+        Assert.True(Service(fixture).IsReady);
+    }
+}

--- a/tests/Moongate.Tests/Http/MapTileGeometryTests.cs
+++ b/tests/Moongate.Tests/Http/MapTileGeometryTests.cs
@@ -1,0 +1,75 @@
+using Moongate.Http.Plugin.Data;
+
+namespace Moongate.Tests.Http;
+
+public class MapTileGeometryTests
+{
+    [Fact]
+    public void TileSize_IsAWholeNumberOfBlocks()
+    {
+        // The reason 256 was chosen: a native tile is exactly 32 blocks, so GetImage never gets a
+        // fractional block and tiles never straddle one.
+        Assert.Equal(0, MapTileGeometry.TileSize % 8);
+        Assert.Equal(MapTileGeometry.TileSize / 8, MapTileGeometry.BlocksPerTile);
+    }
+
+    [Theory]
+    [InlineData(6144, 4096, 5)] // Felucca and Trammel: 6144/256 = 24, ceil(log2 24) = 5
+    [InlineData(2304, 1600, 4)] // Ilshenar: 2304/256 = 9, ceil(log2 9) = 4
+    [InlineData(2560, 2048, 4)] // Malas: 2560/256 = 10, ceil(log2 10) = 4
+    [InlineData(1448, 1448, 3)] // Tokuno: 1448/256 = 5.65, ceil(log2 5.65) = 3
+    [InlineData(1280, 4096, 4)] // TerMur: tall, so height drives it: 4096/256 = 16, log2 16 = 4
+    [InlineData(256, 256, 0)]   // one tile already: no pyramid
+    public void MaxZoom_IsTheSmallestZoomWholeMapFitsOneTileAtZero(int width, int height, int expected)
+    {
+        Assert.Equal(expected, MapTileGeometry.MaxZoom(width, height));
+    }
+
+    [Theory]
+    [InlineData(6144, 4096)]
+    [InlineData(2304, 1600)]
+    [InlineData(1448, 1448)]
+    [InlineData(1280, 4096)]
+    public void MaxZoom_AlwaysLeavesExactlyOneTileAtZoomZero(int width, int height)
+    {
+        // The property MaxZoom exists to guarantee. If z0 were ever a 2x1 grid, a viewer would open on
+        // half a map and nothing in the response would say so.
+        var maxZoom = MapTileGeometry.MaxZoom(width, height);
+
+        Assert.Equal(1, MapTileGeometry.TilesAcross(width, 0, maxZoom));
+        Assert.Equal(1, MapTileGeometry.TilesDown(height, 0, maxZoom));
+    }
+
+    [Fact]
+    public void Scale_IsOneAtNativeAndDoublesDownwards()
+    {
+        Assert.Equal(1, MapTileGeometry.Scale(5, 5));
+        Assert.Equal(2, MapTileGeometry.Scale(4, 5));
+        Assert.Equal(32, MapTileGeometry.Scale(0, 5));
+    }
+
+    [Fact]
+    public void TilesAcross_AtNative_IsTheMapRoundedUpToWholeTiles()
+    {
+        Assert.Equal(24, MapTileGeometry.TilesAcross(6144, 5, 5));
+        Assert.Equal(16, MapTileGeometry.TilesDown(4096, 5, 5));
+    }
+
+    [Fact]
+    public void TilesAcross_RoundsUpSoTheLastPartialTileStillExists()
+    {
+        // 1448 is 5.65 tiles across at native. Rounding down would drop the right edge of Tokuno.
+        Assert.Equal(6, MapTileGeometry.TilesAcross(1448, 3, 3));
+    }
+
+    [Fact]
+    public void Grids_DoNotAlwaysHalveCleanly()
+    {
+        // Felucca's z1 is 2x1, so its single z0 tile asks for children (0,1) and (1,1), which do not
+        // exist. This is the case that makes a "fetch all four children" composer crash on every facet.
+        var maxZoom = MapTileGeometry.MaxZoom(6144, 4096);
+
+        Assert.Equal(2, MapTileGeometry.TilesAcross(6144, 1, maxZoom));
+        Assert.Equal(1, MapTileGeometry.TilesDown(4096, 1, maxZoom));
+    }
+}

--- a/tests/Moongate.Tests/Support/MapImageFixture.cs
+++ b/tests/Moongate.Tests/Support/MapImageFixture.cs
@@ -1,0 +1,144 @@
+using Moongate.Http.Plugin.Interfaces;
+using Moongate.Ultima.Graphics;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Maps;
+using Moongate.Ultima.Tiles;
+using Moongate.UO.Data.Types;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// A synthetic client directory with one map block of land, plus a throwaway runtime root for the tile
+/// cache. Building it mutates Moongate.Ultima's process-wide statics, so every test using it must sit in
+/// the "UltimaClientData" collection.
+/// </summary>
+public sealed class MapImageFixture : IDisposable
+{
+    /// <summary>
+    /// The facet the stub provider serves, sized so the pyramid is small but real: 1024×512 gives maxZoom
+    /// 2, a 4×2 grid at native, 2×1 at z1 and 1×1 at z0 — which means the z0 tile asks for two children
+    /// that exist and two that do not, exercising the case that crashes a naive composer.
+    /// </summary>
+    public const int MapWidth = 1024;
+
+    public const int MapHeight = 512;
+
+    private readonly string _clientDirectory;
+
+    private MapImageFixture(string clientDirectory, string root, DirectoriesConfig directories)
+    {
+        _clientDirectory = clientDirectory;
+        Root = root;
+        Directories = directories;
+        Provider = new StubMapProvider(new(0, 0, MapWidth, MapHeight));
+    }
+
+    public string Root { get; }
+
+    public DirectoriesConfig Directories { get; }
+
+    public IUltimaMapProvider Provider { get; }
+
+    public static MapImageFixture Create()
+    {
+        // The file must hold every block the facet claims: TileMatrix seeks straight to a block and reads,
+        // so a short map0.mul throws EndOfStreamException the moment the renderer passes the first block.
+        // 1024x512 tiles is 128x64 blocks, about 1.6 MB of identical land — small enough for a test, and
+        // the only shape that makes the renderer work at all.
+        var mapBlock = BuildMapFile();
+        var radarCol = UltimaFixtures.BuildRadarCol(BuildColors());
+        var tileData = UltimaFixtures.BuildTileData();
+        var (artIndex, art) = UltimaFixtures.BuildStaticArt(0x10, 2, 2, 0xFFFF);
+        var hues = UltimaFixtures.BuildHues("Red", 0x7C00, 0, 0);
+
+        var clientDirectory = UltimaFixtures.CreateClientDirectory(
+            ("map0.mul", mapBlock),
+            ("radarcol.mul", radarCol),
+            ("tiledata.mul", tileData),
+            ("artidx.mul", artIndex),
+            ("art.mul", art),
+            ("hues.mul", hues)
+        );
+
+        Files.SetDirectory(clientDirectory);
+        Art.Reload();
+        TileData.Initialize();
+        Hues.Initialize();
+
+        // RadarCol.Initialize is public and re-runnable, which matters: its static constructor already ran
+        // against whatever directory the first test to touch it happened to set, and only this call
+        // repoints it. RadarColTests does the same.
+        RadarCol.Initialize();
+
+        // Deliberately no Map.Reload(): it closes streams on the six *static* facets — Trammel and the
+        // rest — whose files this fixture does not create. The facet below is a fresh Map built after
+        // SetDirectory, so it reads this directory and owes the statics nothing.
+
+        var root = Path.Combine(Path.GetTempPath(), $"mg_maps_{Guid.NewGuid():N}");
+
+        return new(clientDirectory, root, new(root, []));
+    }
+
+    /// <summary>
+    /// One land block repeated across the whole facet. The content does not matter — the tests assert
+    /// sizes, caching and composition, not pixels — but the file's length does: it must cover every block
+    /// the facet spans, or the renderer reads past the end.
+    /// </summary>
+    private static byte[] BuildMapFile()
+    {
+        var block = UltimaFixtures.BuildMapBlock(0x0003, 5);
+        var blocks = MapWidth / 8 * (MapHeight / 8);
+        var file = new byte[block.Length * blocks];
+
+        for (var i = 0; i < blocks; i++)
+        {
+            block.CopyTo(file, i * block.Length);
+        }
+
+        return file;
+    }
+
+    private static ushort[] BuildColors()
+    {
+        // RadarCol is indexed by land and static id, so it must span both ranges: land below 0x4000 and
+        // statics above it.
+        var colors = new ushort[0x8000];
+
+        for (var i = 0; i < colors.Length; i++)
+        {
+            colors[i] = 0x7C00;
+        }
+
+        return colors;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_clientDirectory))
+        {
+            Directory.Delete(_clientDirectory, true);
+        }
+
+        if (Directory.Exists(Root))
+        {
+            Directory.Delete(Root, true);
+        }
+    }
+
+    /// <summary>Serves one small facet under Felucca's name, so a test need not render 384 tiles.</summary>
+    private sealed class StubMapProvider : IUltimaMapProvider
+    {
+        private readonly Map _map;
+
+        public StubMapProvider(Map map)
+        {
+            _map = map;
+        }
+
+        public IReadOnlyList<MapType> Facets { get; } = [MapType.Felucca];
+
+        public Map? Get(MapType facet)
+            => facet == MapType.Felucca ? _map : null;
+    }
+}


### PR DESCRIPTION
Map facets as 256×256 slippy-map tiles a browser can actually render, plus a whole-facet PNG, cached on disk, with a staff route that pre-builds them.

## The routes

- `GET /api/v1/images/maps` — the facets and their tile grids
- `GET /api/v1/images/maps/{map}/{z}/{x}/{y}.png` — one tile
- `GET /api/v1/images/maps/{map}/full.png` — the whole facet as one image
- `POST` / `GET /api/v1/admin/images/maps` — staff pre-warm and its progress

All anonymous except the pre-warm: map data is client data every player already has. Facets are **named** (`felucca`, `trammel`, …) via `MapType`, so the routes speak the project's own vocabulary.

## The first commit undoes something from this morning

`Map.GetImage` calls `Art.IsValidStatic`, which reads a shared LRU cache, moves a **shared file-index stream position** and writes a **shared static scratch buffer**. `Map.cs` holds 18 locks of its own — which makes it look safe — but it descends into `Art`, which holds none, and `RadarCol` holds none either.

So the item image gate, private to `ItemImageService` when it was the only caller, had to become shared. A map service with its own semaphore would have been **exactly as broken as one with none**. `IUltimaReadGate` is that gate; all 23 item image tests pass unchanged through the move, concurrency test included, which is what proves the behaviour survived.

## The design worth reviewing: the pyramid

A z0 tile covers the whole facet. Rendering it directly means a 6144×4096 bitmap — about **100 MB** — inside an HTTP request.

Instead a native tile is one `GetImage` of exactly **32 blocks** (which is why 256: a block is 8×8 tiles, so a native tile is a whole number of blocks and never straddles one), and every zoom below is composed by **halving its four children**, recursively, each cached on the way. Memory never exceeds a few 256×256 images.

**Fewer than four children is normal, not an error.** Grids do not double cleanly — each level's size is its own `ceil` — so Felucca's z1 is 2×1 and its z0 tile asks for two children that do not exist. Treating that as a failure would make zoom 0 unreachable on **every non-square facet**, which is all of them. A test covers exactly this, using a 1024×512 fixture chosen to reproduce the shape without rendering Felucca's 384 native tiles.

`full.png` does pay the ~100 MB, unavoidably: the output *is* that image. It is generated once, cached, and built by the pre-warm; the gate plus the double-check mean ten simultaneous first requests do not become ten renders.

## Two things found by running, not planning

**The synthetic map file must span every block the facet claims.** `TileMatrix` seeks straight to a block and reads, so a one-block `map0.mul` throws `EndOfStreamException` the moment the renderer passes the first block. The fixture now repeats one block across the facet — content is irrelevant to these tests, file length is not.

**`MapTileGeometry` is pure arithmetic and tested as such**, including a property test that zoom 0 is always exactly one tile across every facet shape, rather than only the numbers each happens to have.

## Not fixed here, deliberately

Ultima hardcodes Felucca at 6144×4096 while `MapDefinitions` says 7168. The renderer draws what Ultima's `Map` describes, so a shard with post-ML client files renders the older extent and silently omits the right edge. Recorded on `UltimaMapProvider` so it is not mistaken for a tiling bug later.

## Verification

1068 tests (1032 on develop plus 36 here), 0 failures. DocFX 0 warnings. All five routes checked **on the served OpenAPI document**, not only through tests: each carries a summary and a description.
