### PR TITLE
feat: altitude-shaded map style over ?style=relief

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -308,6 +308,11 @@ it reports rather than hardcoding it.
 `GET /api/v1/images/maps/{map}/full.png` is the whole facet in one image, for
 downloading or printing rather than browsing.
 
+Both routes take an optional `?style=`. `flat` (the default) is the radar map —
+one colour per map tile. `relief` renders the same map with altitude shading, so
+hills and valleys read as light and shadow; it is a touch slower to render the
+first time and caches separately from flat, so the two never overwrite each other.
+
 `POST /api/v1/admin/images/maps` builds every tile and whole-facet image ahead of
 time; `GET` on the same route reports progress. Staff-only. Run it before anyone
 opens a viewer: the first request at a low zoom otherwise builds every tile beneath

--- a/src/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Routing;
 using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
 using Moongate.Http.Plugin.Interfaces.Maps;
+using Moongate.Http.Plugin.Types;
 using Moongate.UO.Data.Types;
 
 namespace Moongate.Http.Plugin.Endpoints.Maps;
@@ -119,7 +120,7 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
             );
         }
 
-        var path = await _maps.GetTileAsync(facet, zoom, x, y, cancellationToken);
+        var path = await _maps.GetTileAsync(facet, MapRenderStyleType.Flat, zoom, x, y, cancellationToken);
 
         return path is null
                    ? Results.Problem(
@@ -147,7 +148,7 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
             return NotLoaded();
         }
 
-        var path = await _maps.GetFullAsync(facet, cancellationToken);
+        var path = await _maps.GetFullAsync(facet, MapRenderStyleType.Flat, cancellationToken);
 
         return path is null
                    ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)

--- a/src/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
@@ -84,9 +84,18 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
     /// is the whole facet in one tile, and maxZoom — which GET /api/v1/images/maps reports per facet — is
     /// one pixel per map tile. Tiles are 256×256. A tile at the facet's edge is padded transparent. Tiles
     /// are rendered on first request and cached, so the first call at a low zoom builds everything beneath
-    /// it and is slow; the staff pre-warm exists to do that in advance.
+    /// it and is slow; the staff pre-warm exists to do that in advance. Optional <c>?style=</c> chooses the
+    /// render: <c>flat</c> (default) is the radar map, <c>relief</c> adds altitude shading; each caches on
+    /// its own.
     /// </remarks>
-    private async Task<IResult> GetTile(string map, string z, int x, int y, CancellationToken cancellationToken)
+    private async Task<IResult> GetTile(
+        string map,
+        string z,
+        int x,
+        int y,
+        string? style,
+        CancellationToken cancellationToken
+    )
     {
         if (!TryParseFacet(map, out var facet))
         {
@@ -120,7 +129,12 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
             );
         }
 
-        var path = await _maps.GetTileAsync(facet, MapRenderStyleType.Flat, zoom, x, y, cancellationToken);
+        if (!TryParseStyle(style, out var renderStyle))
+        {
+            return InvalidStyle(style!);
+        }
+
+        var path = await _maps.GetTileAsync(facet, renderStyle, zoom, x, y, cancellationToken);
 
         return path is null
                    ? Results.Problem(
@@ -133,10 +147,11 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
     /// <summary>A whole facet as one PNG.</summary>
     /// <remarks>
     /// Open without a token. The entire facet at one pixel per map tile — 6144×4096 for Felucca — for
-    /// downloading or printing rather than browsing; use the tiles for a viewer. It is generated once and
+    /// downloading or printing rather than browsing; use the tiles for a viewer. Optional <c>?style=</c>
+    /// picks <c>flat</c> (default) or <c>relief</c> as on the tile route. It is generated once and
     /// cached, and the first request is slow and memory-hungry if the staff pre-warm has not run.
     /// </remarks>
-    private async Task<IResult> GetFull(string map, CancellationToken cancellationToken)
+    private async Task<IResult> GetFull(string map, string? style, CancellationToken cancellationToken)
     {
         if (!TryParseFacet(map, out var facet))
         {
@@ -148,7 +163,12 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
             return NotLoaded();
         }
 
-        var path = await _maps.GetFullAsync(facet, MapRenderStyleType.Flat, cancellationToken);
+        if (!TryParseStyle(style, out var renderStyle))
+        {
+            return InvalidStyle(style!);
+        }
+
+        var path = await _maps.GetFullAsync(facet, renderStyle, cancellationToken);
 
         return path is null
                    ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)
@@ -165,6 +185,27 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
     private static IResult InvalidFacet(string name)
         => Results.Problem(
             $"'{name}' is not a map. Valid maps: {string.Join(", ", Enum.GetNames<MapType>())}.",
+            statusCode: StatusCodes.Status400BadRequest
+        );
+
+    /// <summary>
+    /// The optional <c>?style=</c> query: absent or empty means the flat radar map. Case-insensitive.
+    /// </summary>
+    private static bool TryParseStyle(string? name, out MapRenderStyleType style)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            style = MapRenderStyleType.Flat;
+
+            return true;
+        }
+
+        return Enum.TryParse(name, true, out style) && Enum.IsDefined(style);
+    }
+
+    private static IResult InvalidStyle(string name)
+        => Results.Problem(
+            $"'{name}' is not a map style. Valid styles: {string.Join(", ", Enum.GetNames<MapRenderStyleType>())}.",
             statusCode: StatusCodes.Status400BadRequest
         );
 

--- a/src/Moongate.Http.Plugin/Interfaces/Maps/IMapImageService.cs
+++ b/src/Moongate.Http.Plugin/Interfaces/Maps/IMapImageService.cs
@@ -1,3 +1,4 @@
+using Moongate.Http.Plugin.Types;
 using Moongate.UO.Data.Types;
 
 namespace Moongate.Http.Plugin.Interfaces.Maps;
@@ -18,14 +19,27 @@ public interface IMapImageService
     int MaxZoomFor(MapType facet);
 
     /// <summary>
-    /// The path of the cached tile, building it — and, below native zoom, its children — on first request.
-    /// Null when the facet is not served or the tile is outside that zoom's grid.
+    /// The path of the cached tile in the given <paramref name="style" />, building it — and, below native
+    /// zoom, its children — on first request. Null when the facet is not served or the tile is outside that
+    /// zoom's grid.
     /// </summary>
-    Task<string?> GetTileAsync(MapType facet, int zoom, int x, int y, CancellationToken cancellationToken = default);
+    Task<string?> GetTileAsync(
+        MapType facet,
+        MapRenderStyleType style,
+        int zoom,
+        int x,
+        int y,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
-    /// The path of the cached whole-facet image, rendering it on first request. Null when the facet is not
-    /// served. This one is expensive — a facet-sized bitmap — which is what the pre-warm is for.
+    /// The path of the cached whole-facet image in the given <paramref name="style" />, rendering it on
+    /// first request. Null when the facet is not served. This one is expensive — a facet-sized bitmap —
+    /// which is what the pre-warm is for.
     /// </summary>
-    Task<string?> GetFullAsync(MapType facet, CancellationToken cancellationToken = default);
+    Task<string?> GetFullAsync(
+        MapType facet,
+        MapRenderStyleType style,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Moongate.Http.Plugin/Services/Maps/MapImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Services/Maps/MapImageExportJob.cs
@@ -85,11 +85,11 @@ public sealed class MapImageExportJob : IMapImageExportJob
                 {
                     if (zoom == FullImageZoom)
                     {
-                        await _maps.GetFullAsync(facet);
+                        await _maps.GetFullAsync(facet, MapRenderStyleType.Flat);
                     }
                     else
                     {
-                        await _maps.GetTileAsync(facet, zoom, x, y);
+                        await _maps.GetTileAsync(facet, MapRenderStyleType.Flat, zoom, x, y);
                     }
 
                     lock (_sync)

--- a/src/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
@@ -1,7 +1,10 @@
 using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Ultima;
+using Moongate.Http.Plugin.Types;
+using Moongate.Ultima.Imaging;
 using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
 using Moongate.UO.Data.Types;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -30,6 +33,10 @@ public sealed class MapImageService : IMapImageService
         _maps = maps;
         _gate = gate;
         _cachePath = directories.RegisterDirectory(CacheDirectory);
+
+        // Relief shading is driven by process-wide statics that invalidate a per-Map altitude cache, so
+        // they must be fixed once, never per request. Soft matches the UO client's own map most closely.
+        UltimaMap.ShadingPreset = AltitudeShadingPresetType.Soft;
     }
 
     public bool IsReady
@@ -40,6 +47,7 @@ public sealed class MapImageService : IMapImageService
 
     public async Task<string?> GetTileAsync(
         MapType facet,
+        MapRenderStyleType style,
         int zoom,
         int x,
         int y,
@@ -58,7 +66,7 @@ public sealed class MapImageService : IMapImageService
             return null;
         }
 
-        var path = TilePath(facet, zoom, x, y);
+        var path = TilePath(facet, style, zoom, x, y);
 
         // The hit path touches neither the gate nor Ultima. Everything below is the miss.
         if (File.Exists(path))
@@ -67,22 +75,26 @@ public sealed class MapImageService : IMapImageService
         }
 
         using var tile = zoom == maxZoom
-                             ? await RenderNativeAsync(map, x, y, cancellationToken)
-                             : await ComposeAsync(facet, zoom, x, y, cancellationToken);
+                             ? await RenderNativeAsync(map, style, x, y, cancellationToken)
+                             : await ComposeAsync(facet, style, zoom, x, y, cancellationToken);
 
         await WriteAtomicallyAsync(path, tile, cancellationToken);
 
         return path;
     }
 
-    public async Task<string?> GetFullAsync(MapType facet, CancellationToken cancellationToken = default)
+    public async Task<string?> GetFullAsync(
+        MapType facet,
+        MapRenderStyleType style,
+        CancellationToken cancellationToken = default
+    )
     {
         if (_maps.Get(facet) is not { } map)
         {
             return null;
         }
 
-        var path = Path.Combine(FacetDirectory(facet), "full.png");
+        var path = Path.Combine(StyleDirectory(facet, style), "full.png");
 
         if (File.Exists(path))
         {
@@ -99,7 +111,7 @@ public sealed class MapImageService : IMapImageService
                     return null;
                 }
 
-                using var bitmap = map.GetImage(0, 0, Blocks(map.Width), Blocks(map.Height), true);
+                using var bitmap = RenderBlocks(map, style, 0, 0, Blocks(map.Width), Blocks(map.Height));
 
                 return bitmap.ToImage();
             },
@@ -128,6 +140,7 @@ public sealed class MapImageService : IMapImageService
     /// </summary>
     private async Task<Image<Bgra32>> RenderNativeAsync(
         UltimaMap map,
+        MapRenderStyleType style,
         int x,
         int y,
         CancellationToken cancellationToken
@@ -141,7 +154,7 @@ public sealed class MapImageService : IMapImageService
         var rendered = await _gate.ReadAsync(
             () =>
             {
-                using var bitmap = map.GetImage(blockX, blockY, width, height, true);
+                using var bitmap = RenderBlocks(map, style, blockX, blockY, width, height);
 
                 return bitmap.ToImage();
             },
@@ -170,6 +183,7 @@ public sealed class MapImageService : IMapImageService
     /// </summary>
     private async Task<Image<Bgra32>> ComposeAsync(
         MapType facet,
+        MapRenderStyleType style,
         int zoom,
         int x,
         int y,
@@ -181,7 +195,7 @@ public sealed class MapImageService : IMapImageService
 
         foreach (var (dx, dy) in new[] { (0, 0), (1, 0), (0, 1), (1, 1) })
         {
-            var childPath = await GetTileAsync(facet, zoom + 1, x * 2 + dx, y * 2 + dy, cancellationToken);
+            var childPath = await GetTileAsync(facet, style, zoom + 1, x * 2 + dx, y * 2 + dy, cancellationToken);
 
             if (childPath is null)
             {
@@ -196,6 +210,22 @@ public sealed class MapImageService : IMapImageService
         return tile;
     }
 
+    /// <summary>
+    /// The style's block render. Flat is the radar map; Relief is the same map with altitude shading,
+    /// which only differs at native zoom — every lower zoom is composed by downsampling native tiles.
+    /// </summary>
+    private static UltimaBitmap RenderBlocks(
+        UltimaMap map,
+        MapRenderStyleType style,
+        int x,
+        int y,
+        int width,
+        int height
+    )
+        => style == MapRenderStyleType.Relief
+            ? map.GetImageWithAltitude(x, y, width, height, true, MapAltitudeModeType.NormalWithAltitude)
+            : map.GetImage(x, y, width, height, true);
+
     private static bool InGrid(UltimaMap map, int zoom, int maxZoom, int x, int y)
         => x >= 0
            && y >= 0
@@ -206,13 +236,15 @@ public sealed class MapImageService : IMapImageService
     private static int Blocks(int extent)
         => (extent + 7) / 8;
 
-    private string FacetDirectory(MapType facet)
-        => Directory.CreateDirectory(Path.Combine(_cachePath, facet.ToString().ToLowerInvariant())).FullName;
+    private string StyleDirectory(MapType facet, MapRenderStyleType style)
+        => Directory.CreateDirectory(
+            Path.Combine(_cachePath, facet.ToString().ToLowerInvariant(), style.ToString().ToLowerInvariant())
+        ).FullName;
 
-    private string TilePath(MapType facet, int zoom, int x, int y)
+    private string TilePath(MapType facet, MapRenderStyleType style, int zoom, int x, int y)
     {
         var directory = Directory.CreateDirectory(
-            Path.Combine(FacetDirectory(facet), zoom.ToString(), x.ToString())
+            Path.Combine(StyleDirectory(facet, style), zoom.ToString(), x.ToString())
         );
 
         return Path.Combine(directory.FullName, $"{y}.png");

--- a/src/Moongate.Http.Plugin/Types/MapRenderStyleType.cs
+++ b/src/Moongate.Http.Plugin/Types/MapRenderStyleType.cs
@@ -1,0 +1,11 @@
+namespace Moongate.Http.Plugin.Types;
+
+/// <summary>How a map facet is rendered into tiles.</summary>
+public enum MapRenderStyleType
+{
+    /// <summary>The flat radar map: one colour per map tile.</summary>
+    Flat,
+
+    /// <summary>The radar map with altitude-based relief shading — hills and valleys read as light and shadow.</summary>
+    Relief,
+}

--- a/src/Moongate.Ultima/Maps/Map.cs
+++ b/src/Moongate.Ultima/Maps/Map.cs
@@ -1925,8 +1925,8 @@ public sealed class Map
         green = Math.Clamp(green, 0, 31);
         blue = Math.Clamp(blue, 0, 31);
 
-        // Recombine into RGB555 format
-        return (ushort)((red << 10) | (green << 5) | blue);
+        // Recombine into RGB555, opaque — the map surface is ARGB1555 and the top bit means "visible".
+        return (ushort)(OpaqueBit | (red << 10) | (green << 5) | blue);
     }
 
     #endregion

--- a/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
@@ -129,4 +129,28 @@ public class MapImageEndpointsTests
         Assert.Equal(MapTileGeometry.MaxZoom(MapImageFixture.MapWidth, MapImageFixture.MapHeight), only.MaxZoom);
         Assert.Equal(MapTileGeometry.TileSize, only.TileSize);
     }
+
+    [Fact]
+    public async Task GetTile_ReliefStyle_ServesAnImage()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var response = await server.Client.GetAsync("/api/v1/images/maps/felucca/0/0/0.png?style=relief");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task GetTile_UnknownStyle_IsABadRequest()
+    {
+        using var fixture = MapImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            (await server.Client.GetAsync("/api/v1/images/maps/felucca/0/0/0.png?style=bogus")).StatusCode
+        );
+    }
 }

--- a/tests/Moongate.Tests/Http/Services/Maps/MapImageExportJobTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Maps/MapImageExportJobTests.cs
@@ -59,12 +59,12 @@ public class MapImageExportJobTests
         for (var zoom = 0; zoom <= maxZoom; zoom++)
         {
             Assert.True(
-                Directory.Exists(Path.Combine(root, "felucca", zoom.ToString())),
+                Directory.Exists(Path.Combine(root, "felucca", "flat", zoom.ToString())),
                 $"zoom {zoom} was not exported"
             );
         }
 
-        Assert.True(File.Exists(Path.Combine(root, "felucca", "full.png")));
+        Assert.True(File.Exists(Path.Combine(root, "felucca", "flat", "full.png")));
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
@@ -1,5 +1,6 @@
 using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Services.Maps;
+using Moongate.Http.Plugin.Types;
 using Moongate.Http.Plugin.Services.Ultima;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Types;
@@ -31,7 +32,7 @@ public class MapImageServiceTests
         using var fixture = MapImageFixture.Create();
         var service = Service(fixture);
 
-        var path = await service.GetTileAsync(MapType.Felucca, service.MaxZoomFor(MapType.Felucca), 0, 0);
+        var path = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, service.MaxZoomFor(MapType.Felucca), 0, 0);
 
         Assert.NotNull(path);
 
@@ -50,7 +51,7 @@ public class MapImageServiceTests
         using var fixture = MapImageFixture.Create();
         var service = Service(fixture);
 
-        var path = await service.GetTileAsync(MapType.Felucca, service.MaxZoomFor(MapType.Felucca), 0, 0);
+        var path = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, service.MaxZoomFor(MapType.Felucca), 0, 0);
 
         using var image = await Image.LoadAsync<Bgra32>(path!);
         var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];
@@ -66,11 +67,11 @@ public class MapImageServiceTests
         var service = Service(fixture);
         var zoom = service.MaxZoomFor(MapType.Felucca);
 
-        var first = await service.GetTileAsync(MapType.Felucca, zoom, 0, 0);
+        var first = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, 0, 0);
         var marker = DateTime.UtcNow.AddDays(-1);
         File.SetLastWriteTimeUtc(first!, marker);
 
-        var second = await service.GetTileAsync(MapType.Felucca, zoom, 0, 0);
+        var second = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, 0, 0);
 
         Assert.Equal(first, second);
         Assert.Equal(marker, File.GetLastWriteTimeUtc(second!), TimeSpan.FromSeconds(1));
@@ -85,7 +86,7 @@ public class MapImageServiceTests
         using var fixture = MapImageFixture.Create();
         var service = Service(fixture);
 
-        var path = await service.GetTileAsync(MapType.Felucca, 0, 0, 0);
+        var path = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, 0, 0, 0);
 
         Assert.NotNull(path);
 
@@ -102,13 +103,13 @@ public class MapImageServiceTests
         using var fixture = MapImageFixture.Create();
         var service = Service(fixture);
 
-        await service.GetTileAsync(MapType.Felucca, 0, 0, 0);
+        await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, 0, 0, 0);
 
         var native = service.MaxZoomFor(MapType.Felucca);
         var root = fixture.Directories.GetPath("cache/images/maps");
 
-        Assert.True(Directory.Exists(Path.Combine(root, "felucca", native.ToString())), "no native tiles cached");
-        Assert.True(Directory.Exists(Path.Combine(root, "felucca", "0")), "no zoom 0 tile cached");
+        Assert.True(Directory.Exists(Path.Combine(root, "felucca", "flat", native.ToString())), "no native tiles cached");
+        Assert.True(Directory.Exists(Path.Combine(root, "felucca", "flat", "0")), "no zoom 0 tile cached");
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class MapImageServiceTests
     {
         using var fixture = MapImageFixture.Create();
 
-        Assert.Null(await Service(fixture).GetTileAsync(MapType.Felucca, 0, 99, 99));
+        Assert.Null(await Service(fixture).GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, 0, 99, 99));
     }
 
     [Fact]
@@ -124,7 +125,7 @@ public class MapImageServiceTests
     {
         using var fixture = MapImageFixture.Create();
 
-        Assert.Null(await Service(fixture).GetTileAsync(MapType.Malas, 0, 0, 0));
+        Assert.Null(await Service(fixture).GetTileAsync(MapType.Malas, MapRenderStyleType.Flat, 0, 0, 0));
     }
 
     [Fact]
@@ -132,7 +133,7 @@ public class MapImageServiceTests
     {
         using var fixture = MapImageFixture.Create();
 
-        var path = await Service(fixture).GetFullAsync(MapType.Felucca);
+        var path = await Service(fixture).GetFullAsync(MapType.Felucca, MapRenderStyleType.Flat);
 
         Assert.NotNull(path);
 
@@ -148,11 +149,11 @@ public class MapImageServiceTests
         using var fixture = MapImageFixture.Create();
         var service = Service(fixture);
 
-        var first = await service.GetFullAsync(MapType.Felucca);
+        var first = await service.GetFullAsync(MapType.Felucca, MapRenderStyleType.Flat);
         var marker = DateTime.UtcNow.AddDays(-1);
         File.SetLastWriteTimeUtc(first!, marker);
 
-        var second = await service.GetFullAsync(MapType.Felucca);
+        var second = await service.GetFullAsync(MapType.Felucca, MapRenderStyleType.Flat);
 
         Assert.Equal(marker, File.GetLastWriteTimeUtc(second!), TimeSpan.FromSeconds(1));
     }
@@ -167,7 +168,7 @@ public class MapImageServiceTests
         var zoom = service.MaxZoomFor(MapType.Felucca);
 
         var paths = await Task.WhenAll(
-            Enumerable.Range(0, 4).Select(x => service.GetTileAsync(MapType.Felucca, zoom, x, 0))
+            Enumerable.Range(0, 4).Select(x => service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, x, 0))
         );
 
         Assert.All(paths, path => Assert.True(File.Exists(path)));

--- a/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
@@ -61,6 +61,44 @@ public class MapImageServiceTests
     }
 
     [Fact]
+    public async Task GetTileAsync_Relief_RendersOpaquePixels()
+    {
+        // The relief path recomposes each pixel in ApplyLighting and must keep the ARGB1555 opaque bit —
+        // exactly the defect fixed for the flat path. Without it the whole relief tile decodes to alpha 0.
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+
+        var path = await service.GetTileAsync(
+            MapType.Felucca,
+            MapRenderStyleType.Relief,
+            service.MaxZoomFor(MapType.Felucca),
+            0,
+            0
+        );
+
+        using var image = await Image.LoadAsync<Bgra32>(path!);
+        var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];
+
+        Assert.Equal(byte.MaxValue, centre.A);
+    }
+
+    [Fact]
+    public async Task GetTileAsync_FlatAndRelief_AreDistinctCacheFiles()
+    {
+        // Styles must not overwrite each other: the same coordinates cache to separate files.
+        using var fixture = MapImageFixture.Create();
+        var service = Service(fixture);
+        var zoom = service.MaxZoomFor(MapType.Felucca);
+
+        var flat = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, 0, 0);
+        var relief = await service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Relief, zoom, 0, 0);
+
+        Assert.NotEqual(flat, relief);
+        Assert.True(File.Exists(flat));
+        Assert.True(File.Exists(relief));
+    }
+
+    [Fact]
     public async Task GetTileAsync_SecondCall_ServesTheCachedFileWithoutRerendering()
     {
         using var fixture = MapImageFixture.Create();


### PR DESCRIPTION
## What

An optional `?style=` on the map routes:

- `GET /api/v1/images/maps/{map}/{z}/{x}/{y}.png` → `flat` (unchanged default)
- `…?style=relief` → the radar map with altitude-based terrain shading (hills and valleys as light and shadow)
- `…/full.png?style=relief` → the whole facet, shaded
- unknown `style` → 400

## How

- `MapRenderStyleType { Flat, Relief }` threaded through `IMapImageService`; `Relief` renders native tiles via `Map.GetImageWithAltitude(..., NormalWithAltitude)` instead of `GetImage`. Shading happens only at native zoom; every lower zoom inherits it by downsampling.
- Cache is style-segmented (`cache/images/maps/{facet}/{style}/...`) so flat and relief never overwrite each other.
- The shading preset is fixed once at startup (`Soft`, matching the UO client) — those statics invalidate a per-Map cache and must never be mutated per request.

## The opacity fix

`Map.ApplyLighting` recomposed each shaded pixel as `(r<<10)|(g<<5)|b`, dropping the ARGB1555 opaque bit — the same defect fixed for the flat path in #17, in a second place. Without it every relief tile decodes to alpha 0 (blank). One-line fix + a regression test asserting relief tiles are opaque; the existing map tests only checked size and caching, which is how the flat version shipped blank.

## Verification

4 new tests (relief opacity, flat/relief distinct cache files, `?style=relief` 200, `?style=bogus` 400); full suite 1147/1147; DocFX 0 warnings. Manual smoke against real client files: flat and relief both render opaque, relief shows visible terrain relief; `?style=bogus` → 400. The local `/tmp/moongate-map` viewer gained a Flat/Relief switch for side-by-side comparison.

Out of scope (noted): the grayscale heightmap mode, relief pre-warm (warms on demand), a config knob for the preset.