### PR TITLE
feat(news): shard news managed over REST

### DIFF
--- a/Moongate.slnx
+++ b/Moongate.slnx
@@ -1,19 +1,20 @@
 <Solution>
     <Folder Name="/src/">
-        <Project Path="src/Moongate.Core/Moongate.Core.csproj"/>
-        <Project Path="src/Moongate.Network/Moongate.Network.csproj"/>
-        <Project Path="src/Moongate.Persistence/Moongate.Persistence.csproj"/>
-        <Project Path="src/Moongate.Scripting/Moongate.Scripting.csproj"/>
-        <Project Path="src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj"/>
-        <Project Path="src/Moongate.Server/Moongate.Server.csproj"/>
-        <Project Path="src/Moongate.Ultima/Moongate.Ultima.csproj"/>
-        <Project Path="src/Moongate.UO.Data/Moongate.UO.Data.csproj"/>
+        <Project Path="src/Moongate.Core/Moongate.Core.csproj" />
+        <Project Path="src/Moongate.Network/Moongate.Network.csproj" />
+        <Project Path="src/Moongate.Persistence/Moongate.Persistence.csproj" />
+        <Project Path="src/Moongate.Scripting/Moongate.Scripting.csproj" />
+        <Project Path="src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj" />
+        <Project Path="src/Moongate.Server/Moongate.Server.csproj" />
+        <Project Path="src/Moongate.Ultima/Moongate.Ultima.csproj" />
+        <Project Path="src/Moongate.UO.Data/Moongate.UO.Data.csproj" />
     </Folder>
     <Folder Name="/plugins/">
-        <Project Path="plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj"/>
-        <Project Path="plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj"/>
+        <Project Path="plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj" />
+        <Project Path="plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj" />
+        <Project Path="plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj" />
     </Folder>
     <Folder Name="/tests/">
-        <Project Path="tests/Moongate.Tests/Moongate.Tests.csproj"/>
+        <Project Path="tests/Moongate.Tests/Moongate.Tests.csproj" />
     </Folder>
 </Solution>

--- a/docs/under-the-hood/news-api.md
+++ b/docs/under-the-hood/news-api.md
@@ -1,0 +1,23 @@
+# News API
+
+Shard news managed over REST by the `Moongate.News.Plugin`. Staff create and edit news; anyone
+can read the published ones (for a launcher or website).
+
+A news entry is `{ id, title, body, author, publishedAt, updatedAt, isPublished }`. Drafts
+(`isPublished: false`) are visible only through the staff routes.
+
+## Public
+
+- `GET /api/v1/news` — published news, newest first.
+- `GET /api/v1/news/{id}` — one published entry (404 if it is missing or a draft).
+
+## Staff
+
+All require a JWT for an `Administrator` or `GrandMaster` account (the `admin` policy).
+
+- `POST /api/v1/admin/news` — create. Body `{ "title", "body", "isPublished" }`; the author is
+  taken from the token. Returns **201** with the created entry.
+- `PUT /api/v1/admin/news/{id}` — update title, body and published state. **200** / **404**.
+- `DELETE /api/v1/admin/news/{id}` — **204** / **404**.
+- `GET /api/v1/admin/news` — every entry, drafts included, newest first.
+- `GET /api/v1/admin/news/{id}` — one entry in any state.

--- a/docs/under-the-hood/toc.yml
+++ b/docs/under-the-hood/toc.yml
@@ -6,3 +6,5 @@
   href: admin-console.md
 - name: Console over REST
   href: rest-console.md
+- name: News API
+  href: news-api.md

--- a/plugins/Moongate.News.Plugin/Data/Api/CreateNewsRequest.cs
+++ b/plugins/Moongate.News.Plugin/Data/Api/CreateNewsRequest.cs
@@ -1,0 +1,4 @@
+namespace Moongate.News.Plugin.Data.Api;
+
+/// <summary>Body for creating a news entry; the author is taken from the caller's token.</summary>
+public sealed record CreateNewsRequest(string Title, string Body, bool IsPublished);

--- a/plugins/Moongate.News.Plugin/Data/Api/NewsResponse.cs
+++ b/plugins/Moongate.News.Plugin/Data/Api/NewsResponse.cs
@@ -1,0 +1,17 @@
+namespace Moongate.News.Plugin.Data.Api;
+
+/// <summary>A news entry as returned by the API.</summary>
+public sealed record NewsResponse(
+    uint Id,
+    string Title,
+    string Body,
+    string Author,
+    DateTime PublishedAt,
+    DateTime UpdatedAt,
+    bool IsPublished
+)
+{
+    /// <summary>Projects a persisted entry into its API shape.</summary>
+    public static NewsResponse From(NewsEntity news)
+        => new(news.Id.Value, news.Title, news.Body, news.Author, news.PublishedAt, news.UpdatedAt, news.IsPublished);
+}

--- a/plugins/Moongate.News.Plugin/Data/Api/UpdateNewsRequest.cs
+++ b/plugins/Moongate.News.Plugin/Data/Api/UpdateNewsRequest.cs
@@ -1,0 +1,4 @@
+namespace Moongate.News.Plugin.Data.Api;
+
+/// <summary>Body for updating a news entry.</summary>
+public sealed record UpdateNewsRequest(string Title, string Body, bool IsPublished);

--- a/plugins/Moongate.News.Plugin/Endpoints/NewsAdminEndpoints.cs
+++ b/plugins/Moongate.News.Plugin/Endpoints/NewsAdminEndpoints.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.News.Plugin.Data.Api;
+using Moongate.News.Plugin.Interfaces;
+
+namespace Moongate.News.Plugin.Endpoints;
+
+/// <summary>Staff management of shard news.</summary>
+public sealed class NewsAdminEndpoints : IApiEndpointRegistration
+{
+    private readonly INewsService _news;
+
+    public NewsAdminEndpoints(INewsService news)
+    {
+        _news = news;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapPost("/api/v1/admin/news", Create).WithName("CreateNews").WithTags("news").RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapGet("/api/v1/admin/news", ListAll).WithName("ListAllNews").WithTags("news").RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapGet("/api/v1/admin/news/{id}", GetOne).WithName("GetNewsAdmin").WithTags("news").RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapPut("/api/v1/admin/news/{id}", Update).WithName("UpdateNews").WithTags("news").RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapDelete("/api/v1/admin/news/{id}", Delete).WithName("DeleteNews").WithTags("news").RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>Creates a news entry, authored by the calling staff member.</summary>
+    private async Task<IResult> Create(CreateNewsRequest request, ClaimsPrincipal user)
+    {
+        var author = user.FindFirstValue(ClaimTypes.Name) ?? "unknown";
+        var news = await _news.CreateAsync(request.Title, request.Body, author, request.IsPublished);
+
+        return TypedResults.Created($"/api/v1/news/{news.Id.Value}", NewsResponse.From(news));
+    }
+
+    /// <summary>Lists every news entry, drafts included, newest first.</summary>
+    private IResult ListAll()
+        => TypedResults.Ok(_news.GetAll().Select(NewsResponse.From).ToList());
+
+    /// <summary>Returns one news entry in any state.</summary>
+    private IResult GetOne(uint id)
+        => _news.Get(new Serial(id)) is { } news ? TypedResults.Ok(NewsResponse.From(news)) : TypedResults.NotFound();
+
+    /// <summary>Updates a news entry's title, body and published state.</summary>
+    private async Task<IResult> Update(uint id, UpdateNewsRequest request)
+    {
+        var news = await _news.UpdateAsync(new Serial(id), request.Title, request.Body, request.IsPublished);
+
+        return news is { } updated ? TypedResults.Ok(NewsResponse.From(updated)) : TypedResults.NotFound();
+    }
+
+    /// <summary>Deletes a news entry.</summary>
+    private async Task<IResult> Delete(uint id)
+        => await _news.DeleteAsync(new Serial(id)) ? TypedResults.NoContent() : TypedResults.NotFound();
+}

--- a/plugins/Moongate.News.Plugin/Endpoints/NewsEndpoints.cs
+++ b/plugins/Moongate.News.Plugin/Endpoints/NewsEndpoints.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.News.Plugin.Data.Api;
+using Moongate.News.Plugin.Interfaces;
+
+namespace Moongate.News.Plugin.Endpoints;
+
+/// <summary>Public, read-only access to published shard news.</summary>
+public sealed class NewsEndpoints : IApiEndpointRegistration
+{
+    private readonly INewsService _news;
+
+    public NewsEndpoints(INewsService news)
+    {
+        _news = news;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/news", List).WithName("ListNews").WithTags("news");
+        routes.MapGet("/api/v1/news/{id}", GetOne).WithName("GetNews").WithTags("news");
+    }
+
+    /// <summary>Lists published news, newest first.</summary>
+    private IResult List()
+        => TypedResults.Ok(_news.GetPublished().Select(NewsResponse.From).ToList());
+
+    /// <summary>Returns one published news entry; 404 if it is missing or a draft.</summary>
+    private IResult GetOne(uint id)
+        => _news.Get(new Serial(id)) is { IsPublished: true } news ? TypedResults.Ok(NewsResponse.From(news)) : TypedResults.NotFound();
+}

--- a/plugins/Moongate.News.Plugin/Interfaces/INewsService.cs
+++ b/plugins/Moongate.News.Plugin/Interfaces/INewsService.cs
@@ -1,0 +1,25 @@
+using Moongate.Core.Primitives;
+
+namespace Moongate.News.Plugin.Interfaces;
+
+/// <summary>Creates, updates, deletes and reads shard news.</summary>
+public interface INewsService
+{
+    /// <summary>Creates a news entry; the store assigns its id. Timestamps are set to now.</summary>
+    ValueTask<NewsEntity> CreateAsync(string title, string body, string author, bool isPublished, CancellationToken ct = default);
+
+    /// <summary>Updates an entry's title/body/published state and its <c>UpdatedAt</c>; null if not found.</summary>
+    ValueTask<NewsEntity?> UpdateAsync(Serial id, string title, string body, bool isPublished, CancellationToken ct = default);
+
+    /// <summary>Deletes an entry; false if it did not exist.</summary>
+    ValueTask<bool> DeleteAsync(Serial id, CancellationToken ct = default);
+
+    /// <summary>Every entry, drafts included, newest first.</summary>
+    IReadOnlyList<NewsEntity> GetAll();
+
+    /// <summary>Published entries only, newest first.</summary>
+    IReadOnlyList<NewsEntity> GetPublished();
+
+    /// <summary>One entry by id, or null.</summary>
+    NewsEntity? Get(Serial id);
+}

--- a/plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj
+++ b/plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Moongate.Core\Moongate.Core.csproj"/>
+        <ProjectReference Include="..\..\src\Moongate.Persistence\Moongate.Persistence.csproj"/>
+        <ProjectReference Include="..\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
+++ b/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
@@ -1,0 +1,43 @@
+using DryIoc;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.News.Plugin.Endpoints;
+using Moongate.News.Plugin.Interfaces;
+using Moongate.News.Plugin.Services;
+using Moongate.Persistence.Generators;
+using SquidStd.Core.Utils;
+using SquidStd.Persistence.Extensions;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.News.Plugin;
+
+/// <summary>Registers the shard-news feature: its persisted entity, service and REST endpoints.</summary>
+public sealed class MoongateNewsPlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.news.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateNewsPlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate News",
+            Description = "Shard news managed over REST"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        container.RegisterPersistedEntity<NewsEntity, Serial>(
+            4,
+            "news",
+            1,
+            entity => entity.Id,
+            (entity, id) => entity.Id = id,
+            new DefaultSerialGenerator()
+        );
+
+        container.Register<INewsService, NewsService>(Reuse.Singleton);
+        container.RegisterApiEndpoint<NewsAdminEndpoints>();
+        container.RegisterApiEndpoint<NewsEndpoints>();
+    }
+}

--- a/plugins/Moongate.News.Plugin/NewsEntity.cs
+++ b/plugins/Moongate.News.Plugin/NewsEntity.cs
@@ -1,0 +1,22 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Interfaces;
+
+namespace Moongate.News.Plugin;
+
+/// <summary>A shard news entry, persisted in the "news" store.</summary>
+public sealed class NewsEntity : ISerialIdEntity
+{
+    public Serial Id { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Body { get; set; } = string.Empty;
+
+    public string Author { get; set; } = string.Empty;
+
+    public DateTime PublishedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public bool IsPublished { get; set; }
+}

--- a/plugins/Moongate.News.Plugin/Services/NewsService.cs
+++ b/plugins/Moongate.News.Plugin/Services/NewsService.cs
@@ -1,0 +1,61 @@
+using Moongate.Core.Primitives;
+using Moongate.News.Plugin.Interfaces;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.News.Plugin.Services;
+
+/// <summary>News over the persistence store; the store auto-assigns each entry's <see cref="Serial" /> id.</summary>
+public sealed class NewsService : INewsService
+{
+    private readonly IEntityStore<NewsEntity, Serial> _store;
+
+    public NewsService(IPersistenceService persistence)
+    {
+        _store = persistence.GetStore<NewsEntity, Serial>();
+    }
+
+    public async ValueTask<NewsEntity> CreateAsync(string title, string body, string author, bool isPublished, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var news = new NewsEntity
+        {
+            Title = title,
+            Body = body,
+            Author = author,
+            IsPublished = isPublished,
+            PublishedAt = now,
+            UpdatedAt = now
+        };
+        await _store.UpsertAsync(news, ct);
+
+        return news;
+    }
+
+    public async ValueTask<NewsEntity?> UpdateAsync(Serial id, string title, string body, bool isPublished, CancellationToken ct = default)
+    {
+        if (_store.GetById(id) is not { } news)
+        {
+            return null;
+        }
+
+        news.Title = title;
+        news.Body = body;
+        news.IsPublished = isPublished;
+        news.UpdatedAt = DateTime.UtcNow;
+        await _store.UpsertAsync(news, ct);
+
+        return news;
+    }
+
+    public async ValueTask<bool> DeleteAsync(Serial id, CancellationToken ct = default)
+        => await _store.RemoveAsync(id, ct);
+
+    public IReadOnlyList<NewsEntity> GetAll()
+        => _store.GetAll().OrderByDescending(news => news.PublishedAt).ToList();
+
+    public IReadOnlyList<NewsEntity> GetPublished()
+        => _store.GetAll().Where(news => news.IsPublished).OrderByDescending(news => news.PublishedAt).ToList();
+
+    public NewsEntity? Get(Serial id)
+        => _store.GetById(id);
+}

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\plugins\Moongate.Console.Admin.Plugin\Moongate.Console.Admin.Plugin.csproj"/>
         <ProjectReference Include="..\..\plugins\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
+        <ProjectReference Include="..\..\plugins\Moongate.News.Plugin\Moongate.News.Plugin.csproj"/>
         <ProjectReference Include="..\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\Moongate.Persistence\Moongate.Persistence.csproj"/>
         <ProjectReference Include="..\Moongate.Scripting\Moongate.Scripting.csproj"/>

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -3,6 +3,7 @@ using DryIoc;
 using Moongate.Console.Admin.Plugin;
 using Moongate.Core.Interfaces;
 using Moongate.Http.Plugin;
+using Moongate.News.Plugin;
 using Moongate.Persistence;
 using Moongate.Scripting;
 using Moongate.Server;
@@ -125,6 +126,7 @@ await ConsoleApp.RunAsync(
                 }
 
                 builder.Add<MoongateConsolePlugin>();
+                builder.Add<MoongateNewsPlugin>();
             }
         );
 

--- a/tests/Moongate.Tests/Moongate.Tests.csproj
+++ b/tests/Moongate.Tests/Moongate.Tests.csproj
@@ -32,6 +32,7 @@
         <ProjectReference Include="..\..\plugins\Moongate.Console.Admin.Plugin\Moongate.Console.Admin.Plugin.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Core\Moongate.Core.csproj"/>
         <ProjectReference Include="..\..\plugins\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
+        <ProjectReference Include="..\..\plugins\Moongate.News.Plugin\Moongate.News.Plugin.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Server\Moongate.Server.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Ultima\Moongate.Ultima.csproj"/>

--- a/tests/Moongate.Tests/News/MoongateNewsPluginTests.cs
+++ b/tests/Moongate.Tests/News/MoongateNewsPluginTests.cs
@@ -1,0 +1,31 @@
+using DryIoc;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.News.Plugin;
+using Moongate.News.Plugin.Endpoints;
+using Moongate.News.Plugin.Interfaces;
+using Xunit;
+
+namespace Moongate.Tests.News;
+
+public class MoongateNewsPluginTests
+{
+    [Fact]
+    public void Configure_registers_the_service_and_both_endpoint_groups()
+    {
+        var container = new Container();
+
+        new MoongateNewsPlugin().Configure(container, new());
+
+        Assert.True(container.IsRegistered<INewsService>());
+        var endpoints = container.GetServiceRegistrations()
+            .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+            .Select(registration => registration.ImplementationType)
+            .ToArray();
+        Assert.Contains(typeof(NewsAdminEndpoints), endpoints);
+        Assert.Contains(typeof(NewsEndpoints), endpoints);
+    }
+
+    [Fact]
+    public void Metadata_identifies_the_plugin()
+        => Assert.Equal("moongate.news.plugin", new MoongateNewsPlugin().Metadata.Id);
+}

--- a/tests/Moongate.Tests/News/NewsEndpointsTests.cs
+++ b/tests/Moongate.Tests/News/NewsEndpointsTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.News.Plugin.Data.Api;
+using Moongate.News.Plugin.Endpoints;
+using Moongate.News.Plugin.Interfaces;
+using Moongate.News.Plugin.Services;
+using Moongate.Tests.Support;
+using Xunit;
+
+namespace Moongate.Tests.News;
+
+public class NewsEndpointsTests
+{
+    // Wires the real news endpoints over real HTTP. TestApiServer already registers a fake
+    // IPersistenceService, so NewsService gets an in-memory store.
+    private static Task<TestApiServer> StartAsync()
+        => TestApiServer.StartAsync(
+            AccountLevelType.GrandMaster,
+            configure: container =>
+            {
+                container.Register<INewsService, NewsService>(Reuse.Singleton);
+                var news = container.Resolve<INewsService>();
+                container.RegisterApiEndpointInstance(new NewsAdminEndpoints(news));
+                container.RegisterApiEndpointInstance(new NewsEndpoints(news));
+            });
+
+    [Fact]
+    public async Task Admin_can_create_then_read_it_back()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var create = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/news", new CreateNewsRequest("Patch 1", "notes", IsPublished: true));
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+        var created = await create.Content.ReadFromJsonAsync<NewsResponse>();
+        Assert.Equal("Patch 1", created!.Title);
+        Assert.NotEqual(0u, created.Id);
+
+        var one = await server.Client.GetFromJsonAsync<NewsResponse>($"/api/v1/admin/news/{created.Id}");
+        Assert.Equal("Patch 1", one!.Title);
+    }
+
+    [Fact]
+    public async Task Admin_endpoints_require_auth()
+    {
+        await using var server = await StartAsync();
+
+        var res = await server.Client.GetAsync("/api/v1/admin/news");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_and_delete_report_404_for_missing()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+
+        var put = await server.Client.PutAsJsonAsync(
+            "/api/v1/admin/news/999999", new UpdateNewsRequest("x", "y", true));
+        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
+
+        var del = await server.Client.DeleteAsync("/api/v1/admin/news/999999");
+        Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
+    }
+}

--- a/tests/Moongate.Tests/News/NewsEndpointsTests.cs
+++ b/tests/Moongate.Tests/News/NewsEndpointsTests.cs
@@ -66,4 +66,30 @@ public class NewsEndpointsTests
         var del = await server.Client.DeleteAsync("/api/v1/admin/news/999999");
         Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
     }
+
+    [Fact]
+    public async Task Public_list_returns_only_published()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+        await server.Client.PostAsJsonAsync("/api/v1/admin/news", new CreateNewsRequest("draft", "b", false));
+        await server.Client.PostAsJsonAsync("/api/v1/admin/news", new CreateNewsRequest("live", "b", true));
+
+        var list = await server.Client.GetFromJsonAsync<List<NewsResponse>>("/api/v1/news");
+
+        Assert.Equal("live", Assert.Single(list!).Title);
+    }
+
+    [Fact]
+    public async Task Public_get_hides_drafts_as_404()
+    {
+        await using var server = await StartAsync();
+        await server.AuthenticateAsync();
+        var draft = await (await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/news", new CreateNewsRequest("draft", "b", false))).Content.ReadFromJsonAsync<NewsResponse>();
+
+        var res = await server.Client.GetAsync($"/api/v1/news/{draft!.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, res.StatusCode);
+    }
 }

--- a/tests/Moongate.Tests/News/NewsServiceTests.cs
+++ b/tests/Moongate.Tests/News/NewsServiceTests.cs
@@ -1,0 +1,62 @@
+using Moongate.Core.Primitives;
+using Moongate.News.Plugin.Services;
+using Moongate.Tests.Support;
+using Xunit;
+
+namespace Moongate.Tests.News;
+
+public class NewsServiceTests
+{
+    private static NewsService Build()
+        => new(new FakePersistenceService());
+
+    [Fact]
+    public async Task CreateAsync_assigns_an_id_and_timestamps()
+    {
+        var before = DateTime.UtcNow;
+        var news = await Build().CreateAsync("Patch 1", "notes", "gm", isPublished: true);
+
+        Assert.True(news.Id.IsValid);
+        Assert.Equal("gm", news.Author);
+        Assert.True(news.PublishedAt >= before);
+        Assert.Equal(news.PublishedAt, news.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_touches_UpdatedAt_and_returns_null_for_missing()
+    {
+        var service = Build();
+        var created = await service.CreateAsync("t", "b", "gm", true);
+
+        var updated = await service.UpdateAsync(created.Id, "t2", "b2", false);
+        Assert.NotNull(updated);
+        Assert.Equal("t2", updated!.Title);
+        Assert.False(updated.IsPublished);
+        Assert.True(updated.UpdatedAt >= updated.PublishedAt);
+
+        Assert.Null(await service.UpdateAsync(new Serial(999999), "x", "y", true));
+    }
+
+    [Fact]
+    public async Task GetPublished_excludes_drafts()
+    {
+        var service = Build();
+        await service.CreateAsync("draft", "b", "gm", isPublished: false);
+        var pub = await service.CreateAsync("live", "b", "gm", isPublished: true);
+
+        var published = service.GetPublished();
+        Assert.Equal(pub.Id, Assert.Single(published).Id);
+        Assert.Equal(2, service.GetAll().Count);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_removes_the_entry()
+    {
+        var service = Build();
+        var created = await service.CreateAsync("t", "b", "gm", true);
+
+        Assert.True(await service.DeleteAsync(created.Id));
+        Assert.Null(service.Get(created.Id));
+        Assert.False(await service.DeleteAsync(created.Id));
+    }
+}


### PR DESCRIPTION
A self-contained `Moongate.News.Plugin` for managing shard news over REST: staff CRUD (JWT) plus public read, with a draft/published flag.

## What

- **New plugin** `plugins/Moongate.News.Plugin` (wired into `Program.cs` like Http/Console). Self-contained: entity + service + endpoints in one project.
- **`NewsEntity`** persisted via `RegisterPersistedEntity<NewsEntity, Serial>(4, "news", …, DefaultSerialGenerator)` — the store auto-assigns the id.
- **`INewsService`/`NewsService`** over `IEntityStore<NewsEntity, Serial>`: create/update/delete, `GetAll`, `GetPublished` (drafts excluded), `Get`.
- **Staff endpoints** (`AdminPolicy`): `POST` (author from the JWT), `PUT/{id}`, `DELETE/{id}`, `GET`, `GET/{id}`.
- **Public endpoints** (anonymous): `GET /api/v1/news` (published, newest first), `GET /api/v1/news/{id}` (404 for a draft — drafts never leak).
- Docs: `under-the-hood/news-api.md`.

## Notes

- REST only. In-game delivery (login MOTD + `.news` command) is intentionally out of scope — tracked on Trello (https://trello.com/c/MFtPRYyE); it can be added inside this plugin later without touching `.Server`.
- Tested over real HTTP via `TestApiServer` (repo convention, no `InternalsVisibleTo`): `NewsService` unit tests, admin CRUD (201/200/204/404, auth required), public read (published vs 404 for drafts), and a plugin-registration test. Full suite **1272 green**; docfx **0 warnings**.