### PR TITLE
feat(console): admin console plugin over ICommandService

### DIFF
--- a/Moongate.slnx
+++ b/Moongate.slnx
@@ -1,5 +1,6 @@
 <Solution>
     <Folder Name="/src/">
+        <Project Path="src/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj"/>
         <Project Path="src/Moongate.Core/Moongate.Core.csproj"/>
         <Project Path="src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj"/>
         <Project Path="src/Moongate.Network/Moongate.Network.csproj"/>

--- a/docs/under-the-hood/admin-console.md
+++ b/docs/under-the-hood/admin-console.md
@@ -1,0 +1,84 @@
+# Admin console
+
+Moongate can expose a small line-based **admin console** over TCP: connect,
+log in with a staff account, and run the server's commands. It is served by
+`Moongate.Console.Admin.Plugin`, one of the built-in plugins, and like the REST
+API it is genuinely optional — the game server owns the listener, so removing
+the plugin removes the whole console.
+
+It is **disabled by default** and it is **plaintext** (no SSH, no TLS): only
+turn it on where the network already protects it — loopback, a private LAN, or
+a Tailscale interface.
+
+## Turning it on
+
+Set the `console:` section of `moongate.yaml`:
+
+```yaml
+console:
+  Enabled: true          # opt-in; false (default) never binds
+  Address: 127.0.0.1     # keep off public interfaces — traffic is unencrypted
+  Port: 4050
+  MaxSessions: 4         # concurrent connections before new ones are refused
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `Enabled` | bool | `false` | When false the console never binds. |
+| `Address` | string | `127.0.0.1` | Bind address. Plaintext — keep it off public NICs. |
+| `Port` | int | `4050` | Listen port. |
+| `MaxSessions` | int | `4` | Maximum concurrent sessions; further connections are refused. |
+
+On start the server logs `Admin console listening on 127.0.0.1:4050`. A bind
+failure (port in use, bad address) is logged and swallowed — the console
+becomes unavailable but the game server keeps running.
+
+## Connecting
+
+Use a raw line client such as `nc` or `socat` (not the `ssh` command — this is
+not SSH):
+
+```text
+$ nc 127.0.0.1 4050
+Moongate admin console.
+login:
+gm
+password:
+secret
+Authenticated. Type 'help' or 'quit'.
+> broadcast Server restarting in 5 minutes
+Broadcast sent.
+> help
+  broadcast - Sends a server-wide system message.
+  help - list commands
+  quit - close the session
+> quit
+Bye.
+```
+
+Login checks the username and password against the account store and requires
+**GrandMaster or Administrator** level; anything less is refused. Wrong
+credentials give a uniform `Login failed.` (three attempts, then the connection
+closes). An unknown command — or one you are not allowed to run — gives the
+same `Unknown command.` for every case, so the console never reveals which
+commands exist.
+
+Commands run on the game loop, exactly as an in-game `.` command does, so they
+see consistent world state.
+
+## Exposing a command to the console
+
+The console runs the *same* commands as the in-game `.` dispatcher — a command
+is reachable from the console only if its registration lists the `Console`
+source. Add it to the `Sources` flags when registering:
+
+```csharp
+container.RegisterCommand<BroadcastCommand>(
+    "broadcast|bc",
+    AccountLevelType.GrandMaster,
+    "Sends a server-wide system message.",
+    CommandSourceType.InGame | CommandSourceType.Console);
+```
+
+A command that needs an in-world actor should stay `InGame`-only: console
+invocations carry no `MobileEntity` (`CommandContext.Actor` is null).

--- a/docs/under-the-hood/toc.yml
+++ b/docs/under-the-hood/toc.yml
@@ -2,3 +2,5 @@
   href: architecture.md
 - name: REST API
   href: rest-api.md
+- name: Admin console
+  href: admin-console.md

--- a/src/Moongate.Console.Admin.Plugin/Data/Config/MoongateConsoleConfig.cs
+++ b/src/Moongate.Console.Admin.Plugin/Data/Config/MoongateConsoleConfig.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Console.Admin.Plugin.Data.Config;
+
+/// <summary>Config for the admin console (section <c>console</c> in moongate.yaml). Opt-in.</summary>
+public sealed class MoongateConsoleConfig
+{
+    /// <summary>When false the console never binds. Default false.</summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>Bind address. Default loopback — the console is plaintext, keep it off public NICs.</summary>
+    public string Address { get; set; } = "127.0.0.1";
+
+    /// <summary>Listen port. Default 4050. Use 0 to let the OS choose (tests).</summary>
+    public int Port { get; set; } = 4050;
+
+    /// <summary>Maximum concurrent sessions. Default 4.</summary>
+    public int MaxSessions { get; set; } = 4;
+}

--- a/src/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
+++ b/src/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Moongate.Core\Moongate.Core.csproj"/>
+        <!-- Contract assembly the server implements: ICommandService, IAccountService, the command DTOs.
+             The plugin never references Moongate.Server. -->
+        <ProjectReference Include="..\Moongate.Server.Abstractions\Moongate.Server.Abstractions.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/src/Moongate.Console.Admin.Plugin/MoongateConsolePlugin.cs
+++ b/src/Moongate.Console.Admin.Plugin/MoongateConsolePlugin.cs
@@ -1,0 +1,30 @@
+using DryIoc;
+using Moongate.Console.Admin.Plugin.Data.Config;
+using Moongate.Console.Admin.Plugin.Services.Hosting;
+using SquidStd.Abstractions.Extensions.Config;
+using SquidStd.Abstractions.Extensions.Services;
+using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Console.Admin.Plugin;
+
+/// <summary>Registers the line-based admin console: its config section and the server that runs it.</summary>
+public class MoongateConsolePlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.console.admin.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateConsolePlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate Console Admin",
+            Description = "Line-based TCP admin console over ICommandService"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        container.RegisterConfigSection<MoongateConsoleConfig>("console");
+        container.RegisterStdService<ConsoleServerService, ConsoleServerService>();
+    }
+}

--- a/src/Moongate.Console.Admin.Plugin/Services/Console/ConsoleAuth.cs
+++ b/src/Moongate.Console.Admin.Plugin/Services/Console/ConsoleAuth.cs
@@ -1,0 +1,19 @@
+using Moongate.Console.Admin.Plugin.Types;
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Data;
+
+namespace Moongate.Console.Admin.Plugin.Services.Console;
+
+/// <summary>Turns an authentication result plus the account's level into a login outcome. Pure — no I/O.</summary>
+public static class ConsoleAuth
+{
+    public static ConsoleAuthResultType Evaluate(AccountAuthResult auth, AccountLevelType? level, AccountLevelType minLevel)
+    {
+        if (!auth.Success || level is null)
+        {
+            return ConsoleAuthResultType.LoginFailed;
+        }
+
+        return level >= minLevel ? ConsoleAuthResultType.Allowed : ConsoleAuthResultType.InsufficientPrivileges;
+    }
+}

--- a/src/Moongate.Console.Admin.Plugin/Services/Console/ConsoleInput.cs
+++ b/src/Moongate.Console.Admin.Plugin/Services/Console/ConsoleInput.cs
@@ -1,0 +1,30 @@
+using Moongate.Console.Admin.Plugin.Types;
+
+namespace Moongate.Console.Admin.Plugin.Services.Console;
+
+/// <summary>Classifies a console input line. Pure — no I/O.</summary>
+public static class ConsoleInput
+{
+    public static ConsoleInputKind Classify(string line)
+    {
+        var trimmed = line.Trim();
+
+        if (trimmed.Length == 0)
+        {
+            return ConsoleInputKind.Empty;
+        }
+
+        if (trimmed.Equals("help", StringComparison.OrdinalIgnoreCase))
+        {
+            return ConsoleInputKind.Help;
+        }
+
+        if (trimmed.Equals("quit", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("exit", StringComparison.OrdinalIgnoreCase))
+        {
+            return ConsoleInputKind.Quit;
+        }
+
+        return ConsoleInputKind.Command;
+    }
+}

--- a/src/Moongate.Console.Admin.Plugin/Services/Console/ConsoleSession.cs
+++ b/src/Moongate.Console.Admin.Plugin/Services/Console/ConsoleSession.cs
@@ -1,0 +1,235 @@
+using System.Net.Sockets;
+using System.Text;
+using Moongate.Console.Admin.Plugin.Types;
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Types;
+using SquidStd.Core.Interfaces.Threading;
+
+namespace Moongate.Console.Admin.Plugin.Services.Console;
+
+/// <summary>
+/// One admin-console connection: a banner, a login handshake against <see cref="IAccountService" />,
+/// then a read-line REPL that dispatches commands to <see cref="ICommandService" /> on the game loop.
+/// </summary>
+public sealed class ConsoleSession
+{
+    private const int MaxLoginAttempts = 3;
+    private const int MaxLineLength = 1024;
+    private static readonly AccountLevelType MinLevel = AccountLevelType.GrandMaster;
+
+    private readonly TcpClient _client;
+    private readonly ICommandService _commands;
+    private readonly IAccountService _accounts;
+    private readonly IMainThreadDispatcher _dispatcher;
+    private readonly object _writeLock = new();
+
+    private StreamWriter? _writer;
+    private volatile bool _closed;
+
+    public ConsoleSession(
+        TcpClient client,
+        ICommandService commands,
+        IAccountService accounts,
+        IMainThreadDispatcher dispatcher
+    )
+    {
+        _client = client;
+        _commands = commands;
+        _accounts = accounts;
+        _dispatcher = dispatcher;
+    }
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            var stream = _client.GetStream();
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+            _writer = writer;
+
+            WriteLine("Moongate admin console.");
+
+            var level = await AuthenticateAsync(reader, ct);
+
+            if (level is null)
+            {
+                return;
+            }
+
+            WriteLine("Authenticated. Type 'help' or 'quit'.");
+            await ReplLoopAsync(reader, level.Value, ct);
+        }
+        catch (Exception ex) when (ex is IOException or OperationCanceledException or ObjectDisposedException)
+        {
+            // client dropped or the server is shutting down — nothing to report
+        }
+        finally
+        {
+            Close();
+        }
+    }
+
+    private async Task<AccountLevelType?> AuthenticateAsync(StreamReader reader, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < MaxLoginAttempts; attempt++)
+        {
+            WriteLine("login:");
+            var username = await ReadLineAsync(reader, ct);
+            WriteLine("password:");
+            var password = await ReadLineAsync(reader, ct);
+
+            if (username is null || password is null)
+            {
+                return null;
+            }
+
+            var auth = _accounts.Authenticate(username, password);
+            var level = _accounts.GetByUsername(username)?.AccountLevel;
+
+            switch (ConsoleAuth.Evaluate(auth, level, MinLevel))
+            {
+                case ConsoleAuthResultType.Allowed:
+                    return level;
+
+                case ConsoleAuthResultType.InsufficientPrivileges:
+                    WriteLine("Insufficient privileges.");
+
+                    return null;
+
+                default:
+                    WriteLine("Login failed.");
+
+                    break;
+            }
+        }
+
+        WriteLine("Too many attempts.");
+
+        return null;
+    }
+
+    private async Task ReplLoopAsync(StreamReader reader, AccountLevelType level, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && !_closed)
+        {
+            Write("> ");
+            var line = await ReadLineAsync(reader, ct);
+
+            if (line is null)
+            {
+                return;
+            }
+
+            switch (ConsoleInput.Classify(line))
+            {
+                case ConsoleInputKind.Empty:
+                    continue;
+
+                case ConsoleInputKind.Quit:
+                    WriteLine("Bye.");
+
+                    return;
+
+                case ConsoleInputKind.Help:
+                    WriteHelp(level);
+
+                    continue;
+
+                default:
+                    var invocation = new CommandInvocation(CommandSourceType.Console, level, null, line, WriteLine);
+                    _dispatcher.Post(() => _commands.Execute(invocation));
+
+                    continue;
+            }
+        }
+    }
+
+    private void WriteHelp(AccountLevelType level)
+    {
+        foreach (var command in _commands.ListCommands(CommandSourceType.Console))
+        {
+            if (level >= command.MinLevel)
+            {
+                WriteLine($"  {command.Name} - {command.Description}");
+            }
+        }
+
+        WriteLine("  help - list commands");
+        WriteLine("  quit - close the session");
+    }
+
+    private async Task<string?> ReadLineAsync(StreamReader reader, CancellationToken ct)
+    {
+        var raw = await reader.ReadLineAsync(ct);
+
+        if (raw is null)
+        {
+            return null;
+        }
+
+        if (raw.Length > MaxLineLength)
+        {
+            raw = raw[..MaxLineLength];
+        }
+
+        return TelnetInput.StripControls(raw);
+    }
+
+    private void Write(string text)
+        => WriteRaw(text, newline: false);
+
+    private void WriteLine(string text)
+        => WriteRaw(text, newline: true);
+
+    private void WriteRaw(string text, bool newline)
+    {
+        if (_closed)
+        {
+            return;
+        }
+
+        lock (_writeLock)
+        {
+            if (_closed || _writer is null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (newline)
+                {
+                    _writer.WriteLine(text);
+                }
+                else
+                {
+                    _writer.Write(text);
+                }
+
+                _writer.Flush();
+            }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+            {
+                _closed = true;
+            }
+        }
+    }
+
+    public void Close()
+    {
+        _closed = true;
+
+        try
+        {
+            _client.Close();
+        }
+        catch (Exception)
+        {
+            // socket already gone
+        }
+    }
+}

--- a/src/Moongate.Console.Admin.Plugin/Services/Console/TelnetInput.cs
+++ b/src/Moongate.Console.Admin.Plugin/Services/Console/TelnetInput.cs
@@ -1,0 +1,13 @@
+namespace Moongate.Console.Admin.Plugin.Services.Console;
+
+/// <summary>
+/// Cleans a decoded input line of control and replacement characters, then trims it. Telnet clients
+/// send IAC negotiation bytes on connect; under UTF-8 those decode to the replacement char, so this
+/// keeps them out of the first login line. Pure — no I/O. (Not a full telnet parser; <c>nc</c>/<c>socat</c>
+/// are the recommended clients.)
+/// </summary>
+public static class TelnetInput
+{
+    public static string StripControls(string line)
+        => new string(line.Where(c => !char.IsControl(c) && c != '�').ToArray()).Trim();
+}

--- a/src/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
+++ b/src/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
@@ -1,6 +1,9 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using Moongate.Console.Admin.Plugin.Data.Config;
+using Moongate.Console.Admin.Plugin.Services.Console;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Commands;
 using Serilog;
@@ -21,6 +24,7 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
     private readonly ICommandService _commands;
     private readonly IAccountService _accounts;
     private readonly IMainThreadDispatcher _dispatcher;
+    private readonly ConcurrentDictionary<ConsoleSession, byte> _sessions = new();
 
     private TcpListener? _listener;
     private CancellationTokenSource? _cts;
@@ -81,12 +85,52 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
             {
                 var client = await _listener!.AcceptTcpClientAsync(ct);
 
-                // Task 5 replaces this with a ConsoleSession; the lifecycle just refuses connections for now.
-                client.Close();
+                if (_sessions.Count >= _config.MaxSessions)
+                {
+                    await RejectAsync(client);
+
+                    continue;
+                }
+
+                var session = new ConsoleSession(client, _commands, _accounts, _dispatcher);
+                _sessions.TryAdd(session, 0);
+
+                _ = Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            await session.RunAsync(ct);
+                        }
+                        finally
+                        {
+                            _sessions.TryRemove(session, out _);
+                        }
+                    },
+                    ct
+                );
             }
         }
         catch (OperationCanceledException) { }
         catch (ObjectDisposedException) { }
+    }
+
+    private static async Task RejectAsync(TcpClient client)
+    {
+        try
+        {
+            var stream = client.GetStream();
+            var bytes = Encoding.UTF8.GetBytes("Console busy; too many sessions.\r\n");
+            await stream.WriteAsync(bytes);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        {
+            // client gone before the notice landed
+        }
+        finally
+        {
+            client.Close();
+        }
     }
 
     public async ValueTask StopAsync(CancellationToken cancellationToken = default)
@@ -98,6 +142,11 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
 
         _cts?.Cancel();
         _listener.Stop();
+
+        foreach (var session in _sessions.Keys)
+        {
+            session.Close();
+        }
 
         if (_acceptLoop is not null)
         {

--- a/src/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
+++ b/src/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Net.Sockets;
+using Moongate.Console.Admin.Plugin.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Core.Interfaces.Threading;
+
+namespace Moongate.Console.Admin.Plugin.Services.Hosting;
+
+/// <summary>
+/// Runs the line-based admin console. Owns a <see cref="TcpListener" /> and its lifetime, exactly as
+/// the HTTP plugin owns Kestrel: drop the plugin and the game server boots with no console at all. A
+/// bind failure is logged and swallowed — the console is optional and must never take the game down.
+/// </summary>
+public sealed class ConsoleServerService : ISquidStdService, IDisposable
+{
+    private readonly ILogger _logger = Log.ForContext<ConsoleServerService>();
+    private readonly MoongateConsoleConfig _config;
+    private readonly ICommandService _commands;
+    private readonly IAccountService _accounts;
+    private readonly IMainThreadDispatcher _dispatcher;
+
+    private TcpListener? _listener;
+    private CancellationTokenSource? _cts;
+    private Task? _acceptLoop;
+
+    public ConsoleServerService(
+        MoongateConsoleConfig config,
+        ICommandService commands,
+        IAccountService accounts,
+        IMainThreadDispatcher dispatcher
+    )
+    {
+        _config = config;
+        _commands = commands;
+        _accounts = accounts;
+        _dispatcher = dispatcher;
+    }
+
+    /// <summary>The port actually bound — the OS-assigned one when the configured port is 0. Zero when disabled.</summary>
+    public int BoundPort { get; private set; }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_config.Enabled)
+        {
+            _logger.Information("Admin console disabled (console.Enabled = false)");
+
+            return ValueTask.CompletedTask;
+        }
+
+        try
+        {
+            _listener = new TcpListener(IPAddress.Parse(_config.Address), _config.Port);
+            _listener.Start();
+        }
+        catch (Exception ex) when (ex is SocketException or FormatException)
+        {
+            _logger.Error(ex, "Admin console failed to bind {Address}:{Port}; console unavailable", _config.Address, _config.Port);
+            _listener = null;
+
+            return ValueTask.CompletedTask;
+        }
+
+        BoundPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _cts = new();
+        _acceptLoop = AcceptLoopAsync(_cts.Token);
+
+        _logger.Information("Admin console listening on {Address}:{Port}", _config.Address, BoundPort);
+
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var client = await _listener!.AcceptTcpClientAsync(ct);
+
+                // Task 5 replaces this with a ConsoleSession; the lifecycle just refuses connections for now.
+                client.Close();
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    public async ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_listener is null)
+        {
+            return;
+        }
+
+        _cts?.Cancel();
+        _listener.Stop();
+
+        if (_acceptLoop is not null)
+        {
+            try
+            {
+                await _acceptLoop;
+            }
+            catch (Exception)
+            {
+                // accept loop unwinding on cancellation — nothing to report
+            }
+        }
+
+        _listener = null;
+    }
+
+    public void Dispose()
+    {
+        _cts?.Dispose();
+        _listener?.Dispose();
+    }
+}

--- a/src/Moongate.Console.Admin.Plugin/Types/ConsoleAuthResultType.cs
+++ b/src/Moongate.Console.Admin.Plugin/Types/ConsoleAuthResultType.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Console.Admin.Plugin.Types;
+
+/// <summary>Outcome of a console login attempt.</summary>
+public enum ConsoleAuthResultType
+{
+    Allowed,
+    LoginFailed,
+    InsufficientPrivileges
+}

--- a/src/Moongate.Console.Admin.Plugin/Types/ConsoleInputKind.cs
+++ b/src/Moongate.Console.Admin.Plugin/Types/ConsoleInputKind.cs
@@ -1,0 +1,10 @@
+namespace Moongate.Console.Admin.Plugin.Types;
+
+/// <summary>What a console input line is: a built-in or a command to dispatch.</summary>
+public enum ConsoleInputKind
+{
+    Empty,
+    Help,
+    Quit,
+    Command
+}

--- a/src/Moongate.Server.Abstractions/Data/Commands/CommandContext.cs
+++ b/src/Moongate.Server.Abstractions/Data/Commands/CommandContext.cs
@@ -5,12 +5,13 @@ namespace Moongate.Server.Abstractions.Data.Commands;
 
 /// <summary>
 /// One command invocation. <see cref="Reply" /> is a plain delegate rather than a packet-sending
-/// call so a future non-in-game <see cref="CommandSourceType" /> (e.g. a console) can supply a
+/// call so a non-in-game <see cref="CommandSourceType" /> (e.g. the admin console) can supply a
 /// different sink without <see cref="Interfaces.Commands.ICommand" /> implementations changing.
+/// <see cref="Actor" /> is null for actor-less sources such as the admin console.
 /// </summary>
 public readonly record struct CommandContext(
     CommandSourceType Source,
-    MobileEntity Actor,
+    MobileEntity? Actor,
     IReadOnlyList<string> Arguments,
     Action<string> Reply
 );

--- a/src/Moongate.Server.Abstractions/Data/Commands/CommandDescriptor.cs
+++ b/src/Moongate.Server.Abstractions/Data/Commands/CommandDescriptor.cs
@@ -1,0 +1,10 @@
+using Moongate.Core.Types;
+
+namespace Moongate.Server.Abstractions.Data.Commands;
+
+/// <summary>A command's public metadata for listings (e.g. the console's <c>help</c>).</summary>
+public readonly record struct CommandDescriptor(
+    string Name,
+    AccountLevelType MinLevel,
+    string Description
+);

--- a/src/Moongate.Server.Abstractions/Data/Commands/CommandInvocation.cs
+++ b/src/Moongate.Server.Abstractions/Data/Commands/CommandInvocation.cs
@@ -1,0 +1,20 @@
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Data.Commands;
+
+/// <summary>
+/// A source-neutral command request. Carries who is asking (<see cref="ActorLevel" />, optional
+/// <see cref="Actor" />), where from (<see cref="Source" />), the raw prefix-free
+/// <see cref="CommandLine" />, and where output goes (<see cref="Reply" />). The in-game path and the
+/// admin console both build one of these and hand it to
+/// <see cref="Interfaces.Commands.ICommandService" />.
+/// </summary>
+public readonly record struct CommandInvocation(
+    CommandSourceType Source,
+    AccountLevelType ActorLevel,
+    MobileEntity? Actor,
+    string CommandLine,
+    Action<string> Reply
+);

--- a/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommandService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Commands/ICommandService.cs
@@ -1,16 +1,27 @@
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Commands;
 using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Types;
 
 namespace Moongate.Server.Abstractions.Interfaces.Commands;
 
-/// <summary>Dispatches a "." command typed by an actor in a session.</summary>
+/// <summary>Parses and dispatches a command from any source.</summary>
 public interface ICommandService
 {
     /// <summary>
-    /// Unknown command names and commands the actor's
-    /// <see cref="Moongate.Core.Types.AccountLevelType" /> does not meet produce the identical
-    /// "Unknown command." reply — an unauthorized caller cannot distinguish "doesn't exist" from
-    /// "you can't use this".
+    /// In-game adapter: resolves the actor's level from the session's account, strips the leading
+    /// "." prefix, and dispatches via <see cref="Execute(CommandInvocation)" /> as
+    /// <see cref="CommandSourceType.InGame" />.
     /// </summary>
     void Execute(PlayerSession session, MobileEntity actor, string rawText);
+
+    /// <summary>
+    /// Source-neutral core. Unknown names, a command whose <c>Sources</c> excludes
+    /// <see cref="CommandInvocation.Source" />, and an actor level below the command's minimum all
+    /// produce the identical "Unknown command." reply — a caller cannot tell them apart.
+    /// </summary>
+    void Execute(CommandInvocation invocation);
+
+    /// <summary>Commands whose <c>Sources</c> include <paramref name="source" />, for help listings.</summary>
+    IReadOnlyList<CommandDescriptor> ListCommands(CommandSourceType source);
 }

--- a/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
+++ b/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
@@ -1,12 +1,12 @@
 namespace Moongate.Server.Abstractions.Types;
 
 /// <summary>
-/// Where a command invocation originated. Only <see cref="InGame" /> is implemented today — the
-/// <c>[Flags]</c> shape leaves room for a future console/REPL source without breaking existing
-/// command registrations or <see cref="Attributes.CommandAttribute" /> declarations.
+/// Where a command invocation originated. The <c>[Flags]</c> shape lets a command opt into more than
+/// one source; the dispatcher runs a command only for sources its registration lists.
 /// </summary>
 [Flags]
 public enum CommandSourceType : byte
 {
-    InGame = 1 << 0
+    InGame  = 1 << 0,
+    Console = 1 << 1
 }

--- a/src/Moongate.Server/Commands/BroadcastCommand.cs
+++ b/src/Moongate.Server/Commands/BroadcastCommand.cs
@@ -3,6 +3,7 @@ using Moongate.Server.Abstractions.Attributes;
 using Moongate.Server.Abstractions.Data.Commands;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Types;
 
 namespace Moongate.Server.Commands;
 
@@ -13,7 +14,8 @@ namespace Moongate.Server.Commands;
 /// tooling (docs/source generation); the runtime dispatcher indexes it from the explicit
 /// <c>RegisterCommand</c> call in <c>MoongateCommandsPlugin</c>, not by scanning the attribute.
 /// </summary>
-[Command("broadcast|bc", AccountLevelType.GrandMaster, "Sends a server-wide system message.")]
+[Command("broadcast|bc", AccountLevelType.GrandMaster, "Sends a server-wide system message.",
+    Sources = CommandSourceType.InGame | CommandSourceType.Console)]
 public sealed class BroadcastCommand : ICommand
 {
     private readonly IChatService _chat;

--- a/src/Moongate.Server/Handlers/SpeechHandler.cs
+++ b/src/Moongate.Server/Handlers/SpeechHandler.cs
@@ -11,7 +11,8 @@ namespace Moongate.Server.Handlers;
 /// <summary>
 /// Handles player speech (0xAD): rate-limits, classifies the raw text (say/emote/whisper/yell/
 /// command) via <see cref="ChatService" />'s pure core, and either dispatches the "." prefix to
-/// <see cref="ICommandService.Execute" /> or hands the classified message to
+/// <see cref="ICommandService.Execute(Moongate.Server.Abstractions.Data.Session.PlayerSession, Moongate.Persistence.Entities.MobileEntity, string)" />
+/// or hands the classified message to
 /// <see cref="IChatService.Say" />. Packets with the classic-client "encoded" (keyword-menu) flag
 /// are dropped, as is any text that is empty or longer than 128 characters after trimming.
 /// </summary>

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Moongate.Console.Admin.Plugin\Moongate.Console.Admin.Plugin.csproj"/>
         <ProjectReference Include="..\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
         <ProjectReference Include="..\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\Moongate.Persistence\Moongate.Persistence.csproj"/>

--- a/src/Moongate.Server/MoongateCommandsPlugin.cs
+++ b/src/Moongate.Server/MoongateCommandsPlugin.cs
@@ -1,6 +1,7 @@
 using DryIoc;
 using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Extensions;
+using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Commands;
 using SquidStd.Core.Utils;
 using SquidStd.Plugin.Abstractions.Data;
@@ -25,6 +26,7 @@ public class MoongateCommandsPlugin : ISquidStdPlugin
         => container.RegisterCommand<BroadcastCommand>(
             "broadcast|bc",
             AccountLevelType.GrandMaster,
-            "Sends a server-wide system message."
+            "Sends a server-wide system message.",
+            CommandSourceType.InGame | CommandSourceType.Console
         );
 }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -1,5 +1,6 @@
 using ConsoleAppFramework;
 using DryIoc;
+using Moongate.Console.Admin.Plugin;
 using Moongate.Core.Interfaces;
 using Moongate.Http.Plugin;
 using Moongate.Persistence;
@@ -121,6 +122,8 @@ await ConsoleApp.RunAsync(
                 {
                     Log.Logger.Warning("HTTP is disabled");
                 }
+
+                builder.Add<MoongateConsolePlugin>();
             }
         );
 

--- a/src/Moongate.Server/Services/Commands/CommandService.cs
+++ b/src/Moongate.Server/Services/Commands/CommandService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using DryIoc;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
@@ -16,8 +17,8 @@ namespace Moongate.Server.Services.Commands;
 /// Default <see cref="ICommandService" />. <see cref="Parse" />/<see cref="IsAuthorized" />/
 /// <see cref="BuildRegistry" /> are the pure decision core — public and static so they are
 /// unit-testable without a live session, mirroring <c>ChatService.Classify</c>/
-/// <c>MovementService.Evaluate</c>. <see cref="Execute" /> is the impure orchestrator: resolves the
-/// actor's level, checks authorization, resolves and dispatches the command, replies.
+/// <c>MovementService.Evaluate</c>. <c>Execute(CommandInvocation)</c> is the impure core — it gates
+/// by source and level, then resolves and dispatches; the session overload is the in-game adapter.
 /// </summary>
 public sealed class CommandService : ICommandService
 {
@@ -58,30 +59,35 @@ public sealed class CommandService : ICommandService
 
     public void Execute(PlayerSession session, MobileEntity actor, string rawText)
     {
-        var (name, arguments) = Parse(rawText);
-
-        if (name.Length == 0 || !_registry.TryGetValue(name, out var registration))
-        {
-            session.Send(ChatMessageFactory.CreateSystem(UnknownCommandMessage));
-
-            return;
-        }
-
+        var commandLine = rawText.StartsWith('.') ? rawText[1..] : rawText;
         var actorLevel = _accounts.GetById(session.AccountId)?.AccountLevel ?? AccountLevelType.Player;
 
-        if (!IsAuthorized(actorLevel, registration.MinLevel))
+        Execute(
+            new CommandInvocation(
+                CommandSourceType.InGame,
+                actorLevel,
+                actor,
+                commandLine,
+                message => session.Send(ChatMessageFactory.CreateSystem(message))
+            )
+        );
+    }
+
+    public void Execute(CommandInvocation invocation)
+    {
+        var (name, arguments) = Parse(invocation.CommandLine);
+
+        if (name.Length == 0
+            || !_registry.TryGetValue(name, out var registration)
+            || !registration.Sources.HasFlag(invocation.Source)
+            || !IsAuthorized(invocation.ActorLevel, registration.MinLevel))
         {
-            session.Send(ChatMessageFactory.CreateSystem(UnknownCommandMessage));
+            invocation.Reply(UnknownCommandMessage);
 
             return;
         }
 
-        var context = new CommandContext(
-            CommandSourceType.InGame,
-            actor,
-            arguments,
-            message => session.Send(ChatMessageFactory.CreateSystem(message))
-        );
+        var context = new CommandContext(invocation.Source, invocation.Actor, arguments, invocation.Reply);
 
         try
         {
@@ -90,17 +96,29 @@ public sealed class CommandService : ICommandService
         catch (Exception ex)
         {
             _logger.Error(ex, "Command '{Name}' failed", name);
-            session.Send(ChatMessageFactory.CreateSystem(CommandFailedMessage));
+            invocation.Reply(CommandFailedMessage);
         }
     }
+
+    public IReadOnlyList<CommandDescriptor> ListCommands(CommandSourceType source)
+        => _registry.Values
+                    .Where(registration => registration.Sources.HasFlag(source))
+                    .Distinct()
+                    .Select(
+                        registration => new CommandDescriptor(
+                            registration.Name.Split('|')[0],
+                            registration.MinLevel,
+                            registration.Description
+                        )
+                    )
+                    .ToList();
 
     public static bool IsAuthorized(AccountLevelType actorLevel, AccountLevelType minLevel)
         => actorLevel >= minLevel;
 
-    public static (string Name, string[] Arguments) Parse(string rawText)
+    public static (string Name, string[] Arguments) Parse(string commandLine)
     {
-        var withoutPrefix = rawText[1..]; // strip the leading "."
-        var tokens = withoutPrefix.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var tokens = commandLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
         return tokens.Length == 0 ? (string.Empty, []) : (tokens[0], tokens[1..]);
     }

--- a/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
@@ -1,0 +1,202 @@
+using System.Net.Sockets;
+using System.Text;
+using DryIoc;
+using Moongate.Console.Admin.Plugin.Data.Config;
+using Moongate.Console.Admin.Plugin.Services.Hosting;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Commands;
+using Moongate.Server.Services.Commands;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Console;
+
+public class ConsoleAdminIntegrationTests
+{
+    private sealed class RecordingChatService : IChatService
+    {
+        public List<string> Broadcasts { get; } = [];
+
+        public void Broadcast(string text, Hue? hue = null)
+            => Broadcasts.Add(text);
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+    }
+
+    private static (ConsoleServerService Service, RecordingChatService Chat) Build(SeededAccountService accounts)
+    {
+        var chat = new RecordingChatService();
+        var registration = new CommandRegistration(
+            "broadcast|bc",
+            AccountLevelType.GrandMaster,
+            "Sends a server-wide system message.",
+            CommandSourceType.InGame | CommandSourceType.Console,
+            _ => new BroadcastCommand(chat));
+        var commands = new CommandService([registration], new Container(), accounts);
+        var config = new MoongateConsoleConfig { Enabled = true, Address = "127.0.0.1", Port = 0, MaxSessions = 4 };
+        var service = new ConsoleServerService(config, commands, accounts, new InlineMainThreadDispatcher());
+
+        return (service, chat);
+    }
+
+    private static async Task<(StreamReader Reader, StreamWriter Writer, TcpClient Client)> ConnectAsync(int port)
+    {
+        var client = new TcpClient();
+        await client.ConnectAsync("127.0.0.1", port);
+        var stream = client.GetStream();
+        var reader = new StreamReader(stream, Encoding.UTF8);
+        var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+
+        return (reader, writer, client);
+    }
+
+    /// <summary>Reads lines until one contains <paramref name="needle" />, or throws on timeout/EOF.</summary>
+    private static async Task<string> ReadUntilAsync(StreamReader reader, string needle)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        while (true)
+        {
+            var line = await reader.ReadLineAsync(cts.Token);
+            Assert.NotNull(line); // EOF before the expected output
+
+            if (line!.Contains(needle, StringComparison.OrdinalIgnoreCase))
+            {
+                return line;
+            }
+        }
+    }
+
+    private static async Task LoginAsync(StreamReader reader, StreamWriter writer, string user, string password)
+    {
+        await ReadUntilAsync(reader, "login:");
+        await writer.WriteLineAsync(user);
+        await ReadUntilAsync(reader, "password:");
+        await writer.WriteLineAsync(password);
+    }
+
+    [Fact]
+    public async Task GmLogsInAndBroadcasts()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, chat) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "secret");
+                await writer.WriteLineAsync("broadcast hello world");
+
+                await ReadUntilAsync(reader, "Broadcast sent.");
+                Assert.Equal("hello world", Assert.Single(chat.Broadcasts));
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task PlayerLevelIsRejected()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("player", "secret", AccountLevelType.Player);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+            using (client)
+            {
+                await LoginAsync(reader, writer, "player", "secret");
+                await ReadUntilAsync(reader, "Insufficient privileges.");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task WrongPasswordIsRejected()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "wrong");
+                await ReadUntilAsync(reader, "Login failed.");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UnknownCommandRepliesUnknown()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "secret");
+                await writer.WriteLineAsync("frobnicate");
+                await ReadUntilAsync(reader, "Unknown command.");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task HelpListsBroadcast()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "secret");
+                await writer.WriteLineAsync("help");
+                await ReadUntilAsync(reader, "broadcast");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+}

--- a/tests/Moongate.Tests/Console/ConsoleAuthTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAuthTests.cs
@@ -1,0 +1,37 @@
+using Moongate.Console.Admin.Plugin.Services.Console;
+using Moongate.Console.Admin.Plugin.Types;
+using Moongate.Core.Types;
+using Moongate.Network.Types;
+using Moongate.Server.Abstractions.Data;
+
+namespace Moongate.Tests.Console;
+
+public class ConsoleAuthTests
+{
+    private static AccountAuthResult Ok() => AccountAuthResult.Ok("gm");
+    private static AccountAuthResult Denied() => AccountAuthResult.Denied(LoginDeniedReasonType.IncorrectCredentials);
+
+    [Fact]
+    public void Evaluate_SuccessAtOrAboveMinLevel_IsAllowed()
+        => Assert.Equal(
+            ConsoleAuthResultType.Allowed,
+            ConsoleAuth.Evaluate(Ok(), AccountLevelType.GrandMaster, AccountLevelType.GrandMaster));
+
+    [Fact]
+    public void Evaluate_SuccessBelowMinLevel_IsInsufficientPrivileges()
+        => Assert.Equal(
+            ConsoleAuthResultType.InsufficientPrivileges,
+            ConsoleAuth.Evaluate(Ok(), AccountLevelType.Player, AccountLevelType.GrandMaster));
+
+    [Fact]
+    public void Evaluate_AuthFailure_IsLoginFailed()
+        => Assert.Equal(
+            ConsoleAuthResultType.LoginFailed,
+            ConsoleAuth.Evaluate(Denied(), null, AccountLevelType.GrandMaster));
+
+    [Fact]
+    public void Evaluate_SuccessButUnknownAccount_IsLoginFailed()
+        => Assert.Equal(
+            ConsoleAuthResultType.LoginFailed,
+            ConsoleAuth.Evaluate(Ok(), null, AccountLevelType.GrandMaster));
+}

--- a/tests/Moongate.Tests/Console/ConsoleInputTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleInputTests.cs
@@ -1,0 +1,18 @@
+using Moongate.Console.Admin.Plugin.Services.Console;
+using Moongate.Console.Admin.Plugin.Types;
+
+namespace Moongate.Tests.Console;
+
+public class ConsoleInputTests
+{
+    [Theory]
+    [InlineData("", ConsoleInputKind.Empty)]
+    [InlineData("   ", ConsoleInputKind.Empty)]
+    [InlineData("help", ConsoleInputKind.Help)]
+    [InlineData("HELP", ConsoleInputKind.Help)]
+    [InlineData("quit", ConsoleInputKind.Quit)]
+    [InlineData("exit", ConsoleInputKind.Quit)]
+    [InlineData("broadcast hi", ConsoleInputKind.Command)]
+    public void Classify_MapsLinesToKinds(string line, ConsoleInputKind expected)
+        => Assert.Equal(expected, ConsoleInput.Classify(line));
+}

--- a/tests/Moongate.Tests/Console/ConsoleServerServiceLifecycleTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleServerServiceLifecycleTests.cs
@@ -1,0 +1,47 @@
+using System.Net.Sockets;
+using DryIoc;
+using Moongate.Console.Admin.Plugin.Data.Config;
+using Moongate.Console.Admin.Plugin.Services.Hosting;
+using Moongate.Server.Services.Commands;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Console;
+
+public class ConsoleServerServiceLifecycleTests
+{
+    private static ConsoleServerService Service(MoongateConsoleConfig config)
+    {
+        var commands = new CommandService([], new Container(), new StubAccountService());
+
+        return new ConsoleServerService(config, commands, new StubAccountService(), new InlineMainThreadDispatcher());
+    }
+
+    [Fact]
+    public async Task StartAsync_Disabled_DoesNotBind()
+    {
+        var service = Service(new() { Enabled = false });
+
+        await service.StartAsync();
+
+        Assert.Equal(0, service.BoundPort);
+        await service.StopAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_Enabled_BindsAnEphemeralPortThatAcceptsConnections()
+    {
+        var service = Service(new() { Enabled = true, Address = "127.0.0.1", Port = 0 });
+
+        await service.StartAsync();
+
+        Assert.True(service.BoundPort > 0);
+
+        using (var client = new TcpClient())
+        {
+            await client.ConnectAsync("127.0.0.1", service.BoundPort);
+            Assert.True(client.Connected);
+        }
+
+        await service.StopAsync();
+    }
+}

--- a/tests/Moongate.Tests/Console/TelnetInputTests.cs
+++ b/tests/Moongate.Tests/Console/TelnetInputTests.cs
@@ -1,0 +1,20 @@
+using System.Text;
+using Moongate.Console.Admin.Plugin.Services.Console;
+
+namespace Moongate.Tests.Console;
+
+public class TelnetInputTests
+{
+    [Fact]
+    public void StripControls_PlainText_IsTrimmedUnchanged()
+        => Assert.Equal("broadcast hi", TelnetInput.StripControls("  broadcast hi  "));
+
+    [Fact]
+    public void StripControls_RemovesControlAndReplacementChars()
+    {
+        // A telnet IAC negotiation (0xFF 0xFB 0x01) decodes to replacement chars under UTF-8.
+        var decoded = Encoding.UTF8.GetString([0xFF, 0xFB, 0x01]) + "help";
+
+        Assert.Equal("help", TelnetInput.StripControls(decoded));
+    }
+}

--- a/tests/Moongate.Tests/Moongate.Tests.csproj
+++ b/tests/Moongate.Tests/Moongate.Tests.csproj
@@ -29,6 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\src\Moongate.Console.Admin.Plugin\Moongate.Console.Admin.Plugin.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Core\Moongate.Core.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Network\Moongate.Network.csproj"/>

--- a/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
@@ -1,9 +1,11 @@
+using DryIoc;
 using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Data.Commands;
 using Moongate.Server.Abstractions.Data.Internal;
 using Moongate.Server.Abstractions.Interfaces.Commands;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.Commands;
+using Moongate.Tests.Support;
 
 namespace Moongate.Tests.Server.Commands;
 
@@ -17,14 +19,18 @@ public class CommandServiceTests
             => LastContext = context;
     }
 
-    private static CommandRegistration Registration(string name)
-        => new(
-            name,
-            AccountLevelType.GrandMaster,
-            "A recording test command.",
-            CommandSourceType.InGame,
-            static _ => new RecordingCommand()
-        );
+    private static CommandRegistration Registration(
+        string name,
+        CommandSourceType sources = CommandSourceType.InGame,
+        AccountLevelType minLevel = AccountLevelType.GrandMaster,
+        RecordingCommand? command = null
+    )
+        => new(name, minLevel, "A recording test command.", sources, _ => command ?? new RecordingCommand());
+
+    private static CommandService Service(params CommandRegistration[] registrations)
+        => new(registrations, new Container(), new StubAccountService());
+
+    // ---- BuildRegistry (unchanged behavior) ----
 
     [Fact]
     public void BuildRegistry_LookupIsCaseInsensitive()
@@ -46,60 +52,113 @@ public class CommandServiceTests
         Assert.Same(registration, registry["t"]);
     }
 
-    [Fact]
-    public void BuildRegistry_SingleCommand_RegistersItsCanonicalNameAndMetadata()
-    {
-        var registry = CommandService.BuildRegistry([Registration("test|t")]);
-
-        Assert.True(registry.ContainsKey("test"));
-        Assert.Equal(AccountLevelType.GrandMaster, registry["test"].MinLevel);
-    }
-
-    [Fact]
-    public void IsAuthorized_ActorAboveMinLevel_IsTrue()
-        => Assert.True(CommandService.IsAuthorized(AccountLevelType.Administrator, AccountLevelType.GrandMaster));
-
-    [Fact]
-    public void IsAuthorized_ActorAtMinLevel_IsTrue()
-        => Assert.True(CommandService.IsAuthorized(AccountLevelType.GrandMaster, AccountLevelType.GrandMaster));
-
-    [Fact]
-    public void IsAuthorized_ActorBelowMinLevel_IsFalse()
-        => Assert.False(CommandService.IsAuthorized(AccountLevelType.Player, AccountLevelType.GrandMaster));
+    // ---- Parse (now prefix-free) ----
 
     [Fact]
     public void Parse_ExtraWhitespaceBetweenTokens_IsIgnored()
     {
-        var (name, arguments) = CommandService.Parse(".broadcast   hello    world");
+        var (name, arguments) = CommandService.Parse("broadcast   hello    world");
 
         Assert.Equal("broadcast", name);
         Assert.Equal(["hello", "world"], arguments);
     }
 
     [Fact]
-    public void Parse_JustThePrefix_ReturnsEmptyNameAndNoArguments()
+    public void Parse_EmptyLine_ReturnsEmptyNameAndNoArguments()
     {
-        var (name, arguments) = CommandService.Parse(".");
+        var (name, arguments) = CommandService.Parse(string.Empty);
 
         Assert.Equal(string.Empty, name);
         Assert.Empty(arguments);
     }
 
     [Fact]
-    public void Parse_NameOnly_ReturnsNameAndNoArguments()
-    {
-        var (name, arguments) = CommandService.Parse(".broadcast");
-
-        Assert.Equal("broadcast", name);
-        Assert.Empty(arguments);
-    }
-
-    [Fact]
     public void Parse_NameWithArguments_SplitsOnWhitespace()
     {
-        var (name, arguments) = CommandService.Parse(".broadcast Server restarting soon");
+        var (name, arguments) = CommandService.Parse("broadcast Server restarting soon");
 
         Assert.Equal("broadcast", name);
         Assert.Equal(["Server", "restarting", "soon"], arguments);
+    }
+
+    // ---- IsAuthorized ----
+
+    [Fact]
+    public void IsAuthorized_ActorAtOrAboveMinLevel_IsTrue()
+    {
+        Assert.True(CommandService.IsAuthorized(AccountLevelType.GrandMaster, AccountLevelType.GrandMaster));
+        Assert.True(CommandService.IsAuthorized(AccountLevelType.Administrator, AccountLevelType.GrandMaster));
+    }
+
+    [Fact]
+    public void IsAuthorized_ActorBelowMinLevel_IsFalse()
+        => Assert.False(CommandService.IsAuthorized(AccountLevelType.Player, AccountLevelType.GrandMaster));
+
+    // ---- Execute(CommandInvocation): gating ----
+
+    [Fact]
+    public void Execute_KnownAllowedAuthorized_DispatchesWithArguments()
+    {
+        var command = new RecordingCommand();
+        var service = Service(Registration("test|t", CommandSourceType.Console, AccountLevelType.GrandMaster, command));
+
+        service.Execute(new CommandInvocation(
+            CommandSourceType.Console, AccountLevelType.GrandMaster, null, "test a b", _ => { }));
+
+        Assert.NotNull(command.LastContext);
+        Assert.Equal(["a", "b"], command.LastContext!.Value.Arguments);
+        Assert.Equal(CommandSourceType.Console, command.LastContext!.Value.Source);
+    }
+
+    [Fact]
+    public void Execute_UnknownName_RepliesUnknownCommand()
+    {
+        var replies = new List<string>();
+        var service = Service(Registration("test", CommandSourceType.Console));
+
+        service.Execute(new CommandInvocation(
+            CommandSourceType.Console, AccountLevelType.Administrator, null, "nope", replies.Add));
+
+        Assert.Equal("Unknown command.", Assert.Single(replies));
+    }
+
+    [Fact]
+    public void Execute_SourceNotAllowed_RepliesUnknownCommand()
+    {
+        var replies = new List<string>();
+        var service = Service(Registration("test", CommandSourceType.InGame)); // in-game only
+
+        service.Execute(new CommandInvocation(
+            CommandSourceType.Console, AccountLevelType.Administrator, null, "test", replies.Add));
+
+        Assert.Equal("Unknown command.", Assert.Single(replies));
+    }
+
+    [Fact]
+    public void Execute_LevelBelowMinimum_RepliesUnknownCommand()
+    {
+        var replies = new List<string>();
+        var service = Service(Registration("test", CommandSourceType.Console, AccountLevelType.GrandMaster));
+
+        service.Execute(new CommandInvocation(
+            CommandSourceType.Console, AccountLevelType.Player, null, "test", replies.Add));
+
+        Assert.Equal("Unknown command.", Assert.Single(replies));
+    }
+
+    // ---- ListCommands ----
+
+    [Fact]
+    public void ListCommands_ReturnsOnlyCommandsForThatSource_WithCanonicalName()
+    {
+        var service = Service(
+            Registration("broadcast|bc", CommandSourceType.InGame | CommandSourceType.Console),
+            Registration("ingameonly", CommandSourceType.InGame));
+
+        var console = service.ListCommands(CommandSourceType.Console);
+
+        var descriptor = Assert.Single(console);
+        Assert.Equal("broadcast", descriptor.Name);
+        Assert.Equal(AccountLevelType.GrandMaster, descriptor.MinLevel);
     }
 }

--- a/tests/Moongate.Tests/Support/InlineMainThreadDispatcher.cs
+++ b/tests/Moongate.Tests/Support/InlineMainThreadDispatcher.cs
@@ -1,0 +1,15 @@
+using SquidStd.Core.Interfaces.Threading;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Runs posted callbacks synchronously on the calling thread — a game loop that drains instantly.</summary>
+public sealed class InlineMainThreadDispatcher : IMainThreadDispatcher
+{
+    public int PendingCount => 0;
+
+    public int DrainPending(double? budgetMs = null)
+        => 0;
+
+    public void Post(Action action)
+        => action();
+}

--- a/tests/Moongate.Tests/Support/SeededAccountService.cs
+++ b/tests/Moongate.Tests/Support/SeededAccountService.cs
@@ -1,0 +1,70 @@
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Network.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Focused <see cref="IAccountService" /> double for console tests: seed usernames with a plaintext
+/// password and a level; only the login surface (<see cref="Authenticate" />, <see cref="GetByUsername" />,
+/// <see cref="GetById" />) is real, the rest throw so a test that reaches them says so.
+/// </summary>
+public sealed class SeededAccountService : IAccountService
+{
+    private readonly Dictionary<string, (string Password, AccountLevelType Level, Serial Id)> _accounts =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public void Seed(string username, string password, AccountLevelType level)
+        => _accounts[username] = (password, level, (Serial)(uint)(_accounts.Count + 1));
+
+    public AccountAuthResult Authenticate(string username, string password)
+        => _accounts.TryGetValue(username, out var account) && account.Password == password
+            ? AccountAuthResult.Ok(username)
+            : AccountAuthResult.Denied(LoginDeniedReasonType.IncorrectCredentials);
+
+    public AccountEntity? GetByUsername(string username)
+        => _accounts.TryGetValue(username, out var account)
+            ? new AccountEntity { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true }
+            : null;
+
+    public AccountEntity? GetById(Serial accountId)
+    {
+        foreach (var (username, account) in _accounts)
+        {
+            if (account.Id == accountId)
+            {
+                return new AccountEntity { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true };
+            }
+        }
+
+        return null;
+    }
+
+    public Serial? GetAccountIdByUsername(string username)
+        => _accounts.TryGetValue(username, out var account) ? account.Id : null;
+
+    public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
+        => throw new NotSupportedException();
+
+    public AccountDeleteResultType Delete(string username)
+        => throw new NotSupportedException();
+
+    public IReadOnlyList<AccountEntity> GetAll()
+        => throw new NotSupportedException();
+
+    public IReadOnlyList<string> GetUsernames()
+        => throw new NotSupportedException();
+
+    public bool SetActive(string username, bool isActive)
+        => throw new NotSupportedException();
+
+    public bool SetLevel(string username, AccountLevelType level)
+        => throw new NotSupportedException();
+
+    public bool SetPassword(string username, string password)
+        => throw new NotSupportedException();
+}

--- a/tests/Moongate.Tests/Support/StubAccountService.cs
+++ b/tests/Moongate.Tests/Support/StubAccountService.cs
@@ -38,8 +38,10 @@ public sealed class StubAccountService : IAccountService
     public IReadOnlyList<AccountEntity> GetAll()
         => throw new NotSupportedException();
 
+    // The in-game command adapter resolves the actor's level via GetById; this stub does not model
+    // account storage, so it reports "no such account" and the caller defaults to the Player level.
     public AccountEntity? GetById(Serial accountId)
-        => throw new NotSupportedException();
+        => null;
 
     public AccountEntity? GetByUsername(string username)
         => throw new NotSupportedException();


### PR DESCRIPTION
## What

Adds an optional line-based **admin console** over TCP (`Moongate.Console.Admin.Plugin`): connect, log in with a staff account, and run the server's commands through `ICommandService`. Disabled by default and plaintext — meant for loopback / a private (Tailscale) network.

## Command system (source-neutral dispatch)

- `CommandSourceType.Console`; `CommandContext.Actor` is now nullable (actor-less sources)
- new `CommandInvocation` / `CommandDescriptor` DTOs
- `ICommandService` gains `Execute(CommandInvocation)` (source-neutral core) and `ListCommands(source)`; the session overload becomes the in-game adapter (resolves level, strips the `.` prefix, dispatches as `InGame`)
- dispatch now **gates by `Sources` and level**, with the uniform `Unknown command.` reply; `Parse` is prefix-agnostic
- `broadcast` opted into `InGame | Console`

## The plugin

- `ConsoleServerService` (`ISquidStdService`, owns a `TcpListener`; opt-in `console.Enabled`, bind failure logged & swallowed, `MaxSessions`)
- `ConsoleSession`: banner → login (3 attempts, GrandMaster+ required) → REPL (`help`/`quit` built-ins); command execution is posted onto `IMainThreadDispatcher` so it runs on the game loop; writes serialized per session; telnet control bytes stripped
- pure helpers `ConsoleInput` / `ConsoleAuth` / `TelnetInput`
- config section `console:` (Enabled/Address/Port/MaxSessions), wired into `Program.cs`

## Tests & docs

- unit tests for gating, `ListCommands`, and the pure helpers; end-to-end integration tests (login, broadcast, player rejected, wrong password, unknown command, help)
- full suite green (1250); DocFX at 0 warnings
- docs: "Admin console" page + `console:` config reference

## Notes

- Connect with `nc`/`socat` (not the `ssh` command — this is not SSH). Follow-ups tracked on Trello: real SSH/TLS transport, telnet echo suppression, and `save`/`shutdown`/`kick`/`who` commands.