### PR TITLE
feat: make the relief map style visible by default (Sharp preset)

### DIFF
--- a/src/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
@@ -35,8 +35,11 @@ public sealed class MapImageService : IMapImageService
         _cachePath = directories.RegisterDirectory(CacheDirectory);
 
         // Relief shading is driven by process-wide statics that invalidate a per-Map altitude cache, so
-        // they must be fixed once, never per request. Soft matches the UO client's own map most closely.
-        UltimaMap.ShadingPreset = AltitudeShadingPresetType.Soft;
+        // they must be fixed once, never per request. Sharp, not the client-faithful Soft: Soft's contrast
+        // is about a 1% brightness swing — real but imperceptible on screen — so the relief style would
+        // look no different from flat. Sharp makes hills and valleys actually read. Flat terrain has no
+        // slope and so no shading either way, so this only affects the parts worth seeing.
+        UltimaMap.ShadingPreset = AltitudeShadingPresetType.Sharp;
     }
 
     public bool IsReady


### PR DESCRIPTION
## Why

Follow-up to #18. The relief style shipped with the `Soft` shading preset — the one that matches the UO client — but Soft's contrast is ~1% RMSE on real terrain (measured), which is imperceptible on screen. So `?style=relief` looked identical to flat: the feature was there but invisible.

## What

Default the preset to `Sharp` (BrightnessRange 0.40 vs Soft's 0.15). Measured flat-vs-relief difference on a mountainous native tile jumps from 1.1% to 6.2% RMSE — hills and valleys now read as clear light and shadow. Flat terrain has no slope and therefore no shading under any preset, so this only affects the parts worth seeing; open water and plains still look like the flat radar map.

One-line change in `MapImageService`'s constructor (the preset is a process-wide static fixed once at startup). No behaviour change to the flat style, the cache layout, or the API.

## Verification

Map tests green (26/26); relief opacity and flat/relief cache-separation assertions are preset-agnostic and unaffected. Confirmed visually against real client files: Sharp relief shows embossed mountain terrain.