### PR TITLE
docs: add Writing plugins tutorial section

### DIFF
--- a/docs/contributing/toc.yml
+++ b/docs/contributing/toc.yml
@@ -1,2 +1,20 @@
 - name: Build, test & conventions
   href: build-test-conventions.md
+- name: Writing plugins
+  items:
+    - name: Overview
+      href: writing-plugins/index.md
+    - name: Your first plugin
+      href: writing-plugins/first-plugin.md
+    - name: Hosted services
+      href: writing-plugins/hosted-service.md
+    - name: Commands
+      href: writing-plugins/commands.md
+    - name: Packet handlers
+      href: writing-plugins/packet-handlers.md
+    - name: Event subscribers
+      href: writing-plugins/event-subscribers.md
+    - name: Data loaders
+      href: writing-plugins/data-loaders.md
+    - name: Registration reference
+      href: writing-plugins/registration.md

--- a/docs/contributing/writing-plugins/commands.md
+++ b/docs/contributing/writing-plugins/commands.md
@@ -1,0 +1,3 @@
+# Commands
+
+Add GM/admin commands from a plugin. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/commands.md
+++ b/docs/contributing/writing-plugins/commands.md
@@ -1,3 +1,67 @@
 # Commands
 
-Add GM/admin commands from a plugin. _Full content in a following commit._
+A **command** is an action a staff member triggers by typing its name after the `.` prefix —
+`.uptime`, `.broadcast`. A plugin can register its own, and the same command can be reachable
+both in-game and from the [admin console](../../under-the-hood/admin-console.md).
+
+## The interface
+
+```csharp
+public interface ICommand
+{
+    void Execute(CommandContext context);
+}
+```
+
+The `CommandContext` carries the call: `context.Arguments` holds the tokens typed after the
+command name, and `context.Reply(string)` sends a line back to whoever ran it.
+
+```csharp
+using System.Diagnostics;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+
+namespace MyShard.Ops.Commands;
+
+/// <summary>Reports how long the server process has been running.</summary>
+public sealed class UptimeCommand : ICommand
+{
+    public void Execute(CommandContext context)
+    {
+        var uptime = DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime();
+
+        context.Reply($"Uptime: {uptime:d\\.hh\\:mm\\:ss}");
+    }
+}
+```
+
+## Registering
+
+Register the command in your plugin's `Configure`:
+
+```csharp
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Extensions;
+using Moongate.Server.Abstractions.Types;
+
+container.RegisterCommand<UptimeCommand>(
+    "uptime|up",
+    AccountLevelType.GrandMaster,
+    "Reports server uptime.",
+    CommandSourceType.InGame | CommandSourceType.Console
+);
+```
+
+The four arguments:
+
+- **name** — the command name, pipe-delimited for aliases (`"uptime|up"`); the first token is
+  the canonical name, the rest are aliases.
+- **minLevel** — the minimum `AccountLevelType` (`Moongate.Core.Types`) allowed to run it. The
+  dispatcher refuses the command for anyone below it.
+- **description** — the help text shown to tooling and command listings.
+- **sources** — where the command can be invoked. `CommandSourceType` is a flags enum:
+  `InGame | Console` exposes it both to `.uptime` in the game client and to the same command in
+  the admin console. Omit `Console` to keep it in-game only.
+
+A command is resolved from the container, so it can take dependencies through its constructor
+like any other service — inject a game service and call it from `Execute`.

--- a/docs/contributing/writing-plugins/data-loaders.md
+++ b/docs/contributing/writing-plugins/data-loaders.md
@@ -1,3 +1,98 @@
 # Data loaders
 
-Load custom data files at startup. _Full content in a following commit._
+A **data loader** reads a file into memory once, at startup. Moongate loads all of its world
+data this way — skills, professions, regions, item and mobile templates — and a plugin can add
+its own loader for its own files.
+
+## The interface
+
+```csharp
+public interface IDataLoader
+{
+    ValueTask LoadAsync(CancellationToken ct = default);
+}
+```
+
+`LoadAsync` runs once during startup. A loader typically resolves a file under the server root,
+parses it, and hands the result to a registry service the rest of the plugin reads from.
+
+## Locating and parsing the file
+
+Inject `DirectoriesConfig` to resolve a path under the server root, and use `YamlUtils` to
+parse — both from `SquidStd.Core`. `RegisterDirectory` returns the absolute path and creates the
+directory if it is missing, so the file simply sits under `<root>/plugins/myshard/`. This is the
+same shape as the built-in `SkillLoader`.
+
+```csharp
+using Moongate.Server.Abstractions.Interfaces.Loading;
+using SquidStd.Core.Directories;
+using SquidStd.Core.Yaml;
+
+namespace MyShard.Motd.Loading;
+
+/// <summary>Loads plugins/myshard/motd.yaml (a list of lines) into the MOTD registry.</summary>
+public sealed class MotdLoader : IDataLoader
+{
+    private readonly DirectoriesConfig _directories;
+    private readonly MotdRegistry _registry;
+
+    public MotdLoader(DirectoriesConfig directories, MotdRegistry registry)
+    {
+        _directories = directories;
+        _registry = registry;
+    }
+
+    public ValueTask LoadAsync(CancellationToken ct = default)
+    {
+        var directory = _directories.RegisterDirectory("plugins/myshard");
+        var path = Path.Combine(directory, "motd.yaml");
+
+        if (!File.Exists(path))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var lines = YamlUtils.DeserializeFromFile<List<string>>(path) ?? [];
+        _registry.SetLines(lines);
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+The registry is an ordinary singleton the loader fills and everything else injects:
+
+```csharp
+namespace MyShard.Motd;
+
+/// <summary>Holds the message-of-the-day lines loaded at startup.</summary>
+public sealed class MotdRegistry
+{
+    private IReadOnlyList<string> _lines = [];
+
+    public IReadOnlyList<string> Lines => _lines;
+
+    public void SetLines(IReadOnlyList<string> lines)
+        => _lines = lines;
+}
+```
+
+A matching `plugins/myshard/motd.yaml`:
+
+```yaml
+- "Welcome to MyShard!"
+- "Server resets nightly at 04:00."
+```
+
+## Registering and ordering
+
+Register the registry and the loader in your plugin's `Configure`:
+
+```csharp
+container.Register<MotdRegistry>(Reuse.Singleton);
+container.RegisterDataLoader<MotdLoader>(priority: 1000);
+```
+
+Loaders run in **ascending** priority. Moongate's own loaders occupy the low numbers (up to
+150), so pick a priority above them — `1000` here — to load once the core world data your file
+might reference is already in place.

--- a/docs/contributing/writing-plugins/data-loaders.md
+++ b/docs/contributing/writing-plugins/data-loaders.md
@@ -1,0 +1,3 @@
+# Data loaders
+
+Load custom data files at startup. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/event-subscribers.md
+++ b/docs/contributing/writing-plugins/event-subscribers.md
@@ -1,3 +1,63 @@
 # Event subscribers
 
-React to domain events on the game loop. _Full content in a following commit._
+An **event subscriber** reacts to something that happens in the world — a player double-clicks,
+a container opens, the world finishes loading. When your plugin's job is a *reaction* rather
+than owning a resource, a subscriber is the natural fit: its handlers already run on the game
+loop, so they can touch world state directly.
+
+## The interface
+
+```csharp
+public interface IEventSubscriberRegistration
+{
+    void Subscribe(IEventBus eventBus);
+}
+```
+
+In `Subscribe`, attach a handler for each event you care about. A handler is
+`Task Handler(TEvent message, CancellationToken cancellationToken)`.
+
+```csharp
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Serilog;
+using SquidStd.Core.Interfaces.Events;
+
+namespace MyShard.Live.Subscribers;
+
+/// <summary>Logs a banner once the world has finished loading.</summary>
+public sealed class WorldReadySubscriber : IEventSubscriberRegistration
+{
+    private readonly ILogger _logger = Log.ForContext<WorldReadySubscriber>();
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<WorldReadyEvent>(OnWorldReady);
+
+    private Task OnWorldReady(WorldReadyEvent message, CancellationToken cancellationToken)
+    {
+        _logger.Information("=== MyShard is open for business ===");
+
+        return Task.CompletedTask;
+    }
+}
+```
+
+`WorldReadyEvent` lives in `Moongate.Server.Abstractions.Data.Events`, alongside the other
+domain events you can subscribe to.
+
+## Registering
+
+Register the subscriber in your plugin's `Configure`:
+
+```csharp
+container.RegisterEventSubscriber<WorldReadySubscriber>();
+```
+
+The event-subscriber service resolves every registration and attaches it to the bus at startup.
+
+## Loop affinity
+
+Domain-event handlers run on the game loop, so it is safe to read and mutate world state
+directly inside them — no `IMainThreadDispatcher` needed. That is the difference from a
+[hosted service](hosted-service.md), whose background loop runs off the game thread. A
+subscriber can still inject any service it needs through its constructor.

--- a/docs/contributing/writing-plugins/event-subscribers.md
+++ b/docs/contributing/writing-plugins/event-subscribers.md
@@ -1,0 +1,3 @@
+# Event subscribers
+
+React to domain events on the game loop. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/first-plugin.md
+++ b/docs/contributing/writing-plugins/first-plugin.md
@@ -1,0 +1,3 @@
+# Your first plugin
+
+Build, deploy and run a minimal Moongate plugin. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/first-plugin.md
+++ b/docs/contributing/writing-plugins/first-plugin.md
@@ -1,3 +1,183 @@
 # Your first plugin
 
-Build, deploy and run a minimal Moongate plugin. _Full content in a following commit._
+This walkthrough builds a complete plugin from an empty folder: a `greeter` config section
+and a service that writes a configurable line to the log when the server starts. It touches
+the two most common seams — a config section and a hosted service — and shows how to
+reference the host assemblies, build, and deploy.
+
+## Create the project
+
+```bash
+dotnet new classlib -n MyShard.Greeter -f net10.0
+```
+
+## Reference the host assemblies
+
+A plugin loads into the *same* assembly context as the server, with no version isolation, so
+it must be **compiled against the exact assemblies the server ships** — and must **not** carry
+its own copies of them into `plugins/`. You get both by referencing the host DLLs with
+`<Private>false</Private>`: the compiler sees them, but the build does not copy them next to
+your plugin.
+
+Point a property at your server build output and reference from there. In a source checkout
+that is `src/Moongate.Server/bin/Release/net10.0/`; for a published server it is the folder
+next to `Moongate.Server.dll`.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Path to your Moongate server build output -->
+    <MoongateBin>..\..\Moongate\src\Moongate.Server\bin\Release\net10.0</MoongateBin>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="SquidStd.Plugin.Abstractions">
+      <HintPath>$(MoongateBin)\SquidStd.Plugin.Abstractions.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="SquidStd.Abstractions">
+      <HintPath>$(MoongateBin)\SquidStd.Abstractions.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="DryIoc">
+      <HintPath>$(MoongateBin)\DryIoc.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Serilog">
+      <HintPath>$(MoongateBin)\Serilog.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>
+```
+
+Later tutorials add one more reference — `Moongate.Server.Abstractions.dll` — for the
+game-facing seams (commands, packet handlers, events, data loaders). The greeter needs none
+of those.
+
+## The config section
+
+A config section is a plain class. Each property is one key; the class name has no bearing on
+the section name — that is chosen at registration. Give every property a sensible default so
+the plugin works before anyone edits `moongate.yaml`.
+
+```csharp
+namespace MyShard.Greeter.Data.Config;
+
+/// <summary>Config for the greeter plugin (section <c>greeter</c> in moongate.yaml).</summary>
+public sealed class GreeterConfig
+{
+    /// <summary>Line written to the log when the server starts.</summary>
+    public string Message { get; set; } = "Hello from my first Moongate plugin!";
+}
+```
+
+## The service
+
+A hosted service implements `ISquidStdService`; the server calls `StartAsync` at boot and
+`StopAsync` at shutdown. The bound `GreeterConfig` is injected directly — registering it as a
+section (below) is what makes it resolvable.
+
+```csharp
+using Serilog;
+using MyShard.Greeter.Data.Config;
+using SquidStd.Abstractions.Interfaces.Services;
+
+namespace MyShard.Greeter.Services;
+
+public sealed class GreeterService : ISquidStdService
+{
+    private readonly ILogger _logger = Log.ForContext<GreeterService>();
+    private readonly GreeterConfig _config;
+
+    public GreeterService(GreeterConfig config)
+    {
+        _config = config;
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.Information("{Message}", _config.Message);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+        => ValueTask.CompletedTask;
+}
+```
+
+See [Hosted services](hosted-service.md) for background loops, shutdown, and the
+"stay optional" rule.
+
+## The plugin class
+
+`Configure` registers the section and the service. `Metadata.Id` must be unique and stable —
+it is how other plugins depend on yours and how the loader reports it.
+
+```csharp
+using DryIoc;
+using MyShard.Greeter.Data.Config;
+using MyShard.Greeter.Services;
+using SquidStd.Abstractions.Extensions.Config;
+using SquidStd.Abstractions.Extensions.Services;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace MyShard.Greeter;
+
+public sealed class GreeterPlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "myshard.greeter",
+            Name = "MyShard Greeter",
+            Version = new Version(1, 0, 0),
+            Author = "you",
+            Description = "Logs a greeting when the server starts"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        container.RegisterConfigSection<GreeterConfig>("greeter");
+        container.RegisterStdService<GreeterService, GreeterService>();
+    }
+}
+```
+
+To track the assembly's version instead of hard-coding it, use
+`Version = new(VersionUtils.GetVersion(typeof(GreeterPlugin).Assembly))` from
+`SquidStd.Core.Utils` (add a `<Reference>` to `SquidStd.Core.dll`).
+
+## Build, deploy, run
+
+```bash
+dotnet build -c Release
+cp bin/Release/net10.0/MyShard.Greeter.dll <server-root>/plugins/
+```
+
+Only `MyShard.Greeter.dll` lands in `plugins/` — the host assemblies stayed out because they
+are `<Private>false</Private>`. Add the section to `moongate.yaml`:
+
+```yaml
+greeter:
+  message: "Welcome to my shard"
+```
+
+Start the server. You will see the loader pick the plugin up, then the greeting:
+
+```
+Loaded plugin myshard.greeter v1.0.0 by you
+Welcome to my shard
+```
+
+## Next
+
+- [Hosted services](hosted-service.md) — do real background work in your service.
+- [Registration reference](registration.md) — every other seam `Configure` can call.

--- a/docs/contributing/writing-plugins/hosted-service.md
+++ b/docs/contributing/writing-plugins/hosted-service.md
@@ -1,3 +1,100 @@
 # Hosted services
 
-Run background work with a lifecycle service. _Full content in a following commit._
+A **hosted service** is a plugin component with a start/stop lifecycle. The HTTP API and the
+admin console are both hosted services; so is the greeter from
+[your first plugin](first-plugin.md). Use one whenever you need to own a resource — a socket,
+a timer, a connection — for the lifetime of the server.
+
+## The lifecycle
+
+```csharp
+public interface ISquidStdService
+{
+    ValueTask StartAsync(CancellationToken cancellationToken = default);
+    ValueTask StopAsync(CancellationToken cancellationToken = default);
+}
+```
+
+`StartAsync` runs once at server startup, `StopAsync` once at shutdown. Register the service
+in your plugin's `Configure`:
+
+```csharp
+container.RegisterStdService<HeartbeatService, HeartbeatService>();
+```
+
+## Own your resources
+
+Start your background work in `StartAsync` and tear it down in `StopAsync`. `StartAsync`
+should not block — kick off the loop and return. Keep a handle to the loop so `StopAsync` can
+await it, and honour the cancellation token so shutdown is prompt.
+
+```csharp
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+
+namespace MyShard.Heartbeat.Services;
+
+public sealed class HeartbeatService : ISquidStdService
+{
+    private readonly ILogger _logger = Log.ForContext<HeartbeatService>();
+    private readonly PeriodicTimer _timer = new(TimeSpan.FromMinutes(5));
+    private Task? _loop;
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _loop = RunAsync(cancellationToken);
+
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (await _timer.WaitForNextTickAsync(cancellationToken))
+            {
+                _logger.Information("Shard heartbeat");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    public async ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        _timer.Dispose();
+
+        if (_loop is not null)
+        {
+            await _loop;
+        }
+    }
+}
+```
+
+## Stay optional
+
+An optional plugin must never take the server down. If your `StartAsync` does something that
+can fail at runtime — binding a port, opening a file — catch it, log it, and return normally.
+The admin console does exactly this: a failed bind is logged and swallowed, so a misconfigured
+console leaves the game running. See [the admin console](../../under-the-hood/admin-console.md).
+
+> An exception that escapes `Configure` or `StartAsync` aborts startup. That is the right
+> behaviour for a *required* plugin and the wrong behaviour for an optional one — decide which
+> yours is and handle failures accordingly.
+
+## Touching game state
+
+`StartAsync` and your background loop do **not** run on the game loop. To read or mutate world
+state from a hosted service, marshal onto the loop through `IMainThreadDispatcher`
+(`SquidStd.Core.Interfaces.Threading`) — inject it like any other dependency. If your work is
+naturally a *reaction* to something happening in the world, an
+[event subscriber](event-subscribers.md) is usually the better fit: its handlers already run
+on the loop.
+
+## Disposing
+
+Implement `IDisposable` when your service owns something that must be released beyond what
+`StopAsync` handles. Per the code conventions, `Dispose` is the **last** member of the class.

--- a/docs/contributing/writing-plugins/hosted-service.md
+++ b/docs/contributing/writing-plugins/hosted-service.md
@@ -1,0 +1,3 @@
+# Hosted services
+
+Run background work with a lifecycle service. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/index.md
+++ b/docs/contributing/writing-plugins/index.md
@@ -1,3 +1,68 @@
 # Writing plugins
 
-Extend a Moongate server in C# with an external plugin. _Full content in a following commit._
+A **plugin** is a .NET assembly that extends a Moongate server in C#. You build it as a
+class library, drop the resulting `.dll` into the server's `plugins/` directory, and the
+server discovers and loads it at startup — no fork, no changes to the server itself.
+
+Everything the server ships — the HTTP API, the admin console, the command set, the packet
+handlers — is registered through the same plugin mechanism you use here.
+
+## Plugin or Lua script?
+
+Moongate has two extension paths. Reach for a **plugin** when you need to add code that runs
+inside the server process:
+
+- a background **service** (a socket, a timer, a bridge to another system);
+- a **command** (`.something`) for GMs or the admin console;
+- a **packet handler** for an inbound client packet;
+- an **event subscriber** that reacts to something happening in the world;
+- a **data loader** that reads your own files at startup;
+- a **REST endpoint**.
+
+Reach for [Lua scripting](../../scripting/index.md) instead when you are writing game-content
+logic — item and mobile behaviour, loot, world events — and want to iterate live with no
+compile step. Scripting needs no C# at all.
+
+## Anatomy of a plugin
+
+A plugin is one class implementing `ISquidStdPlugin`:
+
+```csharp
+public interface ISquidStdPlugin
+{
+    PluginMetadata Metadata { get; }
+    void Configure(IContainer container, PluginContext context);
+}
+```
+
+- **`Metadata`** is the plugin's identity — a stable id, name, version, author, and an
+  optional list of other plugin ids that must load first.
+- **`Configure`** registers everything the plugin contributes into the DryIoc `container`.
+  It runs once, during startup, before the server begins — so config sections and services
+  registered here are wired up in time. See [the architecture overview](../../under-the-hood/architecture.md)
+  for the container and startup sequence.
+
+## How the server loads a plugin
+
+The server calls `builder.FromDirectory("plugins")` at startup. The loader then:
+
+- scans the `plugins/` directory (relative to the server root) for `*.dll`, **non-recursively**;
+- loads each into the **default assembly load context** and instantiates **every concrete
+  `ISquidStdPlugin`** it finds — so your plugin class needs a **public parameterless constructor**;
+- orders all plugins so each loads after the ids in its `Metadata.Dependencies`.
+
+Two consequences worth stating plainly:
+
+- **There is no version isolation.** Plugins share assembly identity with the host, so you
+  must build against the *same* Moongate and SquidStd assemblies the server runs. The
+  [first-plugin walkthrough](first-plugin.md) shows how to reference them without copying
+  them into `plugins/`.
+- **Plugins are fully trusted, and any failure aborts startup.** A duplicate id, a missing
+  dependency, a dependency cycle, or an exception thrown from `Configure` stops the server
+  from booting. An *optional* plugin should therefore catch and log its own runtime failures
+  rather than let them escape — see [hosted services](hosted-service.md).
+
+## Next
+
+- [Your first plugin](first-plugin.md) — build, deploy and run one end to end.
+- [Registration reference](registration.md) — every seam `Configure` can call, in one table.

--- a/docs/contributing/writing-plugins/index.md
+++ b/docs/contributing/writing-plugins/index.md
@@ -1,0 +1,3 @@
+# Writing plugins
+
+Extend a Moongate server in C# with an external plugin. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/packet-handlers.md
+++ b/docs/contributing/writing-plugins/packet-handlers.md
@@ -1,3 +1,61 @@
 # Packet handlers
 
-React to inbound client packets. _Full content in a following commit._
+A **packet handler** reacts to a decoded packet the client sends. A plugin can register one
+for any inbound opcode, exactly the way the server registers its own.
+
+## Two interfaces, one class
+
+A handler implements two interfaces on the same class:
+
+- `IPacketHandler<TPacket>` — `void Handle(TPacket packet, in PacketContext context)` — the
+  logic that runs when a `TPacket` arrives.
+- `IPacketHandlerRegistration` — `void Register(INetworkService network)` — how the handler
+  attaches itself to the network service. The body is always `network.RegisterHandler(this)`.
+
+This is the shape of every built-in handler, such as the ping/keep-alive handler:
+
+```csharp
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Network;
+
+namespace MyShard.Net.Handlers;
+
+/// <summary>Echoes the client's keep-alive sequence (0x73) back to it.</summary>
+public sealed class MyPingHandler : IPacketHandler<PingPacket>, IPacketHandlerRegistration
+{
+    public void Handle(PingPacket packet, in PacketContext context)
+        => context.Session.Send(new PingAckPacket(packet.Sequence));
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}
+```
+
+## Registering
+
+Register the handler in your plugin's `Configure`:
+
+```csharp
+container.RegisterPacketHandler<MyPingHandler>();
+```
+
+The network service collects every registration and wires each to its packet's opcode at
+startup.
+
+## Threading
+
+`Handle` runs on the network thread. Reply to the client directly with `context.Session.Send(...)`.
+For anything that mutates world state, marshal onto the game loop rather than touching entities
+from the network thread.
+
+## `[PacketDocumentation]` is not yours
+
+The `[PacketDocumentation]` attribute and the packet-docs generator apply to Moongate's *own*
+packet classes — the definitions of the packets themselves. A plugin **consumes** an existing
+packet type from `Moongate.Network`; it does not define one, so it does not use that attribute.
+
+> The example above re-registers an opcode the core already handles, purely to show the seam.
+> Real plugins usually handle opcodes the core leaves open — registering a second handler for an
+> opcode the server already owns is for illustration, not production.

--- a/docs/contributing/writing-plugins/packet-handlers.md
+++ b/docs/contributing/writing-plugins/packet-handlers.md
@@ -1,0 +1,3 @@
+# Packet handlers
+
+React to inbound client packets. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/registration.md
+++ b/docs/contributing/writing-plugins/registration.md
@@ -1,0 +1,3 @@
+# Registration reference
+
+Every registration seam a plugin can use, at a glance. _Full content in a following commit._

--- a/docs/contributing/writing-plugins/registration.md
+++ b/docs/contributing/writing-plugins/registration.md
@@ -1,3 +1,21 @@
 # Registration reference
 
-Every registration seam a plugin can use, at a glance. _Full content in a following commit._
+Every seam a plugin's `Configure(IContainer container, PluginContext context)` can call, at a
+glance. The extension methods live in the assembly named in each row — reference it (with
+`<Private>false</Private>`, as in [your first plugin](first-plugin.md)) to use the seam.
+
+| Seam | Extension method | Assembly | Registers |
+|---|---|---|---|
+| [Config section](first-plugin.md) | `RegisterConfigSection<T>("section")` | `SquidStd.Abstractions` | a YAML-bound config POCO |
+| [Hosted service](hosted-service.md) | `RegisterStdService<TImpl,TImpl>()` | `SquidStd.Abstractions` | an `ISquidStdService` (start/stop lifecycle) |
+| [Command](commands.md) | `RegisterCommand<T>(name, minLevel, desc, sources)` | `Moongate.Server.Abstractions` | an `ICommand` |
+| [Packet handler](packet-handlers.md) | `RegisterPacketHandler<T>()` | `Moongate.Server.Abstractions` | an `IPacketHandlerRegistration` |
+| [Event subscriber](event-subscribers.md) | `RegisterEventSubscriber<T>()` | `Moongate.Server.Abstractions` | an `IEventSubscriberRegistration` |
+| [Data loader](data-loaders.md) | `RegisterDataLoader<T>(priority)` | `Moongate.Server.Abstractions` | an `IDataLoader` |
+| [REST endpoint](../../under-the-hood/rest-api.md) | `RegisterApiEndpoint<T>()` | `Moongate.Http.Plugin` | an HTTP endpoint group |
+| Plain service | `container.Register<I,Impl>(Reuse.Singleton)` | `DryIoc` | any DI dependency |
+
+The last row is plain DryIoc: register any service your plugin needs internally, then inject it
+into the components above.
+
+New to plugins? Start with [the overview](index.md).


### PR DESCRIPTION
Adds a **Writing plugins** section under Contributing that teaches how to extend a Moongate server in C# with an external plugin (a `.dll` dropped into the server's `plugins/` directory, auto-loaded by `builder.FromDirectory("plugins")`).

## Pages (`docs/contributing/writing-plugins/`)

- **Overview** — what a plugin is, plugin vs Lua script, `ISquidStdPlugin` anatomy, and how loading works (default ALC ⇒ build against the same assembly versions, public parameterless ctor, `Metadata.Dependencies` load order, startup aborts on failure).
- **Your first plugin** — end-to-end `GreeterPlugin`: project setup, referencing host assemblies with `<Private>false</Private>`, a config section, a hosted service, build, deploy, run.
- **Hosted services** — `ISquidStdService` lifecycle, resource ownership, the stay-optional/swallow-failures rule, `IMainThreadDispatcher`, disposing.
- **Commands** — `RegisterCommand` with aliases, `AccountLevelType` gating, `CommandSourceType` (in-game + admin console).
- **Packet handlers** — `IPacketHandler<T>` + `IPacketHandlerRegistration`, threading, and why `[PacketDocumentation]` isn't a plugin's concern.
- **Event subscribers** — `IEventSubscriberRegistration`, `eventBus.Subscribe`, loop affinity, a `WorldReadyEvent` example.
- **Data loaders** — `IDataLoader`, priority ordering, `DirectoriesConfig` + `YamlUtils` (the same pattern as the built-in `SkillLoader`).
- **Registration reference** — one lookup table: seam → extension method → assembly.

Also adds the nested "Writing plugins" group to `docs/contributing/toc.yml`.

## Notes

- Documentation only — no production code, no project added to the solution.
- Every code sample is written against the live interfaces (`ISquidStdService`, `ICommand`, `IPacketHandlerRegistration`, `IEventSubscriberRegistration`, `IDataLoader`) and the real registration seams.
- `dotnet docfx docs/docfx.json --warningsAsErrors` builds at 0 warnings / 0 errors.