### PR TITLE
feat(spatial): add sector-grid spatial index

### DIFF
--- a/src/Moongate.Server.Abstractions/Interfaces/Accounts/ISessionManager.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Accounts/ISessionManager.cs
@@ -8,6 +8,10 @@ namespace Moongate.Server.Abstractions.Interfaces.Accounts;
 public interface ISessionManager
 {
     int Count { get; }
+
+    /// <summary>Snapshot of the live sessions at call time.</summary>
+    IReadOnlyCollection<PlayerSession> All { get; }
+
     PlayerSession GetOrCreate(SquidStdTcpClient client);
 
     /// <summary>

--- a/src/Moongate.Server.Abstractions/Interfaces/World/ISpatialIndexService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/ISpatialIndexService.cs
@@ -1,0 +1,35 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>
+/// Sector-grid spatial index over world entities (16×16-tile buckets). Holds serials only and
+/// resolves entities through the persistence stores at query time, so results are detached clones
+/// like every other store read. Loop-affine: call it from the game-loop thread.
+/// </summary>
+public interface ISpatialIndexService
+{
+    /// <summary>
+    /// Indexes <paramref name="mobile" /> at its current <c>MapId</c>/<c>Position</c>, relocating
+    /// it from wherever it was indexed before. Persist position changes before calling.
+    /// </summary>
+    void AddOrUpdate(MobileEntity mobile);
+
+    /// <summary>
+    /// Indexes a ground item at its current <c>MapId</c>/<c>Position</c>. An item that is in a
+    /// container or equipped is removed from the index instead, so callers can invoke this after
+    /// any item write without checking where the item ended up.
+    /// </summary>
+    void AddOrUpdate(ItemEntity item);
+
+    /// <summary>Removes an entity from the index; unknown serials are a no-op.</summary>
+    void Remove(Serial serial);
+
+    /// <summary>Mobiles on <paramref name="mapId" /> within <paramref name="range" /> tiles of <paramref name="center" />.</summary>
+    IReadOnlyList<MobileEntity> GetMobilesInRange(int mapId, Point3D center, int range);
+
+    /// <summary>Ground items on <paramref name="mapId" /> within <paramref name="range" /> tiles of <paramref name="center" />.</summary>
+    IReadOnlyList<ItemEntity> GetItemsInRange(int mapId, Point3D center, int range);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IWorldService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IWorldService.cs
@@ -1,3 +1,6 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Interfaces;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Session;
 
@@ -15,4 +18,13 @@ public interface IWorldService
     /// and raises <see cref="Data.Events.PlayerEnteredWorldEvent" />.
     /// </summary>
     void SendEnterWorld(PlayerSession session, MobileEntity mobile);
+
+    /// <summary>
+    /// Sends <paramref name="packet" /> to every in-world player session whose character is on
+    /// <paramref name="mapId" /> within <paramref name="range" /> tiles of <paramref name="center" />,
+    /// skipping the mobile identified by <paramref name="exclude" /> (typically the originator).
+    /// Returns the number of recipients.
+    /// </summary>
+    int SendToPlayersInRange<TPacket>(int mapId, Point3D center, int range, TPacket packet, Serial? exclude = null)
+        where TPacket : IOutgoingPacket;
 }

--- a/src/Moongate.Server/Data/Internal/World/Sector.cs
+++ b/src/Moongate.Server/Data/Internal/World/Sector.cs
@@ -1,0 +1,14 @@
+using Moongate.Core.Primitives;
+
+namespace Moongate.Server.Data.Internal.World;
+
+/// <summary>One 16×16-tile bucket of the spatial grid: the serials living in it, split by kind.</summary>
+internal sealed class Sector
+{
+    public HashSet<Serial> Mobiles { get; } = [];
+
+    public HashSet<Serial> Items { get; } = [];
+
+    public bool IsEmpty
+        => Mobiles.Count == 0 && Items.Count == 0;
+}

--- a/src/Moongate.Server/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/MoongateEventSubscribersPlugin.cs
@@ -27,6 +27,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
     {
         container.RegisterEventSubscriber<PaperdollSubscriber>();
         container.RegisterEventSubscriber<ContainerSubscriber>();
+        container.RegisterEventSubscriber<SpatialSubscriber>();
 
         container.RegisterStdService<IEventSubscriberService, EventSubscriberService>();
     }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -139,6 +139,7 @@ await ConsoleApp.RunAsync(
                 container.Register<ILootService, LootService>(Reuse.Singleton);
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
+                container.Register<ISpatialIndexService, SpatialIndexService>(Reuse.Singleton);
                 container.Register<IOplService, OplService>(Reuse.Singleton);
 
                 container.Register<TimerAutostartService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Accounts/SessionManager.cs
+++ b/src/Moongate.Server/Services/Accounts/SessionManager.cs
@@ -13,6 +13,8 @@ public sealed class SessionManager : ISessionManager
 
     public int Count => _sessions.Count;
 
+    public IReadOnlyCollection<PlayerSession> All => [.. _sessions.Values];
+
     public PlayerSession GetOrCreate(SquidStdTcpClient client)
         => _sessions.GetOrAdd(client.SessionId, _ => new(client));
 

--- a/src/Moongate.Server/Services/Items/ItemService.cs
+++ b/src/Moongate.Server/Services/Items/ItemService.cs
@@ -15,14 +15,16 @@ public sealed class ItemService : IItemService
     private readonly IEntityStore<ItemEntity, Serial> _items;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
     private readonly IOplService? _opl;
+    private readonly ISpatialIndexService? _spatial;
 
-    // The property-list cache is optional on purpose: tests build a bare ItemService, and the OPL is a
-    // pure cache concern the item flows only need to invalidate.
-    public ItemService(IPersistenceService persistenceService, IOplService? opl = null)
+    // The property-list cache and the spatial index are optional on purpose: tests build a bare
+    // ItemService, and both are concerns the item flows only need to keep in sync, not require.
+    public ItemService(IPersistenceService persistenceService, IOplService? opl = null, ISpatialIndexService? spatial = null)
     {
         _items = persistenceService.GetStore<ItemEntity, Serial>();
         _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
         _opl = opl;
+        _spatial = spatial;
     }
 
     public void AddToContainer(ItemEntity container, ItemEntity item, Point2D position)
@@ -44,11 +46,13 @@ public sealed class ItemService : IItemService
         }
 
         _items.UpsertAsync(container).WaitSync();
+        _spatial?.AddOrUpdate(item);
     }
 
     public Serial Create(ItemEntity item)
     {
         _items.UpsertAsync(item).WaitSync();
+        _spatial?.AddOrUpdate(item);
 
         return item.Id;
     }
@@ -56,6 +60,7 @@ public sealed class ItemService : IItemService
     public bool Delete(Serial itemId)
     {
         _opl?.Invalidate(itemId);
+        _spatial?.Remove(itemId);
 
         return _items.RemoveAsync(itemId).WaitSync();
     }
@@ -72,6 +77,7 @@ public sealed class ItemService : IItemService
         item.EquippedMobileId = mobile.Id;
         item.EquippedLayer = layer;
         _items.UpsertAsync(item).WaitSync();
+        _spatial?.AddOrUpdate(item);
 
         mobile.EquippedItemIds[layer] = item.Id;
 
@@ -124,12 +130,14 @@ public sealed class ItemService : IItemService
         item.ParentContainerId = Serial.Zero;
         item.ContainerPosition = Point2D.Zero;
         _items.UpsertAsync(item).WaitSync();
+        _spatial?.AddOrUpdate(item);
     }
 
     public void Save(ItemEntity item)
     {
         _items.UpsertAsync(item).WaitSync();
         _opl?.Invalidate(item.Id);
+        _spatial?.AddOrUpdate(item);
     }
 
     public ItemEntity? Unequip(MobileEntity mobile, LayerType layer)
@@ -153,6 +161,7 @@ public sealed class ItemService : IItemService
             item.EquippedMobileId = Serial.Zero;
             item.EquippedLayer = null;
             _items.UpsertAsync(item).WaitSync();
+            _spatial?.AddOrUpdate(item);
         }
 
         return item;

--- a/src/Moongate.Server/Services/World/SpatialIndexService.cs
+++ b/src/Moongate.Server/Services/World/SpatialIndexService.cs
@@ -1,0 +1,168 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Data.Internal.World;
+using Moongate.Server.Scripting;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Default <see cref="ISpatialIndexService" />: a sparse 16×16 sector grid holding serials, with a
+/// reverse index for O(1) relocation. Single game-loop writer — plain dictionaries, no locks.
+/// </summary>
+public sealed class SpatialIndexService : ISpatialIndexService
+{
+    // 16-tile sectors: sector coordinates are world coordinates >> 4.
+    private const int SectorShift = 4;
+
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IEntityStore<ItemEntity, Serial> _items;
+    private readonly ILoopThread _loopThread;
+    private readonly Dictionary<(int MapId, int SectorX, int SectorY), Sector> _sectors = [];
+    private readonly Dictionary<Serial, (int MapId, int SectorX, int SectorY)> _locations = [];
+
+    public SpatialIndexService(IPersistenceService persistenceService, ILoopThread loopThread)
+    {
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _items = persistenceService.GetStore<ItemEntity, Serial>();
+        _loopThread = loopThread;
+    }
+
+    public void AddOrUpdate(MobileEntity mobile)
+    {
+        LoopGuard.Warn(_loopThread, nameof(SpatialIndexService) + "." + nameof(AddOrUpdate));
+        Place(mobile.Id, mobile.MapId, mobile.Position, isMobile: true);
+    }
+
+    public void AddOrUpdate(ItemEntity item)
+    {
+        LoopGuard.Warn(_loopThread, nameof(SpatialIndexService) + "." + nameof(AddOrUpdate));
+
+        // A contained or equipped item is not in the world: self-correct instead of polluting sectors.
+        if (item.ParentContainerId != Serial.Zero || item.EquippedMobileId != Serial.Zero)
+        {
+            RemoveCore(item.Id);
+
+            return;
+        }
+
+        Place(item.Id, item.MapId, item.Position, isMobile: false);
+    }
+
+    public void Remove(Serial serial)
+    {
+        LoopGuard.Warn(_loopThread, nameof(SpatialIndexService) + "." + nameof(Remove));
+        RemoveCore(serial);
+    }
+
+    public IReadOnlyList<MobileEntity> GetMobilesInRange(int mapId, Point3D center, int range)
+    {
+        LoopGuard.Warn(_loopThread, nameof(SpatialIndexService) + "." + nameof(GetMobilesInRange));
+        var results = new List<MobileEntity>();
+
+        foreach (var sector in SectorsInRange(mapId, center, range))
+        {
+            foreach (var serial in sector.Mobiles)
+            {
+                if (_mobiles.GetById(serial) is { } mobile && center.InRange(mobile.Position, range))
+                {
+                    results.Add(mobile);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    public IReadOnlyList<ItemEntity> GetItemsInRange(int mapId, Point3D center, int range)
+    {
+        LoopGuard.Warn(_loopThread, nameof(SpatialIndexService) + "." + nameof(GetItemsInRange));
+        var results = new List<ItemEntity>();
+
+        foreach (var sector in SectorsInRange(mapId, center, range))
+        {
+            foreach (var serial in sector.Items)
+            {
+                if (_items.GetById(serial) is { } item && center.InRange(item.Position, range))
+                {
+                    results.Add(item);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private void Place(Serial serial, int mapId, Point3D position, bool isMobile)
+    {
+        var key = (mapId, position.X >> SectorShift, position.Y >> SectorShift);
+
+        if (_locations.TryGetValue(serial, out var current))
+        {
+            if (current == key)
+            {
+                return;
+            }
+
+            RemoveCore(serial);
+        }
+
+        if (!_sectors.TryGetValue(key, out var sector))
+        {
+            sector = new Sector();
+            _sectors[key] = sector;
+        }
+
+        if (isMobile)
+        {
+            sector.Mobiles.Add(serial);
+        }
+        else
+        {
+            sector.Items.Add(serial);
+        }
+
+        _locations[serial] = key;
+    }
+
+    private void RemoveCore(Serial serial)
+    {
+        if (!_locations.Remove(serial, out var key))
+        {
+            return;
+        }
+
+        if (_sectors.TryGetValue(key, out var sector))
+        {
+            sector.Mobiles.Remove(serial);
+            sector.Items.Remove(serial);
+
+            if (sector.IsEmpty)
+            {
+                _sectors.Remove(key);
+            }
+        }
+    }
+
+    private IEnumerable<Sector> SectorsInRange(int mapId, Point3D center, int range)
+    {
+        var minX = (center.X - range) >> SectorShift;
+        var maxX = (center.X + range) >> SectorShift;
+        var minY = (center.Y - range) >> SectorShift;
+        var maxY = (center.Y + range) >> SectorShift;
+
+        for (var x = minX; x <= maxX; x++)
+        {
+            for (var y = minY; y <= maxY; y++)
+            {
+                if (_sectors.TryGetValue((mapId, x, y), out var sector))
+                {
+                    yield return sector;
+                }
+            }
+        }
+    }
+}

--- a/src/Moongate.Server/Services/World/WorldService.cs
+++ b/src/Moongate.Server/Services/World/WorldService.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Network.Data;
 using Moongate.Network.Interfaces;
@@ -5,6 +6,7 @@ using Moongate.Network.Packets.Outgoing;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Abstractions.Interfaces.World;
@@ -19,8 +21,9 @@ namespace Moongate.Server.Services.World;
 
 /// <summary>
 /// Default <see cref="IWorldService" />: builds the self-only enter-world burst from a mobile's state,
-/// streams it in the ModernUO order, and raises <see cref="PlayerEnteredWorldEvent" />. Broadcasting
-/// nearby mobiles/items (SendEverything) waits on a spatial world system and is out of scope here.
+/// streams it in the ModernUO order, and raises <see cref="PlayerEnteredWorldEvent" />. Also broadcasts
+/// packets to in-world players near a point. Full SendEverything (nearby mobile/item snapshots) waits
+/// on later spatial work and is out of scope here.
 /// </summary>
 public sealed class WorldService : IWorldService
 {
@@ -38,6 +41,7 @@ public sealed class WorldService : IWorldService
     private readonly IEventBus _eventBus;
     private readonly TimeProvider _timeProvider;
     private readonly IOplService _opl;
+    private readonly ISessionManager _sessions;
 
     public WorldService(
         IItemService items,
@@ -45,7 +49,8 @@ public sealed class WorldService : IWorldService
         IVirtualSerialService virtualSerials,
         IEventBus eventBus,
         TimeProvider timeProvider,
-        IOplService opl
+        IOplService opl,
+        ISessionManager sessions
     )
     {
         _items = items;
@@ -54,6 +59,7 @@ public sealed class WorldService : IWorldService
         _eventBus = eventBus;
         _timeProvider = timeProvider;
         _opl = opl;
+        _sessions = sessions;
     }
 
     public void SendEnterWorld(PlayerSession session, MobileEntity mobile)
@@ -67,6 +73,44 @@ public sealed class WorldService : IWorldService
 
         _eventBus.Publish(new PlayerEnteredWorldEvent(session.SessionId, session.AccountId, mobile));
     }
+
+    public int SendToPlayersInRange<TPacket>(int mapId, Point3D center, int range, TPacket packet, Serial? exclude = null)
+        where TPacket : IOutgoingPacket
+    {
+        var recipients = 0;
+
+        foreach (var session in _sessions.All)
+        {
+            if (!IsRecipient(session.State, session.Character, mapId, center, range, exclude))
+            {
+                continue;
+            }
+
+            session.Send(packet);
+            recipients++;
+        }
+
+        return recipients;
+    }
+
+    /// <summary>
+    /// True when a session in <paramref name="state" /> playing <paramref name="character" /> should
+    /// receive a broadcast centered on <paramref name="center" />. Static so the filter is testable
+    /// without fabricating live sessions.
+    /// </summary>
+    public static bool IsRecipient(
+        SessionStateType state,
+        MobileEntity? character,
+        int mapId,
+        Point3D center,
+        int range,
+        Serial? exclude
+    )
+        => state == SessionStateType.InWorld &&
+           character is not null &&
+           character.MapId == mapId &&
+           character.Id != exclude &&
+           center.InRange(character.Position, range);
 
     /// <summary>
     /// Builds the ordered self-only enter-world packet sequence for <paramref name="mobile" /> without

--- a/src/Moongate.Server/Subscribers/SpatialSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/SpatialSubscriber.cs
@@ -1,0 +1,88 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Feeds the spatial index from world lifecycle events: indexes the whole world once it is ready
+/// (WorldReadyEvent fires on the game-loop thread, so the bootstrap is loop-affine by construction),
+/// then every player as they enter, removing them when their session dies. Handlers are public so
+/// tests can drive them without a dispatching event bus.
+/// </summary>
+public sealed class SpatialSubscriber : IEventSubscriberRegistration
+{
+    private readonly ISpatialIndexService _spatial;
+    private readonly IEntityStore<AccountEntity, Serial> _accounts;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IEntityStore<ItemEntity, Serial> _items;
+
+    public SpatialSubscriber(ISpatialIndexService spatial, IPersistenceService persistence)
+    {
+        _spatial = spatial;
+        _accounts = persistence.GetStore<AccountEntity, Serial>();
+        _mobiles = persistence.GetStore<MobileEntity, Serial>();
+        _items = persistence.GetStore<ItemEntity, Serial>();
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<WorldReadyEvent>(OnWorldReady);
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(OnPlayerEnteredWorld);
+        eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+    }
+
+    public Task OnWorldReady(WorldReadyEvent message, CancellationToken cancellationToken)
+    {
+        // Accounts' MobileIds tell characters from NPCs (same discriminator as CharacterQueryService):
+        // an offline character must not ghost the world, online ones arrive via PlayerEnteredWorldEvent.
+        var playerCharacters = new HashSet<Serial>();
+
+        foreach (var account in _accounts.GetAll())
+        {
+            foreach (var mobileId in account.MobileIds)
+            {
+                playerCharacters.Add(mobileId);
+            }
+        }
+
+        foreach (var mobile in _mobiles.GetAll())
+        {
+            if (!playerCharacters.Contains(mobile.Id))
+            {
+                _spatial.AddOrUpdate(mobile);
+            }
+        }
+
+        foreach (var item in _items.GetAll())
+        {
+            if (item.ParentContainerId == Serial.Zero && item.EquippedMobileId == Serial.Zero)
+            {
+                _spatial.AddOrUpdate(item);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent message, CancellationToken cancellationToken)
+    {
+        _spatial.AddOrUpdate(message.Mobile);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSessionDestroyed(SessionDestroyedEvent message, CancellationToken cancellationToken)
+    {
+        if (message.Session.Character is { } character)
+        {
+            _spatial.Remove(character.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Moongate.Tests/Server/Accounts/SessionManagerTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/SessionManagerTests.cs
@@ -1,0 +1,15 @@
+using Moongate.Server.Services.Accounts;
+
+namespace Moongate.Tests.Server.Accounts;
+
+public class SessionManagerTests
+{
+    [Fact]
+    public void All_OnFreshManager_IsEmpty()
+    {
+        var manager = new SessionManager();
+
+        Assert.Empty(manager.All);
+        Assert.Equal(0, manager.Count);
+    }
+}

--- a/tests/Moongate.Tests/Server/ItemServiceTests.cs
+++ b/tests/Moongate.Tests/Server/ItemServiceTests.cs
@@ -1,7 +1,10 @@
+using Moongate.Core.Extensions;
 using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
+using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
 using Moongate.Ultima.Types;
 
@@ -214,6 +217,75 @@ public class ItemServiceTests
         return (new(persistence), persistence);
     }
 
+    private static (ItemService Service, SpatialIndexService Spatial, FakePersistenceService Persistence) BuildWithSpatial()
+    {
+        var persistence = new FakePersistenceService();
+        var marker = new LoopThreadMarker();
+        marker.Capture();
+        var spatial = new SpatialIndexService(persistence, marker);
+
+        return (new(persistence, null, spatial), spatial, persistence);
+    }
+
     private static ItemEntity Item(string name = "Dagger", int itemId = 3921)
         => new() { Name = name, ItemId = itemId };
+
+    [Fact]
+    public void Create_GroundItem_IsSpatiallyQueryable()
+    {
+        var (service, spatial, _) = BuildWithSpatial();
+        var item = Item();
+        item.MapId = 0;
+        item.Position = new Point3D(100, 100, 0);
+
+        service.Create(item);
+
+        Assert.Single(spatial.GetItemsInRange(0, new(100, 100, 0), 5));
+    }
+
+    [Fact]
+    public void AddToContainer_RemovesItemFromSpatialIndex()
+    {
+        var (service, spatial, _) = BuildWithSpatial();
+        var container = Item("Backpack", 3701);
+        var item = Item();
+        item.MapId = 0;
+        item.Position = new Point3D(100, 100, 0);
+        service.Create(container);
+        service.Create(item);
+
+        service.AddToContainer(container, item, new(1, 1));
+
+        Assert.Empty(spatial.GetItemsInRange(0, new(100, 100, 0), 5));
+    }
+
+    [Fact]
+    public void Delete_RemovesItemFromSpatialIndex()
+    {
+        var (service, spatial, _) = BuildWithSpatial();
+        var item = Item();
+        item.MapId = 0;
+        item.Position = new Point3D(100, 100, 0);
+        service.Create(item);
+
+        service.Delete(item.Id);
+
+        Assert.Empty(spatial.GetItemsInRange(0, new(100, 100, 0), 5));
+    }
+
+    [Fact]
+    public void Equip_RemovesItemFromSpatialIndex()
+    {
+        var (service, spatial, persistence) = BuildWithSpatial();
+        var mobile = new MobileEntity { Id = new(0x1), MapId = 0, Position = new(100, 100, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+        var item = Item();
+        item.MapId = 0;
+        item.Position = new Point3D(100, 100, 0);
+        service.Create(item);
+
+        service.Equip(mobile, item, LayerType.OneHanded);
+
+        Assert.Empty(spatial.GetItemsInRange(0, new(100, 100, 0), 5));
+    }
 }

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -550,7 +550,8 @@ public class LoginFlowIntegrationTests
                 new VirtualSerialService(),
                 eventBus,
                 TimeProvider.System,
-                opl
+                opl,
+                new SessionManager()
             ),
             opl
         );

--- a/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
@@ -1,0 +1,66 @@
+using Moongate.Core.Extensions;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Game;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Subscribers;
+
+public class SpatialSubscriberTests
+{
+    private static (SpatialSubscriber Subscriber, SpatialIndexService Spatial, FakePersistenceService Persistence) Build()
+    {
+        var persistence = new FakePersistenceService();
+        var marker = new LoopThreadMarker();
+        marker.Capture();
+        var spatial = new SpatialIndexService(persistence, marker);
+
+        return (new(spatial, persistence), spatial, persistence);
+    }
+
+    [Fact]
+    public async Task OnWorldReady_IndexesNpcsAndGroundItems_SkipsCharactersAndContainedItems()
+    {
+        var (subscriber, spatial, persistence) = Build();
+
+        // An NPC and a player character at the same spot: only the NPC must be indexed.
+        var npc = new MobileEntity { Id = new(0x10), MapId = 0, Position = new(100, 100, 0) };
+        var character = new MobileEntity { Id = new(0x20), MapId = 0, Position = new(100, 100, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(npc).WaitSync();
+        persistence.Store<MobileEntity>().UpsertAsync(character).WaitSync();
+        persistence.Store<AccountEntity>()
+                   .UpsertAsync(new() { Id = new(0x999), Username = "bob", MobileIds = [character.Id] })
+                   .WaitSync();
+
+        // A ground item and a contained item: only the ground one must be indexed.
+        var ground = new ItemEntity { Id = new(0x40000001), MapId = 0, Position = new(100, 100, 0) };
+        var contained = new ItemEntity
+        {
+            Id = new(0x40000002), MapId = 0, Position = new(100, 100, 0), ParentContainerId = new(0x40000099)
+        };
+        persistence.Store<ItemEntity>().UpsertAsync(ground).WaitSync();
+        persistence.Store<ItemEntity>().UpsertAsync(contained).WaitSync();
+
+        await subscriber.OnWorldReady(new(), CancellationToken.None);
+
+        var mobiles = spatial.GetMobilesInRange(0, new(100, 100, 0), 5);
+        Assert.Single(mobiles);
+        Assert.Equal(npc.Id, mobiles[0].Id);
+        var items = spatial.GetItemsInRange(0, new(100, 100, 0), 5);
+        Assert.Single(items);
+        Assert.Equal(ground.Id, items[0].Id);
+    }
+
+    [Fact]
+    public async Task OnPlayerEnteredWorld_IndexesTheMobile()
+    {
+        var (subscriber, spatial, persistence) = Build();
+        var character = new MobileEntity { Id = new(0x20), MapId = 0, Position = new(200, 200, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(character).WaitSync();
+
+        await subscriber.OnPlayerEnteredWorld(new(1, new(0x999), character), CancellationToken.None);
+
+        Assert.Single(spatial.GetMobilesInRange(0, new(200, 200, 0), 5));
+    }
+}

--- a/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
@@ -1,0 +1,165 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Game;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.World;
+
+public class SpatialIndexServiceTests
+{
+    private static (SpatialIndexService Index, FakePersistenceService Persistence) Build()
+    {
+        var persistence = new FakePersistenceService();
+        var marker = new LoopThreadMarker();
+        marker.Capture();
+
+        return (new(persistence, marker), persistence);
+    }
+
+    private static MobileEntity SeedMobile(FakePersistenceService persistence, uint serial, int mapId, int x, int y)
+    {
+        var mobile = new MobileEntity { Id = new(serial), MapId = mapId, Position = new(x, y, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        return mobile;
+    }
+
+    private static ItemEntity SeedItem(FakePersistenceService persistence, uint serial, int mapId, int x, int y)
+    {
+        var item = new ItemEntity { Id = new(serial), MapId = mapId, Position = new(x, y, 0) };
+        persistence.Store<ItemEntity>().UpsertAsync(item).WaitSync();
+
+        return item;
+    }
+
+    [Fact]
+    public void AddOrUpdate_ThenQueryInRange_ReturnsMobile()
+    {
+        var (index, persistence) = Build();
+        var mobile = SeedMobile(persistence, 0x1, mapId: 0, x: 100, y: 100);
+
+        index.AddOrUpdate(mobile);
+        var found = index.GetMobilesInRange(0, new(105, 105, 0), 18);
+
+        Assert.Single(found);
+        Assert.Equal(mobile.Id, found[0].Id);
+    }
+
+    [Fact]
+    public void GetMobilesInRange_OutOfRange_ReturnsEmpty()
+    {
+        var (index, persistence) = Build();
+        index.AddOrUpdate(SeedMobile(persistence, 0x1, mapId: 0, x: 100, y: 100));
+
+        Assert.Empty(index.GetMobilesInRange(0, new(300, 300, 0), 18));
+    }
+
+    [Fact]
+    public void Query_IgnoresOtherMaps()
+    {
+        var (index, persistence) = Build();
+        index.AddOrUpdate(SeedMobile(persistence, 0x1, mapId: 1, x: 100, y: 100));
+
+        Assert.Empty(index.GetMobilesInRange(0, new(100, 100, 0), 18));
+        Assert.Single(index.GetMobilesInRange(1, new(100, 100, 0), 18));
+    }
+
+    [Fact]
+    public void GetItemsInRange_ReturnsGroundItem()
+    {
+        var (index, persistence) = Build();
+        index.AddOrUpdate(SeedItem(persistence, 0x40000001, mapId: 0, x: 50, y: 50));
+
+        Assert.Single(index.GetItemsInRange(0, new(52, 52, 0), 10));
+    }
+
+    [Fact]
+    public void AddOrUpdate_AfterMove_RelocatesAcrossSectors()
+    {
+        var (index, persistence) = Build();
+        var mobile = SeedMobile(persistence, 0x1, mapId: 0, x: 15, y: 0);
+        index.AddOrUpdate(mobile);
+
+        // Cross the sector boundary (tile 15 -> sector 0, tile 400 -> sector 25) and re-index.
+        mobile.Position = new(400, 400, 0);
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+        index.AddOrUpdate(mobile);
+
+        Assert.Empty(index.GetMobilesInRange(0, new(15, 0, 0), 10));
+        Assert.Single(index.GetMobilesInRange(0, new(400, 400, 0), 10));
+    }
+
+    [Fact]
+    public void AddOrUpdate_SameSectorTwice_DoesNotDuplicate()
+    {
+        var (index, persistence) = Build();
+        var mobile = SeedMobile(persistence, 0x1, mapId: 0, x: 100, y: 100);
+
+        index.AddOrUpdate(mobile);
+        index.AddOrUpdate(mobile);
+
+        Assert.Single(index.GetMobilesInRange(0, new(100, 100, 0), 5));
+    }
+
+    [Fact]
+    public void Remove_ThenQuery_ReturnsEmpty()
+    {
+        var (index, persistence) = Build();
+        var mobile = SeedMobile(persistence, 0x1, mapId: 0, x: 100, y: 100);
+        index.AddOrUpdate(mobile);
+
+        index.Remove(mobile.Id);
+
+        Assert.Empty(index.GetMobilesInRange(0, new(100, 100, 0), 18));
+    }
+
+    [Fact]
+    public void Remove_UnknownSerial_IsNoOp()
+    {
+        var (index, _) = Build();
+
+        index.Remove(new Serial(0xDEAD));
+    }
+
+    [Fact]
+    public void AddOrUpdate_ItemInContainer_ActsAsRemove()
+    {
+        var (index, persistence) = Build();
+        var item = SeedItem(persistence, 0x40000001, mapId: 0, x: 50, y: 50);
+        index.AddOrUpdate(item);
+
+        item.ParentContainerId = new(0x40000099);
+        persistence.Store<ItemEntity>().UpsertAsync(item).WaitSync();
+        index.AddOrUpdate(item);
+
+        Assert.Empty(index.GetItemsInRange(0, new(50, 50, 0), 10));
+    }
+
+    [Fact]
+    public void Query_SpanningMultipleSectors_ReturnsAllWithoutDuplicates()
+    {
+        var (index, persistence) = Build();
+        index.AddOrUpdate(SeedMobile(persistence, 0x1, mapId: 0, x: 100, y: 100));
+        index.AddOrUpdate(SeedMobile(persistence, 0x2, mapId: 0, x: 118, y: 118));
+
+        var found = index.GetMobilesInRange(0, new(109, 109, 0), 20);
+
+        Assert.Equal(2, found.Count);
+        Assert.Equal(2, found.Select(m => m.Id).Distinct().Count());
+    }
+
+    [Fact]
+    public void Query_SkipsEntitiesDeletedFromStore()
+    {
+        var (index, persistence) = Build();
+        var mobile = SeedMobile(persistence, 0x1, mapId: 0, x: 100, y: 100);
+        index.AddOrUpdate(mobile);
+
+        persistence.Store<MobileEntity>().RemoveAsync(mobile.Id).WaitSync();
+
+        Assert.Empty(index.GetMobilesInRange(0, new(100, 100, 0), 18));
+    }
+}

--- a/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
@@ -6,6 +6,8 @@ using Moongate.Network.Interfaces;
 using Moongate.Network.Packets.Outgoing;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.World;
@@ -26,7 +28,8 @@ public class WorldServiceTests
             new VirtualSerialService(),
             new StubEventBus(),
             time ?? TimeProvider.System,
-            new OplService(new FakePersistenceService(), new ItemTemplateService())
+            new OplService(new FakePersistenceService(), new ItemTemplateService()),
+            new SessionManager()
         );
 
     // Three skills is enough to prove the list is built from the registry rather than from the mobile.
@@ -61,7 +64,8 @@ public class WorldServiceTests
             new VirtualSerialService(),
             new StubEventBus(),
             TimeProvider.System,
-            opl
+            opl,
+            new SessionManager()
         );
 
         var packets = service.BuildSequence(mobile);
@@ -290,5 +294,66 @@ public class WorldServiceTests
         // an entity the server owns.
         Assert.True(new Serial(BinaryPrimitives.ReadUInt32BigEndian(incoming.AsSpan(28))).IsVirtual);
         Assert.Equal((byte)LayerType.Hair, incoming[34]);
+    }
+
+    [Fact]
+    public void IsRecipient_InWorldSameMapInRange_IsTrue()
+    {
+        var character = new MobileEntity { Id = new(0x1), MapId = 0, Position = new(100, 100, 0) };
+
+        Assert.True(WorldService.IsRecipient(SessionStateType.InWorld, character, 0, new(105, 105, 0), 18, null));
+    }
+
+    [Fact]
+    public void IsRecipient_NotInWorld_IsFalse()
+    {
+        var character = new MobileEntity { Id = new(0x1), MapId = 0, Position = new(100, 100, 0) };
+
+        Assert.False(WorldService.IsRecipient(SessionStateType.Authenticated, character, 0, new(100, 100, 0), 18, null));
+    }
+
+    [Fact]
+    public void IsRecipient_NullCharacter_IsFalse()
+        => Assert.False(WorldService.IsRecipient(SessionStateType.InWorld, null, 0, new(100, 100, 0), 18, null));
+
+    [Fact]
+    public void IsRecipient_WrongMap_IsFalse()
+    {
+        var character = new MobileEntity { Id = new(0x1), MapId = 1, Position = new(100, 100, 0) };
+
+        Assert.False(WorldService.IsRecipient(SessionStateType.InWorld, character, 0, new(100, 100, 0), 18, null));
+    }
+
+    [Fact]
+    public void IsRecipient_OutOfRange_IsFalse()
+    {
+        var character = new MobileEntity { Id = new(0x1), MapId = 0, Position = new(200, 200, 0) };
+
+        Assert.False(WorldService.IsRecipient(SessionStateType.InWorld, character, 0, new(100, 100, 0), 18, null));
+    }
+
+    [Fact]
+    public void IsRecipient_ExcludedSerial_IsFalse()
+    {
+        var character = new MobileEntity { Id = new(0x1), MapId = 0, Position = new(100, 100, 0) };
+
+        Assert.False(WorldService.IsRecipient(SessionStateType.InWorld, character, 0, new(100, 100, 0), 18, new Serial(0x1)));
+    }
+
+    [Fact]
+    public void SendToPlayersInRange_NoSessions_ReturnsZero()
+    {
+        var service = Service(new StubItemService([]));
+
+        Assert.Equal(0, service.SendToPlayersInRange(0, new Point3D(100, 100, 0), 18, new NoopPacket()));
+    }
+
+    // IOutgoingPacket's single member is Write(ref SpanWriter); the packet is never written here
+    // because there are no sessions.
+    private sealed class NoopPacket : IOutgoingPacket
+    {
+        public void Write(ref SpanWriter writer)
+        {
+        }
     }
 }

--- a/tests/Moongate.Tests/Support/StubSessionManager.cs
+++ b/tests/Moongate.Tests/Support/StubSessionManager.cs
@@ -17,6 +17,9 @@ public sealed class StubSessionManager : ISessionManager
     public int Count
         => 0;
 
+    public IReadOnlyCollection<PlayerSession> All
+        => [];
+
     public PlayerSession GetOrCreate(SquidStdTcpClient client)
         => throw new NotSupportedException("The stub holds no sessions.");
 


### PR DESCRIPTION
## Summary
- Add a sparse 16x16-tile sector-grid spatial index (`ISpatialIndexService`/`SpatialIndexService`) holding entity serials only, with a reverse index for O(1) relocation
- Expose a live session snapshot on `ISessionManager` and add `WorldService.SendToPlayersInRange` to broadcast packets to in-world players near a point
- Keep the index in sync with every `ItemService` write (create/delete/equip/unequip/container moves)
- Add `SpatialSubscriber`: bootstraps the index from persisted NPCs and ground items on `WorldReadyEvent` (player characters excluded, they arrive via `PlayerEnteredWorldEvent`), and removes entries on `SessionDestroyedEvent`

## Design
Approach and trade-offs documented in the design spec (sectors vs. quadtree — sectors chosen, aligned with RunUO/ModernUO/moongatev2 convention). MoveRequest handling, MovementService and wiring the broadcast helper into actual movement remain out of scope for this branch (tracked on the "12 [M1] Movimento" Trello card).

## Test plan
- [x] `dotnet test`: 1125/1125 passing (25 new tests, 0 regressions)
- [x] `dotnet build`: 0 errors
- [x] `dotnet docfx docs/docfx.json --warningsAsErrors`: 0 warnings