### PR TITLE
feat(console): per-plugin external config via SquidStd 0.38.0 RegisterConfigFile

### DIFF
--- a/docs/contributing/writing-plugins/registration.md
+++ b/docs/contributing/writing-plugins/registration.md
@@ -6,7 +6,8 @@ glance. The extension methods live in the assembly named in each row — referen
 
 | Seam | Extension method | Assembly | Registers |
 |---|---|---|---|
-| [Config section](first-plugin.md) | `RegisterConfigSection<T>("section")` | `SquidStd.Abstractions` | a YAML-bound config POCO |
+| [Config section](first-plugin.md) | `RegisterConfigSection<T>("section")` | `SquidStd.Abstractions` | a YAML-bound config POCO (a section of `moongate.yaml`) |
+| [Config file](#per-plugin-config-file) | `RegisterConfigFile<T>("section", directory)` | `SquidStd.Abstractions` | a config POCO bound from the plugin's **own** YAML file |
 | [Hosted service](hosted-service.md) | `RegisterStdService<TImpl,TImpl>()` | `SquidStd.Abstractions` | an `ISquidStdService` (start/stop lifecycle) |
 | [Command](commands.md) | `RegisterCommand<T>(name, minLevel, desc, sources)` | `Moongate.Server.Abstractions` | an `ICommand` |
 | [Packet handler](packet-handlers.md) | `RegisterPacketHandler<T>()` | `Moongate.Server.Abstractions` | an `IPacketHandlerRegistration` |
@@ -17,5 +18,22 @@ glance. The extension methods live in the assembly named in each row — referen
 
 The last row is plain DryIoc: register any service your plugin needs internally, then inject it
 into the components above.
+
+## Per-plugin config file
+
+`RegisterConfigSection<T>("x")` binds a section of the shared `moongate.yaml`. To give a plugin its
+**own** config file instead, use `RegisterConfigFile<T>("x", directory)`: the section binds from
+`<directory>/x.yaml`, which is generated with defaults at startup and saved/reloaded alongside the
+main file. Resolve the directory from `DirectoriesConfig` (registered for you):
+
+```csharp
+var directories = container.Resolve<DirectoriesConfig>();
+container.RegisterConfigFile<MyPluginConfig>("myplugin", directories["plugins/configs"]);
+// → moongate_root/plugins/configs/myplugin.yaml (section "myplugin")
+```
+
+This suits a drop-in plugin that ships its own config next to its DLL, and keeps `moongate.yaml`
+focused on the core. The [admin console](../../under-the-hood/admin-console.md) uses it; embedded
+plugins keep their section in `moongate.yaml`.
 
 New to plugins? Start with [the overview](index.md).

--- a/docs/under-the-hood/admin-console.md
+++ b/docs/under-the-hood/admin-console.md
@@ -12,7 +12,8 @@ a Tailscale interface.
 
 ## Turning it on
 
-Set the `console:` section of `moongate.yaml`:
+The console has its **own** config file, `moongate_root/plugins/configs/console.yaml`, generated with
+defaults on first start (it does not live in `moongate.yaml`). Set its `console:` section:
 
 ```yaml
 console:

--- a/src/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
+++ b/src/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Console.Admin.Plugin/MoongateConsolePlugin.cs
+++ b/src/Moongate.Console.Admin.Plugin/MoongateConsolePlugin.cs
@@ -3,6 +3,7 @@ using Moongate.Console.Admin.Plugin.Data.Config;
 using Moongate.Console.Admin.Plugin.Services.Hosting;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;
+using SquidStd.Core.Directories;
 using SquidStd.Core.Utils;
 using SquidStd.Plugin.Abstractions.Data;
 using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
@@ -24,7 +25,10 @@ public class MoongateConsolePlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
-        container.RegisterConfigSection<MoongateConsoleConfig>("console");
+        // Per-plugin external config: moongate_root/plugins/configs/console.yaml, generated with
+        // defaults at startup. Embedded plugins keep their section in moongate.yaml.
+        var directories = container.Resolve<DirectoriesConfig>();
+        container.RegisterConfigFile<MoongateConsoleConfig>("console", directories["plugins/configs"]);
         container.RegisterStdService<ConsoleServerService, ConsoleServerService>();
     }
 }

--- a/src/Moongate.Core/Moongate.Core.csproj
+++ b/src/Moongate.Core/Moongate.Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Core" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/src/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -41,8 +41,8 @@
         -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.15" />
-        <PackageReference Include="SquidStd.Abstractions" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Network/Moongate.Network.csproj
+++ b/src/Moongate.Network/Moongate.Network.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Network" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Network" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Persistence/Moongate.Persistence.csproj
+++ b/src/Moongate.Persistence/Moongate.Persistence.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Persistence" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Persistence" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -29,11 +29,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Core" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Plugin" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.37.0"/>
-        <PackageReference Include="SquidStd.Services.Core" Version="0.37.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Services.Core" Version="0.38.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Moongate.Tests/Console/ConsoleConfigFileTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleConfigFileTests.cs
@@ -1,0 +1,39 @@
+using DryIoc;
+using Moongate.Console.Admin.Plugin;
+using Moongate.Console.Admin.Plugin.Data.Config;
+using SquidStd.Core.Config;
+using SquidStd.Core.Directories;
+using SquidStd.Plugin.Abstractions.Data;
+
+namespace Moongate.Tests.Console;
+
+public class ConsoleConfigFileTests
+{
+    [Fact]
+    public void Configure_BindsConsoleFromPluginsConfigsFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-console-cfg-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            // Use DirectoriesConfig itself to resolve (and create) the dir, so the file lands exactly
+            // where the plugin will look — no assumption about the snake-case path transform.
+            var directories = new DirectoriesConfig(root, ["plugins/configs"]);
+            File.WriteAllText(Path.Combine(directories["plugins/configs"], "console.yaml"), "console:\n  Enabled: true\n  Port: 9999\n");
+
+            using var container = new Container();
+            container.RegisterInstance(SquidStdConfig.Load("moongate", root));
+            container.RegisterInstance(directories);
+
+            new MoongateConsolePlugin().Configure(container, new PluginContext());
+
+            var config = container.Resolve<MoongateConsoleConfig>();
+            Assert.True(config.Enabled);
+            Assert.Equal(9999, config.Port);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Support/StubConfigManagerService.cs
+++ b/tests/Moongate.Tests/Support/StubConfigManagerService.cs
@@ -32,4 +32,7 @@ public sealed class StubConfigManagerService : IConfigManagerService
 
     public void Save()
         => SaveCount++;
+
+    public void EnsureFiles()
+        => throw new NotSupportedException();
 }


### PR DESCRIPTION
Adopts SquidStd 0.38.0's per-file plugin config: the admin console's config moves out of `moongate.yaml` into its own file, `moongate_root/plugins/configs/console.yaml`, generated with defaults at startup.

- **build(deps):** bump SquidStd `0.37.0 → 0.38.0` (brings `RegisterConfigFile` / `ConfigManagerService.EnsureFiles`). `IConfigManagerService` gained `EnsureFiles()`, so the `StubConfigManagerService` test double implements it.
- **feat(console):** `MoongateConsolePlugin` registers its config via `RegisterConfigFile<MoongateConsoleConfig>("console", DirectoriesConfig["plugins/configs"])` instead of a section of `moongate.yaml`. Embedded plugins (HTTP, etc.) keep their sections in `moongate.yaml`.
- **docs:** new "Per-plugin config file" section in the writing-plugins guide (`RegisterConfigFile` seam); admin-console page reflects the new config location.

Resolving `DirectoriesConfig` at plugin `Configure` time is an established pattern (persistence/scripting plugins already do it). 1251 tests green; DocFX at 0 warnings.

Depends on SquidStd 0.38.0 (released to nuget.org).