### PR TITLE
feat(http): admin console over REST (POST + per-connection SSE)

### DIFF
--- a/docs/under-the-hood/rest-console.md
+++ b/docs/under-the-hood/rest-console.md
@@ -1,0 +1,48 @@
+# Console over REST
+
+A REST web-terminal onto the admin command set: open a stream to receive output, then POST
+commands to it. Both endpoints require a staff JWT (`Administrator` or `GrandMaster`) — the same
+`admin` policy as the rest of the admin API.
+
+It is the HTTP twin of the [admin console](admin-console.md): a command runs through the same
+`ICommandService` on the game loop, and its reply lines are delivered through a callback — here,
+onto a per-connection [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events)
+feed instead of a telnet socket.
+
+## Open a stream
+
+`GET /api/v1/admin/console/stream` returns a `text/event-stream`. The **first** event is `ready`,
+whose data is a **connection id** — keep it to send commands on this stream:
+
+```
+event: ready
+data: 3f2b8c…
+
+event: line
+data: Broadcast sent.
+
+event: done
+data: broadcast hello
+```
+
+The stream stays open until the client disconnects; each command you send produces one `line`
+event per reply line, then a `done` event carrying the command that finished.
+
+## Send a command
+
+`POST /api/v1/admin/console` with the connection id from the stream:
+
+```json
+{ "command": "broadcast hello", "connectionId": "3f2b8c…" }
+```
+
+It returns **202 Accepted** immediately; the command is dispatched onto the game loop and its
+output arrives asynchronously on that connection's stream. A POST with an unknown or closed
+connection id returns **404**.
+
+## Which commands are reachable
+
+A command is reachable over REST only if its registration opts into the `Rest`
+[source](admin-console.md) — network exposure is curated separately from the loopback telnet
+console. `broadcast` opts in. Unknown or unavailable commands reply `Unknown command.`, exactly as
+they do in-game and on the telnet console.

--- a/docs/under-the-hood/toc.yml
+++ b/docs/under-the-hood/toc.yml
@@ -4,3 +4,5 @@
   href: rest-api.md
 - name: Admin console
   href: admin-console.md
+- name: Console over REST
+  href: rest-console.md

--- a/plugins/Moongate.Http.Plugin/Data/Api/Console/ConsoleCommandRequest.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Console/ConsoleCommandRequest.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Console;
+
+/// <summary>A console command to run and the SSE connection its output should stream to.</summary>
+public sealed record ConsoleCommandRequest(string Command, string ConnectionId);

--- a/plugins/Moongate.Http.Plugin/Data/Console/ConsoleStreamEvent.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Console/ConsoleStreamEvent.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Console;
+
+/// <summary>One server-sent event on a console stream: an <c>Event</c> name (ready/line/done) and its text.</summary>
+public sealed record ConsoleStreamEvent(string Event, string Text);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Api.Console;
+using Moongate.Http.Plugin.Data.Console;
+using Moongate.Http.Plugin.Interfaces.Console;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Types;
+using SquidStd.Core.Interfaces.Threading;
+
+namespace Moongate.Http.Plugin.Endpoints.Console;
+
+/// <summary>A REST web-terminal onto the admin command set: POST a command, receive its output over SSE.</summary>
+public sealed class ConsoleEndpoints : IApiEndpointRegistration
+{
+    private readonly IConsoleStreamRegistry _registry;
+    private readonly ICommandService _commands;
+    private readonly IMainThreadDispatcher _dispatcher;
+
+    public ConsoleEndpoints(IConsoleStreamRegistry registry, ICommandService commands, IMainThreadDispatcher dispatcher)
+    {
+        _registry = registry;
+        _commands = commands;
+        _dispatcher = dispatcher;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+        => routes.MapPost("/api/v1/admin/console", Send)
+                 .WithName("SendConsoleCommand")
+                 .WithTags("console")
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
+
+    /// <summary>Runs a console command; its reply lines stream to the given connection's SSE feed.</summary>
+    /// <remarks>Returns 202 immediately — the command is dispatched onto the game loop and its output
+    /// arrives asynchronously on <c>GET /api/v1/admin/console/stream</c>.</remarks>
+    private IResult Send(ConsoleCommandRequest request, ClaimsPrincipal user)
+    {
+        // Unknown or already-closed connection: nothing to stream to.
+        if (!_registry.TryGetWriter(request.ConnectionId, out var writer))
+        {
+            return TypedResults.NotFound("Unknown connection.");
+        }
+
+        // AdminPolicy guarantees an Administrator/GrandMaster role claim; parse it for the actor level.
+        if (!Enum.TryParse<AccountLevelType>(user.FindFirstValue(ClaimTypes.Role), out var level))
+        {
+            return TypedResults.Forbid();
+        }
+
+        var invocation = new CommandInvocation(
+            CommandSourceType.Rest,
+            level,
+            null,
+            request.Command,
+            line => writer.TryWrite(new ConsoleStreamEvent("line", line))
+        );
+
+        _dispatcher.Post(
+            () =>
+            {
+                _commands.Execute(invocation);
+                writer.TryWrite(new ConsoleStreamEvent("done", request.Command));
+            }
+        );
+
+        return TypedResults.Accepted((string?)null);
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Net.ServerSentEvents;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -7,6 +8,7 @@ using Moongate.Http.Plugin.Data.Api.Console;
 using Moongate.Http.Plugin.Data.Console;
 using Moongate.Http.Plugin.Interfaces.Console;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Console;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Server.Abstractions.Data.Commands;
 using Moongate.Server.Abstractions.Interfaces.Commands;
@@ -30,10 +32,28 @@ public sealed class ConsoleEndpoints : IApiEndpointRegistration
     }
 
     public void Register(IEndpointRouteBuilder routes)
-        => routes.MapPost("/api/v1/admin/console", Send)
-                 .WithName("SendConsoleCommand")
-                 .WithTags("console")
-                 .RequireAuthorization(HttpServerService.AdminPolicy);
+    {
+        routes.MapGet("/api/v1/admin/console/stream", Stream)
+              .WithName("StreamConsole")
+              .WithTags("console")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        routes.MapPost("/api/v1/admin/console", Send)
+              .WithName("SendConsoleCommand")
+              .WithTags("console")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>Opens a per-connection SSE feed; its first event carries the connection id to POST with.</summary>
+    /// <remarks>Emits <c>ready</c> (data = the connection id), then a <c>line</c> per command reply and a
+    /// <c>done</c> when a command finishes. The connection is closed when the client disconnects.</remarks>
+    private IResult Stream(HttpContext context)
+    {
+        var (connectionId, reader) = _registry.Open();
+        context.RequestAborted.Register(() => _registry.Close(connectionId));
+
+        return TypedResults.ServerSentEvents(ConsoleSseStream.From(connectionId, reader, context.RequestAborted));
+    }
 
     /// <summary>Runs a console command; its reply lines stream to the given connection's SSE feed.</summary>
     /// <remarks>Returns 202 immediately — the command is dispatched onto the game loop and its output

--- a/plugins/Moongate.Http.Plugin/Interfaces/Console/IConsoleStreamRegistry.cs
+++ b/plugins/Moongate.Http.Plugin/Interfaces/Console/IConsoleStreamRegistry.cs
@@ -1,0 +1,17 @@
+using System.Threading.Channels;
+using Moongate.Http.Plugin.Data.Console;
+
+namespace Moongate.Http.Plugin.Interfaces.Console;
+
+/// <summary>Holds the open console SSE connections, keyed by an unguessable connection id.</summary>
+public interface IConsoleStreamRegistry
+{
+    /// <summary>Opens a new connection: returns its id and the reader the SSE endpoint streams from.</summary>
+    (string ConnectionId, ChannelReader<ConsoleStreamEvent> Reader) Open();
+
+    /// <summary>Gets the writer for an open connection; false if the id is unknown or closed.</summary>
+    bool TryGetWriter(string connectionId, out ChannelWriter<ConsoleStreamEvent> writer);
+
+    /// <summary>Completes and removes a connection; safe to call more than once.</summary>
+    void Close(string connectionId);
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -4,6 +4,7 @@ using Moongate.Http.Plugin.Endpoints.Accounts;
 using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
+using Moongate.Http.Plugin.Endpoints.Console;
 using Moongate.Http.Plugin.Endpoints.Images;
 using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
@@ -12,11 +13,13 @@ using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Extensions;
 using Moongate.Http.Plugin.Interfaces.Auth;
+using Moongate.Http.Plugin.Interfaces.Console;
 using Moongate.Http.Plugin.Interfaces.Images;
 using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Mobiles;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Services.Auth;
+using Moongate.Http.Plugin.Services.Console;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Services.Images;
 using Moongate.Http.Plugin.Services.Maps;
@@ -99,6 +102,11 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<CharacterEndpoints>();
         container.RegisterApiEndpoint<CharacterAdminEndpoints>();
         container.RegisterApiEndpoint<ItemTemplateEndpoints>();
+
+        // A REST web-terminal onto the admin command set: the registry holds the open SSE feeds,
+        // the endpoints POST commands and stream their output.
+        container.Register<IConsoleStreamRegistry, ConsoleStreamRegistry>(Reuse.Singleton);
+        container.RegisterApiEndpoint<ConsoleEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/plugins/Moongate.Http.Plugin/Services/Console/ConsoleSseStream.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Console/ConsoleSseStream.cs
@@ -1,0 +1,28 @@
+using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Moongate.Http.Plugin.Data.Console;
+
+namespace Moongate.Http.Plugin.Services.Console;
+
+/// <summary>
+/// Turns a console connection's events into the SSE items its stream emits: a <c>ready</c> item carrying
+/// the connection id, then one item per <see cref="ConsoleStreamEvent" /> (its <c>Event</c> becomes the
+/// SSE event type, its <c>Text</c> the data). Ends when the channel completes or the token cancels.
+/// </summary>
+public static class ConsoleSseStream
+{
+    public static async IAsyncEnumerable<SseItem<string>> From(
+        string connectionId,
+        ChannelReader<ConsoleStreamEvent> reader,
+        [EnumeratorCancellation] CancellationToken cancellationToken
+    )
+    {
+        yield return new SseItem<string>(connectionId, "ready");
+
+        await foreach (var evt in reader.ReadAllAsync(cancellationToken))
+        {
+            yield return new SseItem<string>(evt.Text, evt.Event);
+        }
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Services/Console/ConsoleStreamRegistry.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Console/ConsoleStreamRegistry.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Moongate.Http.Plugin.Data.Console;
+using Moongate.Http.Plugin.Interfaces.Console;
+
+namespace Moongate.Http.Plugin.Services.Console;
+
+/// <summary>
+/// In-memory registry of open console SSE connections. Each connection is an unbounded channel; the POST
+/// handler writes reply events to it and the SSE endpoint drains it. Thread-safe: writes come from the
+/// game loop, reads from the ASP.NET request thread.
+/// </summary>
+public sealed class ConsoleStreamRegistry : IConsoleStreamRegistry
+{
+    private readonly ConcurrentDictionary<string, Channel<ConsoleStreamEvent>> _channels = new();
+
+    public (string ConnectionId, ChannelReader<ConsoleStreamEvent> Reader) Open()
+    {
+        var connectionId = Guid.NewGuid().ToString("N");
+        var channel = Channel.CreateUnbounded<ConsoleStreamEvent>();
+        _channels[connectionId] = channel;
+
+        return (connectionId, channel.Reader);
+    }
+
+    public bool TryGetWriter(string connectionId, out ChannelWriter<ConsoleStreamEvent> writer)
+    {
+        if (_channels.TryGetValue(connectionId, out var channel))
+        {
+            writer = channel.Writer;
+
+            return true;
+        }
+
+        writer = Channel.CreateUnbounded<ConsoleStreamEvent>().Writer;
+
+        return false;
+    }
+
+    public void Close(string connectionId)
+    {
+        if (_channels.TryRemove(connectionId, out var channel))
+        {
+            channel.Writer.TryComplete();
+        }
+    }
+}

--- a/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
+++ b/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
@@ -8,5 +8,6 @@ namespace Moongate.Server.Abstractions.Types;
 public enum CommandSourceType : byte
 {
     InGame  = 1 << 0,
-    Console = 1 << 1
+    Console = 1 << 1,
+    Rest    = 1 << 2
 }

--- a/src/Moongate.Server/Commands/BroadcastCommand.cs
+++ b/src/Moongate.Server/Commands/BroadcastCommand.cs
@@ -18,7 +18,7 @@ namespace Moongate.Server.Commands;
     "broadcast|bc",
     AccountLevelType.GrandMaster,
     "Sends a server-wide system message.",
-    Sources = CommandSourceType.InGame | CommandSourceType.Console
+    Sources = CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest
 )]
 public sealed class BroadcastCommand : ICommand
 {

--- a/src/Moongate.Server/Plugins/MoongateCommandsPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateCommandsPlugin.cs
@@ -27,6 +27,6 @@ public class MoongateCommandsPlugin : ISquidStdPlugin
             "broadcast|bc",
             AccountLevelType.GrandMaster,
             "Sends a server-wide system message.",
-            CommandSourceType.InGame | CommandSourceType.Console
+            CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest
         );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Console;
+using Moongate.Http.Plugin.Endpoints.Console;
+using Moongate.Http.Plugin.Interfaces.Console;
+using Moongate.Http.Plugin.Services.Console;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Commands;
+using Moongate.Server.Services.Commands;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using Xunit;
+
+namespace Moongate.Tests.Http.Endpoints.Console;
+
+public class ConsoleEndpointsTests
+{
+    private sealed class RecordingChat : IChatService
+    {
+        public void Broadcast(string text, Hue? hue = null) { }
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+    }
+
+    // Wires the real ConsoleEndpoints (over real HTTP) against the given registry, an inline dispatcher
+    // (so a POSTed command runs before the request returns) and a broadcast command opted into Rest.
+    private static Task<TestApiServer> StartAsync(ConsoleStreamRegistry registry)
+        => TestApiServer.StartAsync(
+            AccountLevelType.GrandMaster,
+            configure: container =>
+            {
+                var registration = new CommandRegistration(
+                    "broadcast|bc",
+                    AccountLevelType.GrandMaster,
+                    "Sends a server-wide system message.",
+                    CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
+                    _ => new BroadcastCommand(new RecordingChat()));
+                var commands = new CommandService([registration], container, container.Resolve<IAccountService>());
+
+                container.RegisterInstance<IConsoleStreamRegistry>(registry);
+                container.RegisterApiEndpointInstance(
+                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher()));
+            });
+
+    [Fact]
+    public async Task Post_with_unknown_connection_returns_404()
+    {
+        var registry = new ConsoleStreamRegistry();
+        await using var server = await StartAsync(registry);
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/console", new { command = "broadcast hi", connectionId = "nope" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_runs_the_command_and_writes_line_then_done_to_the_connection()
+    {
+        var registry = new ConsoleStreamRegistry();
+        await using var server = await StartAsync(registry);
+        await server.AuthenticateAsync();
+        var (id, reader) = registry.Open();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/console", new { command = "broadcast hi", connectionId = id });
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        registry.Close(id); // inline dispatch already ran the command; complete the channel so we can drain it
+
+        var events = new List<ConsoleStreamEvent>();
+        await foreach (var evt in reader.ReadAllAsync())
+        {
+            events.Add(evt);
+        }
+
+        Assert.Contains(events, e => e.Event == "line" && e.Text == "Broadcast sent.");
+        Assert.Contains(events, e => e.Event == "done" && e.Text == "broadcast hi");
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleSseStreamTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleSseStreamTests.cs
@@ -1,0 +1,31 @@
+using System.Net.ServerSentEvents;
+using Moongate.Http.Plugin.Data.Console;
+using Moongate.Http.Plugin.Services.Console;
+using Xunit;
+
+namespace Moongate.Tests.Http.Endpoints.Console;
+
+public class ConsoleSseStreamTests
+{
+    [Fact]
+    public async Task From_yields_ready_then_each_channel_event()
+    {
+        var registry = new ConsoleStreamRegistry();
+        var (id, reader) = registry.Open();
+        Assert.True(registry.TryGetWriter(id, out var writer));
+
+        writer.TryWrite(new ConsoleStreamEvent("line", "hello"));
+        writer.TryWrite(new ConsoleStreamEvent("done", "broadcast hello"));
+        registry.Close(id); // completes the channel so the enumeration ends
+
+        var items = new List<SseItem<string>>();
+        await foreach (var item in ConsoleSseStream.From(id, reader, CancellationToken.None))
+        {
+            items.Add(item);
+        }
+
+        Assert.Equal(("ready", id), (items[0].EventType, items[0].Data));
+        Assert.Equal(("line", "hello"), (items[1].EventType, items[1].Data));
+        Assert.Equal(("done", "broadcast hello"), (items[2].EventType, items[2].Data));
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleStreamRegistryTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleStreamRegistryTests.cs
@@ -1,0 +1,50 @@
+using Moongate.Http.Plugin.Data.Console;
+using Moongate.Http.Plugin.Services.Console;
+using Xunit;
+
+namespace Moongate.Tests.Http.Endpoints.Console;
+
+public class ConsoleStreamRegistryTests
+{
+    [Fact]
+    public void Open_returns_a_unique_id_and_a_live_writer()
+    {
+        var registry = new ConsoleStreamRegistry();
+
+        var (id1, _) = registry.Open();
+        var (id2, _) = registry.Open();
+
+        Assert.NotEqual(id1, id2);
+        Assert.True(registry.TryGetWriter(id1, out _));
+    }
+
+    [Fact]
+    public async Task Written_events_reach_the_reader()
+    {
+        var registry = new ConsoleStreamRegistry();
+        var (id, reader) = registry.Open();
+        Assert.True(registry.TryGetWriter(id, out var writer));
+
+        writer.TryWrite(new ConsoleStreamEvent("line", "hello"));
+        registry.Close(id);
+
+        var events = new List<ConsoleStreamEvent>();
+        await foreach (var evt in reader.ReadAllAsync())
+        {
+            events.Add(evt);
+        }
+
+        Assert.Equal(new ConsoleStreamEvent("line", "hello"), Assert.Single(events));
+    }
+
+    [Fact]
+    public void Close_makes_the_id_unresolvable()
+    {
+        var registry = new ConsoleStreamRegistry();
+        var (id, _) = registry.Open();
+
+        registry.Close(id);
+
+        Assert.False(registry.TryGetWriter(id, out _));
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Net.ServerSentEvents;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Endpoints.Console;
+using Moongate.Http.Plugin.Interfaces.Console;
+using Moongate.Http.Plugin.Services.Console;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Commands;
+using Moongate.Server.Services.Commands;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using Xunit;
+
+namespace Moongate.Tests.Http.Endpoints.Console;
+
+public class RestConsoleIntegrationTests
+{
+    private sealed class RecordingChat : IChatService
+    {
+        public List<string> Broadcasts { get; } = [];
+
+        public void Broadcast(string text, Hue? hue = null)
+            => Broadcasts.Add(text);
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+    }
+
+    [Fact]
+    public async Task Open_stream_then_post_command_streams_reply_over_http()
+    {
+        var chat = new RecordingChat();
+        var registry = new ConsoleStreamRegistry();
+        await using var server = await TestApiServer.StartAsync(
+            AccountLevelType.GrandMaster,
+            configure: container =>
+            {
+                var registration = new CommandRegistration(
+                    "broadcast|bc",
+                    AccountLevelType.GrandMaster,
+                    "Sends a server-wide system message.",
+                    CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
+                    _ => new BroadcastCommand(chat));
+                var commands = new CommandService([registration], container, container.Resolve<IAccountService>());
+
+                container.RegisterInstance<IConsoleStreamRegistry>(registry);
+                container.RegisterApiEndpointInstance(
+                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher()));
+            });
+        await server.AuthenticateAsync();
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        using var streamResponse = await server.Client.GetAsync(
+            "/api/v1/admin/console/stream", HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+        Assert.Equal("text/event-stream", streamResponse.Content.Headers.ContentType?.MediaType);
+
+        await using var body = await streamResponse.Content.ReadAsStreamAsync(timeout.Token);
+        await using var events = SseParser.Create(body).EnumerateAsync(timeout.Token).GetAsyncEnumerator();
+
+        Assert.True(await events.MoveNextAsync());
+        Assert.Equal("ready", events.Current.EventType);
+        var connectionId = events.Current.Data;
+
+        var post = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/console",
+            new { command = "broadcast hello world", connectionId },
+            timeout.Token);
+        Assert.Equal(HttpStatusCode.Accepted, post.StatusCode);
+
+        Assert.True(await events.MoveNextAsync());
+        Assert.Equal(("line", "Broadcast sent."), (events.Current.EventType, events.Current.Data));
+        Assert.True(await events.MoveNextAsync());
+        Assert.Equal(("done", "broadcast hello world"), (events.Current.EventType, events.Current.Data));
+        Assert.Contains("hello world", chat.Broadcasts);
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -5,6 +5,7 @@ using Moongate.Http.Plugin.Endpoints.Accounts;
 using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
+using Moongate.Http.Plugin.Endpoints.Console;
 using Moongate.Http.Plugin.Endpoints.Images;
 using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
@@ -42,6 +43,7 @@ public class MoongateHttpPluginTests
                 typeof(BodyImageEndpoints),
                 typeof(CharacterAdminEndpoints),
                 typeof(CharacterEndpoints),
+                typeof(ConsoleEndpoints),
                 typeof(HairImageEndpoints),
                 typeof(ItemImageAdminEndpoints),
                 typeof(ItemImageEndpoints),

--- a/tests/Moongate.Tests/Server/CommandRestSourceTests.cs
+++ b/tests/Moongate.Tests/Server/CommandRestSourceTests.cs
@@ -1,0 +1,55 @@
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.Commands;
+using Moongate.Tests.Support;
+using Xunit;
+
+namespace Moongate.Tests.Server;
+
+public class CommandRestSourceTests
+{
+    private sealed class Echo : ICommand
+    {
+        public void Execute(CommandContext context)
+            => context.Reply("ran");
+    }
+
+    private static ICommandService Build(CommandSourceType sources)
+    {
+        var registration = new CommandRegistration(
+            "echo", AccountLevelType.GrandMaster, "Echo.", sources, _ => new Echo());
+
+        return new CommandService([registration], new Container(), new SeededAccountService());
+    }
+
+    [Fact]
+    public void Rest_flag_is_distinct()
+        => Assert.Equal(4, (byte)CommandSourceType.Rest);
+
+    [Fact]
+    public void Execute_runs_a_rest_enabled_command_from_the_rest_source()
+    {
+        var lines = new List<string>();
+
+        Build(CommandSourceType.Console | CommandSourceType.Rest)
+            .Execute(new CommandInvocation(CommandSourceType.Rest, AccountLevelType.GrandMaster, null, "echo", lines.Add));
+
+        Assert.Contains("ran", lines);
+    }
+
+    [Fact]
+    public void Execute_refuses_a_console_only_command_from_the_rest_source()
+    {
+        var lines = new List<string>();
+
+        Build(CommandSourceType.Console)
+            .Execute(new CommandInvocation(CommandSourceType.Rest, AccountLevelType.GrandMaster, null, "echo", lines.Add));
+
+        Assert.DoesNotContain("ran", lines);
+        Assert.Contains("Unknown command.", lines);
+    }
+}


### PR DESCRIPTION
A REST web-terminal onto the admin command set: open an SSE stream to receive output, POST commands tagged with that stream's id. Driven by the same `ICommandService` on the game loop as the telnet console.

## What

- **`CommandSourceType.Rest`** — new `[Flags]` value so network exposure is curated separately from the loopback telnet console. `broadcast` opts in (`InGame | Console | Rest`).
- **`GET /api/v1/admin/console/stream`** (SSE, native .NET 10 `TypedResults.ServerSentEvents`) — emits a `ready` event carrying a fresh `connectionId`, then `line`/`done` events. Cleaned up on client disconnect.
- **`POST /api/v1/admin/console`** `{ command, connectionId }` — 404 if the id is unknown, else builds a `CommandInvocation(Rest, level-from-JWT, Actor: null, command, Reply→channel)`, dispatches it on the game loop (`IMainThreadDispatcher.Post`, exactly like `ConsoleSession`), returns **202**. Reply lines stream to that connection.
- **`ConsoleStreamRegistry`** (singleton) maps an unguessable `connectionId` → `Channel<ConsoleStreamEvent>`; **`ConsoleSseStream.From`** is the pure `ready + events` transform the SSE handler wraps.
- Both endpoints under `AdminPolicy` (JWT, `Administrator`/`GrandMaster`). Docs page `under-the-hood/rest-console.md`.

## Notes

- The telnet console is pure REPL (synchronous replies, no async output), so the feed is per-connection command output — no global/log streaming (out of scope, hub is extensible).
- **Tested via real HTTP** (`TestApiServer`), matching the codebase's endpoint-test convention (no `InternalsVisibleTo`): registry unit tests, `ConsoleSseStream` unit test, POST 404/202+routing over HTTP, and an end-to-end test that opens the stream, POSTs, and reads `ready`/`line`/`done` back with `SseParser`. Full suite 1261 green; docfx 0 warnings.