### PR TITLE
feat(commands): GM/admin command dispatcher + .broadcast

### DIFF
--- a/src/Moongate.Server.Abstractions/Attributes/CommandAttribute.cs
+++ b/src/Moongate.Server.Abstractions/Attributes/CommandAttribute.cs
@@ -1,0 +1,28 @@
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Attributes;
+
+/// <summary>
+/// Declares an <see cref="Interfaces.Commands.ICommand" />'s dispatch name(s), minimum
+/// <see cref="AccountLevelType" />, and help text. <paramref name="name" /> may be pipe-delimited
+/// ("broadcast|bc") to register aliases; the first token is the canonical name.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class CommandAttribute : Attribute
+{
+    public string Name { get; }
+
+    public AccountLevelType MinLevel { get; }
+
+    public string Description { get; }
+
+    public CommandSourceType Sources { get; set; } = CommandSourceType.InGame;
+
+    public CommandAttribute(string name, AccountLevelType minLevel, string description)
+    {
+        Name = name;
+        MinLevel = minLevel;
+        Description = description;
+    }
+}

--- a/src/Moongate.Server.Abstractions/Attributes/CommandAttribute.cs
+++ b/src/Moongate.Server.Abstractions/Attributes/CommandAttribute.cs
@@ -5,8 +5,7 @@ namespace Moongate.Server.Abstractions.Attributes;
 
 /// <summary>
 /// Declares an <see cref="Interfaces.Commands.ICommand" />'s dispatch name(s), minimum
-/// <see cref="AccountLevelType" />, and help text. <paramref name="name" /> may be pipe-delimited
-/// ("broadcast|bc") to register aliases; the first token is the canonical name.
+/// <see cref="AccountLevelType" />, and help text.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class CommandAttribute : Attribute
@@ -19,6 +18,10 @@ public sealed class CommandAttribute : Attribute
 
     public CommandSourceType Sources { get; set; } = CommandSourceType.InGame;
 
+    /// <param name="name">
+    /// May be pipe-delimited ("broadcast|bc") to register aliases; the first token is the
+    /// canonical name.
+    /// </param>
     public CommandAttribute(string name, AccountLevelType minLevel, string description)
     {
         Name = name;

--- a/src/Moongate.Server.Abstractions/Data/Commands/CommandContext.cs
+++ b/src/Moongate.Server.Abstractions/Data/Commands/CommandContext.cs
@@ -1,0 +1,16 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Data.Commands;
+
+/// <summary>
+/// One command invocation. <see cref="Reply" /> is a plain delegate rather than a packet-sending
+/// call so a future non-in-game <see cref="CommandSourceType" /> (e.g. a console) can supply a
+/// different sink without <see cref="Interfaces.Commands.ICommand" /> implementations changing.
+/// </summary>
+public readonly record struct CommandContext(
+    CommandSourceType Source,
+    MobileEntity Actor,
+    IReadOnlyList<string> Arguments,
+    Action<string> Reply
+);

--- a/src/Moongate.Server.Abstractions/Extensions/CommandRegistrationExtensions.cs
+++ b/src/Moongate.Server.Abstractions/Extensions/CommandRegistrationExtensions.cs
@@ -1,0 +1,21 @@
+using DryIoc;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+
+namespace Moongate.Server.Abstractions.Extensions;
+
+/// <summary>
+/// Registers GM/admin commands. Each command is collected under <see cref="ICommand" />, the typed
+/// <see cref="System.Collections.Generic.IEnumerable{T}" /> that <c>CommandService</c> resolves and
+/// indexes by name/alias at construction — mirrors <c>RegisterPacketHandler</c>'s
+/// <see cref="Interfaces.Network.IPacketHandlerRegistration" /> collection pattern.
+/// </summary>
+public static class CommandRegistrationExtensions
+{
+    public static IContainer RegisterCommand<TCommand>(this IContainer container)
+        where TCommand : class, ICommand
+    {
+        container.Register<ICommand, TCommand>(Reuse.Singleton);
+
+        return container;
+    }
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommand.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommand.cs
@@ -1,0 +1,9 @@
+using Moongate.Server.Abstractions.Data.Commands;
+
+namespace Moongate.Server.Abstractions.Interfaces.Commands;
+
+/// <summary>A GM/admin command reachable by typing its name (with any alias) after the "." prefix.</summary>
+public interface ICommand
+{
+    void Execute(CommandContext context);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommandService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommandService.cs
@@ -1,0 +1,15 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+
+namespace Moongate.Server.Abstractions.Interfaces.Commands;
+
+/// <summary>
+/// Dispatches a "." command typed by <paramref name="actor" /> in <paramref name="session" />.
+/// Unknown command names and commands the actor's <see cref="Moongate.Core.Types.AccountLevelType" />
+/// does not meet produce the identical "Unknown command." reply — an unauthorized caller cannot
+/// distinguish "doesn't exist" from "you can't use this".
+/// </summary>
+public interface ICommandService
+{
+    void Execute(PlayerSession session, MobileEntity actor, string rawText);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommandService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommandService.cs
@@ -3,13 +3,14 @@ using Moongate.Server.Abstractions.Data.Session;
 
 namespace Moongate.Server.Abstractions.Interfaces.Commands;
 
-/// <summary>
-/// Dispatches a "." command typed by <paramref name="actor" /> in <paramref name="session" />.
-/// Unknown command names and commands the actor's <see cref="Moongate.Core.Types.AccountLevelType" />
-/// does not meet produce the identical "Unknown command." reply — an unauthorized caller cannot
-/// distinguish "doesn't exist" from "you can't use this".
-/// </summary>
+/// <summary>Dispatches a "." command typed by an actor in a session.</summary>
 public interface ICommandService
 {
+    /// <summary>
+    /// Unknown command names and commands the actor's
+    /// <see cref="Moongate.Core.Types.AccountLevelType" /> does not meet produce the identical
+    /// "Unknown command." reply — an unauthorized caller cannot distinguish "doesn't exist" from
+    /// "you can't use this".
+    /// </summary>
     void Execute(PlayerSession session, MobileEntity actor, string rawText);
 }

--- a/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
+++ b/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
@@ -1,0 +1,12 @@
+namespace Moongate.Server.Abstractions.Types;
+
+/// <summary>
+/// Where a command invocation originated. Only <see cref="InGame" /> is implemented today — the
+/// <c>[Flags]</c> shape leaves room for a future console/REPL source without breaking existing
+/// <see cref="Attributes.CommandAttribute" /> declarations.
+/// </summary>
+[Flags]
+public enum CommandSourceType : byte
+{
+    InGame = 1 << 0
+}

--- a/src/Moongate.Server/Commands/BroadcastCommand.cs
+++ b/src/Moongate.Server/Commands/BroadcastCommand.cs
@@ -1,0 +1,36 @@
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Attributes;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+
+namespace Moongate.Server.Commands;
+
+/// <summary>
+/// Sends a server-wide system message. The only real command in this feature — proves the
+/// dispatcher end-to-end by reusing <see cref="IChatService.Broadcast" /> from the chat feature
+/// rather than adding new domain logic.
+/// </summary>
+[Command("broadcast|bc", AccountLevelType.GrandMaster, "Sends a server-wide system message.")]
+public sealed class BroadcastCommand : ICommand
+{
+    private readonly IChatService _chat;
+
+    public BroadcastCommand(IChatService chat)
+    {
+        _chat = chat;
+    }
+
+    public void Execute(CommandContext context)
+    {
+        if (context.Arguments.Count == 0)
+        {
+            context.Reply("Usage: broadcast <message>");
+
+            return;
+        }
+
+        _chat.Broadcast(string.Join(' ', context.Arguments));
+        context.Reply("Broadcast sent.");
+    }
+}

--- a/src/Moongate.Server/Handlers/SpeechHandler.cs
+++ b/src/Moongate.Server/Handlers/SpeechHandler.cs
@@ -1,6 +1,7 @@
 using Moongate.Network.Packets.Incoming;
 using Moongate.Server.Abstractions.Data;
 using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Commands;
 using Moongate.Server.Abstractions.Interfaces.Network;
 using Moongate.Server.Services.Chat;
 using Serilog;
@@ -9,22 +10,23 @@ namespace Moongate.Server.Handlers;
 
 /// <summary>
 /// Handles player speech (0xAD): rate-limits, classifies the raw text (say/emote/whisper/yell/
-/// command) via <see cref="ChatService" />'s pure core, and either replies with a "not implemented"
-/// system message (the "." prefix) or hands the classified message to <see cref="IChatService.Say" />.
-/// Packets with the classic-client "encoded" (keyword-menu) flag are dropped, as is any text that is
-/// empty or longer than 128 characters after trimming.
+/// command) via <see cref="ChatService" />'s pure core, and either dispatches the "." prefix to
+/// <see cref="ICommandService.Execute" /> or hands the classified message to
+/// <see cref="IChatService.Say" />. Packets with the classic-client "encoded" (keyword-menu) flag
+/// are dropped, as is any text that is empty or longer than 128 characters after trimming.
 /// </summary>
 public sealed class SpeechHandler : IPacketHandler<UnicodeSpeechPacket>, IPacketHandlerRegistration
 {
     private const int MaxTextLength = 128;
-    private const string CommandNotImplementedMessage = "That command is not implemented yet.";
 
     private readonly ILogger _logger = Log.ForContext<SpeechHandler>();
     private readonly IChatService _chat;
+    private readonly ICommandService _commands;
 
-    public SpeechHandler(IChatService chat)
+    public SpeechHandler(IChatService chat, ICommandService commands)
     {
         _chat = chat;
+        _commands = commands;
     }
 
     public void Handle(UnicodeSpeechPacket packet, in PacketContext context)
@@ -61,7 +63,7 @@ public sealed class SpeechHandler : IPacketHandler<UnicodeSpeechPacket>, IPacket
 
         if (decision.IsCommand)
         {
-            session.Send(ChatMessageFactory.CreateSystem(CommandNotImplementedMessage));
+            _commands.Execute(session, speaker, decision.Text);
 
             return;
         }

--- a/src/Moongate.Server/MoongateCommandsPlugin.cs
+++ b/src/Moongate.Server/MoongateCommandsPlugin.cs
@@ -1,0 +1,27 @@
+using DryIoc;
+using Moongate.Server.Abstractions.Extensions;
+using Moongate.Server.Commands;
+using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Server;
+
+/// <summary>Registers Moongate's GM/admin commands, keeping the command wiring out of Program.cs.</summary>
+public class MoongateCommandsPlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.commands.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateCommandsPlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate Commands",
+            Description = "GM/admin \".\" command registrations"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        container.RegisterCommand<BroadcastCommand>();
+    }
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -9,6 +9,7 @@ using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Commands;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Abstractions.Interfaces.Network;
@@ -17,6 +18,7 @@ using Moongate.Server.Autostart;
 using Moongate.Server.Data.Exceptions;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Chat;
+using Moongate.Server.Services.Commands;
 using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
@@ -108,6 +110,7 @@ await ConsoleApp.RunAsync(
                 builder.Add<MoongateScriptingPlugin>();
                 builder.Add<MoongateScriptModulesPlugin>();
                 builder.Add<MoongateDataLoaderPlugin>();
+                builder.Add<MoongateCommandsPlugin>();
                 builder.Add<MoongatePacketHandlersPlugin>();
                 builder.Add<MoongateEventSubscribersPlugin>();
 
@@ -141,6 +144,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IChatService, ChatService>(Reuse.Singleton);
+                container.Register<ICommandService, CommandService>(Reuse.Singleton);
                 container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
                 container.Register<IMapTileService, MapTileService>(Reuse.Singleton);
                 container.Register<IMovementService, MovementService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Commands/CommandService.cs
+++ b/src/Moongate.Server/Services/Commands/CommandService.cs
@@ -1,0 +1,23 @@
+using Moongate.Core.Types;
+
+namespace Moongate.Server.Services.Commands;
+
+/// <summary>
+/// Default <see cref="Moongate.Server.Abstractions.Interfaces.Commands.ICommandService" />.
+/// <see cref="Parse" />/<see cref="IsAuthorized" /> are the pure decision core — public and static
+/// so they are unit-testable without a live session, mirroring <c>ChatService.Classify</c>/
+/// <c>MovementService.Evaluate</c>.
+/// </summary>
+public sealed class CommandService
+{
+    public static bool IsAuthorized(AccountLevelType actorLevel, AccountLevelType minLevel)
+        => actorLevel >= minLevel;
+
+    public static (string Name, string[] Arguments) Parse(string rawText)
+    {
+        var withoutPrefix = rawText[1..]; // strip the leading "."
+        var tokens = withoutPrefix.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        return tokens.Length == 0 ? (string.Empty, []) : (tokens[0], tokens[1..]);
+    }
+}

--- a/src/Moongate.Server/Services/Commands/CommandService.cs
+++ b/src/Moongate.Server/Services/Commands/CommandService.cs
@@ -1,15 +1,66 @@
+using System.Reflection;
 using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Attributes;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.Chat;
+using Serilog;
 
 namespace Moongate.Server.Services.Commands;
 
 /// <summary>
-/// Default <see cref="Moongate.Server.Abstractions.Interfaces.Commands.ICommandService" />.
-/// <see cref="Parse" />/<see cref="IsAuthorized" /> are the pure decision core — public and static
-/// so they are unit-testable without a live session, mirroring <c>ChatService.Classify</c>/
-/// <c>MovementService.Evaluate</c>.
+/// Default <see cref="ICommandService" />. <see cref="Parse" />/<see cref="IsAuthorized" />/
+/// <see cref="BuildRegistry" /> are the pure decision core — public and static so they are
+/// unit-testable without a live session, mirroring <c>ChatService.Classify</c>/
+/// <c>MovementService.Evaluate</c>. <see cref="Execute" /> is the impure orchestrator: resolves the
+/// actor's level, checks authorization, dispatches, replies.
 /// </summary>
-public sealed class CommandService
+public sealed class CommandService : ICommandService
 {
+    private const string UnknownCommandMessage = "Unknown command.";
+    private const string CommandFailedMessage = "Command failed. Check server logs.";
+
+    private readonly ILogger _logger = Log.ForContext<CommandService>();
+    private readonly Dictionary<string, (ICommand Command, CommandAttribute Attribute)> _registry;
+    private readonly IAccountService _accounts;
+
+    public CommandService(IEnumerable<ICommand> commands, IAccountService accounts)
+    {
+        _registry = BuildRegistry(commands);
+        _accounts = accounts;
+    }
+
+    /// <summary>
+    /// Reads each command's <see cref="CommandAttribute" /> once and indexes it under every
+    /// pipe-delimited alias in <see cref="CommandAttribute.Name" />, case-insensitively. Pure aside
+    /// from reflection (no I/O), so it is unit-testable without any session/account infrastructure.
+    /// </summary>
+    public static Dictionary<string, (ICommand Command, CommandAttribute Attribute)> BuildRegistry(
+        IEnumerable<ICommand> commands
+    )
+    {
+        var registry = new Dictionary<string, (ICommand, CommandAttribute)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var command in commands)
+        {
+            var attribute = command.GetType().GetCustomAttribute<CommandAttribute>()
+                          ?? throw new InvalidOperationException(
+                                 $"{command.GetType().Name} is missing [Command]."
+                             );
+
+            foreach (var alias in attribute.Name.Split('|'))
+            {
+                registry[alias] = (command, attribute);
+            }
+        }
+
+        return registry;
+    }
+
     public static bool IsAuthorized(AccountLevelType actorLevel, AccountLevelType minLevel)
         => actorLevel >= minLevel;
 
@@ -19,5 +70,43 @@ public sealed class CommandService
         var tokens = withoutPrefix.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
         return tokens.Length == 0 ? (string.Empty, []) : (tokens[0], tokens[1..]);
+    }
+
+    public void Execute(PlayerSession session, MobileEntity actor, string rawText)
+    {
+        var (name, arguments) = Parse(rawText);
+
+        if (name.Length == 0 || !_registry.TryGetValue(name, out var registration))
+        {
+            session.Send(ChatMessageFactory.CreateSystem(UnknownCommandMessage));
+
+            return;
+        }
+
+        var actorLevel = _accounts.GetById(session.AccountId)?.AccountLevel ?? AccountLevelType.Player;
+
+        if (!IsAuthorized(actorLevel, registration.Attribute.MinLevel))
+        {
+            session.Send(ChatMessageFactory.CreateSystem(UnknownCommandMessage));
+
+            return;
+        }
+
+        var context = new CommandContext(
+            CommandSourceType.InGame,
+            actor,
+            arguments,
+            message => session.Send(ChatMessageFactory.CreateSystem(message))
+        );
+
+        try
+        {
+            registration.Command.Execute(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Command '{Name}' failed", name);
+            session.Send(ChatMessageFactory.CreateSystem(CommandFailedMessage));
+        }
     }
 }

--- a/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
@@ -1,0 +1,55 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Commands;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.Commands;
+
+public class BroadcastCommandTests
+{
+    private sealed class RecordingChatService : IChatService
+    {
+        public List<string> Broadcasts { get; } = [];
+
+        public void Broadcast(string text, Hue? hue = null)
+            => Broadcasts.Add(text);
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+    }
+
+    [Fact]
+    public void Execute_NoArguments_RepliesUsageAndDoesNotBroadcast()
+    {
+        var chat = new RecordingChatService();
+        var command = new BroadcastCommand(chat);
+        var replies = new List<string>();
+        var context = new CommandContext(CommandSourceType.InGame, new MobileEntity(), [], replies.Add);
+
+        command.Execute(context);
+
+        Assert.Empty(chat.Broadcasts);
+        Assert.Equal("Usage: broadcast <message>", Assert.Single(replies));
+    }
+
+    [Fact]
+    public void Execute_WithArguments_JoinsThemAndBroadcasts()
+    {
+        var chat = new RecordingChatService();
+        var command = new BroadcastCommand(chat);
+        var replies = new List<string>();
+        var context = new CommandContext(
+            CommandSourceType.InGame,
+            new MobileEntity(),
+            ["Server", "restarting", "soon"],
+            replies.Add
+        );
+
+        command.Execute(context);
+
+        Assert.Equal("Server restarting soon", Assert.Single(chat.Broadcasts));
+        Assert.Equal("Broadcast sent.", Assert.Single(replies));
+    }
+}

--- a/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
@@ -1,0 +1,55 @@
+using Moongate.Core.Types;
+using Moongate.Server.Services.Commands;
+
+namespace Moongate.Tests.Server.Commands;
+
+public class CommandServiceTests
+{
+    [Fact]
+    public void IsAuthorized_ActorAboveMinLevel_IsTrue()
+        => Assert.True(CommandService.IsAuthorized(AccountLevelType.Administrator, AccountLevelType.GrandMaster));
+
+    [Fact]
+    public void IsAuthorized_ActorAtMinLevel_IsTrue()
+        => Assert.True(CommandService.IsAuthorized(AccountLevelType.GrandMaster, AccountLevelType.GrandMaster));
+
+    [Fact]
+    public void IsAuthorized_ActorBelowMinLevel_IsFalse()
+        => Assert.False(CommandService.IsAuthorized(AccountLevelType.Player, AccountLevelType.GrandMaster));
+
+    [Fact]
+    public void Parse_JustThePrefix_ReturnsEmptyNameAndNoArguments()
+    {
+        var (name, arguments) = CommandService.Parse(".");
+
+        Assert.Equal(string.Empty, name);
+        Assert.Empty(arguments);
+    }
+
+    [Fact]
+    public void Parse_NameOnly_ReturnsNameAndNoArguments()
+    {
+        var (name, arguments) = CommandService.Parse(".broadcast");
+
+        Assert.Equal("broadcast", name);
+        Assert.Empty(arguments);
+    }
+
+    [Fact]
+    public void Parse_NameWithArguments_SplitsOnWhitespace()
+    {
+        var (name, arguments) = CommandService.Parse(".broadcast Server restarting soon");
+
+        Assert.Equal("broadcast", name);
+        Assert.Equal(["Server", "restarting", "soon"], arguments);
+    }
+
+    [Fact]
+    public void Parse_ExtraWhitespaceBetweenTokens_IsIgnored()
+    {
+        var (name, arguments) = CommandService.Parse(".broadcast   hello    world");
+
+        Assert.Equal("broadcast", name);
+        Assert.Equal(["hello", "world"], arguments);
+    }
+}

--- a/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
@@ -1,10 +1,64 @@
 using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Attributes;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Commands;
 using Moongate.Server.Services.Commands;
 
 namespace Moongate.Tests.Server.Commands;
 
 public class CommandServiceTests
 {
+    [Command("test|t", AccountLevelType.GrandMaster, "A recording test command.")]
+    private sealed class RecordingCommand : ICommand
+    {
+        public CommandContext? LastContext { get; private set; }
+
+        public void Execute(CommandContext context)
+            => LastContext = context;
+    }
+
+    private sealed class UndecoratedCommand : ICommand
+    {
+        public void Execute(CommandContext context) { }
+    }
+
+    [Fact]
+    public void BuildRegistry_LookupIsCaseInsensitive()
+    {
+        var command = new RecordingCommand();
+
+        var registry = CommandService.BuildRegistry([command]);
+
+        Assert.True(registry.ContainsKey("TEST"));
+        Assert.True(registry.ContainsKey("Test"));
+    }
+
+    [Fact]
+    public void BuildRegistry_MissingCommandAttribute_Throws()
+        => Assert.Throws<InvalidOperationException>(() => CommandService.BuildRegistry([new UndecoratedCommand()]));
+
+    [Fact]
+    public void BuildRegistry_PipeDelimitedAliases_RegisterBothNamesToTheSameCommand()
+    {
+        var command = new RecordingCommand();
+
+        var registry = CommandService.BuildRegistry([command]);
+
+        Assert.Same(command, registry["test"].Command);
+        Assert.Same(command, registry["t"].Command);
+    }
+
+    [Fact]
+    public void BuildRegistry_SingleCommand_RegistersItsCanonicalName()
+    {
+        var command = new RecordingCommand();
+
+        var registry = CommandService.BuildRegistry([command]);
+
+        Assert.True(registry.ContainsKey("test"));
+        Assert.Equal(AccountLevelType.GrandMaster, registry["test"].Attribute.MinLevel);
+    }
+
     [Fact]
     public void IsAuthorized_ActorAboveMinLevel_IsTrue()
         => Assert.True(CommandService.IsAuthorized(AccountLevelType.Administrator, AccountLevelType.GrandMaster));

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -11,8 +11,10 @@ using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Commands;
 using Moongate.Server.Abstractions.Interfaces.Network;
 using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Commands;
 using Moongate.Server.Handlers;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Chat;
@@ -30,6 +32,7 @@ using Moongate.Ultima.Types;
 using Moongate.UO.Data.Types;
 using SquidStd.Core.Interfaces.Events;
 using SquidStd.Core.Interfaces.Threading;
+using SquidStd.Core.Utils;
 using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Server;
@@ -674,6 +677,148 @@ public class LoginFlowIntegrationTests
     }
 
     [Fact]
+    public async Task Command_BroadcastAuthorizedAndUnauthorized_BehaveAsDesigned()
+    {
+        var config = LoopbackConfig();
+        var persistence = new FakePersistenceService();
+        await persistence.Store<AccountEntity>().UpsertAsync(
+            new()
+            {
+                Id = (Serial)1,
+                Username = "gm",
+                PasswordHash = HashUtils.HashPassword("secret"),
+                IsActive = true,
+                AccountLevel = AccountLevelType.GrandMaster
+            }
+        );
+        await persistence.Store<AccountEntity>().UpsertAsync(
+            new()
+            {
+                Id = (Serial)2,
+                Username = "player",
+                PasswordHash = HashUtils.HashPassword("secret"),
+                IsActive = true,
+                AccountLevel = AccountLevelType.Player
+            }
+        );
+
+        var eventBus = new EventBusService();
+        var opl = new OplService(persistence, new ItemTemplateService());
+        var sessions = new SessionManager();
+
+        var world = new WorldService(
+            new ItemService(persistence, opl),
+            CharacterServiceFixture.Skills(),
+            new VirtualSerialService(),
+            eventBus,
+            TimeProvider.System,
+            opl,
+            sessions
+        );
+        var chat = new ChatService(world, eventBus);
+
+        var testCities = new StartingCityService();
+        testCities.Register(
+            new()
+            {
+                City = "TestTown",
+                Building = "Origin",
+                Description = 1075072,
+                X = 5,
+                Y = 5,
+                Z = 0,
+                Map = MapType.Trammel
+            }
+        );
+        var characters = CharacterServiceFixture.Create(persistence, eventBus, sessions, testCities);
+        var accounts = new AccountService(persistence, characters, sessions);
+        var commands = new CommandService([new BroadcastCommand(chat)], accounts);
+
+        using var gmEntered = new ManualResetEventSlim();
+        using var playerEntered = new ManualResetEventSlim();
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(
+            (e, _) =>
+            {
+                if (e.Mobile.Name == "GM")
+                {
+                    gmEntered.Set();
+                }
+                else if (e.Mobile.Name == "Player")
+                {
+                    playerEntered.Set();
+                }
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var network = await StartServerWithCommandsAsync(
+            config,
+            eventBus,
+            characters,
+            world,
+            chat,
+            commands,
+            accounts,
+            opl,
+            sessions
+        );
+
+        try
+        {
+            using var gmSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            EnterWorld(gmSocket, network.Port, "gm", "GM");
+            Assert.True(gmEntered.Wait(TimeSpan.FromSeconds(2)), "GM's PlayerEnteredWorldEvent was not published.");
+
+            using var playerSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            EnterWorld(playerSocket, network.Port, "player", "Player");
+            Assert.True(
+                playerEntered.Wait(TimeSpan.FromSeconds(2)),
+                "Player's PlayerEnteredWorldEvent was not published."
+            );
+
+            // The GM (GrandMaster) broadcasts — both sessions receive it.
+            gmSocket.Send(Speech(".broadcast Server restarting soon"));
+
+            var gmCompressed = new List<byte>();
+            var playerCompressed = new List<byte>();
+            var broadcastPattern = System.Text.Encoding.BigEndianUnicode.GetBytes("restarting soon");
+            Assert.True(
+                PollUntil(gmSocket, gmCompressed, broadcastPattern),
+                "GM never received their own broadcast."
+            );
+            Assert.True(
+                PollUntil(playerSocket, playerCompressed, broadcastPattern),
+                "Player never received the GM's broadcast."
+            );
+
+            // The Player (below GrandMaster) tries the same command — no broadcast reaches anyone,
+            // and the Player gets the generic "Unknown command." reply instead.
+            await Task.Delay(50); // clear the 25ms chat rate limit from the first send
+            playerSocket.Send(Speech(".broadcast should not work"));
+
+            var unknownPattern = System.Text.Encoding.BigEndianUnicode.GetBytes("Unknown command");
+            Assert.True(
+                PollUntil(playerSocket, playerCompressed, unknownPattern),
+                "Player never received the \"Unknown command.\" reply for an unauthorized broadcast."
+            );
+            Assert.False(
+                PollUntil(
+                    gmSocket,
+                    gmCompressed,
+                    System.Text.Encoding.BigEndianUnicode.GetBytes("should not work"),
+                    TimeSpan.FromMilliseconds(300)
+                ),
+                "GM must not receive a broadcast triggered by an unauthorized Player."
+            );
+        }
+        finally
+        {
+            await network.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
     public async Task SessionLifecycle_ConnectAndDisconnect_PublishesEvents()
     {
         var config = LoopbackConfig();
@@ -1177,6 +1322,51 @@ public class LoginFlowIntegrationTests
     {
         var accounts = new StubAccountService();
         var commands = new CommandService([], accounts);
+        var pending = new PendingLoginStore(30000, () => Environment.TickCount64);
+
+        var cities = new StartingCityService();
+        cities.Register(
+            new()
+            {
+                City = "TestTown",
+                Building = "Origin",
+                Description = 1075072,
+                X = 5,
+                Y = 5,
+                Z = 0,
+                Map = MapType.Trammel
+            }
+        );
+
+        var handlers = new List<IPacketHandlerRegistration>
+        {
+            new LoginSeedHandler(),
+            new AccountLoginHandler(accounts, config),
+            new SelectServerHandler(pending, config),
+            new GameServerLoginHandler(pending, cities, accounts, characters),
+            new CharacterCreationHandler(characters, world),
+            new MegaClilocHandler(opl),
+            new SpeechHandler(chat, commands)
+        };
+
+        var network = new NetworkService(sessions, config, [.. handlers], eventBus, new InlineDispatcher());
+        await network.StartAsync(CancellationToken.None);
+
+        return network;
+    }
+
+    private static async Task<NetworkService> StartServerWithCommandsAsync(
+        MoongateConfig config,
+        IEventBus eventBus,
+        ICharacterService characters,
+        WorldService world,
+        IChatService chat,
+        ICommandService commands,
+        IAccountService accounts,
+        OplService opl,
+        ISessionManager sessions
+    )
+    {
         var pending = new PendingLoginStore(30000, () => Environment.TickCount64);
 
         var cities = new StartingCityService();

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -16,6 +16,7 @@ using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Handlers;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Chat;
+using Moongate.Server.Services.Commands;
 using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Network;
@@ -620,13 +621,15 @@ public class LoginFlowIntegrationTests
 
             var aliceCompressed = new List<byte>();
 
-            // Matches on the reply text itself (big-endian unicode, via the same encoding SpeechHandler
-            // writes with) rather than hand-computing the packet's length-prefixed byte offsets — robust
-            // to the exact wording of SpeechHandler.CommandNotImplementedMessage changing later.
-            var systemPattern = System.Text.Encoding.BigEndianUnicode.GetBytes("not implemented");
+            // Matches on the reply text itself (big-endian unicode, via the same encoding
+            // CommandService writes with) rather than hand-computing the packet's length-prefixed
+            // byte offsets. ".kick" is not a registered command, so CommandService.Execute replies
+            // with its generic "Unknown command." message — the same reply an unauthorized caller
+            // of a real command would get, by design (see the command-system design doc).
+            var systemPattern = System.Text.Encoding.BigEndianUnicode.GetBytes("Unknown command");
             Assert.True(
                 PollUntil(aliceSocket, aliceCompressed, systemPattern),
-                "Alice never received the \"command not implemented\" system reply."
+                "Alice never received the \"Unknown command.\" reply."
             );
             Assert.False(
                 PollUntil(bobSocket, bobCompressed, new byte[] { 0, (byte)'k', 0, (byte)'i', 0, (byte)'c' }, TimeSpan.FromMilliseconds(300)),
@@ -1173,6 +1176,7 @@ public class LoginFlowIntegrationTests
     )
     {
         var accounts = new StubAccountService();
+        var commands = new CommandService([], accounts);
         var pending = new PendingLoginStore(30000, () => Environment.TickCount64);
 
         var cities = new StartingCityService();
@@ -1197,7 +1201,7 @@ public class LoginFlowIntegrationTests
             new GameServerLoginHandler(pending, cities, accounts, characters),
             new CharacterCreationHandler(characters, world),
             new MegaClilocHandler(opl),
-            new SpeechHandler(chat)
+            new SpeechHandler(chat, commands)
         };
 
         var network = new NetworkService(sessions, config, [.. handlers], eventBus, new InlineDispatcher());


### PR DESCRIPTION
## Summary
- Replaces the chat feature's hardcoded "." reply with a real command dispatcher: `ICommandService`/`CommandService` resolves `IEnumerable<ICommand>` from DI (same collection pattern `NetworkService` already uses for `IPacketHandlerRegistration`), indexes commands by name/alias via a `[Command]` attribute read once via reflection, and enforces a minimum `AccountLevelType` per command.
- Ships one real command: `.broadcast`/`.bc` (GrandMaster minimum), reusing `IChatService.Broadcast` from the chat feature — proves the dispatcher end-to-end without adding new domain logic.
- Unknown command names and insufficient permission produce the identical "Unknown command." reply, so an unauthorized caller can't distinguish "doesn't exist" from "you can't use this".
- `CommandSourceType` is a `[Flags]` enum with only `InGame` defined today, leaving room for a future console/REPL source without breaking existing `[Command]` declarations.

## Design & scope
Full design doc and rationale: `~/docs/plans/moongate/2026-07-19-command-system-design.md` (not committed, per repo convention). Verified against moongatev2, ModernUO, UOX3 and polserver's own command systems during brainstorming. Explicitly out of scope: target-based (click-to-target) commands (no targeting/cursor infrastructure exists), a console/REPL source (only the enum space), any command beyond `.broadcast` (kick, teleport, etc. are future cards), and a `.help`/list command.

## Test plan
- [x] Unit tests: `CommandService.Parse`/`IsAuthorized`/`BuildRegistry` (pure core), `BroadcastCommand`
- [x] End-to-end integration test: a GrandMaster's `.broadcast` reaches every in-world session; a Player's `.broadcast` is silently rejected with the generic "Unknown command." reply and reaches no one
- [x] Updated the chat feature's own integration test, whose unregistered `.kick` now gets the dispatcher's generic reply instead of the old hardcoded placeholder text
- [x] Full suite: 1229/1229 passing; `dotnet build`: 0 errors, no new warnings