### PR TITLE
docs: agent guidance (CLAUDE.md, AGENTS.md) + CODE_CONVENTION sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+Read **[CLAUDE.md](./CLAUDE.md) first.** It is the single source of guidance for working in this
+repository — build/test/run commands, the high-level architecture, and the project conventions — and
+it applies to every agent or tool, not just Claude Code.
+
+For the authoritative C# style rules, see [CODE_CONVENTION.md](./CODE_CONVENTION.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,25 @@ English.
   data-template pages). Docs deploy to **moongate.sh only from `main`**, so docs merged to `develop`
   are not yet live.
 
+## Development workflow
+
+Every feature follows the same flow:
+
+1. **Open a GitHub issue first**, with a **type** label (`Bug`, `feature`, `improvement`) and an
+   **area** label (`backend`, `client`, `network`, …), and an accurate description of the change.
+2. **Branch from `develop`.** Create a `feature/<name>` branch off the latest `develop` — never work
+   directly on `develop` or `main`. (Isolated worktrees under `.claude/worktrees/` are used for this.)
+3. Implement the change, committing in **English Conventional Commits** (no AI attribution).
+4. **Check the network layer.** If any packet class changed, regenerate the packet reference and
+   commit it — `dotnet run scripts/generate-packet-docs.cs` — and keep each packet's
+   `[PacketDocumentation]` attribute (see §11 / the Packets section).
+5. **Keep the docs coherent.** Update `docs/` for any behaviour or API change, and confirm
+   `dotnet docfx docs/docfx.json --warningsAsErrors` builds at **0 warnings**.
+6. **Merge via PR into `develop`.** Open a PR from the feature branch to `develop` with a clear
+   description; merge once CI is green, then delete the branch.
+
+Releases are separate (see below): they go through a `develop`→`main` PR labelled `release`.
+
 ## Release
 
 `develop` is the integration branch; features branch off it and PR back. Releases go via a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Moongate is a modern Ultima Online server, written from scratch in C# (.NET 10) on top of the
+**SquidStd** framework (a set of NuGet packages providing the bootstrap, DI, plugin loader, config,
+persistence and networking primitives). Game content is authored in Lua and YAML; it targets the
+ClassicUO 7.x client only.
+
+## Commands
+
+SDK is pinned to **10.0.301** in `global.json`. The solution file is `Moongate.slnx` (SLNX format).
+
+```bash
+# Build / test the whole solution
+dotnet build Moongate.slnx
+dotnet test Moongate.slnx
+
+# Run a single test class or method (xUnit)
+dotnet test Moongate.slnx --filter "FullyQualifiedName~<ClassName>"
+dotnet test Moongate.slnx --filter "Name=<TestMethodName>"
+
+# Run the server locally (creates the runtime dir + a default moongate.yaml + admin/admin on first boot)
+dotnet run --project src/Moongate.Server -- --root-directory ~/moongate --uo-directory ~/uo
+# scripts/run_server.sh does a self-contained publish+run for the current RID (AOT is NOT supported)
+
+# Docs site (DocFX). CI runs it with --warningsAsErrors, so it MUST build at 0 warnings.
+dotnet tool restore
+dotnet docfx docs/docfx.json --warningsAsErrors     # build (gate)
+dotnet docfx docs/docfx.json --serve                # preview at http://localhost:8080
+```
+
+Analyzers run during the build (`EnableNETAnalyzers` + `EnforceCodeStyleInBuild` in
+`Directory.Build.props`); `TreatWarningsAsErrors` is **false**, so warnings do not fail the .NET
+build — but the DocFX build does fail on any warning.
+
+## Architecture
+
+**Bootstrap.** `src/Moongate.Server/Program.cs` builds a SquidStd bootstrap: it registers plugins
+via `stdBootstrap.UsePlugins(builder => { builder.FromDirectory("plugins"); builder.Add<T>(); ... })`,
+then `ConfigureServices` on a **DryIoc** container. Config is "config-first": a `RegisterConfigSection<T>("x")`
+binds a section of `moongate.yaml` eagerly at registration. Everything the server does — networking,
+commands, packet handlers, the HTTP API, the admin console — is wired through this plugin mechanism.
+
+**Projects (`src/`).** Each is one bounded responsibility; dependencies flow one way:
+- `Moongate.Core` — domain primitives (Serial, geometry, `Types` enums), extensions.
+- `Moongate.Ultima` — **standalone** reader of UO client MUL/UOP files (maps, art, gumps, anim,
+  hues, tiledata) via process-wide statics. It must **not** reference `Moongate.Core` or any other
+  Moongate project; do not relocate its types into Core to dedupe.
+- `Moongate.UO.Data` — UO data models (bodies, skills, tiles). References Core + Ultima.
+- `Moongate.Network` — typed packet records under `Packets/` and opcode dispatch.
+- `Moongate.Persistence` — entity stores over SquidStd.Persistence (MessagePack).
+- `Moongate.Server.Abstractions` — the **contract assembly**: every service interface, domain event,
+  session model, config record, `Types` enum, and the registration-seam extension methods. Plugins
+  depend on this, **never on `Moongate.Server`**.
+- `Moongate.Server` — the composition root and concrete service implementations.
+- `Moongate.Scripting` — the Lua runtime and script modules (game-content authoring, no recompile).
+
+**Plugins (`plugins/`).** External-DLL plugins implement `ISquidStdPlugin` (`Metadata` +
+`Configure(IContainer, PluginContext)`), have a public parameterless constructor, and are loaded
+into the **default** AssemblyLoadContext (no version isolation — build against the exact host
+assembly versions). `Moongate.Http.Plugin` is the REST API surface; `Moongate.Console.Admin.Plugin`
+is the telnet admin console. Registration seams a plugin's `Configure` calls:
+`RegisterConfigSection`/`RegisterConfigFile` + `RegisterStdService` (SquidStd.Abstractions),
+`RegisterCommand`/`RegisterPacketHandler`/`RegisterEventSubscriber`/`RegisterDataLoader`
+(`Moongate.Server.Abstractions.Extensions`), and `RegisterApiEndpoint` (`Moongate.Http.Plugin`).
+See `docs/contributing/writing-plugins/` for the full walkthrough.
+
+**Game loop.** There is a single game-loop thread. Domain-event subscribers run on it (safe to touch
+world state directly); background work off the loop (a hosted `ISquidStdService`, a socket) must
+marshal onto it via `IMainThreadDispatcher`.
+
+**World data.** The source of truth for templates and world data is the tracked, embedded YAML under
+`src/Moongate.Server/Assets/` (loaded by `IDataLoader`s in priority order at startup and seeded into
+the runtime root on first boot). The runtime working directory is `moongate_root/`; `moongate/` is a
+gitignored leftover with the same shape. When adding a template, bump the hardcoded counts in the
+relevant tests.
+
+## Conventions
+
+The authoritative C# style rules are in **`CODE_CONVENTION.md`** at the repo root (folder-to-namespace
+mapping; domain-first `Types`/`Data`/`Interfaces` buckets; one type per file; class layout = private
+readonly → props → constructor; `Dispose` last; no primary or expression-bodied constructors; `///`
+on interfaces). Note that CODE_CONVENTION.md §10–12 (plugin/D-Bus/hosted-service) predates the current
+SquidStd architecture — trust the actual code and the plugin docs over those sections.
+
+Tests live in `tests/Moongate.Tests/<Domain>/<Subdomain>/<Subject>Tests.cs` with a namespace matching
+the folder path; shared fixtures go in `Support/`. Commit messages are Conventional Commits, in
+English.
+
+## Packets and docs (must stay in sync)
+
+- **Every packet class change** requires rerunning the packet-docs generator from the repo root and
+  committing the regenerated `docs/packets/` markdown:
+  `dotnet run scripts/generate-packet-docs.cs`. Packet classes MUST carry
+  `[PacketDocumentation(family, Length/IsVariableLength, SubCommand?, Name?)]` or generation and tests
+  fail.
+- REST endpoint handlers must be method groups (not lambdas) with `///` summaries — Swashbuckle only
+  reads XML docs off method groups, and they render as the public API reference.
+- Before pushing a feature, check whether `docs/` needs updates (scripting reference, guides,
+  data-template pages). Docs deploy to **moongate.sh only from `main`**, so docs merged to `develop`
+  are not yet live.
+
+## Release
+
+`develop` is the integration branch; features branch off it and PR back. Releases go via a
+develop→main PR labelled `release`: semantic-release derives the version from Conventional Commits,
+publishes container images to GHCR + Docker Hub (`tgiachi/moongate-server`), publishes the
+`Moongate.Server.Abstractions` package closure (6 packages: Core, Network, Persistence, UO.Data,
+Ultima, Server.Abstractions) to the `moongate-community` GitHub Packages NuGet feed, and deploys the
+docs. Only those 6 projects are packable (`<IsPackable>true</IsPackable>`); everything else defaults
+to non-packable in `Directory.Build.props`.

--- a/CODE_CONVENTION.md
+++ b/CODE_CONVENTION.md
@@ -110,7 +110,7 @@ public enum DirectoryType { Scripts, Logs, Plugins, Configs }
 private readonly ILogger _logger = Log.ForContext<MyService>();
 ```
 
-- When both Serilog and Microsoft.Extensions.Logging are in scope (e.g., `Moongate.Service` which uses `Microsoft.NET.Sdk.Web`), add a using alias to resolve the ambiguity:
+- When both Serilog and Microsoft.Extensions.Logging are in scope (e.g. in `Moongate.Http.Plugin`, where ASP.NET Core brings `Microsoft.Extensions.Logging` in), add a using alias to resolve the ambiguity:
 
 ```csharp
 using Serilog;
@@ -122,20 +122,13 @@ using ILogger = Serilog.ILogger;
 
 ## 9. Event Bus
 
-- All event types must implement `IMoongateEvent`.
-- Use `IEventBus.Subscribe<T>` to register handlers; use `IEventBus.PublishAsync<T>` to emit events.
-- Subscriber classes live in `Subscribers/` and register themselves in the constructor.
-
-```csharp
-// Pattern: SocketBroadcastSubscriber
-internal class MySubscriber
-{
-    public MySubscriber(IEventBus eventBus, ...)
-    {
-        eventBus.Subscribe<Notification>(HandleAsync);
-    }
-}
-```
+- The event bus is `IEventBus` (`SquidStd.Core.Interfaces.Events`). Events are plain records/classes —
+  there is no marker interface to implement.
+- Emit with `eventBus.Publish(new SomeEvent(...))` (or `PublishAsync` when you need to await delivery);
+  subscribe with `eventBus.Subscribe<SomeEvent>(handler)`, where a handler is
+  `Task Handler(SomeEvent message, CancellationToken ct)`.
+- Subscriber classes live in `Subscribers/` and are wired as `IEventSubscriberRegistration` (see §12);
+  domain-event handlers run on the game loop.
 
 ## 10. Plugin System
 
@@ -185,9 +178,9 @@ namespace Moongate.Tests.<Domain>.<Subdomain>;
 
 Examples:
 ```
-tests/Moongate.Tests/Core/EventBusServiceTests.cs   → namespace Moongate.Tests.Core;
-tests/Moongate.Tests/Service/UnixSocketServerTests.cs → namespace Moongate.Tests.Service;
-tests/Moongate.Tests/Support/FakeSourcePlugin.cs    → namespace Moongate.Tests.Support;
+tests/Moongate.Tests/Network/PacketDocumentationTests.cs → namespace Moongate.Tests.Network;
+tests/Moongate.Tests/Server/CharacterServiceTests.cs     → namespace Moongate.Tests.Server;
+tests/Moongate.Tests/Support/<SharedFixture>.cs          → namespace Moongate.Tests.Support;
 ```
 
 ### 13.2 Naming
@@ -202,17 +195,10 @@ tests/Moongate.Tests/Support/FakeSourcePlugin.cs    → namespace Moongate.Tests
 - Shared fakes, builders, and helpers go in `tests/Moongate.Tests/Support/`.
 - Do not mix reusable test infrastructure into domain test files.
 
-### 13.4 InternalsVisibleTo
-
-`Moongate.Service.csproj` exposes internals to `Moongate.Tests` via:
-```xml
-<InternalsVisibleTo Include="Moongate.Tests"/>
-```
-
 ## 14. Commits
 
 - Use Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, etc.).
-- Scope commits to the affected subsystem: `feat(dbus):`, `fix(socket):`, `test(eventbus):`.
+- Scope commits to the affected subsystem: `feat(console):`, `fix(network):`, `test(scripting):`.
 - Never add `Co-Authored-By: Claude` to commits.
 
 ## 15. Non-Negotiable Hygiene

--- a/CODE_CONVENTION.md
+++ b/CODE_CONVENTION.md
@@ -139,20 +139,40 @@ internal class MySubscriber
 
 ## 10. Plugin System
 
-- Plugins implement `ISourcePlugin` (Id in reverse-domain format: `com.github.author.Moongate.plugins.name`).
-- Plugins receive an `IPluginContext` — use `context.EventBus` to publish, `context.Logger` to log, `context.ConfigPath` for config.
-- Plugin hosts are loaded via `PluginLoadContext` (`AssemblyLoadContext(isCollectible: true)`) for hot-reload support.
+- Plugins implement `ISquidStdPlugin` (`SquidStd.Plugin.Abstractions`): a `Metadata` property
+  (`PluginMetadata` — a stable lowercase-dotted `Id` such as `moongate.http.plugin`, plus `Name`,
+  `Version`, `Author`, `Description`, `Dependencies`) and `Configure(IContainer, PluginContext)`.
+- A plugin class needs a **public parameterless constructor**. Plugins load either from the
+  `plugins/` directory (`builder.FromDirectory("plugins")`) or in-tree (`builder.Add<T>()` in
+  `Program.cs`), into the **default** `AssemblyLoadContext` — there is no version isolation, so a
+  plugin must be built against the exact host assembly versions.
+- `Configure` registers everything the plugin contributes into the DryIoc container. Seams:
+  `RegisterConfigSection` / `RegisterConfigFile` and `RegisterStdService` (`SquidStd.Abstractions`);
+  `RegisterCommand`, `RegisterPacketHandler`, `RegisterEventSubscriber`, `RegisterDataLoader`
+  (`Moongate.Server.Abstractions.Extensions`); `RegisterApiEndpoint` (`Moongate.Http.Plugin`).
+- Plugins reference `Moongate.Server.Abstractions`, **never `Moongate.Server`**. See
+  `docs/contributing/writing-plugins/`.
 
-## 11. D-Bus Interfaces
+## 11. Networking & Packets
 
-- D-Bus proxy interfaces live in `DBus/` and must be `public` (required by Tmds.DBus runtime proxy generation via Reflection.Emit).
-- Annotate with `[DBusInterface("...")]` and inherit `IDBusObject`.
+- Packets are typed records under `Moongate.Network/Packets/` (`Incoming/`, `Outgoing/`). Each packet
+  class carries `[PacketDocumentation(family, Length | IsVariableLength, SubCommand?, Name?)]` — the
+  attribute is mandatory; doc generation and tests fail without it.
+- Inbound handlers implement `IPacketHandler<TPacket>` **and** `IPacketHandlerRegistration`, and are
+  registered with `RegisterPacketHandler<T>()`.
+- After **any** change to a packet class, regenerate the packet reference from the repo root and
+  commit the result: `dotnet run scripts/generate-packet-docs.cs` (writes `docs/packets/`).
 
-## 12. Hosted Services / Subscribers
+## 12. Hosted Services & Event Subscribers
 
-- Background services implement `IHostedService` (or extend `BackgroundService`).
-- If an optional external dependency (e.g., D-Bus session bus) is unavailable at startup, log a `Warning` and return cleanly — do not crash the host.
-- Subscribers that are not hosted services are registered as singletons and force-resolved in `Program.cs` to trigger constructor subscription registration.
+- Lifecycle/background services implement `ISquidStdService` (`ValueTask StartAsync` / `StopAsync`),
+  registered with `RegisterStdService<TImpl, TImpl>()`. `Dispose` stays last (§4.2).
+- An **optional** service must never take the server down: if a resource it needs at startup is
+  unavailable (e.g. a port to bind), log a `Warning` and return cleanly rather than throwing — an
+  exception out of `Configure` / `StartAsync` aborts startup.
+- Event subscribers implement `IEventSubscriberRegistration` (`Subscribe(IEventBus)`), registered with
+  `RegisterEventSubscriber<T>()`; they attach handlers via `eventBus.Subscribe<TEvent>(...)` and run on
+  the game loop. Work started off the loop reaches world state through `IMainThreadDispatcher`.
 
 ## 13. Test Conventions
 


### PR DESCRIPTION
Documentation/meta only — no code changes.

## What

- **`CLAUDE.md`** (new) — repo guidance for Claude Code / agents: build/test/run commands (`Moongate.slnx`, single-test filter, `dotnet run` the server, DocFX `--warningsAsErrors` gate, SDK 10.0.301), the SquidStd-based architecture and project graph, the external-DLL plugin model and registration seams, the mandatory packet-docs regen workflow, and the release pipeline.
- **`AGENTS.md`** (new) — thin pointer so any agent/tool reads `CLAUDE.md` first.
- **`CODE_CONVENTION.md`** — resynced with the actual codebase:
  - §10 Plugin System → `ISquidStdPlugin` / DryIoc / default-ALC loading / registration seams (was `ISourcePlugin` / collectible ALC).
  - §11 → **Networking & Packets** (`[PacketDocumentation]` + generator regen) replacing the phantom D-Bus section (no D-Bus exists in the repo).
  - §12 Hosted Services → `ISquidStdService` + `IEventSubscriberRegistration` (was `IHostedService`).
  - §8/§9/§13/§14 — fixed stale references: `Moongate.Service` → `Moongate.Http.Plugin`/`Moongate.Server`; events use SquidStd `IEventBus` (no `IMoongateEvent`); removed the phantom `InternalsVisibleTo` subsection; real commit-scope examples.

## Why

CODE_CONVENTION §10–12 described an older/generic template (ISourcePlugin, Tmds.DBus, IHostedService) that no longer matches the SquidStd-based code — verified: those identifiers appear in 0 source files.