### PR TITLE
feat: publish abstraction packages to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,3 +427,53 @@ jobs:
           repository: ${{ env.DOCKERHUB_IMAGE_NAME }}
           short-description: Modern Ultima Online server built from scratch. .NET, Lua scripting, ClassicUO 7.x
           readme-filepath: ./README.md
+
+  publish_packages:
+    name: Publish NuGet packages
+    needs:
+      - gate
+      - verify
+      - semantic_release
+      - reconcile_release
+    if: >-
+      always() &&
+      needs.gate.outputs.should_release == 'true' &&
+      needs.verify.result == 'success' &&
+      (needs.semantic_release.result == 'success' || needs.semantic_release.result == 'skipped') &&
+      (needs.reconcile_release.result == 'success' || needs.reconcile_release.result == 'skipped') &&
+      (needs.semantic_release.outputs.version != '' || needs.gate.outputs.version != '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_VERSION: ${{ needs.semantic_release.outputs.version || needs.gate.outputs.version }}
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: v${{ env.RELEASE_VERSION }}
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: global.json
+
+      - name: Pack
+        run: >-
+          dotnet pack Moongate.slnx -c Release
+          -p:Version=${{ env.RELEASE_VERSION }}
+          -p:IncludeSymbols=false
+          -o ./artifacts
+
+      - name: Push to GitHub Packages
+        run: |
+          for pkg in ./artifacts/*.nupkg; do
+            dotnet nuget push "$pkg" \
+              --source "https://nuget.pkg.github.com/moongate-community/index.json" \
+              --api-key "${{ github.token }}" \
+              --skip-duplicate
+          done

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,8 @@
         <Copyright>© $(Company) $([System.DateTime]::Now.Year)</Copyright>
         <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
         <RepositoryType>git</RepositoryType>
-        <PackageProjectUrl>https://github.com/tgiachi/Moongate</PackageProjectUrl>
+        <IsPackable>false</IsPackable>
+        <PackageProjectUrl>https://github.com/moongate-community/moongate</PackageProjectUrl>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/README.md
+++ b/README.md
@@ -119,6 +119,39 @@ Images are published to Docker Hub as `tgiachi/moongate-server` and to GHCR as
 `ghcr.io/moongate-community/moongate`, tagged `latest`, `X.Y`, `X.Y.Z` and
 `sha-<commit>`.
 
+## NuGet packages
+
+The abstraction assemblies plugin authors compile against are published to **GitHub Packages** on
+each release: `Moongate.Server.Abstractions` plus its dependency closure (`Moongate.Core`,
+`Moongate.Network`, `Moongate.Persistence`, `Moongate.UO.Data`, `Moongate.Ultima`).
+
+GitHub Packages requires authentication even for public feeds, so add a `nuget.config` next to your
+plugin project with a GitHub token that has the `read:packages` scope:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="moongate" value="https://nuget.pkg.github.com/moongate-community/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <moongate>
+      <add key="Username" value="%GITHUB_USER%" />
+      <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+    </moongate>
+  </packageSourceCredentials>
+</configuration>
+```
+
+Then reference the abstractions — the rest of the closure comes transitively:
+
+```xml
+<PackageReference Include="Moongate.Server.Abstractions" Version="X.Y.Z" />
+```
+
+Match the version to the server you target. See the [Writing plugins](https://moongate.sh/contributing/writing-plugins/)
+guide for the full walkthrough.
+
 ## What Is In Scope Today
 
 - UO TCP networking with typed packet records and opcode dispatch.

--- a/docs/contributing/writing-plugins/first-plugin.md
+++ b/docs/contributing/writing-plugins/first-plugin.md
@@ -1,9 +1,9 @@
 # Your first plugin
 
-This walkthrough builds a complete plugin from an empty folder: a `greeter` config section
+This walkthrough builds a complete plugin from an empty folder: a `greeter` config file
 and a service that writes a configurable line to the log when the server starts. It touches
-the two most common seams — a config section and a hosted service — and shows how to
-reference the host assemblies, build, and deploy.
+two of the most common seams — a config file and a hosted service — and shows how to
+reference the assemblies, build, and deploy.
 
 ## Create the project
 
@@ -11,65 +11,104 @@ reference the host assemblies, build, and deploy.
 dotnet new classlib -n MyShard.Greeter -f net10.0
 ```
 
-## Reference the host assemblies
+## Reference the assemblies
 
-A plugin loads into the *same* assembly context as the server, with no version isolation, so
-it must be **compiled against the exact assemblies the server ships** — and must **not** carry
-its own copies of them into `plugins/`. You get both by referencing the host DLLs with
-`<Private>false</Private>`: the compiler sees them, but the build does not copy them next to
-your plugin.
+A plugin loads into the *same* assembly context as the server — there is **no version
+isolation** — so it must be built against the **same** assembly versions the server runs.
 
-Point a property at your server build output and reference from there. In a source checkout
-that is `src/Moongate.Server/bin/Release/net10.0/`; for a published server it is the folder
-next to `Moongate.Server.dll`.
+### PackageReference (recommended)
+
+The greeter only uses SquidStd, DryIoc and Serilog, which are on NuGet.org. Reference the SquidStd
+packages at the **same version the server ships** (check the server's release notes /
+`Directory.Build.props` — currently `0.38.0`); DryIoc and Serilog come with them:
 
 ```xml
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <!-- Path to your Moongate server build output -->
-    <MoongateBin>..\..\Moongate\src\Moongate.Server\bin\Release\net10.0</MoongateBin>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="SquidStd.Plugin.Abstractions">
-      <HintPath>$(MoongateBin)\SquidStd.Plugin.Abstractions.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="SquidStd.Abstractions">
-      <HintPath>$(MoongateBin)\SquidStd.Abstractions.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="DryIoc">
-      <HintPath>$(MoongateBin)\DryIoc.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Serilog">
-      <HintPath>$(MoongateBin)\Serilog.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
-
-</Project>
+<ItemGroup>
+  <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0" />
+  <PackageReference Include="SquidStd.Abstractions" Version="0.38.0" />
+  <PackageReference Include="SquidStd.Core" Version="0.38.0" />
+</ItemGroup>
 ```
 
-Later tutorials add one more reference — `Moongate.Server.Abstractions.dll` — for the
-game-facing seams (commands, packet handlers, events, data loaders). The greeter needs none
-of those.
+Plugins that use Moongate's **game-facing seams** (commands, packet handlers, events, data
+loaders — the later tutorials) additionally reference **`Moongate.Server.Abstractions`**, which
+Moongate publishes to GitHub Packages. Add a repo-local `nuget.config` for the feed, authenticated
+with a GitHub token that has the `read:packages` scope — GitHub Packages requires authentication
+even for public packages:
 
-## The config section
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="moongate" value="https://nuget.pkg.github.com/moongate-community/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <moongate>
+      <add key="Username" value="%GITHUB_USER%" />
+      <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+    </moongate>
+  </packageSourceCredentials>
+</configuration>
+```
 
-A config section is a plain class. Each property is one key; the class name has no bearing on
+```xml
+<PackageReference Include="Moongate.Server.Abstractions" Version="0.5.0" />
+```
+
+Match the version to the server you target; the Moongate packages are available from the first
+release after this feature ships, and a single reference to `Moongate.Server.Abstractions` pulls
+the rest of the closure transitively.
+
+### HintPath to a local build (fallback)
+
+When you build against a source checkout of the server, skip the feed and reference the host DLLs
+directly with `<Private>false</Private>` — the compiler sees them, the build does not copy them
+into `plugins/`, and the versions match because they *are* the server's. Point a property at your
+server build output (`src/Moongate.Server/bin/Release/net10.0/` in a source checkout):
+
+```xml
+<PropertyGroup>
+  <!-- Path to your Moongate server build output -->
+  <MoongateBin>..\..\Moongate\src\Moongate.Server\bin\Release\net10.0</MoongateBin>
+</PropertyGroup>
+
+<ItemGroup>
+  <Reference Include="SquidStd.Plugin.Abstractions">
+    <HintPath>$(MoongateBin)\SquidStd.Plugin.Abstractions.dll</HintPath>
+    <Private>false</Private>
+  </Reference>
+  <Reference Include="SquidStd.Abstractions">
+    <HintPath>$(MoongateBin)\SquidStd.Abstractions.dll</HintPath>
+    <Private>false</Private>
+  </Reference>
+  <Reference Include="SquidStd.Core">
+    <HintPath>$(MoongateBin)\SquidStd.Core.dll</HintPath>
+    <Private>false</Private>
+  </Reference>
+  <Reference Include="DryIoc">
+    <HintPath>$(MoongateBin)\DryIoc.dll</HintPath>
+    <Private>false</Private>
+  </Reference>
+  <Reference Include="Serilog">
+    <HintPath>$(MoongateBin)\Serilog.dll</HintPath>
+    <Private>false</Private>
+  </Reference>
+</ItemGroup>
+```
+
+Add `Moongate.Server.Abstractions.dll` the same way for the game-facing seams. Either way, only
+your plugin's own `.dll` ships into `<root>/plugins/`.
+
+## The config
+
+The config is a plain class. Each property is one key; the class name has no bearing on
 the section name — that is chosen at registration. Give every property a sensible default so
-the plugin works before anyone edits `moongate.yaml`.
+the plugin works before anyone edits the config file.
 
 ```csharp
 namespace MyShard.Greeter.Data.Config;
 
-/// <summary>Config for the greeter plugin (section <c>greeter</c> in moongate.yaml).</summary>
+/// <summary>Config for the greeter plugin (section <c>greeter</c>, in its own file).</summary>
 public sealed class GreeterConfig
 {
     /// <summary>Line written to the log when the server starts.</summary>
@@ -80,8 +119,8 @@ public sealed class GreeterConfig
 ## The service
 
 A hosted service implements `ISquidStdService`; the server calls `StartAsync` at boot and
-`StopAsync` at shutdown. The bound `GreeterConfig` is injected directly — registering it as a
-section (below) is what makes it resolvable.
+`StopAsync` at shutdown. The bound `GreeterConfig` is injected directly — registering it
+(below) is what makes it resolvable.
 
 ```csharp
 using Serilog;
@@ -126,6 +165,7 @@ using MyShard.Greeter.Data.Config;
 using MyShard.Greeter.Services;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;
+using SquidStd.Core.Directories;
 using SquidStd.Plugin.Abstractions.Data;
 using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
 
@@ -145,7 +185,8 @@ public sealed class GreeterPlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
-        container.RegisterConfigSection<GreeterConfig>("greeter");
+        var directories = container.Resolve<DirectoriesConfig>();
+        container.RegisterConfigFile<GreeterConfig>("greeter", directories["plugins/configs"]);
         container.RegisterStdService<GreeterService, GreeterService>();
     }
 }
@@ -162,10 +203,14 @@ dotnet build -c Release
 cp bin/Release/net10.0/MyShard.Greeter.dll <server-root>/plugins/
 ```
 
-Only `MyShard.Greeter.dll` lands in `plugins/` — the host assemblies stayed out because they
-are `<Private>false</Private>`. Add the section to `moongate.yaml`:
+Only `MyShard.Greeter.dll` lands in `plugins/` — the assemblies you referenced are the host's to
+resolve (or `<Private>false</Private>` in the local-build fallback). Because the plugin registers
+its config with `RegisterConfigFile`, the server generates `<root>/plugins/configs/greeter.yaml`
+with the defaults at first start, then binds and reloads it (embedded plugins keep a section in
+`moongate.yaml` instead — see [Per-plugin config file](registration.md#per-plugin-config-file)):
 
 ```yaml
+# plugins/configs/greeter.yaml
 greeter:
   message: "Welcome to my shard"
 ```

--- a/docs/contributing/writing-plugins/registration.md
+++ b/docs/contributing/writing-plugins/registration.md
@@ -19,6 +19,10 @@ glance. The extension methods live in the assembly named in each row — referen
 The last row is plain DryIoc: register any service your plugin needs internally, then inject it
 into the components above.
 
+`Moongate.Server.Abstractions` and its dependency closure are published as NuGet packages of the
+same name on GitHub Packages; the `SquidStd.*` packages and DryIoc are on NuGet.org. See
+[referencing the assemblies](first-plugin.md#reference-the-assemblies).
+
 ## Per-plugin config file
 
 `RegisterConfigSection<T>("x")` binds a section of the shared `moongate.yaml`. To give a plugin its

--- a/src/Moongate.Core/Moongate.Core.csproj
+++ b/src/Moongate.Core/Moongate.Core.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Moongate.Network/Moongate.Network.csproj
+++ b/src/Moongate.Network/Moongate.Network.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Moongate.Persistence/Moongate.Persistence.csproj
+++ b/src/Moongate.Persistence/Moongate.Persistence.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj
+++ b/src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Moongate.UO.Data/Moongate.UO.Data.csproj
+++ b/src/Moongate.UO.Data/Moongate.UO.Data.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Moongate.Ultima/Moongate.Ultima.csproj
+++ b/src/Moongate.Ultima/Moongate.Ultima.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 


### PR DESCRIPTION
Publishes the assemblies plugin authors compile against to the `moongate-community` GitHub Packages NuGet feed on each release, and documents referencing them via `PackageReference`.

## What

- **Packaging** — `Directory.Build.props` defaults `IsPackable=false`; the 6 closure projects (`Moongate.Core`, `Moongate.Network`, `Moongate.Persistence`, `Moongate.UO.Data`, `Moongate.Ultima`, `Moongate.Server.Abstractions`) opt back in. `dotnet pack Moongate.slnx` therefore emits exactly those 6, with `Moongate.Server.Abstractions` depending on the other 5 at the release version. `RepositoryUrl` now points at `moongate-community/moongate` for package↔repo linking.
- **CI** — a new `publish_packages` job in `release.yml` packs at `$RELEASE_VERSION` (`-p:IncludeSymbols=false`, GitHub Packages rejects `.snupkg`) and pushes to `https://nuget.pkg.github.com/moongate-community/index.json` with `github.token`. No new secret; mirrors the container `publish` job's gating.
- **Docs** — `first-plugin.md` now references assemblies via `PackageReference` (SquidStd from NuGet.org for the greeter; `Moongate.Server.Abstractions` from GitHub Packages for game-facing seams) with a local-build HintPath fallback, and switches the Greeter to `RegisterConfigFile` (the external-plugin idiom introduced in #27). `registration.md` notes the packages. `README.md` gains a **NuGet packages** section on configuring the feed.

## Notes

- The dependency closure means all 6 must publish together — `Moongate.Server.Abstractions` can't ship alone.
- GitHub Packages requires auth even for public feeds; consumers need a `nuget.config` + a `read:packages` PAT (documented).
- End-to-end publish runs only on a release push to `main`; this PR is verified by: `dotnet pack` emits exactly 6 nupkg with correct deps, `dotnet build`/`dotnet test` pass (1251 tests), workflow YAML validates, and docfx builds at 0 warnings. First real publish happens at the next release.