### PR TITLE
feat: read-only staff REST routes over the item templates

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -213,6 +213,26 @@ account id is read from `NameIdentifier` before `sub`. `JwtTokenService` writes 
 into `sub`, but JwtBearer's inbound claim mapping is on by default and renames it
 before the principal reaches the route — reading only `sub` 401s every request.
 
+## Item templates
+
+Staff-only, read-only views over the item template registry — the YAML-born
+catalog every item is built from.
+
+`GET /api/v1/admin/items/templates` lists templates as paged summary rows,
+using the shared paging contract: `page` is 1-based, `pageSize` caps at 100,
+and `search` is free text matched case-insensitively against a template's id,
+name, category and tags. Each row carries an `imageUrl` pointing at the item
+art route, so a table can show the sprite without computing anything.
+
+`GET /api/v1/admin/items/templates/{id}` returns one full template, specs
+included — equip, weapon, container, book and script params exactly as the
+[data reference](../scripting/data/item-templates.md) describes them. Ids are
+case-insensitive; an unknown id answers 404.
+
+Templates are read-only over the API on purpose: they are born from YAML and
+reloaded at startup, so a REST write would only diverge from the source of
+truth until the next restart.
+
 ## Item images
 
 `GET /api/v1/images/items/0x1234.png` returns an item's art as a PNG, and is

--- a/src/Moongate.Http.Plugin/Data/Api/Characters/CharacterResponse.cs
+++ b/src/Moongate.Http.Plugin/Data/Api/Characters/CharacterResponse.cs
@@ -1,3 +1,4 @@
+using Moongate.Http.Plugin.Data.Api.Accounts;
 using Moongate.Persistence.Entities;
 
 namespace Moongate.Http.Plugin.Data.Api.Characters;

--- a/src/Moongate.Http.Plugin/Data/Api/Items/ItemTemplateResponse.cs
+++ b/src/Moongate.Http.Plugin/Data/Api/Items/ItemTemplateResponse.cs
@@ -1,0 +1,64 @@
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Http.Plugin.Data.Api.Items;
+
+/// <summary>
+/// The full template: everything the summary carries plus the typed specs, passed through as the
+/// Moongate.UO.Data types — they are the documented data contract of the YAML templates.
+/// </summary>
+public sealed record ItemTemplateResponse(
+    string Id,
+    string Name,
+    string Category,
+    string Description,
+    int ItemId,
+    int Hue,
+    string Rarity,
+    int GoldValue,
+    double Weight,
+    string ScriptId,
+    bool IsMovable,
+    bool? Stackable,
+    bool? Dyeable,
+    string? Visibility,
+    string? LootType,
+    IReadOnlyList<string> Tags,
+    IReadOnlyList<int>? FlippableItemIds,
+    IReadOnlyList<string>? LootTables,
+    IReadOnlyDictionary<string, ItemParam>? Params,
+    EquipSpec? Equip,
+    WeaponSpec? Weapon,
+    ContainerSpec? Container,
+    BookSpec? Book,
+    string ImageUrl
+)
+{
+    /// <summary>Projects a template into its full response, art url included.</summary>
+    public static ItemTemplateResponse From(ItemTemplate template)
+        => new(
+            template.Id,
+            template.Name,
+            template.Category,
+            template.Description,
+            template.ItemId,
+            template.Hue,
+            template.Rarity.ToString(),
+            template.GoldValue,
+            template.Weight,
+            template.ScriptId,
+            template.IsMovable,
+            template.Stackable,
+            template.Dyeable,
+            template.Visibility,
+            template.LootType,
+            template.Tags,
+            template.FlippableItemIds,
+            template.LootTables,
+            template.Params,
+            template.Equip,
+            template.Weapon,
+            template.Container,
+            template.Book,
+            $"/api/v1/images/items/0x{template.ItemId:x4}.png"
+        );
+}

--- a/src/Moongate.Http.Plugin/Data/Api/Items/ItemTemplateSummaryResponse.cs
+++ b/src/Moongate.Http.Plugin/Data/Api/Items/ItemTemplateSummaryResponse.cs
@@ -1,0 +1,33 @@
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Http.Plugin.Data.Api.Items;
+
+/// <summary>One row of the staff item template listing.</summary>
+public sealed record ItemTemplateSummaryResponse(
+    string Id,
+    string Name,
+    string Category,
+    int ItemId,
+    int Hue,
+    string Rarity,
+    int GoldValue,
+    double Weight,
+    IReadOnlyList<string> Tags,
+    string ImageUrl
+)
+{
+    /// <summary>Projects a template into its listing row, art url included.</summary>
+    public static ItemTemplateSummaryResponse From(ItemTemplate template)
+        => new(
+            template.Id,
+            template.Name,
+            template.Category,
+            template.ItemId,
+            template.Hue,
+            template.Rarity.ToString(),
+            template.GoldValue,
+            template.Weight,
+            template.Tags,
+            $"/api/v1/images/items/0x{template.ItemId:x4}.png"
+        );
+}

--- a/src/Moongate.Http.Plugin/Endpoints/Items/ItemTemplateEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Items/ItemTemplateEndpoints.cs
@@ -1,0 +1,92 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Items;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Http.Plugin.Endpoints.Items;
+
+/// <summary>Staff-only, read-only views over the item template registry.</summary>
+public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
+{
+    private readonly IItemTemplateService _templates;
+
+    public ItemTemplateEndpoints(IItemTemplateService templates)
+    {
+        _templates = templates;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/admin/items/templates", List)
+              .WithName("ListItemTemplates")
+              .WithTags("items")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        routes.MapGet("/api/v1/admin/items/templates/{id}", Get)
+              .WithName("GetItemTemplate")
+              .WithTags("items")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>Every item template, paged.</summary>
+    /// <remarks>
+    /// Ordered by template id. Pass search to filter: free text, case-insensitive, matching the
+    /// template's id, name, category or any tag. Page is 1-based and defaults to 1; pageSize defaults
+    /// to 25 and cannot exceed 100. A search matching nothing is an empty page, not an error.
+    /// </remarks>
+    private IResult List(string? page, string? pageSize, string? search)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var matched = Filter(_templates.All, request.Search);
+
+        IReadOnlyList<ItemTemplateSummaryResponse> items =
+        [
+            .. matched.OrderBy(template => template.Id, StringComparer.OrdinalIgnoreCase)
+                      .Skip(request.Skip)
+                      .Take(request.PageSize)
+                      .Select(ItemTemplateSummaryResponse.From)
+        ];
+
+        return Results.Ok(PagedResponse<ItemTemplateSummaryResponse>.From(items, matched.Count, request));
+    }
+
+    /// <summary>Fetches one item template by id, specs included.</summary>
+    /// <remarks>Ids are case-insensitive. Answers 404 when no template carries the id.</remarks>
+    private IResult Get(string id)
+    {
+        var template = _templates.GetById(id);
+
+        return template is null
+            ? Results.Problem($"No item template with id '{id}'.", statusCode: StatusCodes.Status404NotFound)
+            : Results.Ok(ItemTemplateResponse.From(template));
+    }
+
+    private static List<ItemTemplate> Filter(IReadOnlyList<ItemTemplate> all, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return [.. all];
+        }
+
+        return
+        [
+            .. all.Where(template =>
+                Matches(template.Id, search)
+                || Matches(template.Name, search)
+                || Matches(template.Category, search)
+                || template.Tags.Any(tag => Matches(tag, search)))
+        ];
+    }
+
+    private static bool Matches(string value, string search)
+        => value.Contains(search, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -5,6 +5,7 @@ using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Images;
+using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Version;
@@ -77,6 +78,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<PlayerEndpoints>();
         container.RegisterApiEndpoint<CharacterEndpoints>();
         container.RegisterApiEndpoint<CharacterAdminEndpoints>();
+        container.RegisterApiEndpoint<ItemTemplateEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/tests/Moongate.Tests/Http/Endpoints/Items/ItemTemplateEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Items/ItemTemplateEndpointsTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Items;
+using Moongate.Http.Plugin.Endpoints.Items;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Services.Items;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Items;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http.Endpoints.Items;
+
+public class ItemTemplateEndpointsTests
+{
+    private const string Route = "/api/v1/admin/items/templates";
+
+    private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+        => await TestApiServer.StartAsync(
+            level,
+            configure: container =>
+            {
+                var templates = new ItemTemplateService();
+                templates.Register(
+                    Template("katana", "a katana", "weapons", 0x13FF, ["weapon", "sword"], ItemRarityType.Common)
+                );
+                templates.Register(Template("bread", "a bread loaf", "food", 0x103B, ["food"]));
+                templates.Register(
+                    Template("elder_katana", "an elder katana", "weapons", 0x13FF, ["weapon", "sword"], ItemRarityType.Legendary)
+                );
+                container.RegisterInstance<IItemTemplateService>(templates);
+                container.RegisterApiEndpointInstance(new ItemTemplateEndpoints(templates));
+            }
+        );
+
+    [Fact]
+    public async Task List_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsStaff_ReturnsPagedSummariesOrderedById()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<ItemTemplateSummaryResponse>>(Route);
+
+        Assert.Equal(3, page!.Total);
+        Assert.Equal(["bread", "elder_katana", "katana"], page.Items.Select(item => item.Id));
+        var katana = page.Items.Single(item => item.Id == "katana");
+        Assert.Equal("/api/v1/images/items/0x13ff.png", katana.ImageUrl);
+        Assert.Equal("Common", katana.Rarity);
+    }
+
+    [Fact]
+    public async Task List_SearchMatchesNameCategoryAndTags_CaseInsensitively()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var byTag = await server.Client.GetFromJsonAsync<PagedResponse<ItemTemplateSummaryResponse>>($"{Route}?search=SWORD");
+        var byCategory = await server.Client.GetFromJsonAsync<PagedResponse<ItemTemplateSummaryResponse>>($"{Route}?search=food");
+
+        Assert.Equal(2, byTag!.Total);
+        Assert.Equal(["bread"], byCategory!.Items.Select(item => item.Id));
+    }
+
+    [Fact]
+    public async Task List_NoMatches_IsAnEmptyPageNotAnError()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<ItemTemplateSummaryResponse>>($"{Route}?search=nothing");
+
+        Assert.Equal(0, page!.Total);
+        Assert.Empty(page.Items);
+    }
+
+    [Fact]
+    public async Task List_BadPaging_IsABadRequest()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync($"{Route}?page=0")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsTheFullTemplate_SpecsIncluded()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var template = await server.Client.GetFromJsonAsync<ItemTemplateResponse>($"{Route}/KATANA");
+
+        Assert.Equal("katana", template!.Id);
+        Assert.Equal("a fine blade", template.Description);
+        Assert.True(template.Stackable is null or false);
+        Assert.NotNull(template.Params);
+        Assert.Equal("100", template.Params!["durability"].Value);
+        Assert.Equal("/api/v1/images/items/0x13ff.png", template.ImageUrl);
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_IsANotFound()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, (await server.Client.GetAsync($"{Route}/nope")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync($"{Route}/katana")).StatusCode);
+    }
+
+    private static ItemTemplate Template(
+        string id,
+        string name,
+        string category,
+        int itemId,
+        string[] tags,
+        ItemRarityType rarity = ItemRarityType.Common
+    )
+        => new()
+        {
+            Id = id,
+            Name = name,
+            Category = category,
+            Description = id == "katana" ? "a fine blade" : string.Empty,
+            ItemId = itemId,
+            GoldValue = 10,
+            Weight = 2.5,
+            Rarity = rarity,
+            Tags = [.. tags],
+            Params = id == "katana"
+                ? new() { ["durability"] = new() { Type = "int", Value = "100" } }
+                : null
+        };
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -6,6 +6,7 @@ using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Images;
+using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Version;
@@ -64,6 +65,7 @@ public class MoongateHttpPluginTests
                 typeof(CharacterEndpoints),
                 typeof(ItemImageAdminEndpoints),
                 typeof(ItemImageEndpoints),
+                typeof(ItemTemplateEndpoints),
                 typeof(MapImageAdminEndpoints),
                 typeof(MapImageEndpoints),
                 typeof(PlayerEndpoints),


### PR DESCRIPTION
## What

- `GET /api/v1/admin/items/templates` — paged summary list over the item template registry, shared paging contract, free-text search matched case-insensitively against id, name, category and tags; each row carries an `imageUrl` pointing at the item art route.
- `GET /api/v1/admin/items/templates/{id}` — the full template, specs (equip, weapon, container, book, params) passed through as the documented `Moongate.UO.Data` types; 404 on unknown id.
- Both admin-only, registered in `MoongateHttpPlugin` (12 endpoint groups now) and covered by the merged registration test.
- Feature lives entirely in `Moongate.Http.Plugin`: the endpoint filters over `IItemTemplateService.All` in memory — no change to Abstractions or Server.

## Why

Operator tooling: browse the YAML-born item catalog from the admin API, with art previews for a picker/table UI. Read-only on purpose — templates are reloaded from YAML at startup, a REST write would diverge from the source of truth.

## Verification

9 new endpoint tests over real HTTP (auth 401/403, paging, search, empty page, 400, detail, 404). Full suite 1076/1076, DocFX 0 warnings, routes documented in rest-api.md.