### PR TITLE
feat: public statistics endpoint

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -9,6 +9,7 @@ launch generates it with defaults; edit and restart to apply changes.
 | Key | Type | Default | Meaning |
 |---|---|---|---|
 | `ShardName` | string | `Moongate` | The shard's name, shown in the client's server list. |
+| `StatsRefreshSeconds` | int | `30` | How often the public statistics snapshot is recomputed on the game loop. |
 | `UltimaDirectory` | string | — | Path to the UO client files. See the override note below. |
 | `Network.Address` | string | `0.0.0.0` | Local bind address for the TCP listener. |
 | `Network.Port` | int | `2593` | TCP port for both login and game traffic (single process, single port). |

--- a/docs/getting-started/server-settings-and-web-registration.md
+++ b/docs/getting-started/server-settings-and-web-registration.md
@@ -116,3 +116,42 @@ These live in the `http` section of `moongate.yaml`:
 | `MaxAssetUploadBytes` | long | `2097152` (2 MB) | Maximum size of an uploaded asset. |
 | `RegistrationRateLimitPermits` | int | `5` | Registration attempts allowed per window, per IP. |
 | `RegistrationRateLimitWindowMinutes` | int | `10` | Length of the rate-limit window, in minutes. |
+
+## Public statistics
+
+`GET /api/v1/stats` — anonymous, like `/api/v1/server-info`. Where
+`server-info` describes the shard's identity, this reports its numbers.
+
+```json
+{
+  "generatedAt": "2026-07-21T08:31:00+00:00",
+  "uptimeSeconds": 43200,
+  "players":  { "online": 12, "connections": 15 },
+  "accounts": { "total": 340, "active": 300, "characters": 512 },
+  "world":    { "npcs": 1840, "items": 27310 },
+  "content":  { "itemTemplates": 412, "mobileTemplates": 19 }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `players.online` | Characters currently being played — who is actually in the world. |
+| `players.connections` | Every open connection, including clients still at the login or character-select screen. |
+| `accounts.total` | Accounts registered on the shard. |
+| `accounts.active` | Accounts that are enabled — the flag web registration sets on verification. |
+| `accounts.characters` | Characters created across all accounts, online or not. |
+| `world.npcs` | Mobiles no account owns. |
+| `world.items` | Persisted world items, including container contents. |
+| `content.itemTemplates` | Item templates loaded at startup. |
+| `content.mobileTemplates` | Mobile templates loaded at startup. |
+| `uptimeSeconds` | Seconds since the server started. |
+| `generatedAt` | When the snapshot was taken. `0001-01-01T00:00:00+00:00` means the world is not ready yet, so no snapshot has been computed. |
+
+> [!NOTE]
+> The figures are a **cached snapshot**, not a live read. Counting world
+> entities has to happen on the game loop, so the server takes a first
+> snapshot there as soon as the world is ready and recomputes it every
+> `StatsRefreshSeconds` (30 by default); the endpoint serves the last one, up
+> to that many seconds old. The response carries a matching
+> `Cache-Control: public, max-age=…`, so a website polling the route cannot
+> ask for data more often than it changes.

--- a/plugins/Moongate.Http.Plugin/Data/Api/Stats/ServerStatsResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Stats/ServerStatsResponse.cs
@@ -1,0 +1,11 @@
+namespace Moongate.Http.Plugin.Data.Api.Stats;
+
+/// <summary>The shard's public statistics, as a website or launcher reads them.</summary>
+public sealed record ServerStatsResponse(
+    DateTimeOffset GeneratedAt,
+    long UptimeSeconds,
+    StatsPlayersResponse Players,
+    StatsAccountsResponse Accounts,
+    StatsWorldResponse World,
+    StatsContentResponse Content
+);

--- a/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsAccountsResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsAccountsResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Stats;
+
+/// <summary>The shard's user base: accounts registered, accounts verified, and characters created.</summary>
+public sealed record StatsAccountsResponse(int Total, int Active, int Characters);

--- a/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsContentResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsContentResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Stats;
+
+/// <summary>How much content the shard has loaded: the templates available to spawn from.</summary>
+public sealed record StatsContentResponse(int ItemTemplates, int MobileTemplates);

--- a/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsPlayersResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsPlayersResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Stats;
+
+/// <summary>Who is connected: players in the world, and every open connection including the login screen.</summary>
+public sealed record StatsPlayersResponse(int Online, int Connections);

--- a/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsWorldResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Stats/StatsWorldResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Stats;
+
+/// <summary>How much the world holds: creatures nobody plays, and persisted items.</summary>
+public sealed record StatsWorldResponse(int Npcs, int Items);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Stats/StatsEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Stats/StatsEndpoints.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data.Api.Stats;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Stats;
+using Moongate.Server.Abstractions.Interfaces.Server;
+
+namespace Moongate.Http.Plugin.Endpoints.Stats;
+
+/// <summary>The shard's public numbers: who is online, how big the world is, how much content is loaded.</summary>
+public sealed class StatsEndpoints : IApiEndpointRegistration
+{
+    private readonly IServerStatsService _stats;
+    private readonly MoongateConfig _config;
+
+    public StatsEndpoints(IServerStatsService stats, MoongateConfig config)
+    {
+        _stats = stats;
+        _config = config;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+        => routes.MapGet("/api/v1/stats", Get).WithName("GetServerStats").WithTags("stats").AllowAnonymous();
+
+    internal static ServerStatsResponse ToResponse(ServerStatsSnapshot snapshot)
+        => new(
+            snapshot.GeneratedAt,
+            (long)snapshot.Uptime.TotalSeconds,
+            new(snapshot.OnlinePlayers, snapshot.Connections),
+            new(snapshot.Accounts, snapshot.ActiveAccounts, snapshot.Characters),
+            new(snapshot.Npcs, snapshot.WorldItems),
+            new(snapshot.ItemTemplates, snapshot.MobileTemplates)
+        );
+
+    /// <summary>Reports the shard's public statistics: players online, accounts, world size and loaded content.</summary>
+    /// <remarks>
+    /// The figures come from a snapshot recomputed on the game loop every <c>StatsRefreshSeconds</c>;
+    /// <c>generatedAt</c> says when it was taken, and equals <c>0001-01-01T00:00:00+00:00</c> until the
+    /// first one has been computed. The response caches for the same interval.
+    /// </remarks>
+
+    // Reads one volatile reference and nothing else: the counting happens on the game loop, so this route
+    // never reads world state from an ASP.NET thread.
+    private IResult Get(HttpContext context)
+    {
+        context.Response.Headers.CacheControl = $"public, max-age={_config.StatsRefreshSeconds}";
+
+        return Results.Ok(ToResponse(_stats.Current));
+    }
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -12,6 +12,7 @@ using Moongate.Http.Plugin.Endpoints.Mobiles;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Registration;
 using Moongate.Http.Plugin.Endpoints.ServerInfo;
+using Moongate.Http.Plugin.Endpoints.Stats;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Extensions;
 using Moongate.Http.Plugin.Interfaces.Assets;
@@ -136,6 +137,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<ServerInfoEndpoints>();
         container.RegisterApiEndpoint<ServerSettingsAdminEndpoints>();
         container.RegisterApiEndpoint<RegistrationEndpoints>();
+        container.RegisterApiEndpoint<StatsEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
+++ b/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
@@ -27,8 +27,11 @@ public sealed class MoongateNewsPlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
+        // Type id 100, not 4: the core entities in MoongatePersistencePlugin own the low ids, and 4 is
+        // already ServerSettingsEntity. External plugins take ids from 100 up, so a new core entity can
+        // never collide with one of theirs.
         container.RegisterPersistedEntity<NewsEntity, Serial>(
-            4,
+            100,
             "news",
             1,
             entity => entity.Id,

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -39,6 +39,9 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
         container.RegisterMessagePackSerializer();
         container.RegisterPersistence(persistenceConfig);
 
+        // Type ids are process-wide: registering one twice throws at startup. Core entities take 1-99 and
+        // are listed here; external plugins take 100 and up, so the two sets cannot collide as either
+        // side grows.
         container.RegisterPersistedEntity<AccountEntity, Serial>(
             1,
             "accounts",

--- a/src/Moongate.Server.Abstractions/Data/Config/MoongateConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/MoongateConfig.cs
@@ -5,6 +5,8 @@ public sealed class MoongateConfig
 {
     public string ShardName { get; set; } = "Moongate";
 
+    public int StatsRefreshSeconds { get; set; } = 30;
+
     public string UltimaDirectory { get; set; }
 
     public MoongateNetworkConfig Network { get; set; } = new();

--- a/src/Moongate.Server.Abstractions/Data/Stats/ServerStatsSnapshot.cs
+++ b/src/Moongate.Server.Abstractions/Data/Stats/ServerStatsSnapshot.cs
@@ -1,0 +1,28 @@
+namespace Moongate.Server.Abstractions.Data.Stats;
+
+/// <summary>
+/// A point-in-time count of what the shard holds. Computed on the game loop and published for readers
+/// on any thread, so it is immutable by construction.
+/// </summary>
+public sealed record ServerStatsSnapshot(
+    DateTimeOffset GeneratedAt,
+    TimeSpan Uptime,
+    int OnlinePlayers,
+    int Connections,
+    int Accounts,
+    int ActiveAccounts,
+    int Characters,
+    int Npcs,
+    int WorldItems,
+    int ItemTemplates,
+    int MobileTemplates
+)
+{
+    /// <summary>
+    /// What readers see between startup and the first refresh: every count zero, with
+    /// <see cref="GeneratedAt" /> at <see cref="DateTimeOffset.MinValue" /> so the gap is
+    /// distinguishable from a genuinely empty shard.
+    /// </summary>
+    public static ServerStatsSnapshot Empty { get; } =
+        new(DateTimeOffset.MinValue, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Server/IServerStatsService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Server/IServerStatsService.cs
@@ -1,0 +1,16 @@
+using Moongate.Server.Abstractions.Data.Stats;
+
+namespace Moongate.Server.Abstractions.Interfaces.Server;
+
+/// <summary>Publishes the shard's live figures as a snapshot recomputed on the game loop.</summary>
+public interface IServerStatsService
+{
+    /// <summary>The most recent snapshot. Never null, and safe to read from any thread.</summary>
+    ServerStatsSnapshot Current { get; }
+
+    /// <summary>
+    /// Recomputes the snapshot and publishes it. Must run on the game loop: it reads the world stores,
+    /// which are single-writer there.
+    /// </summary>
+    void Refresh();
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -152,6 +152,11 @@ await ConsoleApp.RunAsync(
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IChatService, ChatService>(Reuse.Singleton);
                 container.Register<IServerSettingsService, ServerSettingsService>(Reuse.Singleton);
+
+                // RegisterStdService rather than Register: the type is both the domain service the stats
+                // endpoint resolves and the hosted service owning the refresh timer, and it must be the
+                // same singleton in both roles.
+                container.RegisterStdService<IServerStatsService, ServerStatsService>();
                 container.RegisterCommandService();
                 container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
                 container.Register<IMapTileService, MapTileService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Server/ServerStatsService.cs
+++ b/src/Moongate.Server/Services/Server/ServerStatsService.cs
@@ -2,6 +2,7 @@ using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Stats;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Items;
@@ -9,6 +10,7 @@ using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Abstractions.Interfaces.Server;
 using Serilog;
 using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Core.Interfaces.Events;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.Server.Services.Server;
@@ -29,6 +31,7 @@ public sealed class ServerStatsService : IServerStatsService, ISquidStdService
     private readonly IItemTemplateService _itemTemplates;
     private readonly IMobileTemplateService _mobileTemplates;
     private readonly IGameLoopContext _loop;
+    private readonly IEventBus _eventBus;
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _interval;
     private readonly DateTimeOffset _startedAt;
@@ -42,6 +45,7 @@ public sealed class ServerStatsService : IServerStatsService, ISquidStdService
         IItemTemplateService itemTemplates,
         IMobileTemplateService mobileTemplates,
         IGameLoopContext loop,
+        IEventBus eventBus,
         TimeProvider timeProvider,
         MoongateConfig config
     )
@@ -53,6 +57,7 @@ public sealed class ServerStatsService : IServerStatsService, ISquidStdService
         _itemTemplates = itemTemplates;
         _mobileTemplates = mobileTemplates;
         _loop = loop;
+        _eventBus = eventBus;
         _timeProvider = timeProvider;
         _interval = TimeSpan.FromSeconds(config.StatsRefreshSeconds);
         _startedAt = timeProvider.GetUtcNow();
@@ -95,7 +100,21 @@ public sealed class ServerStatsService : IServerStatsService, ISquidStdService
 
     public ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
-        _timerId = _loop.ScheduleRepeating(TimerName, _interval, Refresh, TimeSpan.Zero);
+        // World-ready, not the timer, produces the first snapshot: this service starts before the data
+        // loaders do, so a refresh scheduled for the next tick would count zero templates and publish that
+        // for a whole interval. The event fires on the loop once the world is loaded, which is both the
+        // earliest correct moment and the right thread. Refreshing inline here is not an option — StartAsync
+        // runs off the loop, and reading the world stores from there is what this snapshot exists to avoid.
+        _eventBus.Subscribe<WorldReadyEvent>(
+            (_, _) =>
+            {
+                Refresh();
+
+                return Task.CompletedTask;
+            }
+        );
+
+        _timerId = _loop.ScheduleRepeating(TimerName, _interval, Refresh);
 
         return ValueTask.CompletedTask;
     }

--- a/src/Moongate.Server/Services/Server/ServerStatsService.cs
+++ b/src/Moongate.Server/Services/Server/ServerStatsService.cs
@@ -1,0 +1,113 @@
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Stats;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.Server;
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Services.Server;
+
+/// <summary>
+/// Counts what the shard holds on a repeating game-loop timer and publishes the result as an immutable
+/// snapshot, so readers off the loop — the REST API — never touch the world stores themselves.
+/// </summary>
+public sealed class ServerStatsService : IServerStatsService, ISquidStdService
+{
+    private const string TimerName = "server-stats";
+
+    private readonly ILogger _logger = Log.ForContext<ServerStatsService>();
+    private readonly IEntityStore<AccountEntity, Serial> _accounts;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IEntityStore<ItemEntity, Serial> _items;
+    private readonly ISessionManager _sessions;
+    private readonly IItemTemplateService _itemTemplates;
+    private readonly IMobileTemplateService _mobileTemplates;
+    private readonly IGameLoopContext _loop;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _interval;
+    private readonly DateTimeOffset _startedAt;
+
+    private volatile ServerStatsSnapshot _current = ServerStatsSnapshot.Empty;
+    private string? _timerId;
+
+    public ServerStatsService(
+        IPersistenceService persistenceService,
+        ISessionManager sessions,
+        IItemTemplateService itemTemplates,
+        IMobileTemplateService mobileTemplates,
+        IGameLoopContext loop,
+        TimeProvider timeProvider,
+        MoongateConfig config
+    )
+    {
+        _accounts = persistenceService.GetStore<AccountEntity, Serial>();
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _items = persistenceService.GetStore<ItemEntity, Serial>();
+        _sessions = sessions;
+        _itemTemplates = itemTemplates;
+        _mobileTemplates = mobileTemplates;
+        _loop = loop;
+        _timeProvider = timeProvider;
+        _interval = TimeSpan.FromSeconds(config.StatsRefreshSeconds);
+        _startedAt = timeProvider.GetUtcNow();
+    }
+
+    public ServerStatsSnapshot Current => _current;
+
+    public void Refresh()
+    {
+        try
+        {
+            var now = _timeProvider.GetUtcNow();
+            var accounts = _accounts.GetAll();
+            var characterIds = accounts.SelectMany(account => account.MobileIds).ToList();
+
+            _current = new(
+                now,
+                now - _startedAt,
+                characterIds.Count(_sessions.IsCharacterPlayed),
+                _sessions.Count,
+                accounts.Count,
+                accounts.Count(account => account.IsActive),
+                characterIds.Count,
+
+                // Mobiles nobody owns are the NPCs. Floored, because an account can outlive the mobiles
+                // its character ids point at.
+                Math.Max(0, _mobiles.Count() - characterIds.Count),
+                _items.Count(),
+                _itemTemplates.Count,
+                _mobileTemplates.Count
+            );
+        }
+        catch (Exception exception)
+        {
+            // Keep the previous snapshot. This runs inside a game-loop timer callback: a stale number is
+            // cheap, an exception escaping into the loop is not.
+            _logger.Warning(exception, "Server stats refresh failed; keeping the previous snapshot");
+        }
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _timerId = _loop.ScheduleRepeating(TimerName, _interval, Refresh, TimeSpan.Zero);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is not null)
+        {
+            _loop.Cancel(_timerId);
+            _timerId = null;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Stats/StatsEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Stats/StatsEndpointsTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Json;
+using Moongate.Http.Plugin.Data.Api.Stats;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http.Endpoints.Stats;
+
+public sealed class StatsEndpointsTests
+{
+    [Fact]
+    public async Task Stats_IsPublic_AndGroupsTheSnapshot()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.Stats.Current = new(
+            new DateTimeOffset(2026, 7, 21, 8, 31, 0, TimeSpan.Zero),
+            TimeSpan.FromHours(12),
+            OnlinePlayers: 12,
+            Connections: 15,
+            Accounts: 340,
+            ActiveAccounts: 300,
+            Characters: 512,
+            Npcs: 1840,
+            WorldItems: 27310,
+            ItemTemplates: 412,
+            MobileTemplates: 19
+        );
+
+        var response = await server.Client.GetAsync("/api/v1/stats"); // no auth header
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var stats = await response.Content.ReadFromJsonAsync<ServerStatsResponse>();
+        Assert.Equal(43200, stats!.UptimeSeconds);
+        Assert.Equal(12, stats.Players.Online);
+        Assert.Equal(15, stats.Players.Connections);
+        Assert.Equal(340, stats.Accounts.Total);
+        Assert.Equal(300, stats.Accounts.Active);
+        Assert.Equal(512, stats.Accounts.Characters);
+        Assert.Equal(1840, stats.World.Npcs);
+        Assert.Equal(27310, stats.World.Items);
+        Assert.Equal(412, stats.Content.ItemTemplates);
+        Assert.Equal(19, stats.Content.MobileTemplates);
+    }
+
+    [Fact]
+    public async Task Stats_BeforeTheFirstRefresh_AnswersOkWithAnUncomputedTimestamp()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.GetAsync("/api/v1/stats");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var stats = await response.Content.ReadFromJsonAsync<ServerStatsResponse>();
+        Assert.Equal(DateTimeOffset.MinValue, stats!.GeneratedAt);
+        Assert.Equal(0, stats.Players.Online);
+    }
+
+    [Fact]
+    public async Task Stats_CachesForTheRefreshInterval()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.GetAsync("/api/v1/stats");
+
+        Assert.Equal("public, max-age=30", response.Headers.CacheControl!.ToString());
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -13,6 +13,7 @@ using Moongate.Http.Plugin.Endpoints.Mobiles;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Registration;
 using Moongate.Http.Plugin.Endpoints.ServerInfo;
+using Moongate.Http.Plugin.Endpoints.Stats;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Interfaces.Auth;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
@@ -60,6 +61,7 @@ public class MoongateHttpPluginTests
                 typeof(RegistrationEndpoints),
                 typeof(ServerInfoEndpoints),
                 typeof(ServerSettingsAdminEndpoints),
+                typeof(StatsEndpoints),
                 typeof(VersionEndpoints)
             ],
             registered

--- a/tests/Moongate.Tests/Server/Stats/ServerStatsServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Stats/ServerStatsServiceTests.cs
@@ -1,12 +1,16 @@
 using Moongate.Core.Extensions;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Stats;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Server;
 using Moongate.Tests.Support;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Server.Stats;
 
@@ -120,20 +124,16 @@ public sealed class ServerStatsServiceTests
     public async Task StartAsync_RegistersTheRepeatingRefreshTimer_AndStopAsyncCancelsIt()
     {
         var loop = new StubGameLoopContext();
-        var service = new ServerStatsService(
-            new FakePersistenceService(),
-            new StubSessionManager(),
-            new ItemTemplateService(),
-            new MobileTemplateService(),
-            loop,
-            TimeProvider.System,
-            new() { UltimaDirectory = "/tmp", StatsRefreshSeconds = 45 }
-        );
+        var service = Started(loop, new EventBusService(), refreshSeconds: 45);
 
         await service.StartAsync();
 
         Assert.True(loop.Repeating.ContainsKey("server-stats"));
         Assert.Equal(TimeSpan.FromSeconds(45), loop.RepeatingInterval);
+
+        // No explicit first delay: the timer wheel rejects a non-positive one outright, and the first
+        // snapshot is world-ready's job anyway.
+        Assert.Null(loop.RepeatingDelay);
 
         // The registered callback is the refresh itself: firing it publishes a snapshot.
         loop.Repeating["server-stats"]();
@@ -143,29 +143,63 @@ public sealed class ServerStatsServiceTests
         Assert.False(loop.Repeating.ContainsKey("server-stats"));
     }
 
+    [Fact]
+    public async Task StartAsync_TakesTheFirstSnapshotOnWorldReady()
+    {
+        var bus = new EventBusService();
+        var service = Started(new StubGameLoopContext(), bus, refreshSeconds: 30);
+
+        await service.StartAsync();
+        Assert.Same(ServerStatsSnapshot.Empty, service.Current);
+
+        // This service starts before the data loaders do, so the first snapshot has to wait for the world
+        // to be ready — otherwise it would publish zero templates for a whole interval.
+        await bus.PublishAsync(new WorldReadyEvent());
+
+        Assert.NotEqual(DateTimeOffset.MinValue, service.Current.GeneratedAt);
+        Assert.Equal(1, service.Current.ItemTemplates);
+        Assert.Equal(1, service.Current.MobileTemplates);
+    }
+
     /// <summary>A service over fake persistence, one item template and one mobile template.</summary>
     private static (ServerStatsService Service, FakePersistenceService Persistence, StubSessionManager Sessions) Build()
     {
         var persistence = new FakePersistenceService();
         var sessions = new StubSessionManager();
 
+        var service = Create(persistence, sessions, new StubGameLoopContext(), new EventBusService(), 30);
+
+        return (service, persistence, sessions);
+    }
+
+    /// <summary>The same service, when the test drives the loop or the bus rather than the stores.</summary>
+    private static ServerStatsService Started(IGameLoopContext loop, IEventBus eventBus, int refreshSeconds)
+        => Create(new FakePersistenceService(), new StubSessionManager(), loop, eventBus, refreshSeconds);
+
+    private static ServerStatsService Create(
+        FakePersistenceService persistence,
+        StubSessionManager sessions,
+        IGameLoopContext loop,
+        IEventBus eventBus,
+        int refreshSeconds
+    )
+    {
         var itemTemplates = new ItemTemplateService();
         itemTemplates.Register(new() { Id = "sword" });
 
         var mobileTemplates = new MobileTemplateService();
         mobileTemplates.Register(new() { Id = "orc" });
 
-        var service = new ServerStatsService(
+        return new(
             persistence,
             sessions,
             itemTemplates,
             mobileTemplates,
-            new StubGameLoopContext(),
+            loop,
+            eventBus,
             TimeProvider.System,
-            new() { UltimaDirectory = "/tmp" }
+            new() { UltimaDirectory = "/tmp", StatsRefreshSeconds = refreshSeconds }
         );
-
-        return (service, persistence, sessions);
     }
 
     /// <summary>Stores an account owning <paramref name="characters" /> freshly created mobiles.</summary>

--- a/tests/Moongate.Tests/Server/Stats/ServerStatsServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Stats/ServerStatsServiceTests.cs
@@ -1,0 +1,198 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Stats;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Server.Services.Server;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Stats;
+
+public sealed class ServerStatsServiceTests
+{
+    [Fact]
+    public void Current_BeforeTheFirstRefresh_IsTheEmptySnapshot()
+    {
+        var (service, _, _) = Build();
+
+        Assert.Same(ServerStatsSnapshot.Empty, service.Current);
+        Assert.Equal(DateTimeOffset.MinValue, service.Current.GeneratedAt);
+    }
+
+    [Fact]
+    public void Refresh_CountsAccountsCharactersAndTemplates()
+    {
+        var (service, persistence, _) = Build();
+        SeedAccount(persistence, "tom", isActive: true, characters: 2);
+        SeedAccount(persistence, "ann", isActive: false, characters: 1);
+
+        service.Refresh();
+
+        Assert.Equal(2, service.Current.Accounts);
+        Assert.Equal(1, service.Current.ActiveAccounts);
+        Assert.Equal(3, service.Current.Characters);
+        Assert.Equal(1, service.Current.ItemTemplates);
+        Assert.Equal(1, service.Current.MobileTemplates);
+    }
+
+    [Fact]
+    public void Refresh_CountsNpcsAsMobilesThatNoAccountOwns()
+    {
+        var (service, persistence, _) = Build();
+        SeedAccount(persistence, "tom", isActive: true, characters: 2);
+
+        // Two more mobiles owned by nobody: what an NPC looks like in the store.
+        persistence.Store<MobileEntity>().UpsertAsync(new() { Name = "orc" }).WaitSync();
+        persistence.Store<MobileEntity>().UpsertAsync(new() { Name = "rat" }).WaitSync();
+
+        service.Refresh();
+
+        Assert.Equal(2, service.Current.Npcs);
+    }
+
+    [Fact]
+    public void Refresh_NpcCountNeverGoesNegative()
+    {
+        var (service, persistence, _) = Build();
+
+        // An account claiming characters whose mobiles are gone: orphaned ids would drive the
+        // subtraction below zero.
+        var account = new AccountEntity
+        {
+            Username = "tom",
+            PasswordHash = "x",
+            ActivationToken = string.Empty,
+            IsActive = true,
+            MobileIds = [new(900), new(901), new(902)]
+        };
+        persistence.Store<AccountEntity>().UpsertAsync(account).WaitSync();
+
+        service.Refresh();
+
+        Assert.Equal(0, service.Current.Npcs);
+    }
+
+    [Fact]
+    public void Refresh_CountsWorldItems()
+    {
+        var (service, persistence, _) = Build();
+        persistence.Store<ItemEntity>().UpsertAsync(new() { Name = "sword" }).WaitSync();
+        persistence.Store<ItemEntity>().UpsertAsync(new() { Name = "shield" }).WaitSync();
+
+        service.Refresh();
+
+        Assert.Equal(2, service.Current.WorldItems);
+    }
+
+    [Fact]
+    public void Refresh_OnlinePlayers_CountsOnlyCharactersASessionIsPlaying()
+    {
+        var (service, persistence, sessions) = Build();
+        var account = SeedAccount(persistence, "tom", isActive: true, characters: 2);
+        sessions.Played.Add(account.MobileIds[0]);
+        sessions.Count = 5;
+
+        service.Refresh();
+
+        Assert.Equal(1, service.Current.OnlinePlayers);
+        Assert.Equal(5, service.Current.Connections);
+    }
+
+    [Fact]
+    public void Refresh_WhenAReadThrows_KeepsThePreviousSnapshot()
+    {
+        var (service, _, sessions) = Build();
+
+        service.Refresh();
+        var previous = service.Current;
+        Assert.NotEqual(DateTimeOffset.MinValue, previous.GeneratedAt);
+
+        sessions.ThrowOnCount = true;
+        service.Refresh();
+
+        // No exception escapes — it would poison the game loop — and the last good numbers survive.
+        Assert.Same(previous, service.Current);
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistersTheRepeatingRefreshTimer_AndStopAsyncCancelsIt()
+    {
+        var loop = new StubGameLoopContext();
+        var service = new ServerStatsService(
+            new FakePersistenceService(),
+            new StubSessionManager(),
+            new ItemTemplateService(),
+            new MobileTemplateService(),
+            loop,
+            TimeProvider.System,
+            new() { UltimaDirectory = "/tmp", StatsRefreshSeconds = 45 }
+        );
+
+        await service.StartAsync();
+
+        Assert.True(loop.Repeating.ContainsKey("server-stats"));
+        Assert.Equal(TimeSpan.FromSeconds(45), loop.RepeatingInterval);
+
+        // The registered callback is the refresh itself: firing it publishes a snapshot.
+        loop.Repeating["server-stats"]();
+        Assert.NotEqual(DateTimeOffset.MinValue, service.Current.GeneratedAt);
+
+        await service.StopAsync();
+        Assert.False(loop.Repeating.ContainsKey("server-stats"));
+    }
+
+    /// <summary>A service over fake persistence, one item template and one mobile template.</summary>
+    private static (ServerStatsService Service, FakePersistenceService Persistence, StubSessionManager Sessions) Build()
+    {
+        var persistence = new FakePersistenceService();
+        var sessions = new StubSessionManager();
+
+        var itemTemplates = new ItemTemplateService();
+        itemTemplates.Register(new() { Id = "sword" });
+
+        var mobileTemplates = new MobileTemplateService();
+        mobileTemplates.Register(new() { Id = "orc" });
+
+        var service = new ServerStatsService(
+            persistence,
+            sessions,
+            itemTemplates,
+            mobileTemplates,
+            new StubGameLoopContext(),
+            TimeProvider.System,
+            new() { UltimaDirectory = "/tmp" }
+        );
+
+        return (service, persistence, sessions);
+    }
+
+    /// <summary>Stores an account owning <paramref name="characters" /> freshly created mobiles.</summary>
+    private static AccountEntity SeedAccount(
+        FakePersistenceService persistence,
+        string username,
+        bool isActive,
+        int characters
+    )
+    {
+        var account = new AccountEntity
+        {
+            Username = username,
+            PasswordHash = "x",
+            ActivationToken = string.Empty,
+            IsActive = isActive
+        };
+
+        for (var index = 0; index < characters; index++)
+        {
+            var mobile = new MobileEntity { Name = $"{username}-{index}" };
+            persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            account.MobileIds.Add(mobile.Id);
+        }
+
+        persistence.Store<AccountEntity>().UpsertAsync(account).WaitSync();
+
+        return account;
+    }
+}

--- a/tests/Moongate.Tests/Support/StubGameLoopContext.cs
+++ b/tests/Moongate.Tests/Support/StubGameLoopContext.cs
@@ -27,6 +27,9 @@ public sealed class StubGameLoopContext : IGameLoopContext
     /// <summary>The interval the last repeating timer was registered with.</summary>
     public TimeSpan RepeatingInterval { get; private set; }
 
+    /// <summary>The initial delay the last repeating timer was registered with, if any.</summary>
+    public TimeSpan? RepeatingDelay { get; private set; }
+
     public IMainThreadDispatcher Dispatcher => throw new NotSupportedException();
 
     public ITimerService Timers => throw new NotSupportedException();
@@ -51,6 +54,7 @@ public sealed class StubGameLoopContext : IGameLoopContext
     {
         Repeating[name] = callback;
         RepeatingInterval = interval;
+        RepeatingDelay = delay;
 
         return name;
     }

--- a/tests/Moongate.Tests/Support/StubGameLoopContext.cs
+++ b/tests/Moongate.Tests/Support/StubGameLoopContext.cs
@@ -21,12 +21,18 @@ public sealed class StubGameLoopContext : IGameLoopContext
     /// <summary>How many times work was handed to the loop.</summary>
     public int PostCount { get; private set; }
 
+    /// <summary>Repeating timers registered on this loop, keyed by name, holding the callback handed over.</summary>
+    public Dictionary<string, Action> Repeating { get; } = [];
+
+    /// <summary>The interval the last repeating timer was registered with.</summary>
+    public TimeSpan RepeatingInterval { get; private set; }
+
     public IMainThreadDispatcher Dispatcher => throw new NotSupportedException();
 
     public ITimerService Timers => throw new NotSupportedException();
 
     public bool Cancel(string timerId)
-        => throw new NotSupportedException();
+        => Repeating.Remove(timerId);
 
     public void Post(Action action)
     {
@@ -42,5 +48,10 @@ public sealed class StubGameLoopContext : IGameLoopContext
         => throw new NotSupportedException();
 
     public string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null)
-        => throw new NotSupportedException();
+    {
+        Repeating[name] = callback;
+        RepeatingInterval = interval;
+
+        return name;
+    }
 }

--- a/tests/Moongate.Tests/Support/StubServerStatsService.cs
+++ b/tests/Moongate.Tests/Support/StubServerStatsService.cs
@@ -1,0 +1,15 @@
+using Moongate.Server.Abstractions.Data.Stats;
+using Moongate.Server.Abstractions.Interfaces.Server;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Test double for <see cref="IServerStatsService" />: lets a test state exactly which snapshot the
+/// endpoint serves, so the route's behaviour is tested without a game loop or a timer.
+/// </summary>
+public sealed class StubServerStatsService : IServerStatsService
+{
+    public ServerStatsSnapshot Current { get; set; } = ServerStatsSnapshot.Empty;
+
+    public void Refresh() { }
+}

--- a/tests/Moongate.Tests/Support/StubSessionManager.cs
+++ b/tests/Moongate.Tests/Support/StubSessionManager.cs
@@ -11,10 +11,20 @@ namespace Moongate.Tests.Support;
 /// </summary>
 public sealed class StubSessionManager : ISessionManager
 {
+    private int _count;
+
     /// <summary>Characters a session is pretending to play.</summary>
     public HashSet<Serial> Played { get; } = [];
 
-    public int Count => 0;
+    /// <summary>When set, reading <see cref="Count" /> throws, so a caller's failure handling can be exercised.</summary>
+    public bool ThrowOnCount { get; set; }
+
+    /// <summary>Connections the stub reports, including clients that have not entered the world.</summary>
+    public int Count
+    {
+        get => ThrowOnCount ? throw new InvalidOperationException("session count unavailable") : _count;
+        set => _count = value;
+    }
 
     public IReadOnlyCollection<PlayerSession> All => [];
 

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -11,6 +11,7 @@ using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Players;
 using Moongate.Http.Plugin.Endpoints.Registration;
 using Moongate.Http.Plugin.Endpoints.ServerInfo;
+using Moongate.Http.Plugin.Endpoints.Stats;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Interfaces.Assets;
 using Moongate.Http.Plugin.Interfaces.Auth;
@@ -44,7 +45,8 @@ public sealed class TestApiServer : IAsyncDisposable
         CharacterService characters,
         StubSessionManager sessions,
         FakePersistenceService persistence,
-        ServerSettingsService serverSettings
+        ServerSettingsService serverSettings,
+        StubServerStatsService stats
     )
     {
         _service = service;
@@ -54,6 +56,7 @@ public sealed class TestApiServer : IAsyncDisposable
         Sessions = sessions;
         Persistence = persistence;
         ServerSettings = serverSettings;
+        Stats = stats;
     }
 
     public HttpClient Client { get; }
@@ -62,6 +65,9 @@ public sealed class TestApiServer : IAsyncDisposable
 
     /// <summary>The real server-settings service behind the endpoints, so a test can seed settings and assets.</summary>
     public ServerSettingsService ServerSettings { get; }
+
+    /// <summary>The snapshot the stats route serves, so a test can state the figures it expects to read.</summary>
+    public StubServerStatsService Stats { get; }
 
     /// <summary>Real, over the same fake persistence: a test can give an account a character.</summary>
     public CharacterService Characters { get; }
@@ -161,6 +167,10 @@ public sealed class TestApiServer : IAsyncDisposable
         var rateLimiter = new RegistrationRateLimiter(TimeProvider.System, permitPerWindow: 2, window: TimeSpan.FromMinutes(10));
         container.RegisterApiEndpointInstance(new RegistrationEndpoints(accounts, serverSettings, rateLimiter));
 
+        var stats = new StubServerStatsService();
+        container.RegisterInstance<IServerStatsService>(stats);
+        container.RegisterApiEndpointInstance(new StatsEndpoints(stats, moongateConfig));
+
         // Lets a test add endpoint groups this fixture cannot know about — the ones the HTTP plugin owns.
         configure?.Invoke(container);
 
@@ -174,7 +184,8 @@ public sealed class TestApiServer : IAsyncDisposable
             characters,
             sessions,
             persistence,
-            serverSettings
+            serverSettings,
+            stats
         );
     }
 }


### PR DESCRIPTION
Closes #36.

Adds `GET /api/v1/stats` — anonymous — reporting players online, accounts, characters, NPCs and items in the world, content template counts and uptime.

## How it works

Counting world entities means reading the mobile and item stores, which are single-writer on the game loop; `PlayerEndpoints` already refuses to touch them from an ASP.NET thread. So the numbers are computed **on the loop** and published as an immutable snapshot:

- `ServerStatsSnapshot` + `IServerStatsService` in `Moongate.Server.Abstractions`.
- `ServerStatsService` in `Moongate.Server`, registered with `RegisterStdService` so the one singleton is both the hosted service owning the timer and the contract the API resolves. It takes the first snapshot on `WorldReadyEvent` and refreshes every `StatsRefreshSeconds` (new `moongate` config key, default 30).
- `StatsEndpoints` in `Moongate.Http.Plugin` reads the published snapshot and nothing else, grouping it into `players` / `accounts` / `world` / `content` and setting a matching `Cache-Control: public, max-age=…`.

NPCs are mobiles no account owns, floored at zero. A failing refresh logs a warning and keeps the previous snapshot rather than letting an exception escape into the game loop.

## Also fixes a boot failure on develop

`NewsEntity` (#34) and `ServerSettingsEntity` (#35) were both registered as persisted **type id 4**, landing on develop from two branches developed in parallel. Type ids are process-wide, so a shard with both plugins loaded died at startup with `InvalidOperationException: Type id 4 is already registered` — **develop does not currently boot**. `NewsEntity` moves to 100, and the ranges are now reserved: core entities 1-99, external plugins 100+.

Fake-persistence tests cannot see this — they create stores on demand with no registry — which is why it only surfaced on a real boot.

## Verification

- 1323 tests pass.
- `dotnet docfx docs/docfx.json --warningsAsErrors` at 0 warnings.
- Real boot: `GET /api/v1/stats` answers 200 immediately after startup with `itemTemplates: 1665` and `mobileTemplates: 19`, matching the loader log, and `cache-control: public, max-age=30`.

Docs: new "Public statistics" section in the server-settings guide, plus the `StatsRefreshSeconds` key in the configuration reference.