### PR TITLE
fix: render map tiles opaque instead of fully transparent

### DIFF
--- a/src/Moongate.Ultima/Maps/Map.cs
+++ b/src/Moongate.Ultima/Maps/Map.cs
@@ -9,6 +9,9 @@ namespace Moongate.Ultima.Maps;
 
 public sealed class Map
 {
+    /// <summary>The ARGB1555 "visible" bit, set on every rendered map pixel so it decodes opaque.</summary>
+    private const ushort OpaqueBit = 0x8000;
+
     private TileMatrix _tiles;
     private readonly int _mapId;
     private readonly string _path;
@@ -1486,6 +1489,17 @@ public sealed class Map
                     }
                 }
             }
+        }
+
+        // Radar colours and hue ramps are RGB555 palettes: opaque colours with the top bit clear. The
+        // reference SDK renders maps into a Format16bppRgb555 bitmap, where that bit is ignored and every
+        // pixel is opaque; UltimaBitmap has only an ARGB1555 surface, whose top bit means "visible", so
+        // without this the whole map decodes to alpha 0 and reads as blank. Out-of-bounds blocks never
+        // reach here — GetRenderedBlock returns a transparent block before calling in — so genuine
+        // no-data areas stay transparent.
+        for (var i = 0; i < data.Length; i++)
+        {
+            data[i] |= OpaqueBit;
         }
 
         return data;

--- a/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
@@ -42,6 +42,24 @@ public class MapImageServiceTests
     }
 
     [Fact]
+    public async Task GetTileAsync_Native_RendersOpaqueLandPixels()
+    {
+        // Radar colours are RGB555 with no alpha bit — a palette, not a sprite. The renderer must mark
+        // the map opaque anyway; without that every pixel decodes to alpha 0 and the tile is a
+        // fully-transparent square that reads as blank. The fixture's land colour is 0x7C00 (red).
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+
+        var path = await service.GetTileAsync(MapType.Felucca, service.MaxZoomFor(MapType.Felucca), 0, 0);
+
+        using var image = await Image.LoadAsync<Bgra32>(path!);
+        var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];
+
+        Assert.Equal(byte.MaxValue, centre.A);
+        Assert.Equal(byte.MaxValue, centre.R);
+    }
+
+    [Fact]
     public async Task GetTileAsync_SecondCall_ServesTheCachedFileWithoutRerendering()
     {
         using var fixture = MapImageFixture.Create();


### PR DESCRIPTION
## The bug

Every map tile PNG served by `/api/v1/images/maps/...` was a fully transparent square — it looked blank/white in a browser. Confirmed against real client files (`map0LegacyMUL.uop`): not a coordinate issue, the whole-facet zoom-0 thumbnail was equally blank.

## Root cause

`Map.RenderBlock` composites radar colours — RGB555 palette entries from `radarcol.mul` that never carry the top bit (verified: 0 of 79,082 non-zero entries have it) — into an ARGB1555 surface without setting the visible bit. The reference SDK (UOFiddler/Ultima.dll) renders maps into a `Format16bppRgb555` bitmap, where that bit is ignored and every pixel is opaque, and uses `Argb1555` only for sprite MULs. Our single `UltimaBitmap` surface treats the top bit as alpha, so every map pixel decoded to alpha 0.

The diagnosis ruled out the initially-suspected UOP land-block offset path first (a direct read returned correct tile Ids); `Map.GetImage` produced real colour bytes; the loss was isolated to the alpha bit at the RadarCol → surface boundary.

## The fix

Mark the rendered map block opaque before returning it, matching the reference's opaque-map semantics. Out-of-bounds blocks are unaffected — they return a transparent block before reaching the renderer — so the tile pyramid's padding stays transparent.

## Why it shipped

The existing map tests asserted tile size, caching and composition, never pixel visibility, and the fixture's radar colour (`0x7C00`) also lacks the alpha bit — so the whole suite passed on transparent output. Added a regression test asserting rendered land pixels are opaque.

## Verification

Regression test red→green, full suite 1143/1143, and a manual smoke against real client files: Felucca renders Britannia; the previously-blank `felucca/5/10/10` is now correct opaque ocean.