### PR TITLE
feat: body, hair and mobile-template figure images over REST

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -344,6 +344,28 @@ gate: a service with its own semaphore is exactly as broken as one with none.
 None of this is visible from those types' signatures, which is why it is written
 down here.
 
+## Mobile images
+
+`GET /api/v1/images/bodies/{body}.png` serves a body's idle, front-facing
+frame, lazily rendered from the animation files and cached on disk; `hue`
+gives a skin-hued variant its own cache entry. Bodies with no usable
+animation answer 404. Like the item art, these are anonymous: it is client
+data every player already has.
+
+`GET /api/v1/images/hair/{style}.png` renders a hair style over a reference
+body (400 unless `body` says otherwise); `facial=true` switches to beards,
+`hue` dyes. `GET /api/v1/images/mobiles/templates/{id}.png` serves the
+dressed figure of a mobile template — body, hair and worn equipment
+composited in draw order. Hue specs resolve to their low end so the image is
+deterministic and cacheable.
+
+Three staff routes support the pickers and the cache:
+`GET /api/v1/admin/bodies` pages the classified bodies (mobtypes.txt,
+Equipment excluded, decimal or hex search); `GET /api/v1/admin/hair-styles`
+lists the selectable styles; `POST /api/v1/admin/images/bodies` warms the
+body cache in the background, polled with GET on the same route — the same
+contract as the item and map exports.
+
 ## Browsing the API
 
 [Scalar](https://scalar.com) serves an interactive reference at `/scalar/v1`,

--- a/src/Moongate.Http.Plugin/Data/Api/Mobiles/BodySummary.cs
+++ b/src/Moongate.Http.Plugin/Data/Api/Mobiles/BodySummary.cs
@@ -1,0 +1,11 @@
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>One row of the staff body picker.</summary>
+public sealed record BodySummary(int Body, string Hex, string Type, string ImageUrl)
+{
+    /// <summary>Projects a classified body into its picker row.</summary>
+    public static BodySummary From(int body, MobType type)
+        => new(body, $"0x{body:X4}", type.ToString(), $"/api/v1/images/bodies/{body}.png");
+}

--- a/src/Moongate.Http.Plugin/Data/Api/Mobiles/HairStyleSummary.cs
+++ b/src/Moongate.Http.Plugin/Data/Api/Mobiles/HairStyleSummary.cs
@@ -1,0 +1,17 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>One row of the staff hair-style picker.</summary>
+public sealed record HairStyleSummary(int Style, string Hex, string Name, bool Facial, string ImageUrl)
+{
+    /// <summary>Projects a catalog entry into its picker row.</summary>
+    public static HairStyleSummary From(HairStyleEntry entry)
+        => new(
+            entry.Style,
+            entry.Hex,
+            entry.Name,
+            entry.Facial,
+            $"/api/v1/images/hair/{entry.Style}.png{(entry.Facial ? "?facial=true" : string.Empty)}"
+        );
+}

--- a/src/Moongate.Http.Plugin/Data/BodyImageExportStatus.cs
+++ b/src/Moongate.Http.Plugin/Data/BodyImageExportStatus.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Http.Plugin.Data;
+
+/// <summary>How far the bulk body-image export has got.</summary>
+/// <param name="State">Idle, Running, Completed or Failed.</param>
+/// <param name="Done">Bodies processed so far.</param>
+/// <param name="Total">Classified, non-equipment bodies to process. 0 until the export has counted them.</param>
+/// <param name="Failed">Bodies whose frame could not be rendered or written. The reasons are in the log.</param>
+/// <param name="StartedAt">When the current or last export started; null if none ever has.</param>
+public record BodyImageExportStatus(string State, int Done, int Total, int Failed, DateTimeOffset? StartedAt);

--- a/src/Moongate.Http.Plugin/Data/Mobiles/EquipmentDrawOrder.cs
+++ b/src/Moongate.Http.Plugin/Data/Mobiles/EquipmentDrawOrder.cs
@@ -1,0 +1,39 @@
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>
+/// Front-facing draw priority for mobile figure layers (lower draws first/behind). The body sits at
+/// <see cref="BodyPriority" />; non-drawable layers return <see cref="Skip" />. Tuned for a catalog
+/// thumbnail (single facing); per-direction order is a later refinement.
+/// </summary>
+public static class EquipmentDrawOrder
+{
+    public const int Skip = int.MaxValue;
+
+    public const int BodyPriority = 5;
+
+    public static int Priority(LayerType layer)
+        => layer switch
+        {
+            LayerType.Cloak => 0,
+            LayerType.InnerLegs => 10,
+            LayerType.Pants => 11,
+            LayerType.Shoes => 12,
+            LayerType.Shirt => 13,
+            LayerType.InnerTorso => 14,
+            LayerType.Arms => 15,
+            LayerType.MiddleTorso => 16,
+            LayerType.Gloves => 17,
+            LayerType.Neck => 18,
+            LayerType.Waist => 19,
+            LayerType.OuterLegs => 20,
+            LayerType.OuterTorso => 21,
+            LayerType.Hair => 25,
+            LayerType.FacialHair => 26,
+            LayerType.Helm => 30,
+            LayerType.OneHanded => 35,
+            LayerType.TwoHanded => 36,
+            _ => Skip
+        };
+}

--- a/src/Moongate.Http.Plugin/Data/Mobiles/HairStyleCatalog.cs
+++ b/src/Moongate.Http.Plugin/Data/Mobiles/HairStyleCatalog.cs
@@ -1,0 +1,36 @@
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>The selectable human hair and facial-hair styles (graphic ids from the race validation tables).</summary>
+public static class HairStyleCatalog
+{
+    public static IReadOnlyList<HairStyleEntry> Hair { get; } =
+    [
+        CreateHair(0x203B, "Short"),
+        CreateHair(0x203C, "Long"),
+        CreateHair(0x203D, "Pony Tail"),
+        CreateHair(0x2044, "Mohawk"),
+        CreateHair(0x2045, "Pageboy"),
+        CreateHair(0x2046, "Buns"),
+        CreateHair(0x2047, "Afro"),
+        CreateHair(0x2048, "Receding"),
+        CreateHair(0x2049, "Two Pig Tails"),
+        CreateHair(0x204A, "Topknot")
+    ];
+
+    public static IReadOnlyList<HairStyleEntry> Facial { get; } =
+    [
+        CreateFacial(0x203E, "Long Beard"),
+        CreateFacial(0x203F, "Short Beard"),
+        CreateFacial(0x2040, "Goatee"),
+        CreateFacial(0x2041, "Moustache"),
+        CreateFacial(0x204B, "Medium Short Beard"),
+        CreateFacial(0x204C, "Medium Long Beard"),
+        CreateFacial(0x204D, "Vandyke")
+    ];
+
+    private static HairStyleEntry CreateFacial(int style, string name)
+        => new(style, $"0x{style:X4}", name, true);
+
+    private static HairStyleEntry CreateHair(int style, string name)
+        => new(style, $"0x{style:X4}", name, false);
+}

--- a/src/Moongate.Http.Plugin/Data/Mobiles/HairStyleEntry.cs
+++ b/src/Moongate.Http.Plugin/Data/Mobiles/HairStyleEntry.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>A selectable hair or facial-hair style: item graphic id, display hex and name.</summary>
+public sealed record HairStyleEntry(int Style, string Hex, string Name, bool Facial);

--- a/src/Moongate.Http.Plugin/Data/Mobiles/MobileFigureEquipment.cs
+++ b/src/Moongate.Http.Plugin/Data/Mobiles/MobileFigureEquipment.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>One worn item to draw: the item template id and the already-resolved hue (0 = template's).</summary>
+public sealed record MobileFigureEquipment(string ItemTemplateId, int Hue);

--- a/src/Moongate.Http.Plugin/Data/Mobiles/MobileFigureRequest.cs
+++ b/src/Moongate.Http.Plugin/Data/Mobiles/MobileFigureRequest.cs
@@ -1,0 +1,12 @@
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>The inputs needed to render a dressed mobile figure. Hues are resolved values, not specs.</summary>
+public sealed record MobileFigureRequest(
+    int Body,
+    int SkinHue,
+    int HairStyle,
+    int HairHue,
+    int FacialHairStyle,
+    int FacialHairHue,
+    IReadOnlyList<MobileFigureEquipment> Equipment
+);

--- a/src/Moongate.Http.Plugin/Data/Mobiles/MobileFrame.cs
+++ b/src/Moongate.Http.Plugin/Data/Mobiles/MobileFrame.cs
@@ -1,0 +1,13 @@
+using Moongate.Ultima.Imaging;
+
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>
+/// One decoded animation frame for compositing: the bitmap and its anim.mul anchor point. The frame
+/// owns its bitmap (catalog implementations hand out clones, never cache-owned surfaces).
+/// </summary>
+public sealed record MobileFrame(int CenterX, int CenterY, UltimaBitmap Bitmap) : IDisposable
+{
+    public void Dispose()
+        => Bitmap.Dispose();
+}

--- a/src/Moongate.Http.Plugin/Endpoints/Mobiles/BodyImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Mobiles/BodyImageEndpoints.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+
+namespace Moongate.Http.Plugin.Endpoints.Mobiles;
+
+/// <summary>Public PNG views over UO body graphics.</summary>
+public sealed class BodyImageEndpoints : IApiEndpointRegistration
+{
+    private readonly IBodyImageService _bodies;
+
+    public BodyImageEndpoints(IBodyImageService bodies)
+    {
+        _bodies = bodies;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/images/bodies/{body}.png", Get)
+              .WithName("GetBodyImage")
+              .WithTags("mobiles");
+    }
+
+    /// <summary>Serves a body's idle, front-facing frame as PNG.</summary>
+    /// <remarks>
+    /// The body is a decimal graphic id; pass hue for a skin-hued variant. Generated lazily and cached
+    /// on disk. A body with no usable animation answers 404. Anonymous on purpose: it is client data
+    /// every player already has on disk.
+    /// </remarks>
+    private async Task<IResult> Get(string body, int? hue, CancellationToken cancellationToken)
+    {
+        if (!int.TryParse(body, out var bodyId) || bodyId < 0)
+        {
+            return Results.Problem("body must be a non-negative integer", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var path = await _bodies.GetOrCreateAsync(bodyId, hue.GetValueOrDefault(), cancellationToken);
+
+        return path is null
+            ? Results.Problem($"No animation for body {bodyId}.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
+    }
+}

--- a/src/Moongate.Http.Plugin/Endpoints/Mobiles/HairImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Mobiles/HairImageEndpoints.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+
+namespace Moongate.Http.Plugin.Endpoints.Mobiles;
+
+/// <summary>Public PNG views over hair styles, rendered on a reference body.</summary>
+public sealed class HairImageEndpoints : IApiEndpointRegistration
+{
+    private const int DefaultReferenceBody = 400;
+
+    private readonly IHairImageService _hair;
+
+    public HairImageEndpoints(IHairImageService hair)
+    {
+        _hair = hair;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/images/hair/{style}.png", Get)
+              .WithName("GetHairImage")
+              .WithTags("mobiles");
+    }
+
+    /// <summary>Serves a hair (or facial-hair) style as PNG, rendered over a reference body.</summary>
+    /// <remarks>
+    /// The style is the hair item's decimal graphic id (see /api/v1/admin/hair-styles). Pass hue to dye
+    /// it, body to change the reference body (default 400, the human male), facial=true for beards.
+    /// 404 when nothing decodes for the pair.
+    /// </remarks>
+    private async Task<IResult> Get(string style, int? hue, int? body, bool? facial, CancellationToken cancellationToken)
+    {
+        if (!int.TryParse(style, out var styleId) || styleId <= 0)
+        {
+            return Results.Problem("style must be a positive integer", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var referenceBody = body is > 0 ? body.Value : DefaultReferenceBody;
+        var path = await _hair.GetOrCreateAsync(
+            styleId,
+            hue.GetValueOrDefault(),
+            referenceBody,
+            facial.GetValueOrDefault(),
+            cancellationToken
+        );
+
+        return path is null
+            ? Results.Problem($"Nothing decodes for style {styleId}.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
+    }
+}

--- a/src/Moongate.Http.Plugin/Endpoints/Mobiles/MobileImageAdminEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Mobiles/MobileImageAdminEndpoints.cs
@@ -1,0 +1,148 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Mobiles;
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Ultima.Types;
+using System.Globalization;
+
+namespace Moongate.Http.Plugin.Endpoints.Mobiles;
+
+/// <summary>Staff pickers over bodies and hair styles, and the body image cache warm-up.</summary>
+public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
+{
+    private readonly IAnimationCatalog _catalog;
+    private readonly IBodyImageExportJob _export;
+    private readonly IBodyImageService _images;
+
+    public MobileImageAdminEndpoints(
+        IAnimationCatalog catalog,
+        IBodyImageExportJob export,
+        IBodyImageService images
+    )
+    {
+        _catalog = catalog;
+        _export = export;
+        _images = images;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        var export = routes.MapGroup("/api/v1/admin/images/bodies")
+                           .WithTags("mobiles")
+                           .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        export.MapPost("/", Start).WithName("StartBodyImageExport");
+        export.MapGet("/", GetStatus).WithName("GetBodyImageExportStatus");
+
+        routes.MapGet("/api/v1/admin/bodies", ListBodies)
+              .WithName("ListBodies")
+              .WithTags("mobiles")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        routes.MapGet("/api/v1/admin/hair-styles", ListHairStyles)
+              .WithName("ListHairStyles")
+              .WithTags("mobiles")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>Generates every classified body's image into the cache.</summary>
+    /// <remarks>
+    /// Answers 202 and works in the background; poll this same route with GET for progress. Only one
+    /// export runs at a time, so a second request while one is going answers 409. Unhued frames only —
+    /// hued variants are generated on demand by the public image route.
+    /// </remarks>
+    private IResult Start()
+    {
+        if (!_images.IsReady)
+        {
+            return Results.Problem(
+                "The UO client files are not loaded; there is nothing to export.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        if (!_export.TryStart())
+        {
+            return Results.Problem(
+                "A body image export is already running.",
+                statusCode: StatusCodes.Status409Conflict
+            );
+        }
+
+        return Results.Accepted("/api/v1/admin/images/bodies", _export.Status);
+    }
+
+    /// <summary>Reports how far the body image export has got.</summary>
+    /// <remarks>State is Idle before any export has run, then Running, and finally Completed or Failed.</remarks>
+    private IResult GetStatus()
+        => Results.Ok(_export.Status);
+
+    /// <summary>Every classified body, paged, for the picker.</summary>
+    /// <remarks>
+    /// Classification comes from mobtypes.txt; Equipment-type bodies never appear. Search matches the
+    /// decimal id or the 0x-prefixed hex. Ordered by body id.
+    /// </remarks>
+    private IResult ListBodies(string? page, string? pageSize, string? search)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var classified = _catalog.ClassifiedBodies
+                                 .Where(entry => entry.Type != MobType.Equipment)
+                                 .Where(entry => Matches(entry.Body, request.Search))
+                                 .OrderBy(entry => entry.Body)
+                                 .ToArray();
+
+        IReadOnlyList<BodySummary> items =
+        [
+            .. classified.Skip(request.Skip)
+                         .Take(request.PageSize)
+                         .Select(entry => BodySummary.From(entry.Body, entry.Type))
+        ];
+
+        return Results.Ok(PagedResponse<BodySummary>.From(items, classified.Length, request));
+    }
+
+    /// <summary>The selectable hair (or facial-hair) styles, paged.</summary>
+    /// <remarks>Pass facial=true for beards. Search matches the style name, case-insensitively.</remarks>
+    private IResult ListHairStyles(string? page, string? pageSize, string? search, bool? facial)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var source = facial.GetValueOrDefault() ? HairStyleCatalog.Facial : HairStyleCatalog.Hair;
+        var matched = source
+                      .Where(entry => request.Search is null
+                                      || entry.Name.Contains(request.Search, StringComparison.OrdinalIgnoreCase))
+                      .ToArray();
+
+        IReadOnlyList<HairStyleSummary> items =
+        [
+            .. matched.Skip(request.Skip).Take(request.PageSize).Select(HairStyleSummary.From)
+        ];
+
+        return Results.Ok(PagedResponse<HairStyleSummary>.From(items, matched.Length, request));
+    }
+
+    private static bool Matches(int body, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return true;
+        }
+
+        var term = search.Trim();
+
+        return body.ToString(CultureInfo.InvariantCulture).Contains(term, StringComparison.OrdinalIgnoreCase)
+               || $"0x{body:X4}".Contains(term, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateImageEndpoints.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+
+namespace Moongate.Http.Plugin.Endpoints.Mobiles;
+
+/// <summary>Public PNG views over dressed mobile-template figures.</summary>
+public sealed class MobileTemplateImageEndpoints : IApiEndpointRegistration
+{
+    private readonly IMobileTemplateImageService _figures;
+
+    public MobileTemplateImageEndpoints(IMobileTemplateImageService figures)
+    {
+        _figures = figures;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/images/mobiles/templates/{id}.png", Get)
+              .WithName("GetMobileTemplateImage")
+              .WithTags("mobiles");
+    }
+
+    /// <summary>Serves a mobile template's dressed figure as PNG: body, hair and worn equipment.</summary>
+    /// <remarks>
+    /// Hue specs on the template resolve to their low end so the image is stable and cacheable. 404 on
+    /// an unknown template id, or when the template's body has no animation.
+    /// </remarks>
+    private async Task<IResult> Get(string id, CancellationToken cancellationToken)
+    {
+        var path = await _figures.GetOrCreateAsync(id, cancellationToken);
+
+        return path is null
+            ? Results.Problem($"No renderable figure for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
+    }
+}

--- a/src/Moongate.Http.Plugin/Interfaces/Mobiles/IAnimationCatalog.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Mobiles/IAnimationCatalog.cs
@@ -1,0 +1,26 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>
+/// Decoded animation frames and body classification, behind a seam the tests can fake: the real
+/// implementation reads Moongate.Ultima's process-wide statics, which tests do not have.
+/// </summary>
+public interface IAnimationCatalog
+{
+    /// <summary>True once the client files behind the statics are loaded.</summary>
+    bool IsReady { get; }
+
+    /// <summary>Classified bodies from mobtypes.txt, with their type.</summary>
+    IReadOnlyList<(int Body, MobType Type)> ClassifiedBodies { get; }
+
+    /// <summary>A decoded, hued frame the caller owns, or null when the graphic has none.</summary>
+    MobileFrame? GetFrame(int body, int action, int direction, int frame, int hue);
+
+    /// <summary>The animation id tiledata assigns to an item graphic (equipment, hair), or null.</summary>
+    int? GetItemAnimation(int itemId);
+
+    /// <summary>Equipconv.def lookup: fits an equipment animation to a body, optionally re-hued.</summary>
+    bool TryConvertEquipment(int body, int equipmentAnim, out (int AnimId, int Hue) conversion);
+}

--- a/src/Moongate.Http.Plugin/Interfaces/Mobiles/IBodyImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Mobiles/IBodyImageExportJob.cs
@@ -1,0 +1,13 @@
+using Moongate.Http.Plugin.Data;
+
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>Background warm-up of the body image cache over the classified bodies.</summary>
+public interface IBodyImageExportJob
+{
+    /// <summary>Where the export stands right now.</summary>
+    BodyImageExportStatus Status { get; }
+
+    /// <summary>Starts an export unless one is already running; false when refused.</summary>
+    bool TryStart();
+}

--- a/src/Moongate.Http.Plugin/Interfaces/Mobiles/IBodyImageService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Mobiles/IBodyImageService.cs
@@ -1,0 +1,11 @@
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>Disk PNG cache over body animation frames.</summary>
+public interface IBodyImageService
+{
+    /// <summary>True once the client files behind the frames are loaded.</summary>
+    bool IsReady { get; }
+
+    /// <summary>The cached PNG's path, generating it on miss; null when the body has no animation.</summary>
+    Task<string?> GetOrCreateAsync(int body, int hue, CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Http.Plugin/Interfaces/Mobiles/IHairImageService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Mobiles/IHairImageService.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>Disk PNG cache over hair styles rendered on a reference body.</summary>
+public interface IHairImageService
+{
+    /// <summary>The cached PNG's path, generating it on miss; null when nothing decodes.</summary>
+    Task<string?> GetOrCreateAsync(
+        int style,
+        int hue,
+        int referenceBody,
+        bool facial,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Moongate.Http.Plugin/Interfaces/Mobiles/IMobileFigureRenderer.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Mobiles/IMobileFigureRenderer.cs
@@ -1,0 +1,11 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Ultima.Imaging;
+
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>Composites a dressed mobile figure (body + hair + facial hair + equipment).</summary>
+public interface IMobileFigureRenderer
+{
+    /// <summary>The composited figure the caller owns, or null when the body has no animation.</summary>
+    UltimaBitmap? Render(MobileFigureRequest request);
+}

--- a/src/Moongate.Http.Plugin/Interfaces/Mobiles/IMobileTemplateImageService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Mobiles/IMobileTemplateImageService.cs
@@ -1,0 +1,8 @@
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>Disk PNG cache over dressed mobile-template figures.</summary>
+public interface IMobileTemplateImageService
+{
+    /// <summary>The cached PNG's path, generating it on miss; null on unknown template or bodiless figure.</summary>
+    Task<string?> GetOrCreateAsync(string templateId, CancellationToken cancellationToken = default);
+}

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -7,17 +7,20 @@ using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Images;
 using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
+using Moongate.Http.Plugin.Endpoints.Mobiles;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Extensions;
 using Moongate.Http.Plugin.Interfaces.Auth;
 using Moongate.Http.Plugin.Interfaces.Images;
 using Moongate.Http.Plugin.Interfaces.Maps;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Services.Auth;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Services.Images;
 using Moongate.Http.Plugin.Services.Maps;
+using Moongate.Http.Plugin.Services.Mobiles;
 using Moongate.Http.Plugin.Services.Ultima;
 using Moongate.Ultima.Catalog;
 using Moongate.Ultima.Interfaces;
@@ -68,6 +71,19 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<MapImageEndpoints>();
         container.RegisterApiEndpoint<MapImageAdminEndpoints>();
         container.RegisterApiEndpoint<ItemImageAdminEndpoints>();
+
+        // Mobile figures share the same statics as the other image routes, so the same gate serializes
+        // them; the renderer's game-facing inputs come through the Abstractions contracts.
+        container.Register<IAnimationCatalog, AnimationCatalog>(Reuse.Singleton);
+        container.Register<IMobileFigureRenderer, MobileFigureRenderer>(Reuse.Singleton);
+        container.Register<IBodyImageService, BodyImageService>(Reuse.Singleton);
+        container.Register<IHairImageService, HairImageService>(Reuse.Singleton);
+        container.Register<IMobileTemplateImageService, MobileTemplateImageService>(Reuse.Singleton);
+        container.Register<IBodyImageExportJob, BodyImageExportJob>(Reuse.Singleton);
+        container.RegisterApiEndpoint<BodyImageEndpoints>();
+        container.RegisterApiEndpoint<HairImageEndpoints>();
+        container.RegisterApiEndpoint<MobileTemplateImageEndpoints>();
+        container.RegisterApiEndpoint<MobileImageAdminEndpoints>();
 
         // The game-facing groups consume the contracts in Moongate.Server.Abstractions, which the
         // server implements — the plugin never sees Moongate.Server itself.

--- a/src/Moongate.Http.Plugin/Services/Mobiles/AnimationCatalog.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/AnimationCatalog.cs
@@ -1,0 +1,78 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Ultima.Animation;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// The real catalog over Moongate.Ultima's statics. Frames are cloned out of the animation LRU cache:
+/// callers dispose what they get, and the cache keeps what it owns. Callers serialize access through
+/// the Ultima read gate — this class does not take it itself.
+/// </summary>
+public sealed class AnimationCatalog : IAnimationCatalog
+{
+    private readonly Lock _equipConvSync = new();
+
+    private EquipConvTable? _equipConv;
+
+    public bool IsReady
+        => TileData.ItemTable is not null && MobTypes.IsLoaded;
+
+    public IReadOnlyList<(int Body, MobType Type)> ClassifiedBodies
+        => [.. MobTypes.GetDefinedBodies().Order().Select(body => (body, MobTypes.GetTypeOrDefault(body)))];
+
+    public MobileFrame? GetFrame(int body, int action, int direction, int frame, int hue)
+    {
+        var resolvedHue = hue;
+        var frames = Animations.GetAnimation(body, action, direction, ref resolvedHue, false, frame == 0);
+
+        if (frames is null || frames.Length == 0)
+        {
+            return null;
+        }
+
+        var index = frame < frames.Length ? frame : 0;
+        var decoded = frames[index];
+
+        if (decoded.Bitmap is null || (decoded.Bitmap.Width <= 1 && decoded.Bitmap.Height <= 1))
+        {
+            return null;
+        }
+
+        return new MobileFrame(decoded.Center.X, decoded.Center.Y, decoded.Bitmap.Clone());
+    }
+
+    public int? GetItemAnimation(int itemId)
+    {
+        var table = TileData.ItemTable;
+
+        if (table is null || itemId < 0 || itemId >= table.Length)
+        {
+            return null;
+        }
+
+        var animation = table[itemId].Animation;
+
+        return animation > 0 ? animation : null;
+    }
+
+    public bool TryConvertEquipment(int body, int equipmentAnim, out (int AnimId, int Hue) conversion)
+    {
+        // Lazy: equipconv.def is resolvable only after the client files are located, which happens
+        // during startup, before any request reaches us.
+        if (_equipConv is null)
+        {
+            lock (_equipConvSync)
+            {
+                _equipConv ??= new EquipConvTable(
+                    Files.GetFilePath("equipconv.def") ?? Path.Combine(Path.GetTempPath(), "equipconv.def.missing")
+                );
+            }
+        }
+
+        return _equipConv.TryConvert(body, equipmentAnim, out conversion);
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/BodyImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/BodyImageExportJob.cs
@@ -1,0 +1,129 @@
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Types;
+using Moongate.Ultima.Types;
+using Serilog;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Warms the body image cache by walking every classified, non-equipment body. It goes through
+/// <see cref="IBodyImageService" /> like any request, so it takes the same gate per body and
+/// interleaves with live traffic rather than blocking it for the length of the run.
+/// </summary>
+public sealed class BodyImageExportJob : IBodyImageExportJob
+{
+    private readonly ILogger _logger = Log.ForContext<BodyImageExportJob>();
+    private readonly IBodyImageService _images;
+    private readonly IAnimationCatalog _catalog;
+    private readonly object _sync = new();
+
+    private BodyImageExportStateType _state = BodyImageExportStateType.Idle;
+    private int _done;
+    private int _total;
+    private int _failed;
+    private DateTimeOffset? _startedAt;
+
+    public BodyImageExportJob(IBodyImageService images, IAnimationCatalog catalog)
+    {
+        _images = images;
+        _catalog = catalog;
+    }
+
+    public BodyImageExportStatus Status
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return new(_state.ToString(), _done, _total, _failed, _startedAt);
+            }
+        }
+    }
+
+    public bool TryStart()
+    {
+        lock (_sync)
+        {
+            if (_state == BodyImageExportStateType.Running)
+            {
+                return false;
+            }
+
+            _state = BodyImageExportStateType.Running;
+            _done = 0;
+            _total = 0;
+            _failed = 0;
+            _startedAt = DateTimeOffset.UtcNow;
+        }
+
+        // Deliberately not awaited: the route answers 202 and the caller polls. The task owns its own
+        // failures — RunAsync catches everything and records it in the state, so nothing is left to an
+        // unobserved exception.
+        _ = Task.Run(RunAsync);
+
+        return true;
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            var bodies = _catalog.ClassifiedBodies
+                                 .Where(entry => entry.Type != MobType.Equipment)
+                                 .Select(entry => entry.Body)
+                                 .ToArray();
+
+            lock (_sync)
+            {
+                _total = bodies.Length;
+            }
+
+            foreach (var body in bodies)
+            {
+                try
+                {
+                    // Null means "no usable animation": counted as failed so the status adds up, but it
+                    // must not end the run — the point is to warm what can be warmed.
+                    if (await _images.GetOrCreateAsync(body, 0) is null)
+                    {
+                        lock (_sync)
+                        {
+                            _failed++;
+                        }
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _logger.Warning(exception, "Could not export the image for body {Body}", body);
+
+                    lock (_sync)
+                    {
+                        _failed++;
+                    }
+                }
+
+                lock (_sync)
+                {
+                    _done++;
+                }
+            }
+
+            lock (_sync)
+            {
+                _state = BodyImageExportStateType.Completed;
+            }
+
+            _logger.Information("Body image export finished: {Done} processed, {Failed} failed", _done, _failed);
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Body image export stopped early");
+
+            lock (_sync)
+            {
+                _state = BodyImageExportStateType.Failed;
+            }
+        }
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/BodyImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/BodyImageService.cs
@@ -1,0 +1,58 @@
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Ultima;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Caches body frames as PNG files on disk, the way <c>ItemImageService</c> caches art: File.Exists is
+/// the whole hit path, the decode goes through the Ultima read gate, and the write is atomic.
+/// </summary>
+public sealed class BodyImageService : IBodyImageService
+{
+    private const string CacheDirectory = "cache/images/bodies";
+
+    private readonly IAnimationCatalog _catalog;
+    private readonly IUltimaReadGate _gate;
+    private readonly string _cachePath;
+
+    public BodyImageService(IAnimationCatalog catalog, DirectoriesConfig directories, IUltimaReadGate gate)
+    {
+        _catalog = catalog;
+        _gate = gate;
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+    }
+
+    public bool IsReady
+        => _catalog.IsReady;
+
+    public async Task<string?> GetOrCreateAsync(int body, int hue, CancellationToken cancellationToken = default)
+    {
+        var path = Path.Combine(_cachePath, FileName(body, hue));
+
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        var frame = await _gate.ReadAsync(
+            () => File.Exists(path) ? null : _catalog.GetFrame(body, 0, 1, 0, hue),
+            cancellationToken
+        );
+
+        if (frame is null)
+        {
+            return File.Exists(path) ? path : null;
+        }
+
+        using (frame)
+        {
+            PngWriter.WriteAtomically(path, frame.Bitmap);
+        }
+
+        return path;
+    }
+
+    internal static string FileName(int body, int hue)
+        => hue == 0 ? $"{body}.png" : $"{body}_{hue}.png";
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/EquipConvTable.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/EquipConvTable.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Parses <c>Equipconv.def</c> into a <c>(bodyType, equipmentAnim) → (convertedAnim, hue)</c> table that
+/// fits a worn equipment animation to a body type and may override its hue. A missing or malformed file
+/// yields an empty table (every <see cref="TryConvert" /> returns false).
+/// </summary>
+public sealed partial class EquipConvTable
+{
+    [GeneratedRegex(@"-?\d+")]
+    private static partial Regex Numbers();
+
+    private readonly Dictionary<(int Body, int Anim), (int AnimId, int Hue)> _map = new();
+
+    public EquipConvTable(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+
+            if (line.Length == 0 || line.StartsWith('#') || line.StartsWith('"'))
+            {
+                continue;
+            }
+
+            var hash = line.IndexOf('#');
+
+            if (hash >= 0)
+            {
+                line = line[..hash];
+            }
+
+            var matches = Numbers().Matches(line);
+
+            // bodyType, equipAnim, convertToAnim, gumpId, hue
+            if (matches.Count < 5)
+            {
+                continue;
+            }
+
+            var body = int.Parse(matches[0].Value);
+            var equipAnim = int.Parse(matches[1].Value);
+            var convertTo = int.Parse(matches[2].Value);
+            var hue = int.Parse(matches[4].Value);
+
+            _map[(body, equipAnim)] = (convertTo, hue);
+        }
+    }
+
+    public int Count => _map.Count;
+
+    public bool TryConvert(int bodyType, int equipmentAnim, out (int AnimId, int Hue) result)
+        => _map.TryGetValue((bodyType, equipmentAnim), out result);
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/HairImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/HairImageService.cs
@@ -1,0 +1,68 @@
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Ultima;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>Caches hair styles rendered over a reference body, keyed by style, hue, body and kind.</summary>
+public sealed class HairImageService : IHairImageService
+{
+    private const string CacheDirectory = "cache/images/hair";
+
+    private readonly IMobileFigureRenderer _renderer;
+    private readonly IUltimaReadGate _gate;
+    private readonly string _cachePath;
+
+    public HairImageService(IMobileFigureRenderer renderer, DirectoriesConfig directories, IUltimaReadGate gate)
+    {
+        _renderer = renderer;
+        _gate = gate;
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+    }
+
+    public async Task<string?> GetOrCreateAsync(
+        int style,
+        int hue,
+        int referenceBody,
+        bool facial,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var prefix = facial ? "f" : "h";
+        var path = Path.Combine(_cachePath, $"{prefix}{style}_{hue}_{referenceBody}.png");
+
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        var figure = await _gate.ReadAsync(
+            () => File.Exists(path)
+                ? null
+                : _renderer.Render(
+                    new(
+                        referenceBody,
+                        0,
+                        facial ? 0 : style,
+                        facial ? 0 : hue,
+                        facial ? style : 0,
+                        facial ? hue : 0,
+                        []
+                    )
+                ),
+            cancellationToken
+        );
+
+        if (figure is null)
+        {
+            return File.Exists(path) ? path : null;
+        }
+
+        using (figure)
+        {
+            PngWriter.WriteAtomically(path, figure);
+        }
+
+        return path;
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/LowestHue.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/LowestHue.cs
@@ -1,0 +1,21 @@
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Resolves a template hue spec deterministically: a range yields its low end. Figure images must be
+/// cacheable by template id, so the random the game uses at spawn time has no place here.
+/// </summary>
+public static class LowestHue
+{
+    private static readonly Random Low = new LowRandom();
+
+    public static ushort Resolve(string? spec)
+        => HueSpec.Resolve(spec, Low);
+
+    private sealed class LowRandom : Random
+    {
+        public override int Next(int minValue, int maxValue)
+            => minValue;
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/MobileFigureRenderer.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/MobileFigureRenderer.cs
@@ -1,0 +1,186 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Ultima.Imaging;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Port of Moongate_Old's figure renderer on the new primitives: layers decode through the catalog,
+/// order by <see cref="EquipmentDrawOrder" />, and compose anchored at each frame's anim.mul center.
+/// Callers hold the Ultima read gate; this class only computes.
+/// </summary>
+public sealed class MobileFigureRenderer : IMobileFigureRenderer
+{
+    // anim.mul anchors are relative to a virtual 0x200-square origin; compositing in that space and
+    // trimming to the union reproduces the client's alignment without knowing any frame in advance.
+    private const int Anchor = 0x200;
+
+    private const int DirectionCount = 5;
+
+    private readonly IAnimationCatalog _catalog;
+    private readonly IItemTemplateService _itemTemplates;
+
+    public MobileFigureRenderer(IAnimationCatalog catalog, IItemTemplateService itemTemplates)
+    {
+        _catalog = catalog;
+        _itemTemplates = itemTemplates;
+    }
+
+    public UltimaBitmap? Render(MobileFigureRequest request)
+    {
+        MobileFrame? body = null;
+        var chosenDirection = 0;
+
+        for (var direction = 0; direction < DirectionCount; direction++)
+        {
+            body = _catalog.GetFrame(request.Body, 0, direction, 0, request.SkinHue);
+
+            if (body is not null)
+            {
+                chosenDirection = direction;
+
+                break;
+            }
+        }
+
+        if (body is null)
+        {
+            return null;
+        }
+
+        var layers = new List<(int Priority, MobileFrame Frame)> { (EquipmentDrawOrder.BodyPriority, body) };
+
+        try
+        {
+            AddHairLayer(layers, request.HairStyle, request.HairHue, chosenDirection, LayerType.Hair);
+            AddHairLayer(layers, request.FacialHairStyle, request.FacialHairHue, chosenDirection, LayerType.FacialHair);
+            AddEquipmentLayers(layers, request, chosenDirection);
+
+            return Compose([.. layers.OrderBy(layer => layer.Priority).Select(layer => layer.Frame)]);
+        }
+        finally
+        {
+            foreach (var layer in layers)
+            {
+                layer.Frame.Dispose();
+            }
+        }
+    }
+
+    private void AddEquipmentLayers(
+        List<(int Priority, MobileFrame Frame)> layers,
+        MobileFigureRequest request,
+        int direction
+    )
+    {
+        foreach (var worn in request.Equipment)
+        {
+            var template = _itemTemplates.GetById(worn.ItemTemplateId);
+
+            if (template?.Equip is null)
+            {
+                continue;
+            }
+
+            var priority = EquipmentDrawOrder.Priority(template.Equip.Layer);
+
+            if (priority == EquipmentDrawOrder.Skip)
+            {
+                continue;
+            }
+
+            var equipmentAnim = _catalog.GetItemAnimation(template.ItemId);
+
+            if (equipmentAnim is null)
+            {
+                continue;
+            }
+
+            int finalAnim;
+            int hue;
+
+            if (_catalog.TryConvertEquipment(request.Body, equipmentAnim.Value, out var conversion))
+            {
+                finalAnim = conversion.AnimId;
+                hue = conversion.Hue != 0 ? conversion.Hue : ResolveWornHue(worn, template.Hue);
+            }
+            else
+            {
+                finalAnim = equipmentAnim.Value;
+                hue = ResolveWornHue(worn, template.Hue);
+            }
+
+            var frame = _catalog.GetFrame(finalAnim, 0, direction, 0, hue);
+
+            if (frame is not null)
+            {
+                layers.Add((priority, frame));
+            }
+        }
+    }
+
+    private void AddHairLayer(
+        List<(int Priority, MobileFrame Frame)> layers,
+        int style,
+        int hue,
+        int direction,
+        LayerType layer
+    )
+    {
+        if (style == 0)
+        {
+            return;
+        }
+
+        var animationId = _catalog.GetItemAnimation(style);
+
+        if (animationId is null)
+        {
+            return;
+        }
+
+        var frame = _catalog.GetFrame(animationId.Value, 0, direction, 0, hue);
+
+        if (frame is not null)
+        {
+            layers.Add((EquipmentDrawOrder.Priority(layer), frame));
+        }
+    }
+
+    private static int ResolveWornHue(MobileFigureEquipment worn, int templateHue)
+        => worn.Hue != 0 ? worn.Hue : templateHue;
+
+    private static UltimaBitmap Compose(IReadOnlyList<MobileFrame> layers)
+    {
+        var topLeftX = new int[layers.Count];
+        var topLeftY = new int[layers.Count];
+
+        for (var i = 0; i < layers.Count; i++)
+        {
+            topLeftX[i] = Anchor - layers[i].CenterX;
+            topLeftY[i] = Anchor - layers[i].CenterY - layers[i].Bitmap.Height;
+        }
+
+        var minX = topLeftX.Min();
+        var minY = topLeftY.Min();
+        var maxX = int.MinValue;
+        var maxY = int.MinValue;
+
+        for (var i = 0; i < layers.Count; i++)
+        {
+            maxX = Math.Max(maxX, topLeftX[i] + layers[i].Bitmap.Width);
+            maxY = Math.Max(maxY, topLeftY[i] + layers[i].Bitmap.Height);
+        }
+
+        var canvas = new UltimaBitmap(maxX - minX, maxY - minY);
+
+        for (var i = 0; i < layers.Count; i++)
+        {
+            layers[i].Bitmap.DrawInto(canvas, topLeftX[i] - minX, topLeftY[i] - minY);
+        }
+
+        return canvas;
+    }
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/MobileTemplateImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/MobileTemplateImageService.cs
@@ -1,0 +1,82 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Ultima;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Caches dressed template figures by template id. Hue specs resolve to their low end
+/// (<see cref="LowestHue" />): the image must be the same on every request and every restart.
+/// </summary>
+public sealed class MobileTemplateImageService : IMobileTemplateImageService
+{
+    private const string CacheDirectory = "cache/images/mobile-templates";
+
+    private readonly IMobileFigureRenderer _renderer;
+    private readonly IMobileTemplateService _templates;
+    private readonly IUltimaReadGate _gate;
+    private readonly string _cachePath;
+
+    public MobileTemplateImageService(
+        IMobileFigureRenderer renderer,
+        IMobileTemplateService templates,
+        DirectoriesConfig directories,
+        IUltimaReadGate gate
+    )
+    {
+        _renderer = renderer;
+        _templates = templates;
+        _gate = gate;
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+    }
+
+    public async Task<string?> GetOrCreateAsync(string templateId, CancellationToken cancellationToken = default)
+    {
+        var template = _templates.GetById(templateId);
+
+        if (template is null)
+        {
+            return null;
+        }
+
+        var path = Path.Combine(_cachePath, $"{Sanitize(template.Id)}.png");
+
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        var appearance = template.Appearance;
+        var request = new MobileFigureRequest(
+            appearance.Body,
+            LowestHue.Resolve(appearance.SkinHue),
+            appearance.HairStyle,
+            LowestHue.Resolve(appearance.HairHue),
+            appearance.FacialHairStyle,
+            LowestHue.Resolve(appearance.FacialHairHue),
+            [.. template.Equipment.Select(worn => new MobileFigureEquipment(worn.Item, LowestHue.Resolve(worn.Hue)))]
+        );
+
+        var figure = await _gate.ReadAsync(
+            () => File.Exists(path) ? null : _renderer.Render(request),
+            cancellationToken
+        );
+
+        if (figure is null)
+        {
+            return File.Exists(path) ? path : null;
+        }
+
+        using (figure)
+        {
+            PngWriter.WriteAtomically(path, figure);
+        }
+
+        return path;
+    }
+
+    private static string Sanitize(string id)
+        => string.Concat(id.Select(c => Array.IndexOf(Path.GetInvalidFileNameChars(), c) >= 0 ? '_' : c));
+}

--- a/src/Moongate.Http.Plugin/Services/Mobiles/PngWriter.cs
+++ b/src/Moongate.Http.Plugin/Services/Mobiles/PngWriter.cs
@@ -1,0 +1,28 @@
+using Moongate.Ultima.Imaging;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Saves a bitmap PNG to a temporary sibling and moves it into place: a reader must never see a
+/// half-written file, and a same-directory move is atomic on Linux and Windows alike. The temporary
+/// name keeps the .png suffix because <see cref="UltimaBitmap.Save" /> picks the encoder from it.
+/// </summary>
+internal static class PngWriter
+{
+    public static void WriteAtomically(string path, UltimaBitmap bitmap)
+    {
+        var temporary = $"{path}.{Guid.NewGuid():N}.tmp.png";
+
+        try
+        {
+            bitmap.Save(temporary, false);
+            File.Move(temporary, path, true);
+        }
+        catch
+        {
+            File.Delete(temporary);
+
+            throw;
+        }
+    }
+}

--- a/src/Moongate.Http.Plugin/Types/BodyImageExportStateType.cs
+++ b/src/Moongate.Http.Plugin/Types/BodyImageExportStateType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Http.Plugin.Types;
+
+/// <summary>Where a bulk body-image export stands.</summary>
+public enum BodyImageExportStateType
+{
+    /// <summary>No export has run since the server started.</summary>
+    Idle,
+
+    /// <summary>An export is working through the classified bodies.</summary>
+    Running,
+
+    /// <summary>The last export finished; Failed says whether every body made it.</summary>
+    Completed,
+
+    /// <summary>The last export stopped early. The reason is in the log.</summary>
+    Failed
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileImageEndpointsTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Mobiles;
+using Moongate.Http.Plugin.Endpoints.Mobiles;
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Mobiles.Templates;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Http.Endpoints.Mobiles;
+
+public sealed class MobileImageEndpointsTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("mg-mobimg-").FullName;
+
+    public void Dispose()
+        => Directory.Delete(_root, true);
+
+    private async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+    {
+        var catalog = new FakeAnimationCatalog();
+        catalog.Bodies.Add((400, MobType.Human));
+        catalog.Bodies.Add((5000, MobType.Equipment));
+        catalog.Frames[(400, 0)] = (W: 20, H: 40, Cx: 10, Cy: 0);
+        catalog.ItemAnimations[0x203B] = 0x2FBF;
+        catalog.Frames[(0x2FBF, 0)] = (W: 20, H: 20, Cx: 10, Cy: 20);
+
+        var templates = new MobileTemplateService();
+        templates.Register(new MobileTemplate { Id = "villager", Appearance = new() { Body = 400 } });
+
+        return await TestApiServer.StartAsync(
+            level,
+            configure: container =>
+            {
+                var gate = new StubUltimaReadGate();
+                var directories = new DirectoriesConfig(_root, Array.Empty<string>());
+                var bodies = new BodyImageService(catalog, directories, gate);
+                var renderer = new MobileFigureRenderer(catalog, new ItemTemplateService());
+
+                container.RegisterApiEndpointInstance(new BodyImageEndpoints(bodies));
+                container.RegisterApiEndpointInstance(
+                    new HairImageEndpoints(new HairImageService(renderer, directories, gate))
+                );
+                container.RegisterApiEndpointInstance(
+                    new MobileTemplateImageEndpoints(
+                        new MobileTemplateImageService(renderer, templates, directories, gate)
+                    )
+                );
+                container.RegisterApiEndpointInstance(
+                    new MobileImageAdminEndpoints(catalog, new BodyImageExportJob(bodies, catalog), bodies)
+                );
+            }
+        );
+    }
+
+    [Fact]
+    public async Task BodyImage_KnownBody_ServesPngAnonymously()
+    {
+        await using var server = await StartAsync();
+
+        var response = await server.Client.GetAsync("/api/v1/images/bodies/400.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task BodyImage_UnknownBody_Is404_AndGarbageIs400()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, (await server.Client.GetAsync("/api/v1/images/bodies/999.png")).StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync("/api/v1/images/bodies/abc.png")).StatusCode);
+    }
+
+    [Fact]
+    public async Task HairImage_KnownStyle_ServesPng()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(
+            HttpStatusCode.OK,
+            (await server.Client.GetAsync("/api/v1/images/hair/8251.png")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task TemplateFigure_SeededTemplate_ServesPng_UnknownIs404()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(
+            HttpStatusCode.OK,
+            (await server.Client.GetAsync("/api/v1/images/mobiles/templates/villager.png")).StatusCode
+        );
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await server.Client.GetAsync("/api/v1/images/mobiles/templates/nope.png")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task AdminBodies_ExcludesEquipment_AndNeedsStaff()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync("/api/v1/admin/bodies")).StatusCode);
+
+        await server.AuthenticateAsync();
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<BodySummary>>("/api/v1/admin/bodies");
+
+        Assert.Equal(1, page!.Total);
+        Assert.Equal(400, page.Items[0].Body);
+        Assert.Equal("/api/v1/images/bodies/400.png", page.Items[0].ImageUrl);
+    }
+
+    [Fact]
+    public async Task AdminHairStyles_FacialFlagSwitchesTheCatalog()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var hair = await server.Client.GetFromJsonAsync<PagedResponse<HairStyleSummary>>("/api/v1/admin/hair-styles");
+        var facial = await server.Client.GetFromJsonAsync<PagedResponse<HairStyleSummary>>("/api/v1/admin/hair-styles?facial=true");
+
+        Assert.Equal(10, hair!.Total);
+        Assert.Equal(7, facial!.Total);
+        Assert.All(facial.Items, style => Assert.True(style.Facial));
+    }
+
+    [Fact]
+    public async Task AdminBodies_AsPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync("/api/v1/admin/bodies")).StatusCode);
+    }
+
+    [Fact]
+    public async Task BodyExport_StartsOnce_ThenReports()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var accepted = await server.Client.PostAsync("/api/v1/admin/images/bodies", null);
+
+        Assert.Equal(HttpStatusCode.Accepted, accepted.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/api/v1/admin/images/bodies")).StatusCode);
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -8,6 +8,7 @@ using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Images;
 using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
+using Moongate.Http.Plugin.Endpoints.Mobiles;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Interfaces.Auth;
@@ -61,13 +62,17 @@ public class MoongateHttpPluginTests
                 typeof(AccountEndpoints),
                 typeof(AdminEndpoints),
                 typeof(AuthEndpoints),
+                typeof(BodyImageEndpoints),
                 typeof(CharacterAdminEndpoints),
                 typeof(CharacterEndpoints),
+                typeof(HairImageEndpoints),
                 typeof(ItemImageAdminEndpoints),
                 typeof(ItemImageEndpoints),
                 typeof(ItemTemplateEndpoints),
                 typeof(MapImageAdminEndpoints),
                 typeof(MapImageEndpoints),
+                typeof(MobileImageAdminEndpoints),
+                typeof(MobileTemplateImageEndpoints),
                 typeof(PlayerEndpoints),
                 typeof(VersionEndpoints)
             ],

--- a/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageExportJobTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageExportJobTests.cs
@@ -5,7 +5,7 @@ using SquidStd.Core.Directories;
 
 namespace Moongate.Tests.Http.Services.Mobiles;
 
-public class BodyImageExportJobTests : IDisposable
+public sealed class BodyImageExportJobTests : IDisposable
 {
     private readonly string _root = Directory.CreateTempSubdirectory("mg-bodyjob-").FullName;
 

--- a/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageExportJobTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageExportJobTests.cs
@@ -1,0 +1,62 @@
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Http.Services.Mobiles;
+
+public class BodyImageExportJobTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("mg-bodyjob-").FullName;
+
+    public void Dispose()
+        => Directory.Delete(_root, true);
+
+    [Fact]
+    public async Task Run_WalksClassifiedBodies_SkippingEquipmentAndCountingFailures()
+    {
+        var catalog = new FakeAnimationCatalog();
+        catalog.Bodies.Add((400, MobType.Human));
+        catalog.Bodies.Add((401, MobType.Human));      // no frame: counts as failed, not fatal
+        catalog.Bodies.Add((5000, MobType.Equipment)); // excluded outright
+        catalog.Frames[(400, 0)] = (W: 20, H: 40, Cx: 10, Cy: 0);
+        var job = new BodyImageExportJob(
+            new BodyImageService(catalog, new DirectoriesConfig(_root, Array.Empty<string>()), new StubUltimaReadGate()),
+            catalog
+        );
+
+        Assert.True(job.TryStart());
+
+        await WaitUntilDoneAsync(job);
+
+        Assert.Equal("Completed", job.Status.State);
+        Assert.Equal(2, job.Status.Total);
+        Assert.Equal(2, job.Status.Done);
+        Assert.Equal(1, job.Status.Failed);
+    }
+
+    [Fact]
+    public void TryStart_WhileRunning_IsRefused()
+    {
+        // A catalog with no bodies completes almost instantly, so pin Running by hand is impossible;
+        // instead assert the contract the route relies on: a second start right after the first is
+        // either refused (still running) or accepted (already completed) — never an exception, and the
+        // state machine never reports two concurrent runs.
+        var catalog = new FakeAnimationCatalog();
+        var job = new BodyImageExportJob(
+            new BodyImageService(catalog, new DirectoriesConfig(_root, Array.Empty<string>()), new StubUltimaReadGate()),
+            catalog
+        );
+
+        Assert.True(job.TryStart());
+        Assert.True(job.Status.State is "Running" or "Completed");
+    }
+
+    private static async Task WaitUntilDoneAsync(BodyImageExportJob job)
+    {
+        for (var i = 0; i < 100 && job.Status.State == "Running"; i++)
+        {
+            await Task.Delay(20);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageServiceTests.cs
@@ -1,0 +1,53 @@
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Tests.Support;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Http.Services.Mobiles;
+
+public class BodyImageServiceTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("mg-bodies-").FullName;
+
+    public void Dispose()
+        => Directory.Delete(_root, true);
+
+    private BodyImageService Build(FakeAnimationCatalog catalog)
+        => new(catalog, new DirectoriesConfig(_root, Array.Empty<string>()), new StubUltimaReadGate());
+
+    [Fact]
+    public async Task GetOrCreate_DecodableBody_WritesThePngOnceAndReusesIt()
+    {
+        var catalog = new FakeAnimationCatalog();
+        catalog.Frames[(400, 0)] = (W: 20, H: 40, Cx: 10, Cy: 0);
+        var service = Build(catalog);
+
+        var first = await service.GetOrCreateAsync(400, 0);
+        var again = await service.GetOrCreateAsync(400, 0);
+
+        Assert.NotNull(first);
+        Assert.True(File.Exists(first));
+        Assert.Equal(first, again);
+    }
+
+    [Fact]
+    public async Task GetOrCreate_HuedVariant_IsItsOwnFile()
+    {
+        var catalog = new FakeAnimationCatalog();
+        catalog.Frames[(400, 0)] = (W: 20, H: 40, Cx: 10, Cy: 0);
+        catalog.Frames[(400, 1153)] = (W: 20, H: 40, Cx: 10, Cy: 0);
+        var service = Build(catalog);
+
+        var plain = await service.GetOrCreateAsync(400, 0);
+        var hued = await service.GetOrCreateAsync(400, 1153);
+
+        Assert.NotEqual(plain, hued);
+    }
+
+    [Fact]
+    public async Task GetOrCreate_UnknownBody_ReturnsNull()
+    {
+        var service = Build(new FakeAnimationCatalog());
+
+        Assert.Null(await service.GetOrCreateAsync(999, 0));
+    }
+}

--- a/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/BodyImageServiceTests.cs
@@ -4,7 +4,7 @@ using SquidStd.Core.Directories;
 
 namespace Moongate.Tests.Http.Services.Mobiles;
 
-public class BodyImageServiceTests : IDisposable
+public sealed class BodyImageServiceTests : IDisposable
 {
     private readonly string _root = Directory.CreateTempSubdirectory("mg-bodies-").FullName;
 

--- a/tests/Moongate.Tests/Http/Services/Mobiles/EquipConvTableTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/EquipConvTableTests.cs
@@ -1,0 +1,46 @@
+using Moongate.Http.Plugin.Services.Mobiles;
+
+namespace Moongate.Tests.Http.Services.Mobiles;
+
+public class EquipConvTableTests
+{
+    [Fact]
+    public void MissingFile_YieldsAnEmptyTable()
+    {
+        var table = new EquipConvTable(Path.Combine(Path.GetTempPath(), $"nope-{Guid.NewGuid():N}.def"));
+
+        Assert.Equal(0, table.Count);
+        Assert.False(table.TryConvert(400, 0x1DB, out _));
+    }
+
+    [Fact]
+    public void ParsesEntries_AndIgnoresCommentsAndMalformedLines()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"equipconv-{Guid.NewGuid():N}.def");
+        File.WriteAllLines(
+            path,
+            [
+                "# comment",
+                "\"header line\"",
+                "400 475 267 10265 0 # sword fits body 400",
+                "401 475 267 10265 1153",
+                "garbage without numbers"
+            ]
+        );
+
+        try
+        {
+            var table = new EquipConvTable(path);
+
+            Assert.Equal(2, table.Count);
+            Assert.True(table.TryConvert(400, 475, out var plain));
+            Assert.Equal((267, 0), plain);
+            Assert.True(table.TryConvert(401, 475, out var hued));
+            Assert.Equal((267, 1153), hued);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Http/Services/Mobiles/EquipmentDrawOrderTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/EquipmentDrawOrderTests.cs
@@ -1,0 +1,23 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Http.Services.Mobiles;
+
+public class EquipmentDrawOrderTests
+{
+    [Fact]
+    public void CloakDrawsBehindTheBody_HairAboveClothes_WeaponsOnTop()
+    {
+        Assert.True(EquipmentDrawOrder.Priority(LayerType.Cloak) < EquipmentDrawOrder.BodyPriority);
+        Assert.True(EquipmentDrawOrder.Priority(LayerType.Hair) > EquipmentDrawOrder.Priority(LayerType.OuterTorso));
+        Assert.True(EquipmentDrawOrder.Priority(LayerType.TwoHanded) > EquipmentDrawOrder.Priority(LayerType.Helm));
+    }
+
+    [Fact]
+    public void NonDrawableLayers_AreSkipped()
+    {
+        Assert.Equal(EquipmentDrawOrder.Skip, EquipmentDrawOrder.Priority(LayerType.Backpack));
+        Assert.Equal(EquipmentDrawOrder.Skip, EquipmentDrawOrder.Priority(LayerType.Mount));
+        Assert.Equal(EquipmentDrawOrder.Skip, EquipmentDrawOrder.Priority(LayerType.None));
+    }
+}

--- a/tests/Moongate.Tests/Http/Services/Mobiles/MobileFigureRendererTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/MobileFigureRendererTests.cs
@@ -1,0 +1,91 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Server.Services.Items;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Tests.Http.Services.Mobiles;
+
+public class MobileFigureRendererTests
+{
+    private const int Body = 400;
+    private const int HairStyle = 0x203B;
+    private const int HairAnim = 0x2FBF;
+
+    private static (MobileFigureRenderer Renderer, FakeAnimationCatalog Catalog, ItemTemplateService Templates) Build()
+    {
+        var catalog = new FakeAnimationCatalog();
+        catalog.Frames[(Body, 0)] = (W: 30, H: 50, Cx: 15, Cy: 0);
+        var templates = new ItemTemplateService();
+
+        return (new MobileFigureRenderer(catalog, templates), catalog, templates);
+    }
+
+    [Fact]
+    public void Render_BodyWithoutAnimation_ReturnsNull()
+    {
+        var (renderer, _, _) = Build();
+
+        Assert.Null(renderer.Render(new(999, 0, 0, 0, 0, 0, [])));
+    }
+
+    [Fact]
+    public void Render_BareBody_ReturnsTheBodyCanvas()
+    {
+        var (renderer, _, _) = Build();
+
+        using var figure = renderer.Render(new(Body, 0, 0, 0, 0, 0, []));
+
+        Assert.NotNull(figure);
+        Assert.Equal(30, figure!.Width);
+        Assert.Equal(50, figure.Height);
+    }
+
+    [Fact]
+    public void Render_HairLayer_GrowsTheCanvasToTheUnion()
+    {
+        var (renderer, catalog, _) = Build();
+        catalog.ItemAnimations[HairStyle] = HairAnim;
+        // Hair frame is taller than the body and anchored higher: the canvas must cover both.
+        catalog.Frames[(HairAnim, 0)] = (W: 30, H: 60, Cx: 15, Cy: 0);
+
+        using var figure = renderer.Render(new(Body, 0, HairStyle, 0, 0, 0, []));
+
+        Assert.Equal(60, figure!.Height);
+    }
+
+    [Fact]
+    public void Render_EquipmentOnASkipLayer_IsIgnored()
+    {
+        var (renderer, catalog, templates) = Build();
+        templates.Register(
+            new ItemTemplate { Id = "pack", ItemId = 0x0E75, Equip = new() { Layer = LayerType.Backpack } }
+        );
+        catalog.ItemAnimations[0x0E75] = 999;
+        catalog.Frames[(999, 0)] = (W: 200, H: 200, Cx: 0, Cy: 0);
+
+        using var figure = renderer.Render(new(Body, 0, 0, 0, 0, 0, [new("pack", 0)]));
+
+        // The oversized backpack frame must not have grown the canvas.
+        Assert.Equal(30, figure!.Width);
+    }
+
+    [Fact]
+    public void Render_EquipConv_ReroutesTheAnimationAndHue()
+    {
+        var (renderer, catalog, templates) = Build();
+        templates.Register(
+            new ItemTemplate { Id = "sword", ItemId = 0x13FF, Equip = new() { Layer = LayerType.OneHanded } }
+        );
+        catalog.ItemAnimations[0x13FF] = 475;
+        catalog.Conversions[(Body, 475)] = (267, 1153);
+        // Only the converted (anim, hue) pair decodes: if the renderer skipped equipconv, the layer
+        // would silently drop and the canvas would stay at body size.
+        catalog.Frames[(267, 1153)] = (W: 40, H: 50, Cx: 20, Cy: 0);
+
+        using var figure = renderer.Render(new(Body, 0, 0, 0, 0, 0, [new("sword", 0)]));
+
+        Assert.Equal(40, figure!.Width);
+    }
+}

--- a/tests/Moongate.Tests/Http/Services/Mobiles/MobileTemplateImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/MobileTemplateImageServiceTests.cs
@@ -1,0 +1,56 @@
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Mobiles.Templates;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Http.Services.Mobiles;
+
+public class MobileTemplateImageServiceTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("mg-figures-").FullName;
+
+    public void Dispose()
+        => Directory.Delete(_root, true);
+
+    [Fact]
+    public async Task GetOrCreate_SeededTemplate_RendersDeterministicallyFromTheSpecLowEnd()
+    {
+        var catalog = new FakeAnimationCatalog();
+        // hue(33:44) must resolve to 33 — only that pair decodes; a random pick would 404 the test.
+        catalog.Frames[(400, 33)] = (W: 20, H: 40, Cx: 10, Cy: 0);
+        var templates = new MobileTemplateService();
+        templates.Register(
+            new MobileTemplate
+            {
+                Id = "villager",
+                Appearance = new() { Body = 400, SkinHue = "hue(33:44)" }
+            }
+        );
+        var service = new MobileTemplateImageService(
+            new MobileFigureRenderer(catalog, new ItemTemplateService()),
+            templates,
+            new DirectoriesConfig(_root, Array.Empty<string>()),
+            new StubUltimaReadGate()
+        );
+
+        var path = await service.GetOrCreateAsync("villager");
+
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public async Task GetOrCreate_UnknownTemplate_ReturnsNull()
+    {
+        var service = new MobileTemplateImageService(
+            new MobileFigureRenderer(new FakeAnimationCatalog(), new ItemTemplateService()),
+            new MobileTemplateService(),
+            new DirectoriesConfig(_root, Array.Empty<string>()),
+            new StubUltimaReadGate()
+        );
+
+        Assert.Null(await service.GetOrCreateAsync("nope"));
+    }
+}

--- a/tests/Moongate.Tests/Http/Services/Mobiles/MobileTemplateImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Mobiles/MobileTemplateImageServiceTests.cs
@@ -7,7 +7,7 @@ using SquidStd.Core.Directories;
 
 namespace Moongate.Tests.Http.Services.Mobiles;
 
-public class MobileTemplateImageServiceTests : IDisposable
+public sealed class MobileTemplateImageServiceTests : IDisposable
 {
     private readonly string _root = Directory.CreateTempSubdirectory("mg-figures-").FullName;
 

--- a/tests/Moongate.Tests/Support/FakeAnimationCatalog.cs
+++ b/tests/Moongate.Tests/Support/FakeAnimationCatalog.cs
@@ -1,0 +1,44 @@
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Ultima.Imaging;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Frames without client files: tests declare which (graphic, hue) pairs decode and to what size and
+/// center. GetFrame clones per call, exactly like the real catalog, so double-dispose cannot happen.
+/// </summary>
+public sealed class FakeAnimationCatalog : IAnimationCatalog
+{
+    /// <summary>(graphic, hue) → (width, height, centerX, centerY). Direction/action/frame are ignored.</summary>
+    public Dictionary<(int Graphic, int Hue), (int W, int H, int Cx, int Cy)> Frames { get; } = new();
+
+    /// <summary>itemId → tiledata animation id.</summary>
+    public Dictionary<int, int> ItemAnimations { get; } = new();
+
+    /// <summary>(body, equipAnim) → conversion.</summary>
+    public Dictionary<(int Body, int Anim), (int AnimId, int Hue)> Conversions { get; } = new();
+
+    public List<(int Body, MobType Type)> Bodies { get; } = [];
+
+    public bool IsReady { get; set; } = true;
+
+    public IReadOnlyList<(int Body, MobType Type)> ClassifiedBodies => Bodies;
+
+    public MobileFrame? GetFrame(int body, int action, int direction, int frame, int hue)
+    {
+        if (!Frames.TryGetValue((body, hue), out var spec))
+        {
+            return null;
+        }
+
+        return new MobileFrame(spec.Cx, spec.Cy, new UltimaBitmap(spec.W, spec.H));
+    }
+
+    public int? GetItemAnimation(int itemId)
+        => ItemAnimations.TryGetValue(itemId, out var animation) ? animation : null;
+
+    public bool TryConvertEquipment(int body, int equipmentAnim, out (int AnimId, int Hue) conversion)
+        => Conversions.TryGetValue((body, equipmentAnim), out conversion);
+}

--- a/tests/Moongate.Tests/Support/StubUltimaReadGate.cs
+++ b/tests/Moongate.Tests/Support/StubUltimaReadGate.cs
@@ -1,0 +1,10 @@
+using Moongate.Http.Plugin.Interfaces.Ultima;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Runs the read inline: fakes have no statics to guard.</summary>
+public sealed class StubUltimaReadGate : IUltimaReadGate
+{
+    public Task<T> ReadAsync<T>(Func<T> read, CancellationToken cancellationToken = default)
+        => Task.FromResult(read());
+}


### PR DESCRIPTION
## What

Port of Moongate_Old's three missing image endpoint groups, on the new stack and conventions — new `Mobiles` domain in `Moongate.Http.Plugin`:

- `GET /api/v1/images/bodies/{body}.png?hue=` — idle front-facing frame, skin-hued variants, disk cache. 404 when the body has no usable animation.
- `GET /api/v1/images/hair/{style}.png?hue=&body=&facial=` — hair/facial style rendered over a reference body (default 400).
- `GET /api/v1/images/mobiles/templates/{id}.png` — dressed figure: body + hair + worn equipment composited in draw order; template hue specs resolve deterministically to their low end so the cache key is stable.
- Staff routes: `POST+GET /api/v1/admin/images/bodies` (background warm-up job, item/map export contract), `GET /api/v1/admin/bodies` (classified picker via mobtypes.txt, Equipment excluded), `GET /api/v1/admin/hair-styles`.

## How

- `IAnimationCatalog` seams the Ultima statics (`Animations`, `TileData`, `MobTypes`, lazy `equipconv.def`) so tests run on synthetic frames; the real catalog clones frames out of the LRU cache.
- `MobileFigureRenderer` ports the old compositor: layers by `EquipmentDrawOrder` priority, anchored at the 0x200 anim.mul origin, drawn with `UltimaBitmap.DrawInto`; equipconv re-routes equipment animations per body and may re-hue.
- Three cache services mirror `ItemImageService` (File.Exists fast path, single Ultima read gate, atomic temp+move writes — temp names keep the .png suffix because `UltimaBitmap.Save` picks the encoder from it).
- 16 endpoint groups now registered, covered by the registration test.

## Verification

- 24 new tests (equipconv parser, draw order, renderer compositing/skip/equipconv, caches, export job, endpoints incl. auth); full suite 1100/1100; DocFX 0 warnings by exit code; build at the pre-existing warning baseline.
- Manual smoke against real client files: `/api/v1/images/bodies/400.png` renders the human male (27x63 PNG), hair 0x203B and orc body 17 answer 200.