### PR TITLE
feat(movement): player movement — MoveRequest, tile validation, rate limiting, broadcast

### DIFF
--- a/docs/getting-started/connect-with-classicuo.md
+++ b/docs/getting-started/connect-with-classicuo.md
@@ -43,12 +43,14 @@ The flow the server implements today:
    and the season of the facet you stand on.
 
 > [!IMPORTANT]
-> **The world you enter is empty, and you cannot move yet.** World entry is
-> self-only: the server sends you your own character, but nearby mobiles and
-> items are not broadcast to you, and movement requests are not handled. Your
-> backpack cannot be opened yet either, so the starting kit stays out of
-> reach. You will load into the map and stand still, alone. This is the
-> current frontier of the project.
+> World entry is self-only: the server sends you your own character, but
+> nearby mobiles and items already in range are not sent to you when you
+> first log in (that needs SendEverything, still pending). You can walk and
+> turn — moves are validated against the map and broadcast to players
+> already in range of you — but no new objects appear as you walk into view
+> of them yet. Your backpack cannot be opened yet either, so the starting
+> kit stays out of reach. Nearby mobiles and items staying invisible until
+> SendEverything lands is the current frontier of the project.
 
 ## Troubleshooting
 

--- a/docs/getting-started/what-is-moongate.md
+++ b/docs/getting-started/what-is-moongate.md
@@ -21,8 +21,11 @@ Moongate is young and moves fast. What works today:
   character list, **character creation and deletion** (the created player
   mobile is persisted) and **world entry** — creating or selecting a character
   loads you into the map with its stats, skills and gear. World entry is
-  self-only: nearby mobiles and items are not broadcast, and movement is not
-  handled yet, which is the next milestone.
+  self-only: nearby mobiles and items already in range are not sent to you
+  on login (SendEverything, still pending). Movement is handled — validated
+  against the map, rate-limited, and broadcast to players already in range —
+  but objects entering view as you walk are not yet, which is the next
+  milestone.
 - Item, mobile and loot systems driven by YAML templates, with a Lua API
   (`item`, `mobile`, `loot`, `game`, `events`, `log`) for shard logic.
 - Binary snapshot persistence for accounts, mobiles and items.

--- a/docs/packets/families/movement.md
+++ b/docs/packets/families/movement.md
@@ -6,5 +6,7 @@ Move requests, acks, and mobile position updates.
 |---|---|---|---|---|
 | [`0x02`](../incoming/0x02-move-request.md) | Move Request | C → S | 7 bytes (fixed) | One step or turn, with anti-fastwalk key. |
 | [`0x20`](../outgoing/0x20-draw-game-player.md) | Draw Game Player | S → C | 19 bytes (fixed) | Positions and renders the player's own mobile. |
+| [`0x21`](../outgoing/0x21-char-move-rejection.md) | Char Move Rejection | S → C | 8 bytes (fixed) | Echoes the rejected sequence with the mover's true position, forcing a client snap-back. |
 | [`0x22`](../outgoing/0x22-movement-ack.md) | Movement Ack | S → C | 3 bytes (fixed) | Confirms the step with the client's sequence number. |
+| [`0x77`](../outgoing/0x77-update-player.md) | Update Player | S → C | 17 bytes (fixed) | Broadcasts another mobile's position/facing to nearby players. |
 | [`0x78`](../outgoing/0x78-draw-object.md) | Draw Object | S → C | Variable | Draws a mobile and its equipped items on the client. |

--- a/docs/packets/includes/family-cards.md
+++ b/docs/packets/includes/family-cards.md
@@ -26,7 +26,7 @@
   </a>
   <a class="mg-card" href="families/movement.md">
     <h3>Movement</h3>
-    <div class="mg-card-ops">0x02 · 0x20 · 0x22 · 0x78</div>
+    <div class="mg-card-ops">0x02 · 0x20 · 0x21 · 0x22 · 0x77 · 0x78</div>
     <p>Move requests, acks, and mobile position updates.</p>
   </a>
   <a class="mg-card" href="families/status-skills.md">

--- a/docs/packets/includes/packet-table.md
+++ b/docs/packets/includes/packet-table.md
@@ -1,7 +1,7 @@
 <div class="mg-stats">
-  <div class="mg-stat"><div class="mg-stat-num">48</div><div class="mg-stat-label">implemented packets</div></div>
+  <div class="mg-stat"><div class="mg-stat-num">50</div><div class="mg-stat-label">implemented packets</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-grass">15</div><div class="mg-stat-label">incoming (client → server)</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-violet">33</div><div class="mg-stat-label">outgoing (server → client)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-violet">35</div><div class="mg-stat-label">outgoing (server → client)</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-stone">7.x</div><div class="mg-stat-label">client target</div></div>
 </div>
 
@@ -14,6 +14,7 @@
 | [`0x1B`](../outgoing/0x1b-login-confirm.md) | Login Confirm | S → C | 37 bytes (fixed) | The first packet of the enter-world burst. |
 | [`0x1D`](../outgoing/0x1d-delete-object.md) | Delete Object | S → C | 5 bytes (fixed) | The entity is gone — stop drawing it. |
 | [`0x20`](../outgoing/0x20-draw-game-player.md) | Draw Game Player | S → C | 19 bytes (fixed) | Positions and renders the player's own mobile. |
+| [`0x21`](../outgoing/0x21-char-move-rejection.md) | Char Move Rejection | S → C | 8 bytes (fixed) | Echoes the rejected sequence with the mover's true position, forcing a client snap-back. |
 | [`0x22`](../outgoing/0x22-movement-ack.md) | Movement Ack | S → C | 3 bytes (fixed) | Confirms the step with the client's sequence number. |
 | [`0x24`](../outgoing/0x24-draw-container.md) | Draw Container | S → C | 7 bytes (fixed) | Opens the container's gump on the client. |
 | [`0x25`](../outgoing/0x25-add-item-to-container.md) | Add Item To Container | S → C | 21 bytes (fixed) | Drops one item into an already-open container gump. |
@@ -30,6 +31,7 @@
 | [`0x72`](../outgoing/0x72-war-mode.md) | War Mode | S → C | 5 bytes (fixed) | Toggles the client's combat stance. |
 | [`0x73`](../incoming/0x73-ping.md) | Ping | C → S | 2 bytes (fixed) | The client sends this periodically with a rolling sequence byte and expects the server to echo it straight back, or it eventually drops the connection. |
 | [`0x73`](../outgoing/0x73-ping-ack.md) | Ping Ack | S → C | 2 bytes (fixed) | Echoes the client's keep-alive sequence byte straight back. |
+| [`0x77`](../outgoing/0x77-update-player.md) | Update Player | S → C | 17 bytes (fixed) | Broadcasts another mobile's position/facing to nearby players. |
 | [`0x78`](../outgoing/0x78-draw-object.md) | Draw Object | S → C | Variable | Draws a mobile and its equipped items on the client. |
 | [`0x80`](../incoming/0x80-account-login-request.md) | Account Login Request | C → S | 62 bytes (fixed) | Credentials for the login server. |
 | [`0x82`](../outgoing/0x82-login-denied.md) | Login Denied | S → C | 2 bytes (fixed) | Rejects the login with a protocol reason code. |

--- a/docs/packets/outgoing/0x21-char-move-rejection.md
+++ b/docs/packets/outgoing/0x21-char-move-rejection.md
@@ -1,0 +1,18 @@
+# 0x21 — Char Move Rejection
+
+<span class="mg-dir mg-dir-out">Server → Client</span>
+
+Move rejected (0x21): echoes the rejected sequence with the mover's true position, forcing a client snap-back.
+
+- **Class:** [`MoveRejectPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Outgoing/MoveRejectPacket.cs)
+- **Size:** 8 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Sequence` | `byte` |
+| `X` | `ushort` |
+| `Y` | `ushort` |
+| `Direction` | `DirectionType` |
+| `Z` | `sbyte` |

--- a/docs/packets/outgoing/0x77-update-player.md
+++ b/docs/packets/outgoing/0x77-update-player.md
@@ -1,0 +1,22 @@
+# 0x77 — Update Player
+
+<span class="mg-dir mg-dir-out">Server → Client</span>
+
+Update player (0x77): broadcasts another mobile's position/facing to nearby players.
+
+- **Class:** [`UpdatePlayerPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Outgoing/UpdatePlayerPacket.cs)
+- **Size:** 17 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Serial` | `Serial` |
+| `Body` | `ushort` |
+| `X` | `ushort` |
+| `Y` | `ushort` |
+| `Z` | `sbyte` |
+| `Direction` | `DirectionType` |
+| `Hue` | `Hue` |
+| `Flags` | `byte` |
+| `Notoriety` | `NotorietyType` |

--- a/docs/packets/toc.yml
+++ b/docs/packets/toc.yml
@@ -62,6 +62,8 @@
       href: outgoing/0x1d-delete-object.md
     - name: "0x20 — Draw Game Player"
       href: outgoing/0x20-draw-game-player.md
+    - name: "0x21 — Char Move Rejection"
+      href: outgoing/0x21-char-move-rejection.md
     - name: "0x22 — Movement Ack"
       href: outgoing/0x22-movement-ack.md
     - name: "0x24 — Draw Container"
@@ -88,6 +90,8 @@
       href: outgoing/0x72-war-mode.md
     - name: "0x73 — Ping Ack"
       href: outgoing/0x73-ping-ack.md
+    - name: "0x77 — Update Player"
+      href: outgoing/0x77-update-player.md
     - name: "0x78 — Draw Object"
       href: outgoing/0x78-draw-object.md
     - name: "0x82 — Login Denied"

--- a/src/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
+++ b/src/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
@@ -5,6 +5,7 @@ using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
 using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Types;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.UO.Data.Types;
 
 namespace Moongate.Http.Plugin.Endpoints.Maps;

--- a/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/src/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -60,7 +60,6 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // One gate over Ultima's statics for every reader. Map rendering descends into Art too, and a
         // second gate would be no gate at all.
         container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-        container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
         container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
         container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
         container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);

--- a/src/Moongate.Http.Plugin/Services/Maps/MapImageExportJob.cs
+++ b/src/Moongate.Http.Plugin/Services/Maps/MapImageExportJob.cs
@@ -2,6 +2,7 @@ using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Types;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.UO.Data.Types;
 using Serilog;
 

--- a/src/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
+++ b/src/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
@@ -2,6 +2,7 @@ using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Types;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Ultima.Imaging;
 using Moongate.Ultima.Tiles;
 using Moongate.Ultima.Types;

--- a/src/Moongate.Network/Packets/Incoming/MoveRequestPacket.cs
+++ b/src/Moongate.Network/Packets/Incoming/MoveRequestPacket.cs
@@ -1,5 +1,6 @@
 using Moongate.Core.Types;
 using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
 using Moongate.Network.Types;
 using SquidStd.Network.Spans;
 
@@ -7,9 +8,9 @@ namespace Moongate.Network.Packets.Incoming;
 
 /// <summary>Move request (0x02): one step or turn, with anti-fastwalk key.</summary>
 [PacketDocumentation(PacketFamilyType.Movement, Length = 7)]
-public readonly record struct MoveRequestPacket(DirectionType Direction, byte Sequence, uint FastwalkKey)
+public readonly record struct MoveRequestPacket(DirectionType Direction, byte Sequence, uint FastwalkKey) : IIncomingPacket<MoveRequestPacket>
 {
-    public const byte PacketId = 0x02;
+    public static byte PacketId => 0x02;
 
     public static MoveRequestPacket Read(ref SpanReader reader)
     {

--- a/src/Moongate.Network/Packets/Outgoing/MoveRejectPacket.cs
+++ b/src/Moongate.Network/Packets/Outgoing/MoveRejectPacket.cs
@@ -1,0 +1,24 @@
+using Moongate.Core.Types;
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Outgoing;
+
+/// <summary>Move rejected (0x21): echoes the rejected sequence with the mover's true position, forcing a client snap-back.</summary>
+[PacketDocumentation(PacketFamilyType.Movement, Length = 8, Name = "Char Move Rejection")]
+public readonly record struct MoveRejectPacket(byte Sequence, ushort X, ushort Y, DirectionType Direction, sbyte Z) : IOutgoingPacket
+{
+    public const byte PacketId = 0x21;
+
+    public void Write(ref SpanWriter writer)
+    {
+        writer.Write(PacketId);
+        writer.Write(Sequence);
+        writer.Write(X);
+        writer.Write(Y);
+        writer.Write((byte)Direction);
+        writer.Write(Z);
+    }
+}

--- a/src/Moongate.Network/Packets/Outgoing/UpdatePlayerPacket.cs
+++ b/src/Moongate.Network/Packets/Outgoing/UpdatePlayerPacket.cs
@@ -1,0 +1,41 @@
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Outgoing;
+
+/// <summary>Update player (0x77): broadcasts another mobile's position/facing to nearby players.</summary>
+[PacketDocumentation(PacketFamilyType.Movement, Length = 17, Name = "Update Player")]
+public readonly record struct UpdatePlayerPacket(
+    Serial Serial,
+    ushort Body,
+    ushort X,
+    ushort Y,
+    sbyte Z,
+    DirectionType Direction,
+    Hue Hue,
+    byte Flags,
+    NotorietyType Notoriety
+) : IOutgoingPacket
+{
+    public const byte PacketId = 0x77;
+
+    public void Write(ref SpanWriter writer)
+    {
+        writer.Write(PacketId);
+        writer.Write(Serial);
+        writer.Write(Body);
+        writer.Write(X);
+        writer.Write(Y);
+        writer.Write(Z);
+        writer.Write((byte)Direction);
+        writer.Write(Hue);
+        writer.Write(Flags);
+        writer.Write((byte)Notoriety);
+    }
+}

--- a/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
+++ b/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
@@ -40,6 +40,12 @@ public sealed class PlayerSession : ISeedTarget
 
     public string? Language { get; private set; }
 
+    /// <summary>The last movement sequence number accepted from this client, or null before the first accepted move (or after a resync).</summary>
+    public byte? LastMoveSequence { get; private set; }
+
+    /// <summary>When the last accepted move was recorded — the baseline the walk/run rate limit measures against.</summary>
+    public DateTimeOffset LastMoveAt { get; private set; }
+
     public UoCompressionMiddleware Compression { get; }
 
     public PlayerSession(SquidStdTcpClient client)
@@ -142,6 +148,19 @@ public sealed class PlayerSession : ISeedTarget
         lock (_stateSync)
         {
             Language = language;
+        }
+    }
+
+    /// <summary>
+    /// Records the outcome of a movement rate-limit check: the accepted sequence (or null to force a
+    /// resync, so the next packet's sequence is accepted unconditionally) and when it happened.
+    /// </summary>
+    public void SetLastMove(byte? sequence, DateTimeOffset at)
+    {
+        lock (_stateSync)
+        {
+            LastMoveSequence = sequence;
+            LastMoveAt = at;
         }
     }
 

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IMapTileService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IMapTileService.cs
@@ -1,0 +1,21 @@
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>
+/// Resolves tile walkability and standing height from the shard's client files: land, statics, and
+/// (via the caller-supplied ground items) dynamic obstacles. A port of the classic "CanFit" check,
+/// scoped to a single tile — no diagonal-neighbor or other-mobile awareness.
+/// </summary>
+public interface IMapTileService
+{
+    /// <summary>
+    /// Finds the Z a mobile currently at <paramref name="currentZ" /> could stand at on tile
+    /// (<paramref name="x" />, <paramref name="y" />) of <paramref name="mapId" />, preferring the
+    /// candidate closest to <paramref name="currentZ" />. <paramref name="groundItems" /> are dynamic
+    /// items to consider as obstacles/surfaces, treated identically to statics — items whose position
+    /// is not exactly (<paramref name="x" />, <paramref name="y" />) are ignored, so callers may pass
+    /// a wider sweep (e.g. every neighboring tile) without pre-filtering to the exact target.
+    /// </summary>
+    bool TryGetWalkableZ(int mapId, int x, int y, int currentZ, IReadOnlyList<ItemEntity> groundItems, out int newZ);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IMovementService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IMovementService.cs
@@ -1,0 +1,19 @@
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Data.Session;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>
+/// Validates and applies player movement: rate limiting, region gating, tile walkability, persistence,
+/// spatial re-indexing, and broadcasting — replying to the mover and notifying nearby players.
+/// </summary>
+public interface IMovementService
+{
+    /// <summary>
+    /// Attempts to turn or step <paramref name="session" />'s character in <paramref name="direction" />,
+    /// validating <paramref name="sequence" /> against the session's rate-limit state. Always replies to
+    /// the mover (ack or reject) and, on success, broadcasts to nearby players. No-ops if the session has
+    /// no character attached yet.
+    /// </summary>
+    void TryMove(PlayerSession session, DirectionType direction, byte sequence);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IRegionService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IRegionService.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Geometry;
 using Moongate.UO.Data.Regions;
 using Moongate.UO.Data.Types;
 
@@ -14,6 +15,12 @@ public interface IRegionService
 
     /// <summary>Returns the regions on the given map.</summary>
     IReadOnlyList<RegionDefinition> ForMap(MapType map);
+
+    /// <summary>
+    /// Resolves the highest-priority region on <paramref name="map" /> whose area contains
+    /// <paramref name="point" />, or null when none matches.
+    /// </summary>
+    RegionDefinition? At(MapType map, Point3D point);
 
     /// <summary>Adds a region to the registry.</summary>
     void Register(RegionDefinition region);

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IUltimaMapProvider.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IUltimaMapProvider.cs
@@ -1,7 +1,7 @@
 using Moongate.Ultima.Maps;
 using Moongate.UO.Data.Types;
 
-namespace Moongate.Http.Plugin.Interfaces.Maps;
+namespace Moongate.Server.Abstractions.Interfaces.World;
 
 /// <summary>
 /// The facets the shard's client files describe. Exists as an interface because Ultima's facets are static

--- a/src/Moongate.Server/Data/Internal/World/MovementDecision.cs
+++ b/src/Moongate.Server/Data/Internal/World/MovementDecision.cs
@@ -1,0 +1,7 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Types;
+
+namespace Moongate.Server.Data.Internal.World;
+
+/// <summary>The pure result of evaluating one movement attempt, before any side effect is applied.</summary>
+public readonly record struct MovementDecision(bool Accepted, bool PositionChanged, Point3D NewPosition, DirectionType NewDirection);

--- a/src/Moongate.Server/Handlers/MoveRequestHandler.cs
+++ b/src/Moongate.Server/Handlers/MoveRequestHandler.cs
@@ -1,0 +1,28 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Network;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Server.Handlers;
+
+/// <summary>
+/// Handles player movement (0x02): validates and applies the step or turn via
+/// <see cref="IMovementService" />, which replies to the mover and broadcasts to nearby players.
+/// <c>FastwalkKey</c> is parsed by <see cref="MoveRequestPacket" /> but intentionally unused — rate
+/// limiting is sequence- and timing-based, not the legacy fastwalk-key scheme.
+/// </summary>
+public sealed class MoveRequestHandler : IPacketHandler<MoveRequestPacket>, IPacketHandlerRegistration
+{
+    private readonly IMovementService _movement;
+
+    public MoveRequestHandler(IMovementService movement)
+    {
+        _movement = movement;
+    }
+
+    public void Handle(MoveRequestPacket packet, in PacketContext context)
+        => _movement.TryMove(context.Session, packet.Direction, packet.Sequence);
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -20,6 +20,7 @@
         <ProjectReference Include="..\Moongate.Persistence\Moongate.Persistence.csproj"/>
         <ProjectReference Include="..\Moongate.Scripting\Moongate.Scripting.csproj"/>
         <ProjectReference Include="..\Moongate.Server.Abstractions\Moongate.Server.Abstractions.csproj"/>
+        <ProjectReference Include="..\Moongate.Ultima\Moongate.Ultima.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Moongate.Server/MoongatePacketHandlersPlugin.cs
+++ b/src/Moongate.Server/MoongatePacketHandlersPlugin.cs
@@ -36,5 +36,6 @@ public class MoongatePacketHandlersPlugin : ISquidStdPlugin
         container.RegisterPacketHandler<SingleClickHandler>();
         container.RegisterPacketHandler<MegaClilocHandler>();
         container.RegisterPacketHandler<DoubleClickHandler>();
+        container.RegisterPacketHandler<MoveRequestHandler>();
     }
 }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -140,6 +140,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
+                container.Register<IMapTileService, MapTileService>(Reuse.Singleton);
                 container.Register<ISpatialIndexService, SpatialIndexService>(Reuse.Singleton);
                 container.Register<IOplService, OplService>(Reuse.Singleton);
 

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -21,7 +21,6 @@ using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Network;
 using Moongate.Server.Services.World;
-using Moongate.Ultima.Maps;
 using Serilog;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -141,6 +141,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
                 container.Register<IMapTileService, MapTileService>(Reuse.Singleton);
+                container.Register<IMovementService, MovementService>(Reuse.Singleton);
                 container.Register<ISpatialIndexService, SpatialIndexService>(Reuse.Singleton);
                 container.Register<IOplService, OplService>(Reuse.Singleton);
 

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -21,6 +21,7 @@ using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Network;
 using Moongate.Server.Services.World;
+using Moongate.Ultima.Maps;
 using Serilog;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;
@@ -139,6 +140,7 @@ await ConsoleApp.RunAsync(
                 container.Register<ILootService, LootService>(Reuse.Singleton);
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
+                container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
                 container.Register<ISpatialIndexService, SpatialIndexService>(Reuse.Singleton);
                 container.Register<IOplService, OplService>(Reuse.Singleton);
 

--- a/src/Moongate.Server/Services/World/MapTileService.cs
+++ b/src/Moongate.Server/Services/World/MapTileService.cs
@@ -109,6 +109,9 @@ public sealed class MapTileService : IMapTileService
         }
     }
 
+    // Only correct when paired with PathBlocked below: an obstacle whose Bottom sits below the
+    // candidate surface is caught there, not here. Called in isolation, this alone cannot detect
+    // that case, so do not separate the two calls in TryGetWalkableZ without re-checking this.
     private static bool HasHeadroom(int surfaceZ, List<(int Bottom, int Top)> obstacles)
     {
         var ceiling = int.MaxValue;

--- a/src/Moongate.Server/Services/World/MapTileService.cs
+++ b/src/Moongate.Server/Services/World/MapTileService.cs
@@ -1,0 +1,142 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Default <see cref="IMapTileService" />: a single-tile port of the classic "CanFit" walkability
+/// check. Constants (person height, step height) are taken from ModernUO's
+/// <c>Engines/Pathing/Movement.cs</c>. Deliberately does not port ModernUO's diagonal-neighbor
+/// corner-cutting check, other-mobile obstacles, or swim/fly/door special-casing — single tile only.
+/// </summary>
+public sealed class MapTileService : IMapTileService
+{
+    // A mobile's standing headroom requirement (ModernUO: MovementImpl.PersonHeight).
+    private const int PersonHeight = 16;
+
+    // Max Z difference between where a mobile stands and a static/item's base for it to be
+    // directly climbable in one step (ModernUO: MovementImpl.StepHeight).
+    private const int StepHeight = 2;
+
+    private readonly IUltimaMapProvider _mapProvider;
+
+    public MapTileService(IUltimaMapProvider mapProvider)
+    {
+        _mapProvider = mapProvider;
+    }
+
+    public bool TryGetWalkableZ(int mapId, int x, int y, int currentZ, IReadOnlyList<ItemEntity> groundItems, out int newZ)
+    {
+        newZ = 0;
+        var map = _mapProvider.Get((MapType)mapId);
+
+        if (map is null)
+        {
+            return false;
+        }
+
+        var candidates = new List<int>();
+        var obstacles = new List<(int Bottom, int Top)>();
+
+        var land = map.Tiles.GetLandTile(x, y);
+        var landFlags = TileData.LandTable[land.Id].Flags;
+
+        if ((landFlags & TileFlagType.Impassable) == 0)
+        {
+            candidates.Add(land.Z);
+        }
+
+        foreach (var tile in map.Tiles.GetStaticTiles(x, y))
+        {
+            CollectTile(tile.Id, tile.Z, currentZ, candidates, obstacles);
+        }
+
+        foreach (var item in groundItems)
+        {
+            // groundItems may come from a wider-than-one-tile sweep (the caller doesn't know the
+            // target tile until it has already fetched candidates for every direction) — filter to
+            // exactly this tile rather than assuming the caller pre-filtered.
+            if (item.Position.X != x || item.Position.Y != y)
+            {
+                continue;
+            }
+
+            CollectTile(item.ItemId, item.Position.Z, currentZ, candidates, obstacles);
+        }
+
+        candidates.Sort((a, b) => Math.Abs(a - currentZ).CompareTo(Math.Abs(b - currentZ)));
+
+        foreach (var candidate in candidates)
+        {
+            if (!HasHeadroom(candidate, obstacles))
+            {
+                continue;
+            }
+
+            if (PathBlocked(currentZ, candidate, obstacles))
+            {
+                continue;
+            }
+
+            newZ = candidate;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void CollectTile(int itemId, int z, int currentZ, List<int> candidates, List<(int Bottom, int Top)> obstacles)
+    {
+        if (itemId < 0 || itemId >= TileData.ItemTable.Length)
+        {
+            return;
+        }
+
+        var data = TileData.ItemTable[itemId];
+
+        if ((data.Surface || data.Bridge) && z <= currentZ + StepHeight)
+        {
+            candidates.Add(z + data.CalcHeight);
+        }
+
+        if (data.Impassable)
+        {
+            obstacles.Add((z, z + data.Height));
+        }
+    }
+
+    private static bool HasHeadroom(int surfaceZ, List<(int Bottom, int Top)> obstacles)
+    {
+        var ceiling = int.MaxValue;
+
+        foreach (var obstacle in obstacles)
+        {
+            if (obstacle.Bottom >= surfaceZ && obstacle.Bottom < ceiling)
+            {
+                ceiling = obstacle.Bottom;
+            }
+        }
+
+        return ceiling - surfaceZ >= PersonHeight;
+    }
+
+    private static bool PathBlocked(int fromZ, int toZ, List<(int Bottom, int Top)> obstacles)
+    {
+        var low = Math.Min(fromZ, toZ);
+        var high = Math.Max(fromZ, toZ);
+
+        foreach (var obstacle in obstacles)
+        {
+            if (obstacle.Bottom < high && obstacle.Top > low)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -122,11 +122,11 @@ public sealed class MovementService : IMovementService
         IReadOnlyList<ItemEntity> groundItems
     )
     {
-        var expected = lastSequence is { } last ? unchecked((byte)(last + 1)) : sequence;
+        var expected = lastSequence is { } last ? WrapNextSequence(last) : (byte)0;
 
         if (sequence != expected)
         {
-            return new(false, false, mobile.Position, mobile.Direction);
+            return RejectDecision(mobile);
         }
 
         var isTurnOnly = direction.StripRunning() != mobile.Direction.StripRunning();
@@ -138,7 +138,7 @@ public sealed class MovementService : IMovementService
 
             if (now - lastMoveAt < minInterval)
             {
-                return new(false, false, mobile.Position, mobile.Direction);
+                return RejectDecision(mobile);
             }
         }
 
@@ -152,16 +152,28 @@ public sealed class MovementService : IMovementService
 
         if (regionService.At((MapType)mobile.MapId, target)?.IsImpassable == true)
         {
-            return new(false, false, mobile.Position, mobile.Direction);
+            return RejectDecision(mobile);
         }
 
         if (!mapTiles.TryGetWalkableZ(mobile.MapId, target.X, target.Y, mobile.Position.Z, groundItems, out var newZ))
         {
-            return new(false, false, mobile.Position, mobile.Direction);
+            return RejectDecision(mobile);
         }
 
         return new(true, true, new(target.X, target.Y, newZ), direction);
     }
+
+    // ModernUO wraps the move-sequence counter 255 -> 1, never to 0: sequence 0 is a reserved
+    // sentinel meaning "no baseline / just reset" (MovementThrottle.cs:272-277, verified against
+    // others/ModernUO).
+    private static byte WrapNextSequence(byte sequence)
+        => sequence == 255 ? (byte)1 : (byte)(sequence + 1);
+
+    // Pure rejection shorthand for Evaluate's four "current position/direction, unchanged" exits.
+    // Not to be confused with the instance Reject(PlayerSession, MobileEntity, byte) below, which
+    // sends the MoveRejectPacket to the client.
+    private static MovementDecision RejectDecision(MobileEntity mobile)
+        => new(false, false, mobile.Position, mobile.Direction);
 
     private void Accept(PlayerSession session, MobileEntity mobile, byte sequence)
         => session.Send(new MovementAckPacket(sequence, Notoriety.Resolve(mobile.Kills, mobile.Criminal)));

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -1,0 +1,198 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Data.Internal.World;
+using Moongate.UO.Data.Mobiles;
+using Moongate.UO.Data.Types;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Default <see cref="IMovementService" />. <see cref="Evaluate" /> is the pure decision core (rate
+/// limit, turn-vs-step, region, tile) — public and static so it is unit-testable without a live
+/// <see cref="PlayerSession" />, mirroring <c>WorldService.IsRecipient</c>. <see cref="TryMove" /> is
+/// the impure orchestrator: reads/writes the session, persists, re-indexes, broadcasts, replies.
+/// </summary>
+public sealed class MovementService : IMovementService
+{
+    // ModernUO's MovementImpl.WalkFootDelay / RunFootDelay, verified against others/ModernUO.
+    private static readonly TimeSpan WalkInterval = TimeSpan.FromMilliseconds(400);
+    private static readonly TimeSpan RunInterval = TimeSpan.FromMilliseconds(200);
+
+    // Classic UO client view range.
+    private const int ViewRange = 18;
+
+    private readonly IMapTileService _mapTiles;
+    private readonly IRegionService _regions;
+    private readonly ISpatialIndexService _spatial;
+    private readonly IWorldService _world;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly TimeProvider _timeProvider;
+
+    public MovementService(
+        IMapTileService mapTiles,
+        IRegionService regions,
+        ISpatialIndexService spatial,
+        IWorldService world,
+        IPersistenceService persistenceService,
+        TimeProvider timeProvider
+    )
+    {
+        _mapTiles = mapTiles;
+        _regions = regions;
+        _spatial = spatial;
+        _world = world;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _timeProvider = timeProvider;
+    }
+
+    public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
+    {
+        var mobile = session.Character;
+
+        if (mobile is null)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        // Chebyshev range 1 around the mobile's current position covers every tile a single step
+        // could land on (target is always exactly distance 1 away); MapTileService filters these
+        // down to the exact target tile itself.
+        var groundItems = _spatial.GetItemsInRange(mobile.MapId, mobile.Position, 1);
+
+        var decision = Evaluate(
+            mobile,
+            direction,
+            sequence,
+            session.LastMoveSequence,
+            session.LastMoveAt,
+            now,
+            _mapTiles,
+            _regions,
+            groundItems
+        );
+
+        if (!decision.Accepted)
+        {
+            // Any rejection forces a resync: the next packet's sequence is accepted unconditionally,
+            // matching how a real UO client resets its counter after a rejected move. The timing
+            // baseline (LastMoveAt) is left untouched so a burst of illegal attempts cannot keep
+            // resetting the clock and starve the rate limiter.
+            session.SetLastMove(null, session.LastMoveAt);
+            Reject(session, mobile, sequence);
+
+            return;
+        }
+
+        session.SetLastMove(sequence, now);
+        mobile.Direction = decision.NewDirection;
+
+        if (decision.PositionChanged)
+        {
+            mobile.Position = decision.NewPosition;
+        }
+
+        _mobiles.UpsertAsync(mobile).WaitSync();
+        _spatial.AddOrUpdate(mobile);
+        Broadcast(mobile);
+        Accept(session, mobile, sequence);
+    }
+
+    /// <summary>
+    /// Pure decision core: no I/O, no session, no persistence. Returns what the caller should do —
+    /// accept-and-apply, or reject — without doing it.
+    /// </summary>
+    public static MovementDecision Evaluate(
+        MobileEntity mobile,
+        DirectionType direction,
+        byte sequence,
+        byte? lastSequence,
+        DateTimeOffset lastMoveAt,
+        DateTimeOffset now,
+        IMapTileService mapTiles,
+        IRegionService regionService,
+        IReadOnlyList<ItemEntity> groundItems
+    )
+    {
+        var expected = lastSequence is { } last ? unchecked((byte)(last + 1)) : sequence;
+
+        if (sequence != expected)
+        {
+            return new(false, false, mobile.Position, mobile.Direction);
+        }
+
+        var isTurnOnly = direction.StripRunning() != mobile.Direction.StripRunning();
+
+        // Turning has no timing gate (ModernUO: TurnDelay = 0); only an actual step does.
+        if (!isTurnOnly)
+        {
+            var minInterval = direction.IsRunning() ? RunInterval : WalkInterval;
+
+            if (lastSequence.HasValue && now - lastMoveAt < minInterval)
+            {
+                return new(false, false, mobile.Position, mobile.Direction);
+            }
+        }
+
+        if (isTurnOnly)
+        {
+            return new(true, false, mobile.Position, direction);
+        }
+
+        var (dx, dy) = direction.ToOffset();
+        var target = new Point3D(mobile.Position.X + dx, mobile.Position.Y + dy, mobile.Position.Z);
+
+        if (regionService.At((MapType)mobile.MapId, target)?.IsImpassable == true)
+        {
+            return new(false, false, mobile.Position, mobile.Direction);
+        }
+
+        if (!mapTiles.TryGetWalkableZ(mobile.MapId, target.X, target.Y, mobile.Position.Z, groundItems, out var newZ))
+        {
+            return new(false, false, mobile.Position, mobile.Direction);
+        }
+
+        return new(true, true, new(target.X, target.Y, newZ), direction);
+    }
+
+    private void Accept(PlayerSession session, MobileEntity mobile, byte sequence)
+        => session.Send(new MovementAckPacket(sequence, Notoriety.Resolve(mobile.Kills, mobile.Criminal)));
+
+    private void Reject(PlayerSession session, MobileEntity mobile, byte sequence)
+        => session.Send(
+            new MoveRejectPacket(
+                sequence,
+                (ushort)mobile.Position.X,
+                (ushort)mobile.Position.Y,
+                mobile.Direction,
+                (sbyte)mobile.Position.Z
+            )
+        );
+
+    private void Broadcast(MobileEntity mobile)
+        => _world.SendToPlayersInRange(
+            mobile.MapId,
+            mobile.Position,
+            ViewRange,
+            new UpdatePlayerPacket(
+                mobile.Id,
+                (ushort)mobile.Body,
+                (ushort)mobile.Position.X,
+                (ushort)mobile.Position.Y,
+                (sbyte)mobile.Position.Z,
+                mobile.Direction,
+                mobile.SkinHue,
+                0,
+                Notoriety.Resolve(mobile.Kills, mobile.Criminal)
+            ),
+            exclude: mobile.Id
+        );
+}

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -136,7 +136,7 @@ public sealed class MovementService : IMovementService
         {
             var minInterval = direction.IsRunning() ? RunInterval : WalkInterval;
 
-            if (lastSequence.HasValue && now - lastMoveAt < minInterval)
+            if (now - lastMoveAt < minInterval)
             {
                 return new(false, false, mobile.Position, mobile.Direction);
             }

--- a/src/Moongate.Server/Services/World/RegionService.cs
+++ b/src/Moongate.Server/Services/World/RegionService.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Geometry;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.UO.Data.Regions;
 using Moongate.UO.Data.Types;
@@ -19,6 +20,43 @@ public sealed class RegionService : IRegionService
 
     public IReadOnlyList<RegionDefinition> ForMap(MapType map)
         => [.. _regions.Where(region => region.Map == map)];
+
+    public RegionDefinition? At(MapType map, Point3D point)
+    {
+        RegionDefinition? best = null;
+
+        foreach (var region in _regions)
+        {
+            if (region.Map != map)
+            {
+                continue;
+            }
+
+            var inArea = false;
+
+            foreach (var rect in region.Area)
+            {
+                if (point.X >= rect.X1 && point.X <= rect.X2 && point.Y >= rect.Y1 && point.Y <= rect.Y2)
+                {
+                    inArea = true;
+
+                    break;
+                }
+            }
+
+            if (!inArea)
+            {
+                continue;
+            }
+
+            if (best is null || region.Priority > best.Priority)
+            {
+                best = region;
+            }
+        }
+
+        return best;
+    }
 
     public void Register(RegionDefinition region)
         => _regions.Add(region);

--- a/src/Moongate.Server/Services/World/UltimaMapProvider.cs
+++ b/src/Moongate.Server/Services/World/UltimaMapProvider.cs
@@ -1,13 +1,13 @@
-using Moongate.Http.Plugin.Interfaces.Maps;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Ultima.Maps;
 using Moongate.UO.Data.Types;
 
-namespace Moongate.Http.Plugin.Services.Maps;
+namespace Moongate.Server.Services.World;
 
 /// <summary>
 /// Ultima's own facets, by <see cref="MapType" />. The sizes are Ultima's, not MapDefinitions': Ultima
-/// hardcodes Felucca at 6144×4096 while MapDefinitions says 7168, and the renderer can only draw what
-/// Ultima's Map object describes. On a shard with post-ML client files this renders the older extent.
+/// hardcodes Felucca at 6144×4096 while MapDefinitions says 7168, and callers can only query what
+/// Ultima's Map object describes. On a shard with post-ML client files this reports the older extent.
 /// </summary>
 public sealed class UltimaMapProvider : IUltimaMapProvider
 {
@@ -24,8 +24,8 @@ public sealed class UltimaMapProvider : IUltimaMapProvider
     public Map? Get(MapType facet)
         => facet switch
         {
-            MapType.Felucca => Map.Felucca,
-            MapType.Trammel => Map.Trammel,
+            MapType.Felucca  => Map.Felucca,
+            MapType.Trammel  => Map.Trammel,
             MapType.Ilshenar => Map.Ilshenar,
             MapType.Malas    => Map.Malas,
             MapType.Tokuno   => Map.Tokuno,

--- a/src/Moongate.UO.Data/Regions/RegionDefinition.cs
+++ b/src/Moongate.UO.Data/Regions/RegionDefinition.cs
@@ -12,6 +12,8 @@ public sealed class RegionDefinition
     public MapType Map { get; set; }
     public string Name { get; set; } = string.Empty;
     public int Priority { get; set; }
+    /// <summary>When true, movement into this region is blocked. Defaults to false; no loaded region sets it yet.</summary>
+    public bool IsImpassable { get; set; }
     public List<RegionRectangle> Area { get; set; } = [];
     public string? Music { get; set; }
     public RegionParent? Parent { get; set; }

--- a/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
@@ -7,6 +7,7 @@ using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Services.Maps;
 using Moongate.Http.Plugin.Services.Ultima;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Tests.Support;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;

--- a/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
+++ b/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
@@ -27,7 +27,7 @@ public class PacketDocumentationTests
 
     [Fact]
     public void AllPacketTypes_AreDiscovered()
-        => Assert.Equal(48, PacketTypes.Count);
+        => Assert.Equal(50, PacketTypes.Count);
 
     [Theory, MemberData(nameof(Packets))]
     public void EveryPacket_DeclaresExactlyOneSizeKind(Type packetType)

--- a/tests/Moongate.Tests/Network/Packets/Outgoing/MoveRejectPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/Outgoing/MoveRejectPacketTests.cs
@@ -1,0 +1,39 @@
+using System.Buffers.Binary;
+using Moongate.Core.Types;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Packets.Outgoing;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Tests.Network.Packets.Outgoing;
+
+public class MoveRejectPacketTests
+{
+    private static byte[] Serialize(IOutgoingPacket packet)
+    {
+        var writer = new SpanWriter(256, true);
+        packet.Write(ref writer);
+
+        return writer.Span.ToArray();
+    }
+
+    [Fact]
+    public void Write_ProducesEightBytesWithTheOpcodeFirst()
+    {
+        var bytes = Serialize(new MoveRejectPacket(7, 100, 200, DirectionType.South, 5));
+
+        Assert.Equal(8, bytes.Length);
+        Assert.Equal(0x21, bytes[0]);
+    }
+
+    [Fact]
+    public void Write_EncodesSequenceXYDirectionZInOrder()
+    {
+        var bytes = Serialize(new MoveRejectPacket(7, 100, 200, DirectionType.South, 5));
+
+        Assert.Equal(7, bytes[1]);
+        Assert.Equal((ushort)100, BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(2)));
+        Assert.Equal((ushort)200, BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(4)));
+        Assert.Equal((byte)DirectionType.South, bytes[6]);
+        Assert.Equal(5, (sbyte)bytes[7]);
+    }
+}

--- a/tests/Moongate.Tests/Network/Packets/Outgoing/UpdatePlayerPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/Outgoing/UpdatePlayerPacketTests.cs
@@ -1,0 +1,50 @@
+using System.Buffers.Binary;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Tests.Network.Packets.Outgoing;
+
+public class UpdatePlayerPacketTests
+{
+    private static byte[] Serialize(IOutgoingPacket packet)
+    {
+        var writer = new SpanWriter(256, true);
+        packet.Write(ref writer);
+
+        return writer.Span.ToArray();
+    }
+
+    [Fact]
+    public void Write_ProducesSeventeenBytesWithTheOpcodeFirst()
+    {
+        var bytes = Serialize(
+            new UpdatePlayerPacket(new Serial(0x1000), 400, 100, 200, 5, DirectionType.East, new(0x10), 0, NotorietyType.Innocent)
+        );
+
+        Assert.Equal(17, bytes.Length);
+        Assert.Equal(0x77, bytes[0]);
+    }
+
+    [Fact]
+    public void Write_EncodesFieldsInOrder()
+    {
+        var bytes = Serialize(
+            new UpdatePlayerPacket(new Serial(0x1000), 400, 100, 200, 5, DirectionType.East, new(0x10), 3, NotorietyType.Criminal)
+        );
+
+        Assert.Equal(0x1000u, BinaryPrimitives.ReadUInt32BigEndian(bytes.AsSpan(1)));
+        Assert.Equal((ushort)400, BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(5)));
+        Assert.Equal((ushort)100, BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(7)));
+        Assert.Equal((ushort)200, BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(9)));
+        Assert.Equal(5, (sbyte)bytes[11]);
+        Assert.Equal((byte)DirectionType.East, bytes[12]);
+        Assert.Equal((ushort)0x10, BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(13)));
+        Assert.Equal(3, bytes[15]);
+        Assert.Equal((byte)NotorietyType.Criminal, bytes[16]);
+    }
+}

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -4,17 +4,24 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using Moongate.Core.Primitives;
+using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Handlers;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Network;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Services.Accounts;
+using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Network;
 using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
 using Moongate.Tests.Support;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Maps;
+using Moongate.Ultima.Tiles;
 using Moongate.Ultima.Types;
 using Moongate.UO.Data.Types;
 using SquidStd.Core.Interfaces.Events;
@@ -23,6 +30,7 @@ using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Server;
 
+[Collection("UltimaClientData")]
 public class LoginFlowIntegrationTests
 {
     // How long a wire read waits before it is called a failure. Deliberately far above what the reads
@@ -431,6 +439,241 @@ public class LoginFlowIntegrationTests
         {
             await network.StopAsync(CancellationToken.None);
         }
+    }
+
+    [Fact]
+    public async Task Movement_TurnThenStep_AcksBothAndBroadcastsToNearbyPlayer()
+    {
+        var config = LoopbackConfig();
+        var persistence = new FakePersistenceService();
+        await persistence.Store<AccountEntity>().UpsertAsync(new() { Id = (Serial)1, Username = "alice" });
+
+        var eventBus = new EventBusService();
+        var opl = new OplService(persistence, new ItemTemplateService());
+        var sessions = new SessionManager();
+
+        // Synthetic 8x8-tile flat map at mapId 0 (Felucca). "testCities" below is registered as
+        // starting city 0 for the character factory, so a freshly created character spawns at (5,5)
+        // on this same tiny map — real client coordinates (e.g. Britain at 1495,1629, the shared
+        // CharacterServiceFixture default) would fall outside it.
+        var tileData = UltimaFixtures.BuildTileData();
+        var mapBlock = UltimaFixtures.BuildMapBlock(landId: 3, z: 0);
+        var dir = UltimaFixtures.CreateClientDirectory(("map0.mul", mapBlock), ("tiledata.mul", tileData));
+
+        try
+        {
+            Files.SetDirectory(dir);
+            TileData.Initialize();
+            var map = new Map(dir, 0, 0, 8, 8);
+            var mapProvider = new StubMapProvider(MapType.Felucca, map);
+
+            var loopThread = new LoopThreadMarker();
+            loopThread.Capture();
+            var spatial = new SpatialIndexService(persistence, loopThread);
+            new SpatialSubscriber(spatial, persistence).Subscribe(eventBus);
+
+            var mapTiles = new MapTileService(mapProvider);
+            var regions = new RegionService();
+
+            var world = new WorldService(
+                new ItemService(persistence, opl),
+                CharacterServiceFixture.Skills(),
+                new VirtualSerialService(),
+                eventBus,
+                TimeProvider.System,
+                opl,
+                sessions
+            );
+            var movement = new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System);
+
+            // CharacterServiceFixture.Create wires its own MobileFactoryService, whose starting-city
+            // lookup is independent of the city StartServerWithMovementAsync registers for the
+            // client-facing character list — the fixture's default (Britain, off this tiny map) has to
+            // be overridden here too, or a fresh character would spawn outside the synthetic map.
+            var testCities = new StartingCityService();
+            testCities.Register(
+                new()
+                {
+                    City = "TestTown",
+                    Building = "Origin",
+                    Description = 1075072,
+                    X = 5,
+                    Y = 5,
+                    Z = 0,
+                    Map = MapType.Felucca
+                }
+            );
+            var characters = CharacterServiceFixture.Create(persistence, (EventBusService)eventBus, sessions, testCities);
+
+            using var aliceEntered = new ManualResetEventSlim();
+            using var bobEntered = new ManualResetEventSlim();
+            eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
+                {
+                    if (e.Mobile.Name == "Alice")
+                    {
+                        aliceEntered.Set();
+                    }
+                    else if (e.Mobile.Name == "Bob")
+                    {
+                        bobEntered.Set();
+                    }
+
+                    return Task.CompletedTask;
+                }
+            );
+
+            var network = await StartServerWithMovementAsync(config, eventBus, characters, world, movement, opl, sessions);
+
+            try
+            {
+                using var aliceSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                EnterWorld(aliceSocket, network.Port, "alice", "Alice");
+                Assert.True(aliceEntered.Wait(TimeSpan.FromSeconds(2)), "Alice's PlayerEnteredWorldEvent was not published.");
+
+                using var bobSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                EnterWorld(bobSocket, network.Port, "bob", "Bob");
+                Assert.True(bobEntered.Wait(TimeSpan.FromSeconds(2)), "Bob's PlayerEnteredWorldEvent was not published.");
+
+                var aliceMobile = persistence.Store<MobileEntity>().Query().Single(m => m.Name == "Alice");
+
+                // InMemoryEntityStore.Query() hands back a live reference, not a clone (unlike the real
+                // store), so aliceMobile keeps aging as MovementService mutates it in place. Position is
+                // an immutable struct, so copying it now freezes the pre-move value for the assertions
+                // below instead of comparing the post-move mobile against itself.
+                var aliceStartPosition = aliceMobile.Position;
+
+                // Alice spawns facing North (the factory default); the first move request toward East
+                // only turns her — real UO client behavior — and must still be acked.
+                var turn = new byte[7];
+                turn[0] = 0x02;
+                turn[1] = 0x02; // DirectionType.East
+                turn[2] = 0x00; // sequence
+                aliceSocket.Send(turn);
+
+                var aliceCompressed = new List<byte>();
+                var turnAck = new byte[] { 0x22, 0x00, 0x01 }; // 0x22 + sequence 0 + Notoriety.Innocent
+                Assert.True(PollUntil(aliceSocket, aliceCompressed, turnAck), "Alice never received an ack for the turn.");
+
+                // A turn is an accepted move too, so it re-baselines the walk-rate-limit clock
+                // (PlayerSession.LastMoveAt) exactly like a real step does. Clearing the 400ms walk
+                // interval here is what makes the next request a real step rather than a rejected one —
+                // without it, the two sends race the clock and the outcome depends on machine speed.
+                await Task.Delay(450);
+
+                // Second request, now already facing East, is a real step.
+                var step = new byte[7];
+                step[0] = 0x02;
+                step[1] = 0x02; // DirectionType.East
+                step[2] = 0x01; // sequence
+                aliceSocket.Send(step);
+
+                var stepAck = new byte[] { 0x22, 0x01, 0x01 }; // 0x22 + sequence 1 + Notoriety.Innocent
+                Assert.True(PollUntil(aliceSocket, aliceCompressed, stepAck), "Alice never received an ack for the step.");
+
+                var bobCompressed = new List<byte>();
+                var broadcastPattern = new byte[] { 0x77 }.Concat(SerialBytes(aliceMobile.Id)).ToArray();
+                Assert.True(
+                    PollUntil(bobSocket, bobCompressed, broadcastPattern),
+                    "Bob never received Alice's movement broadcast (0x77)."
+                );
+
+                var moved = persistence.Store<MobileEntity>().GetById(aliceMobile.Id)!;
+                Assert.Equal(aliceStartPosition.X + 1, moved.Position.X);
+                Assert.Equal(aliceStartPosition.Y, moved.Position.Y);
+                Assert.Equal(DirectionType.East, moved.Direction);
+
+                // The spatial index was re-indexed at the new position, closing the loop with the
+                // earlier spatial-index feature. Range 0 (exact tile) rather than 1: Bob spawned at the
+                // same city as Alice (the fixture registers only one starting city), so a range wide
+                // enough to reach Alice's old tile would also still catch Bob standing right next to her.
+                Assert.Single(spatial.GetMobilesInRange(0, moved.Position, 0));
+            }
+            finally
+            {
+                await network.StopAsync(CancellationToken.None);
+            }
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// Drives one client through the full login handshake (seed, account login, server select, game
+    /// login) and sends character creation for <paramref name="characterName" />, mirroring the inline
+    /// steps every other test in this file repeats — parameterized so two independent clients can each
+    /// reach the world over their own socket. Does not itself wait for the enter-world burst; callers
+    /// observe that via <see cref="PlayerEnteredWorldEvent" /> or by reading the socket.
+    /// </summary>
+    private static void EnterWorld(Socket socket, int port, string account, string characterName)
+    {
+        socket.Connect(IPAddress.Loopback, port);
+
+        var seed = new byte[21];
+        seed[0] = 0xEF;
+        seed[4] = 0x2A;
+        socket.Send(seed);
+
+        socket.Send(AccountLogin(account, "secret"));
+        ReadResponse(socket, 0xA8);
+
+        socket.Send(new byte[] { 0xA0, 0x00, 0x00 });
+        var redirect = ReadResponse(socket, 0x8C);
+        var authKey = BinaryPrimitives.ReadUInt32BigEndian(redirect.AsSpan(7));
+
+        var gameLogin = new byte[65];
+        gameLogin[0] = 0x91;
+        BinaryPrimitives.WriteUInt32BigEndian(gameLogin.AsSpan(1), authKey);
+        Encoding.ASCII.GetBytes(account).CopyTo(gameLogin.AsSpan(5));
+        socket.Send(gameLogin);
+        ReadBytes(socket, 1); // features + character list
+
+        socket.Send(CharacterCreation(characterName));
+    }
+
+    private static async Task<NetworkService> StartServerWithMovementAsync(
+        MoongateConfig config,
+        IEventBus eventBus,
+        ICharacterService characters,
+        WorldService world,
+        IMovementService movement,
+        OplService opl,
+        ISessionManager sessions
+    )
+    {
+        var accounts = new StubAccountService();
+        var pending = new PendingLoginStore(30000, () => Environment.TickCount64);
+
+        var cities = new StartingCityService();
+        cities.Register(
+            new()
+            {
+                City = "TestTown",
+                Building = "Origin",
+                Description = 1075072,
+                X = 5,
+                Y = 5,
+                Z = 0,
+                Map = MapType.Felucca
+            }
+        );
+
+        var handlers = new List<IPacketHandlerRegistration>
+        {
+            new LoginSeedHandler(),
+            new AccountLoginHandler(accounts, config),
+            new SelectServerHandler(pending, config),
+            new GameServerLoginHandler(pending, cities, accounts, characters),
+            new CharacterCreationHandler(characters, world),
+            new MegaClilocHandler(opl),
+            new MoveRequestHandler(movement)
+        };
+
+        var network = new NetworkService(sessions, config, [.. handlers], eventBus, new InlineDispatcher());
+        await network.StartAsync(CancellationToken.None);
+
+        return network;
     }
 
     private static byte[] AccountLogin(string account, string password)

--- a/tests/Moongate.Tests/Server/RegionServiceTests.cs
+++ b/tests/Moongate.Tests/Server/RegionServiceTests.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Geometry;
 using Moongate.Server.Services.World;
 using Moongate.UO.Data.Regions;
 using Moongate.UO.Data.Types;
@@ -27,6 +28,69 @@ public class RegionServiceTests
         Assert.Equal("Britain", service.ForMap(MapType.Felucca)[0].Name);
     }
 
+    [Fact]
+    public void At_PointInsideRegion_ReturnsRegion()
+    {
+        var service = new RegionService();
+        service.Register(RegionWithArea(MapType.Felucca, "Britain", 0, 0, 10, 10));
+
+        var found = service.At(MapType.Felucca, new(5, 5, 0));
+
+        Assert.NotNull(found);
+        Assert.Equal("Britain", found!.Name);
+    }
+
+    [Fact]
+    public void At_PointOutsideRegion_ReturnsNull()
+    {
+        var service = new RegionService();
+        service.Register(RegionWithArea(MapType.Felucca, "Britain", 0, 0, 10, 10));
+
+        Assert.Null(service.At(MapType.Felucca, new(999, 999, 0)));
+    }
+
+    [Fact]
+    public void At_WrongMap_ReturnsNull()
+    {
+        var service = new RegionService();
+        service.Register(RegionWithArea(MapType.Felucca, "Britain", 0, 0, 10, 10));
+
+        Assert.Null(service.At(MapType.Trammel, new(5, 5, 0)));
+    }
+
+    [Fact]
+    public void At_OverlappingRegions_ReturnsHighestPriority()
+    {
+        var service = new RegionService();
+        service.Register(RegionWithArea(MapType.Felucca, "Outer", 0, 0, 100, 100, priority: 1));
+        service.Register(RegionWithArea(MapType.Felucca, "Inner", 40, 40, 60, 60, priority: 10));
+
+        var found = service.At(MapType.Felucca, new(50, 50, 0));
+
+        Assert.Equal("Inner", found!.Name);
+    }
+
+    [Fact]
+    public void At_RegionMarkedImpassable_CarriesTheFlag()
+    {
+        var service = new RegionService();
+        var region = RegionWithArea(MapType.Felucca, "Blocked", 0, 0, 10, 10);
+        region.IsImpassable = true;
+        service.Register(region);
+
+        Assert.True(service.At(MapType.Felucca, new(5, 5, 0))!.IsImpassable);
+    }
+
     private static RegionDefinition Region(MapType map, string name)
         => new() { Type = "TownRegion", Map = map, Name = name };
+
+    private static RegionDefinition RegionWithArea(MapType map, string name, int x1, int y1, int x2, int y2, int priority = 0)
+        => new()
+        {
+            Type = "TownRegion",
+            Map = map,
+            Name = name,
+            Priority = priority,
+            Area = [new() { X1 = x1, Y1 = y1, X2 = x2, Y2 = y2 }]
+        };
 }

--- a/tests/Moongate.Tests/Server/World/MapTileServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MapTileServiceTests.cs
@@ -1,0 +1,190 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Graphics;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Maps;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.World;
+
+[Collection("UltimaClientData")]
+public class MapTileServiceTests
+{
+    private const ushort FlatLandId = 3;
+
+    // Kept inside 0-31: UltimaFixtures.BuildTileData() allocates exactly one 32-item old-format
+    // group, so an id >= 32 (the brief's original 100-103) writes past the buffer and
+    // UltimaFixtures.SetItem throws ArgumentOutOfRangeException before the test body ever runs.
+    // Confirmed against tests/Moongate.Tests/Ultima/TileDataTests.cs, whose passing item-id fixtures
+    // (id 5) all stay under 32 too.
+    private const ushort WallStaticId = 10;
+    private const ushort PlatformStaticId = 11;
+    private const ushort LowCeilingStaticId = 12;
+    private const ushort ImpassableItemId = 13;
+
+    private static MapTileService Build(string dir)
+    {
+        Files.SetDirectory(dir);
+        Art.Reload();
+        TileData.Initialize();
+
+        var map = new Map(dir, 0, 0, 8, 8);
+        var provider = new StubMapProvider(MapType.Felucca, map);
+
+        return new(provider);
+    }
+
+    private static string ClientDir(ushort landId, sbyte landZ, params (ushort Id, byte CellX, byte CellY, sbyte Z, ushort Hue)[] statics)
+    {
+        var tileData = UltimaFixtures.BuildTileData();
+
+        // WallStaticId: a wall you cannot pass through and cannot stand on.
+        UltimaFixtures.SetItem(tileData, WallStaticId, (uint)TileFlagType.Impassable, height: 20, name: "wall");
+
+        // PlatformStaticId: a walkable surface with no obstruction of its own.
+        UltimaFixtures.SetItem(tileData, PlatformStaticId, (uint)TileFlagType.Surface, height: 4, name: "platform");
+
+        // LowCeilingStaticId: impassable, but its base sits above the ground, leaving too little headroom.
+        UltimaFixtures.SetItem(tileData, LowCeilingStaticId, (uint)TileFlagType.Impassable, height: 4, name: "low ceiling");
+
+        // ImpassableItemId: the dynamic (ground-item) counterpart to WallStaticId.
+        UltimaFixtures.SetItem(tileData, ImpassableItemId, (uint)TileFlagType.Impassable, height: 20, name: "crate");
+
+        var mapBlock = UltimaFixtures.BuildMapBlock(landId, landZ);
+        var files = new List<(string, byte[])> { ("map0.mul", mapBlock), ("tiledata.mul", tileData) };
+
+        if (statics.Length > 0)
+        {
+            var (index, staticsBytes) = UltimaFixtures.BuildStatics(statics);
+            files.Add(("staidx0.mul", index));
+            files.Add(("statics0.mul", staticsBytes));
+        }
+
+        return UltimaFixtures.CreateClientDirectory(files.ToArray());
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_FlatTerrain_ReturnsLandZ()
+    {
+        var dir = ClientDir(FlatLandId, landZ: 0);
+
+        try
+        {
+            var service = Build(dir);
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 0, groundItems: [], out var newZ);
+
+            Assert.True(found);
+            Assert.Equal(0, newZ);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_WallOnTheTile_ReturnsFalse()
+    {
+        var dir = ClientDir(FlatLandId, landZ: 0, (WallStaticId, 1, 1, 0, 0));
+
+        try
+        {
+            var service = Build(dir);
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 0, groundItems: [], out _);
+
+            Assert.False(found);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_PlatformAtCurrentHeight_StaysOnPlatform()
+    {
+        // Ground is at Z=0, the platform static sits on it and is 4 units tall (top = 4). A mobile
+        // already standing at Z=4 (elsewhere on the same platform) stepping onto this tile should stay
+        // on the platform, not drop to the ground below.
+        var dir = ClientDir(FlatLandId, landZ: 0, (PlatformStaticId, 1, 1, 0, 0));
+
+        try
+        {
+            var service = Build(dir);
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 4, groundItems: [], out var newZ);
+
+            Assert.True(found);
+            Assert.Equal(4, newZ);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_InsufficientHeadroom_ReturnsFalse()
+    {
+        // Ground at Z=0 is a valid candidate, but LowCeilingStaticId is impassable starting at Z=4,
+        // leaving only 4 units of headroom — less than the 16-unit person height.
+        var dir = ClientDir(FlatLandId, landZ: 0, (LowCeilingStaticId, 1, 1, 4, 0));
+
+        try
+        {
+            var service = Build(dir);
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 0, groundItems: [], out _);
+
+            Assert.False(found);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_DynamicItemObstacle_ReturnsFalse()
+    {
+        var dir = ClientDir(FlatLandId, landZ: 0);
+
+        try
+        {
+            var service = Build(dir);
+            var groundItem = new ItemEntity { Id = new(0x40000001), ItemId = ImpassableItemId, MapId = 0, Position = new(1, 1, 0) };
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 0, groundItems: [groundItem], out _);
+
+            Assert.False(found);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_UnknownMap_ReturnsFalse()
+    {
+        var dir = ClientDir(FlatLandId, landZ: 0);
+
+        try
+        {
+            var service = Build(dir);
+
+            var found = service.TryGetWalkableZ(mapId: 99, 1, 1, currentZ: 0, groundItems: [], out _);
+
+            Assert.False(found);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/World/MapTileServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MapTileServiceTests.cs
@@ -24,6 +24,7 @@ public class MapTileServiceTests
     private const ushort PlatformStaticId = 11;
     private const ushort LowCeilingStaticId = 12;
     private const ushort ImpassableItemId = 13;
+    private const ushort NearSurfaceId = 14;
 
     private static MapTileService Build(string dir)
     {
@@ -52,6 +53,10 @@ public class MapTileServiceTests
 
         // ImpassableItemId: the dynamic (ground-item) counterpart to WallStaticId.
         UltimaFixtures.SetItem(tileData, ImpassableItemId, (uint)TileFlagType.Impassable, height: 20, name: "crate");
+
+        // NearSurfaceId: a zero-height walkable surface, used to place a second candidate close to
+        // currentZ that a separate obstacle then shadows, forcing the fallback loop to move on.
+        UltimaFixtures.SetItem(tileData, NearSurfaceId, (uint)TileFlagType.Surface, height: 0, name: "near surface");
 
         var mapBlock = UltimaFixtures.BuildMapBlock(landId, landZ);
         var files = new List<(string, byte[])> { ("map0.mul", mapBlock), ("tiledata.mul", tileData) };
@@ -181,6 +186,60 @@ public class MapTileServiceTests
             var found = service.TryGetWalkableZ(mapId: 99, 1, 1, currentZ: 0, groundItems: [], out _);
 
             Assert.False(found);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_ClosestCandidateBlocked_FallsBackToFartherCandidate()
+    {
+        // Two candidates exist: NearSurfaceId at Z=18 (distance 2 from currentZ=20, the closer one)
+        // and land at Z=0 (distance 20, the farther one). LowCeilingStaticId sits right above the
+        // near surface (bottom=20), leaving only 2 units of headroom there — less than the 16-unit
+        // person height — so the loop must skip it and fall back to land, which has a clear 20 units
+        // of headroom underneath that same static.
+        var dir = ClientDir(
+            FlatLandId,
+            landZ: 0,
+            (NearSurfaceId, 1, 1, 18, 0),
+            (LowCeilingStaticId, 1, 1, 20, 0)
+        );
+
+        try
+        {
+            var service = Build(dir);
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 20, groundItems: [], out var newZ);
+
+            Assert.True(found);
+            Assert.Equal(0, newZ);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void TryGetWalkableZ_GroundItemAtDifferentPosition_IsIgnored()
+    {
+        // ImpassableItemId would block (1,1) if it were actually there (see
+        // TryGetWalkableZ_DynamicItemObstacle_ReturnsFalse), but here it sits at (2,2) — a wider
+        // sweep the caller may pass without pre-filtering to the queried tile. It must be ignored.
+        var dir = ClientDir(FlatLandId, landZ: 0);
+
+        try
+        {
+            var service = Build(dir);
+            var groundItem = new ItemEntity { Id = new(0x40000002), ItemId = ImpassableItemId, MapId = 0, Position = new(2, 2, 0) };
+
+            var found = service.TryGetWalkableZ(0, 1, 1, currentZ: 0, groundItems: [groundItem], out var newZ);
+
+            Assert.True(found);
+            Assert.Equal(0, newZ);
         }
         finally
         {

--- a/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
@@ -1,0 +1,141 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Maps;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.World;
+
+[Collection("UltimaClientData")]
+public class MovementServiceTests
+{
+    private const ushort FlatLandId = 3;
+
+    // Kept inside 0-31: UltimaFixtures.BuildTileData() allocates exactly one 32-item old-format
+    // group, so an id >= 32 (the brief's original 100) writes past the buffer and
+    // UltimaFixtures.SetItem throws ArgumentOutOfRangeException before the test body ever runs.
+    // Same fix already applied in MapTileServiceTests.cs for the identical reason.
+    private const ushort WallStaticId = 10;
+
+    private static (MapTileService MapTiles, RegionService Regions) Build(bool withWall = false)
+    {
+        var tileData = UltimaFixtures.BuildTileData();
+        UltimaFixtures.SetItem(tileData, WallStaticId, (uint)TileFlagType.Impassable, height: 20, name: "wall");
+
+        var mapBlock = UltimaFixtures.BuildMapBlock(FlatLandId, 0);
+        var files = new List<(string, byte[])> { ("map0.mul", mapBlock), ("tiledata.mul", tileData) };
+
+        if (withWall)
+        {
+            var (index, statics) = UltimaFixtures.BuildStatics((WallStaticId, 2, 1, 0, 0));
+            files.Add(("staidx0.mul", index));
+            files.Add(("statics0.mul", statics));
+        }
+
+        var dir = UltimaFixtures.CreateClientDirectory(files.ToArray());
+        Files.SetDirectory(dir);
+        TileData.Initialize();
+
+        var map = new Map(dir, 0, 0, 8, 8);
+        var provider = new StubMapProvider(MapType.Felucca, map);
+
+        return (new(provider), new());
+    }
+
+    private static MobileEntity Mobile(int x = 1, int y = 1, int z = 0, DirectionType direction = DirectionType.East)
+        => new() { Id = new Serial(0x1), MapId = 0, Position = new(x, y, z), Direction = direction };
+
+    [Fact]
+    public void Evaluate_ValidStep_IsAcceptedAndResolvesPosition()
+    {
+        var (mapTiles, regions) = Build();
+        var mobile = Mobile(direction: DirectionType.East);
+        var now = DateTimeOffset.UtcNow;
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, now, now, mapTiles, regions, []);
+
+        Assert.True(decision.Accepted);
+        Assert.True(decision.PositionChanged);
+        Assert.Equal(new Point3D(2, 1, 0), decision.NewPosition);
+    }
+
+    [Fact]
+    public void Evaluate_SequenceMismatch_IsRejected()
+    {
+        var (mapTiles, regions) = Build();
+        var mobile = Mobile(direction: DirectionType.East);
+        var now = DateTimeOffset.UtcNow;
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 5, 0, now, now, mapTiles, regions, []);
+
+        Assert.False(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_TooSoonAfterLastMove_IsRejected()
+    {
+        var (mapTiles, regions) = Build();
+        var mobile = Mobile(direction: DirectionType.East);
+        var lastMoveAt = DateTimeOffset.UtcNow;
+        var now = lastMoveAt.AddMilliseconds(100);
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 1, 0, lastMoveAt, now, mapTiles, regions, []);
+
+        Assert.False(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_TurnInPlace_AcceptedImmediately_NoTimingGate()
+    {
+        var (mapTiles, regions) = Build();
+        var mobile = Mobile(direction: DirectionType.East);
+        var lastMoveAt = DateTimeOffset.UtcNow;
+        var now = lastMoveAt.AddMilliseconds(1); // far under the 400ms walk interval
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.South, 1, 0, lastMoveAt, now, mapTiles, regions, []);
+
+        Assert.True(decision.Accepted);
+        Assert.False(decision.PositionChanged);
+        Assert.Equal(DirectionType.South, decision.NewDirection);
+    }
+
+    [Fact]
+    public void Evaluate_ImpassableRegion_IsRejected()
+    {
+        var (mapTiles, regions) = Build();
+        regions.Register(
+            new()
+            {
+                Type = "TestRegion",
+                Map = MapType.Felucca,
+                Name = "Blocked",
+                IsImpassable = true,
+                Area = [new() { X1 = 0, Y1 = 0, X2 = 10, Y2 = 10 }]
+            }
+        );
+        var mobile = Mobile(direction: DirectionType.East);
+        var now = DateTimeOffset.UtcNow;
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, now, now, mapTiles, regions, []);
+
+        Assert.False(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_WallOnTargetTile_IsRejected()
+    {
+        var (mapTiles, regions) = Build(withWall: true);
+        var mobile = Mobile(x: 1, y: 1, direction: DirectionType.East); // steps to (2, 1), where the wall sits
+
+        var now = DateTimeOffset.UtcNow;
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, now, now, mapTiles, regions, []);
+
+        Assert.False(decision.Accepted);
+    }
+}

--- a/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
@@ -58,7 +58,7 @@ public class MovementServiceTests
         var mobile = Mobile(direction: DirectionType.East);
         var now = DateTimeOffset.UtcNow;
 
-        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, now, now, mapTiles, regions, []);
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, DateTimeOffset.MinValue, now, mapTiles, regions, []);
 
         Assert.True(decision.Accepted);
         Assert.True(decision.PositionChanged);
@@ -122,7 +122,7 @@ public class MovementServiceTests
         var mobile = Mobile(direction: DirectionType.East);
         var now = DateTimeOffset.UtcNow;
 
-        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, now, now, mapTiles, regions, []);
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, DateTimeOffset.MinValue, now, mapTiles, regions, []);
 
         Assert.False(decision.Accepted);
     }
@@ -134,7 +134,24 @@ public class MovementServiceTests
         var mobile = Mobile(x: 1, y: 1, direction: DirectionType.East); // steps to (2, 1), where the wall sits
 
         var now = DateTimeOffset.UtcNow;
-        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, now, now, mapTiles, regions, []);
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, DateTimeOffset.MinValue, now, mapTiles, regions, []);
+
+        Assert.False(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_AfterRejectionResetsSequence_StillEnforcesTimingAgainstPriorRealMove()
+    {
+        var (mapTiles, regions) = Build();
+        var mobile = Mobile(direction: DirectionType.East);
+        var lastRealMoveAt = DateTimeOffset.UtcNow;
+        var now = lastRealMoveAt.AddMilliseconds(50); // well under the 400ms walk interval
+
+        // Simulates: a real move was accepted at lastRealMoveAt, then a later packet was rejected
+        // (e.g. sequence mismatch), which reset lastSequence to null but left lastMoveAt untouched
+        // (TryMove's resync behavior). A subsequent attempt must still be timing-gated against the
+        // real prior move, not treated as a fresh first-ever move.
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, null, lastRealMoveAt, now, mapTiles, regions, []);
 
         Assert.False(decision.Accepted);
     }

--- a/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
@@ -155,4 +155,31 @@ public class MovementServiceTests
 
         Assert.False(decision.Accepted);
     }
+
+    [Fact]
+    public void Evaluate_SequenceWrapsFrom255To1_NotToZero()
+    {
+        var (mapTiles, regions) = Build();
+        // Mobile faces South so the East move below is a turn-in-place, skipping the timing gate
+        // entirely and leaving the sequence check as the only thing under test.
+        var mobile = Mobile(direction: DirectionType.South);
+        var now = DateTimeOffset.UtcNow;
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 1, 255, now, now, mapTiles, regions, []);
+
+        Assert.True(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_SequenceWrapsFrom255ButClientSendsZero_IsRejected()
+    {
+        var (mapTiles, regions) = Build();
+        // Same turn-in-place setup as above; only the sequence value under test differs.
+        var mobile = Mobile(direction: DirectionType.South);
+        var now = DateTimeOffset.UtcNow;
+
+        var decision = MovementService.Evaluate(mobile, DirectionType.East, 0, 255, now, now, mapTiles, regions, []);
+
+        Assert.False(decision.Accepted);
+    }
 }

--- a/tests/Moongate.Tests/Support/CharacterServiceFixture.cs
+++ b/tests/Moongate.Tests/Support/CharacterServiceFixture.cs
@@ -1,4 +1,5 @@
 using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
@@ -20,7 +21,8 @@ public static class CharacterServiceFixture
     public static CharacterService Create(
         FakePersistenceService persistence,
         IEventBus eventBus,
-        ISessionManager? sessions = null
+        ISessionManager? sessions = null,
+        IStartingCityService? cities = null
     )
     {
         var templates = Templates();
@@ -28,7 +30,7 @@ public static class CharacterServiceFixture
 
         return new(
             persistence,
-            new MobileFactoryService(Cities(), new MobileTemplateService(), random),
+            new MobileFactoryService(cities ?? Cities(), new MobileTemplateService(), random),
             new ItemFactoryService(templates, random),
             new ItemService(persistence),
             templates,

--- a/tests/Moongate.Tests/Support/MapImageFixture.cs
+++ b/tests/Moongate.Tests/Support/MapImageFixture.cs
@@ -1,5 +1,5 @@
-using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Ultima;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Ultima.Graphics;
 using Moongate.Ultima.Io;
 using Moongate.Ultima.Maps;
@@ -32,7 +32,7 @@ public sealed class MapImageFixture : IDisposable
         _clientDirectory = clientDirectory;
         Root = root;
         Directories = directories;
-        Provider = new StubMapProvider(new(0, 0, MapWidth, MapHeight));
+        Provider = new StubMapProvider(MapType.Felucca, new(0, 0, MapWidth, MapHeight));
     }
 
     public string Root { get; }
@@ -127,19 +127,4 @@ public sealed class MapImageFixture : IDisposable
         }
     }
 
-    /// <summary>Serves one small facet under Felucca's name, so a test need not render 384 tiles.</summary>
-    private sealed class StubMapProvider : IUltimaMapProvider
-    {
-        private readonly Map _map;
-
-        public StubMapProvider(Map map)
-        {
-            _map = map;
-        }
-
-        public IReadOnlyList<MapType> Facets { get; } = [MapType.Felucca];
-
-        public Map? Get(MapType facet)
-            => facet == MapType.Felucca ? _map : null;
-    }
 }

--- a/tests/Moongate.Tests/Support/StubMapProvider.cs
+++ b/tests/Moongate.Tests/Support/StubMapProvider.cs
@@ -10,14 +10,14 @@ public sealed class StubMapProvider : IUltimaMapProvider
     private readonly MapType _facet;
     private readonly Map _map;
 
+    public IReadOnlyList<MapType> Facets { get; }
+
     public StubMapProvider(MapType facet, Map map)
     {
         _facet = facet;
         _map = map;
         Facets = [facet];
     }
-
-    public IReadOnlyList<MapType> Facets { get; }
 
     public Map? Get(MapType facet)
         => facet == _facet ? _map : null;

--- a/tests/Moongate.Tests/Support/StubMapProvider.cs
+++ b/tests/Moongate.Tests/Support/StubMapProvider.cs
@@ -1,0 +1,24 @@
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Ultima.Maps;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Test double for <see cref="IUltimaMapProvider" />: serves exactly one synthetic facet.</summary>
+public sealed class StubMapProvider : IUltimaMapProvider
+{
+    private readonly MapType _facet;
+    private readonly Map _map;
+
+    public StubMapProvider(MapType facet, Map map)
+    {
+        _facet = facet;
+        _map = map;
+        Facets = [facet];
+    }
+
+    public IReadOnlyList<MapType> Facets { get; }
+
+    public Map? Get(MapType facet)
+        => facet == _facet ? _map : null;
+}


### PR DESCRIPTION
## Summary
- `IMapTileService`: single-tile port of the classic UO "CanFit" walkability/Z-resolution algorithm (land + statics + dynamic ground items), with `PersonHeight`/`StepHeight` constants verified byte-for-byte against ModernUO's real source
- `IRegionService.At(map, point)` + `RegionDefinition.IsImpassable`: a region-gating hook for movement (no region uses it yet)
- `MoveRejectPacket` (0x21) and `UpdatePlayerPacket` (0x77): wire formats verified byte-for-byte against ModernUO
- Movement rate-limit state on `PlayerSession` (sequence + timing), consumed by `MovementService`
- `IMovementService`/`MovementService`: orchestrates rate limiting, turn-vs-step, region check, tile check, persistence, spatial re-index, and broadcast. The decision core (`Evaluate`) is a public static pure function, unit-testable without a live session (mirrors `WorldService.IsRecipient`)
- `MoveRequestHandler`: wires the 0x02 packet to `IMovementService`
- Refactor: `IUltimaMapProvider` moved from `Moongate.Http.Plugin` to `Moongate.Server.Abstractions`/`Moongate.Server` (avoids a circular project reference; movement needs it, plugins can't be depended on by the server)
- End-to-end integration test: two real TCP clients, turn + step + broadcast + spatial re-index, over a synthetic map
- Docs updated to no longer claim movement is unhandled

## Notable fixes found during review
- **Rate-limit bypass**: rejecting a movement packet reset the sequence baseline, which was also (incorrectly) used to gate the timing check — a client could defeat the walk/run interval by preceding every real step with one deliberately-mismatched-sequence packet. Fixed: the timing check is now unconditional.
- **Sequence wraparound**: verified against ModernUO's actual source that the move-sequence counter wraps 255→**1** (not 0 — sequence 0 is a reserved resync sentinel), and that a post-resync client is expected to resume at exactly 0, not "any value." Both corrected with regression tests.
- A test-fixture buffer-overflow bug and a plan premise error (starting-city registration doesn't control spawn location) were also found and fixed during implementation.

## Explicitly out of scope (documented, not silent gaps)
SendEverything (nearby objects appearing as you walk into view), a real speed/mount system, full region rules beyond the impassable flag, sector-changed events, NPC movement, diagonal-neighbor/other-mobile obstacle checks. A follow-up card was filed for general inbound packet rate limiting (systemic gap, not specific to this feature — a turn-flood could still trigger unthrottled broadcast amplification).

## Test plan
- [x] `dotnet test`: 1178/1178 passing, 0 regressions
- [x] `dotnet build`: 0 errors
- [x] `dotnet docfx docs/docfx.json --warningsAsErrors`: 0 warnings
- [x] Every task implemented via a fresh subagent, independently task-reviewed, with fix rounds where issues were found
- [x] Final whole-branch review (opus) — verdict "ready to merge with fixes"; fixes applied
- [ ] Manual verification with a real ClassicUO client — deferred, not blocking