### PR TITLE
feat(scripting): ILuaTable views for account/item/mobile get

### DIFF
--- a/plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
+++ b/plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -41,8 +41,8 @@
         -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.15" />
-        <PackageReference Include="SquidStd.Abstractions" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Core/Moongate.Core.csproj
+++ b/src/Moongate.Core/Moongate.Core.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Core" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Network/Moongate.Network.csproj
+++ b/src/Moongate.Network/Moongate.Network.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Network" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Network" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Persistence/Moongate.Persistence.csproj
+++ b/src/Moongate.Persistence/Moongate.Persistence.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Persistence" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Persistence" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -29,11 +29,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Core" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Plugin" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.38.0"/>
-        <PackageReference Include="SquidStd.Services.Core" Version="0.38.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Services.Core" Version="0.39.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Server/Scripting/AccountModule.cs
+++ b/src/Moongate.Server/Scripting/AccountModule.cs
@@ -2,6 +2,7 @@ using Moongate.Core.Interfaces;
 using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Scripting.Views;
 using Serilog;
 using SquidStd.Scripting.Lua.Attributes.Scripts;
 
@@ -65,23 +66,8 @@ public sealed class AccountModule
         => _accounts.GetByUsername(username) is not null;
 
     [ScriptFunction("get", "Returns a field table for the account, or nil.")]
-    public Dictionary<string, object?>? Get(string username)
-    {
-        if (_accounts.GetByUsername(username) is not { } account)
-        {
-            return null;
-        }
-
-        return new()
-        {
-            ["id"] = account.Id.Value,
-            ["username"] = account.Username,
-            ["email"] = account.Email,
-            ["level"] = account.AccountLevel.ToString(),
-            ["is_active"] = account.IsActive,
-            ["mobiles"] = account.MobileIds.Select(id => id.Value).ToList()
-        };
-    }
+    public AccountLuaView? Get(string username)
+        => _accounts.GetByUsername(username) is { } account ? new AccountLuaView(account) : null;
 
     [ScriptFunction("list", "Returns every account's username.")]
     public List<string> List()

--- a/src/Moongate.Server/Scripting/ItemModule.cs
+++ b/src/Moongate.Server/Scripting/ItemModule.cs
@@ -2,6 +2,7 @@ using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Scripting.Views;
 using Moongate.Ultima.Types;
 using Moongate.UO.Data.Hues;
 using MoonSharp.Interpreter;
@@ -133,27 +134,8 @@ public sealed class ItemModule
     }
 
     [ScriptFunction("get", "Returns a field table for the item, or nil.")]
-    public Dictionary<string, object?>? Get(uint serial)
-    {
-        var item = _items.GetById((Serial)serial);
-
-        if (item is null)
-        {
-            return null;
-        }
-
-        return new()
-        {
-            ["id"] = item.Id.Value,
-            ["item_id"] = item.ItemId,
-            ["name"] = item.Name,
-            ["amount"] = item.Amount,
-            ["hue"] = (int)item.Hue.Value,
-            ["layer"] = item.EquippedLayer?.ToString(),
-            ["container"] = item.ParentContainerId.Value,
-            ["mobile"] = item.EquippedMobileId.Value
-        };
-    }
+    public ItemLuaView? Get(uint serial)
+        => _items.GetById((Serial)serial) is { } item ? new ItemLuaView(item) : null;
 
     [ScriptFunction("remove_from_container", "Removes an item from a container; false on unknown serials.")]
     public bool RemoveFromContainer(uint container, uint serial)

--- a/src/Moongate.Server/Scripting/MobileModule.cs
+++ b/src/Moongate.Server/Scripting/MobileModule.cs
@@ -6,6 +6,7 @@ using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Scripting.Views;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
@@ -95,33 +96,8 @@ public sealed class MobileModule
     }
 
     [ScriptFunction("get", "Returns a field table for the mobile, or nil.")]
-    public Dictionary<string, object?>? Get(uint serial)
-    {
-        var mobile = _mobiles.GetById((Serial)serial);
-
-        if (mobile is null)
-        {
-            return null;
-        }
-
-        return new()
-        {
-            ["id"] = mobile.Id.Value,
-            ["name"] = mobile.Name,
-            ["map"] = mobile.MapId,
-            ["x"] = mobile.Position.X,
-            ["y"] = mobile.Position.Y,
-            ["z"] = mobile.Position.Z,
-            ["direction"] = mobile.Direction.ToString(),
-            ["gender"] = mobile.Gender.ToString(),
-            ["race"] = mobile.Race.ToString(),
-            ["profession"] = (int)mobile.ProfessionId,
-            ["str"] = mobile.Strength,
-            ["dex"] = mobile.Dexterity,
-            ["int"] = mobile.Intelligence,
-            ["backpack"] = mobile.BackpackId.Value
-        };
-    }
+    public MobileLuaView? Get(uint serial)
+        => _mobiles.GetById((Serial)serial) is { } mobile ? new MobileLuaView(mobile) : null;
 
     [ScriptFunction("get_skill", "Returns the skill value for the mobile by skill name or id, or 0.")]
     public int GetSkill(uint serial, object skill)

--- a/src/Moongate.Server/Scripting/Views/AccountLuaView.cs
+++ b/src/Moongate.Server/Scripting/Views/AccountLuaView.cs
@@ -1,0 +1,19 @@
+using Moongate.Persistence.Entities;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+
+namespace Moongate.Server.Scripting.Views;
+
+/// <summary>Projects an <see cref="AccountEntity" /> into the Lua field table returned by <c>account.get</c>.</summary>
+public sealed record AccountLuaView(AccountEntity Account) : ILuaTable
+{
+    public Dictionary<string, object?> ToDictionary()
+        => new()
+        {
+            ["id"] = Account.Id.Value,
+            ["username"] = Account.Username,
+            ["email"] = Account.Email,
+            ["level"] = Account.AccountLevel.ToString(),
+            ["is_active"] = Account.IsActive,
+            ["mobiles"] = Account.MobileIds.Select(id => id.Value).ToList()
+        };
+}

--- a/src/Moongate.Server/Scripting/Views/ItemLuaView.cs
+++ b/src/Moongate.Server/Scripting/Views/ItemLuaView.cs
@@ -1,0 +1,21 @@
+using Moongate.Persistence.Entities;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+
+namespace Moongate.Server.Scripting.Views;
+
+/// <summary>Projects an <see cref="ItemEntity" /> into the Lua field table returned by <c>item.get</c>.</summary>
+public sealed record ItemLuaView(ItemEntity Item) : ILuaTable
+{
+    public Dictionary<string, object?> ToDictionary()
+        => new()
+        {
+            ["id"] = Item.Id.Value,
+            ["item_id"] = Item.ItemId,
+            ["name"] = Item.Name,
+            ["amount"] = Item.Amount,
+            ["hue"] = (int)Item.Hue.Value,
+            ["layer"] = Item.EquippedLayer?.ToString(),
+            ["container"] = Item.ParentContainerId.Value,
+            ["mobile"] = Item.EquippedMobileId.Value
+        };
+}

--- a/src/Moongate.Server/Scripting/Views/MobileLuaView.cs
+++ b/src/Moongate.Server/Scripting/Views/MobileLuaView.cs
@@ -1,0 +1,27 @@
+using Moongate.Persistence.Entities;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+
+namespace Moongate.Server.Scripting.Views;
+
+/// <summary>Projects a <see cref="MobileEntity" /> into the Lua field table returned by <c>mobile.get</c>.</summary>
+public sealed record MobileLuaView(MobileEntity Mobile) : ILuaTable
+{
+    public Dictionary<string, object?> ToDictionary()
+        => new()
+        {
+            ["id"] = Mobile.Id.Value,
+            ["name"] = Mobile.Name,
+            ["map"] = Mobile.MapId,
+            ["x"] = Mobile.Position.X,
+            ["y"] = Mobile.Position.Y,
+            ["z"] = Mobile.Position.Z,
+            ["direction"] = Mobile.Direction.ToString(),
+            ["gender"] = Mobile.Gender.ToString(),
+            ["race"] = Mobile.Race.ToString(),
+            ["profession"] = (int)Mobile.ProfessionId,
+            ["str"] = Mobile.Strength,
+            ["dex"] = Mobile.Dexterity,
+            ["int"] = Mobile.Intelligence,
+            ["backpack"] = Mobile.BackpackId.Value
+        };
+}

--- a/tests/Moongate.Tests/Server/ItemModuleTests.cs
+++ b/tests/Moongate.Tests/Server/ItemModuleTests.cs
@@ -107,7 +107,7 @@ public class ItemModuleTests
         var serial = module.Create("armoire", 1, 0)!.Value;
 
         Assert.True(module.Flip(serial));
-        Assert.Equal(2643, module.Get(serial)!["item_id"]);
+        Assert.Equal(2643, module.Get(serial)!.ToDictionary()["item_id"]);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class ItemModuleTests
         var (module, _) = Build();
         var serial = module.Create("dagger", 2, 0)!.Value;
 
-        var table = module.Get(serial);
+        var table = module.Get(serial)?.ToDictionary();
 
         Assert.NotNull(table);
         Assert.Equal(3921, table!["item_id"]);

--- a/tests/Moongate.Tests/Server/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/MobileModuleTests.cs
@@ -77,7 +77,7 @@ public class MobileModuleTests
         var (module, _) = Build();
         var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
 
-        var table = module.Get(serial);
+        var table = module.Get(serial)?.ToDictionary();
 
         Assert.NotNull(table);
         Assert.Equal("Guard", table!["name"]);

--- a/tests/Moongate.Tests/Server/Scripting/AccountModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/AccountModuleTests.cs
@@ -78,7 +78,7 @@ public class AccountModuleTests
         var (module, _) = Build();
         module.Create("tom", "secret", null, "Player");
 
-        Assert.DoesNotContain(module.Get("tom")!.Keys, key => key.Contains("password", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(module.Get("tom")!.ToDictionary().Keys, key => key.Contains("password", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class AccountModuleTests
         var (module, accounts) = Build();
         module.Create("tom", "secret", "tom@example.com", "GrandMaster");
 
-        var table = module.Get("tom");
+        var table = module.Get("tom")?.ToDictionary();
 
         Assert.NotNull(table);
         Assert.Equal("tom", table!["username"]);


### PR DESCRIPTION
Adopts SquidStd 0.39.0's `ILuaTable` marshalling: `account.get` / `item.get` / `mobile.get` now return small **view records** (`AccountLuaView`, `ItemLuaView`, `MobileLuaView`) that own the exact Lua-facing projection in an explicit, reflection-free `ToDictionary()` — instead of hand-building a `Dictionary<string, object?>` inline, and without leaking the live entity to scripts.

- **build(deps):** bump SquidStd `0.38.0 → 0.39.0` (brings `ILuaTable` + engine marshalling).
- **feat(scripting):** three `ILuaTable` view records under `Moongate.Server/Scripting/Views/`; the modules' `get` return the view. The engine converts an `ILuaTable` return via `ToDictionary()`, so the **Lua table shape is unchanged**.
- C# module tests read the projection through `.ToDictionary()`.

No Lua-facing behavior change (same keys/values), so the scripting docs stay accurate. 1251 tests green.

Depends on SquidStd 0.39.0 (released to nuget.org).