### PR TITLE
feat: notifications abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# The notification channel named "log" ships its templates as tracked assets; the rule above is meant
+# for runtime logs and would silently drop them from the repository.
+!src/Moongate.Server/Assets/Notification/Templates/log/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/docs/getting-started/notifications.md
+++ b/docs/getting-started/notifications.md
@@ -1,0 +1,104 @@
+# Notifications
+
+Moongate sends messages to people — account verification today, more later —
+through a channel-agnostic pipeline. What a notification *says* lives in a
+template on disk; what carries it is a **channel**.
+
+## Where templates live
+
+```
+<root>/notification/templates/
+  log/
+    account_verification.mgtmpl
+  email/
+    account_verification.mgtmpl
+```
+
+Two conventions, and there is no registry to maintain:
+
+- **The directory name is the channel id.** Adding a channel means adding a
+  directory.
+- **The file name, without its extension, is the template id.**
+
+Template ids are `snake_case` and contain no dots. The defaults are seeded into
+the runtime root on first boot; edit them there, not in the repository.
+
+> [!NOTE]
+> `.mgtmpl` files are [Scriban](https://github.com/scriban/scriban) templates.
+> The extension is Moongate's own, so map `*.mgtmpl` to Scriban — or to Liquid,
+> which is close enough — in your editor to get highlighting.
+
+## Writing a template
+
+The body uses `{{ }}`. Model members are exposed in **snake_case**: a model
+carrying `Username` is written `{{ username }}`.
+
+A subject — for channels that have one — goes in Scriban **front matter**,
+between `+++` markers. Front matter is already in script mode, so it takes no
+braces:
+
+```
++++
+subject = "Verify your " + shard_name + " account"
++++
+Hello {{ username }},
+
+Confirm your account:
+{{ website }}/verify?token={{ token }}
+```
+
+Channels without a subject simply omit the front matter block.
+
+Note that the verification URL is composed **here**, not in the server: its
+shape belongs to your website, so changing it costs an edit rather than a
+release.
+
+## Available templates
+
+| Template | Raised when | Model |
+|---|---|---|
+| `account_verification` | A web registration creates a pending account | `username`, `email`, `token`, `website`, `shard_name` |
+
+`website` comes from the shard's **Website** contact in the server settings; if
+it is unset the value is empty, and any link built from it will be broken.
+
+## Channels
+
+`log` is the only channel shipped today: it writes the rendered notification to
+the server log, which is how the verification token is reachable on a shard with
+no transport configured. The `email/` templates ship ready for the SMTP channel
+that follows; addressing a channel that is not registered logs a warning and
+drops the notification.
+
+A plugin adds a transport by implementing `INotificationChannel` and registering
+it from its `Configure`:
+
+```csharp
+container.RegisterNotificationChannel<DiscordNotificationChannel>();
+```
+
+The channel's `Id` is the only coordination point: notifications addressed to
+that id reach it, and it reads its templates from the directory of the same
+name.
+
+## Configuration
+
+The `notifications` section of `moongate.yaml`:
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `MaxAttempts` | int | `3` | Total delivery attempts per notification. |
+| `RetryDelaySeconds` | int | `5` | Wait between one attempt and the next. |
+
+> [!WARNING]
+> **Delivery is best-effort.** Notifications are delivered on a worker thread and
+> are not persisted: if every attempt fails, the failure is logged and the
+> notification is gone. A lost verification message means an account that never
+> activates — watch the log for `Gave up delivering`.
+
+## Troubleshooting
+
+A broken template does not stop the shard from booting. It is logged at startup
+as `Skipping notification template <path>` and counted in the
+`Loaded N notification template(s) ... (M skipped)` line. Fix the file and
+restart.

--- a/docs/getting-started/server-settings-and-web-registration.md
+++ b/docs/getting-started/server-settings-and-web-registration.md
@@ -97,8 +97,10 @@ for a missing/invalid field, and `429` when the caller is rate-limited.
 > for email verification: it creates the token and raises an
 > `AccountRegistrationRequestedEvent` (carrying the account, email and token) that
 > a future email feature will subscribe to in order to send the verification link.
-> Until then no mail is sent — the token is written to the server log, and the
-> verify endpoint works with whatever token you hold.
+> Until then no mail is sent: the request goes through the
+> [notification pipeline](notifications.md) and is delivered on the `log`
+> channel, so the token appears in the server log and the verify endpoint works
+> with whatever token you hold.
 
 ### Abuse protection
 

--- a/docs/getting-started/toc.yml
+++ b/docs/getting-started/toc.yml
@@ -10,3 +10,5 @@
   href: configuration.md
 - name: Server settings & web registration
   href: server-settings-and-web-registration.md
+- name: Notifications
+  href: notifications.md

--- a/src/Moongate.Server.Abstractions/Data/Config/NotificationConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/NotificationConfig.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Server.Abstractions.Data.Config;
+
+/// <summary>Notification delivery settings, loaded from the <c>notifications</c> section of moongate.yaml.</summary>
+public sealed class NotificationConfig
+{
+    public int MaxAttempts { get; set; } = 3;
+
+    public int RetryDelaySeconds { get; set; } = 5;
+}

--- a/src/Moongate.Server.Abstractions/Data/Notifications/NotificationContent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Notifications/NotificationContent.cs
@@ -1,0 +1,7 @@
+namespace Moongate.Server.Abstractions.Data.Notifications;
+
+/// <summary>
+/// A rendered notification, ready to deliver. <see cref="Subject" /> is null for channels that have no
+/// concept of one.
+/// </summary>
+public sealed record NotificationContent(string? Subject, string Body);

--- a/src/Moongate.Server.Abstractions/Data/Notifications/NotificationRecipient.cs
+++ b/src/Moongate.Server.Abstractions/Data/Notifications/NotificationRecipient.cs
@@ -1,0 +1,7 @@
+namespace Moongate.Server.Abstractions.Data.Notifications;
+
+/// <summary>
+/// Where a notification goes: the channel that delivers it, and the address that channel understands —
+/// an email address, a webhook URL, whatever the channel's own vocabulary is.
+/// </summary>
+public sealed record NotificationRecipient(string ChannelId, string Address);

--- a/src/Moongate.Server.Abstractions/Extensions/NotificationChannelRegistrationExtensions.cs
+++ b/src/Moongate.Server.Abstractions/Extensions/NotificationChannelRegistrationExtensions.cs
@@ -1,0 +1,24 @@
+using DryIoc;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+
+namespace Moongate.Server.Abstractions.Extensions;
+
+/// <summary>
+/// Registers notification channels. Each one is collected under <see cref="INotificationChannel" />, the
+/// typed list the notification service resolves to decide who can deliver what.
+/// </summary>
+public static class NotificationChannelRegistrationExtensions
+{
+    /// <summary>
+    /// Records a notification channel as a singleton <see cref="INotificationChannel" /> so notifications
+    /// addressed to its <see cref="INotificationChannel.Id" /> reach it. A plugin adds a transport by
+    /// calling this and shipping a template directory named after the same id.
+    /// </summary>
+    public static IContainer RegisterNotificationChannel<TChannel>(this IContainer container)
+        where TChannel : class, INotificationChannel
+    {
+        container.Register<INotificationChannel, TChannel>(Reuse.Singleton);
+
+        return container;
+    }
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Notifications/INotificationChannel.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Notifications/INotificationChannel.cs
@@ -1,0 +1,23 @@
+using Moongate.Server.Abstractions.Data.Notifications;
+
+namespace Moongate.Server.Abstractions.Interfaces.Notifications;
+
+/// <summary>
+/// One way of getting a message to a person: email, a chat webhook, the log. A channel receives text
+/// that is already rendered — it knows nothing about templates.
+/// </summary>
+public interface INotificationChannel
+{
+    /// <summary>
+    /// The channel's id. It is also the name of the directory its templates live in, so it must be a
+    /// valid directory name: lowercase, no separators.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>Delivers the rendered notification. Throwing signals a failure worth retrying.</summary>
+    ValueTask SendAsync(
+        NotificationRecipient recipient,
+        NotificationContent content,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Notifications/INotificationService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Notifications/INotificationService.cs
@@ -1,0 +1,20 @@
+using Moongate.Server.Abstractions.Data.Notifications;
+
+namespace Moongate.Server.Abstractions.Interfaces.Notifications;
+
+/// <summary>Sends notifications. The caller says what and to whom; the channel decides how.</summary>
+public interface INotificationService
+{
+    /// <summary>
+    /// Queues a notification and returns immediately — delivery happens on a worker thread, so this is
+    /// safe to call from the game loop or from a web request. Nothing about the delivery is reported
+    /// back: a notification is a side effect and must never fail the operation that raised it.
+    /// </summary>
+    /// <param name="templateId">Template id, matching a file under the channel's template directory.</param>
+    /// <param name="recipient">The channel and address to deliver to.</param>
+    /// <param name="model">
+    /// The data the template renders against, as an anonymous object or record. Members are exposed to
+    /// the template in snake_case: <c>Username</c> is written <c>{{ username }}</c>.
+    /// </param>
+    void Notify(string templateId, NotificationRecipient recipient, object model);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Notifications/INotificationTemplateService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Notifications/INotificationTemplateService.cs
@@ -1,0 +1,23 @@
+using Moongate.Server.Abstractions.Data.Notifications;
+
+namespace Moongate.Server.Abstractions.Interfaces.Notifications;
+
+/// <summary>Holds the notification templates, compiled once at startup and rendered on demand.</summary>
+public interface INotificationTemplateService
+{
+    /// <summary>How many templates are registered, across every channel.</summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Compiles <paramref name="source" /> and registers it for the channel. Throws
+    /// <see cref="InvalidDataException" /> naming the template when the source does not compile, so a
+    /// broken template is a startup failure rather than a surprise at send time.
+    /// </summary>
+    void Register(string channelId, string templateId, string source);
+
+    /// <summary>
+    /// Renders the template against <paramref name="model" />, or returns null when the channel has no
+    /// template with that id.
+    /// </summary>
+    NotificationContent? Render(string channelId, string templateId, object model);
+}

--- a/src/Moongate.Server/Assets/Notification/Templates/email/account_verification.mgtmpl
+++ b/src/Moongate.Server/Assets/Notification/Templates/email/account_verification.mgtmpl
@@ -1,0 +1,9 @@
++++
+subject = "Verify your " + shard_name + " account"
++++
+Hello {{ username }},
+
+Confirm your account:
+{{ website }}/verify?token={{ token }}
+
+If you did not register, ignore this message.

--- a/src/Moongate.Server/Assets/Notification/Templates/log/account_verification.mgtmpl
+++ b/src/Moongate.Server/Assets/Notification/Templates/log/account_verification.mgtmpl
@@ -1,0 +1,1 @@
+Verification token for {{ username }} <{{ email }}>: {{ token }}

--- a/src/Moongate.Server/Loaders/NotificationTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/NotificationTemplatesLoader.cs
@@ -1,0 +1,88 @@
+using Moongate.Server.Abstractions.Interfaces.Loading;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Internal;
+using Serilog;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Server.Loaders;
+
+/// <summary>
+/// Seeds and loads notification templates. The directory name is the channel id and the file name is
+/// the template id, so adding a channel is adding a directory — there is no registry to keep in sync.
+/// </summary>
+public sealed class NotificationTemplatesLoader : IDataLoader
+{
+    private const string EmbeddedDirectory = "Assets/Notification/Templates";
+    private const string EmbeddedNamespace = "Moongate.Server.Assets.Notification.Templates";
+    private const string Extension = "*.mgtmpl";
+
+    private readonly ILogger _logger = Log.ForContext<NotificationTemplatesLoader>();
+    private readonly INotificationTemplateService _templates;
+    private readonly DirectoriesConfig _directories;
+
+    public NotificationTemplatesLoader(INotificationTemplateService templates, DirectoriesConfig directories)
+    {
+        _templates = templates;
+        _directories = directories;
+    }
+
+    public ValueTask LoadAsync(CancellationToken ct = default)
+    {
+        var notificationDirectory = _directories.RegisterDirectory("notification");
+        var templatesDirectory = Path.Combine(notificationDirectory, "templates");
+
+        if (!Directory.Exists(templatesDirectory))
+        {
+            EmbeddedResourceDirectorySeeder.SeedAtomic(
+                typeof(NotificationTemplatesLoader).Assembly,
+                EmbeddedDirectory,
+                EmbeddedNamespace,
+                templatesDirectory
+            );
+
+            _logger.Information("Seeded default notification templates at {Path}", templatesDirectory);
+        }
+
+        if (!Directory.Exists(templatesDirectory))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var loaded = 0;
+        var failed = 0;
+
+        foreach (var channelDirectory in Directory.GetDirectories(templatesDirectory)
+                                                  .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+        {
+            var channelId = Path.GetFileName(channelDirectory);
+
+            foreach (var file in Directory.GetFiles(channelDirectory, Extension, SearchOption.TopDirectoryOnly)
+                                          .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+            {
+                var templateId = Path.GetFileNameWithoutExtension(file);
+
+                try
+                {
+                    _templates.Register(channelId, templateId, File.ReadAllText(file));
+                    loaded++;
+                }
+                catch (Exception exception)
+                {
+                    // One broken template must not stop the shard from booting, but it must be loud: this
+                    // is the moment the operator can still fix it.
+                    failed++;
+                    _logger.Error(exception, "Skipping notification template {Path}", file);
+                }
+            }
+        }
+
+        _logger.Information(
+            "Loaded {Count} notification template(s) from {Path} ({Failed} skipped)",
+            loaded,
+            templatesDirectory,
+            failed
+        );
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -30,6 +30,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Scriban" Version="7.2.5"/>
         <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
         <PackageReference Include="SquidStd.Core" Version="0.39.0"/>
         <PackageReference Include="SquidStd.Plugin" Version="0.39.0"/>

--- a/src/Moongate.Server/Plugins/MoongateDataLoaderPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateDataLoaderPlugin.cs
@@ -2,12 +2,14 @@ using DryIoc;
 using Moongate.Server.Abstractions.Extensions;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Extensions;
 using Moongate.Server.Loaders;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Loading;
 using Moongate.Server.Services.Mobiles;
+using Moongate.Server.Services.Notifications;
 using Moongate.Server.Services.World;
 using SquidStd.Abstractions.Extensions.Services;
 using SquidStd.Core.Utils;
@@ -81,6 +83,9 @@ public class MoongateDataLoaderPlugin : ISquidStdPlugin
 
         container.Register<IMobileTemplateService, MobileTemplateService>(Reuse.Singleton);
         container.RegisterDataLoader<MobileTemplatesLoader>(150);
+
+        container.Register<INotificationTemplateService, NotificationTemplateService>(Reuse.Singleton);
+        container.RegisterDataLoader<NotificationTemplatesLoader>(160);
 
         container.RegisterDataLoaderService();
     }

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -28,6 +28,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<PaperdollSubscriber>();
         container.RegisterEventSubscriber<ContainerSubscriber>();
         container.RegisterEventSubscriber<SpatialSubscriber>();
+        container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
 
         container.RegisterStdService<IEventSubscriberService, EventSubscriberService>();
     }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -9,6 +9,7 @@ using Moongate.Scripting;
 using Moongate.Server;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Extensions;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.Items;
@@ -26,6 +27,9 @@ using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Network;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Services.Notifications;
+using Moongate.Server.Services.Notifications.Channels;
 using Moongate.Server.Services.Server;
 using Moongate.Server.Services.World;
 using Serilog;
@@ -137,6 +141,7 @@ await ConsoleApp.RunAsync(
             {
                 // Binds the SAME cached instance mutated above; the file cannot clobber it.
                 container.RegisterConfigSection<MoongateConfig>("moongate");
+                container.RegisterConfigSection<NotificationConfig>("notifications");
 
                 container.Register<IAccountService, AccountService>(Reuse.Singleton);
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);
@@ -157,6 +162,11 @@ await ConsoleApp.RunAsync(
                 // endpoint resolves and the hosted service owning the refresh timer, and it must be the
                 // same singleton in both roles.
                 container.RegisterStdService<IServerStatsService, ServerStatsService>();
+
+                // INotificationTemplateService is registered by the data-loader plugin, alongside the
+                // loader that fills it, the same way the template services are.
+                container.Register<INotificationService, NotificationService>(Reuse.Singleton);
+                container.RegisterNotificationChannel<LogNotificationChannel>();
                 container.RegisterCommandService();
                 container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
                 container.Register<IMapTileService, MapTileService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Notifications/Channels/LogNotificationChannel.cs
+++ b/src/Moongate.Server/Services/Notifications/Channels/LogNotificationChannel.cs
@@ -1,0 +1,45 @@
+using Moongate.Server.Abstractions.Data.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Serilog;
+
+namespace Moongate.Server.Services.Notifications.Channels;
+
+/// <summary>
+/// Writes notifications to the server log. It is the channel that always works, which makes it the one
+/// a shard falls back on before it has configured a real transport.
+/// </summary>
+public sealed class LogNotificationChannel : INotificationChannel
+{
+    private readonly ILogger _logger = Log.ForContext<LogNotificationChannel>();
+
+    public string Id => "log";
+
+    public ValueTask SendAsync(
+        NotificationRecipient recipient,
+        NotificationContent content,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (content.Subject is { } subject)
+        {
+            _logger.Information(
+                "Notification to {Address} — {Subject}{NewLine}{Body}",
+                recipient.Address,
+                subject,
+                Environment.NewLine,
+                content.Body
+            );
+        }
+        else
+        {
+            _logger.Information(
+                "Notification to {Address}{NewLine}{Body}",
+                recipient.Address,
+                Environment.NewLine,
+                content.Body
+            );
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Moongate.Server/Services/Notifications/NotificationService.cs
+++ b/src/Moongate.Server/Services/Notifications/NotificationService.cs
@@ -1,0 +1,130 @@
+using Moongate.Core.Extensions;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Serilog;
+using SquidStd.Core.Interfaces.Jobs;
+
+namespace Moongate.Server.Services.Notifications;
+
+/// <summary>
+/// Routes a notification to its channel and delivers it on a worker thread, so neither the game loop nor
+/// a web request ever waits on a transport. Every failure ends here: a notification is a side effect and
+/// must not reach the code that raised it.
+/// </summary>
+public sealed class NotificationService : INotificationService
+{
+    private readonly ILogger _logger = Log.ForContext<NotificationService>();
+    private readonly INotificationTemplateService _templates;
+    private readonly IReadOnlyDictionary<string, INotificationChannel> _channels;
+    private readonly IJobSystem _jobs;
+    private readonly NotificationConfig _config;
+
+    public NotificationService(
+        INotificationTemplateService templates,
+        IEnumerable<INotificationChannel> channels,
+        IJobSystem jobs,
+        NotificationConfig config
+    )
+    {
+        _templates = templates;
+        _channels = channels.ToDictionary(channel => channel.Id, StringComparer.OrdinalIgnoreCase);
+        _jobs = jobs;
+        _config = config;
+    }
+
+    public void Notify(string templateId, NotificationRecipient recipient, object model)
+    {
+        if (!_channels.TryGetValue(recipient.ChannelId, out var channel))
+        {
+            _logger.Warning(
+                "No notification channel '{Channel}' is registered; dropping '{Template}'",
+                recipient.ChannelId,
+                templateId
+            );
+
+            return;
+        }
+
+        // Deliberately not awaited: the caller may be the game loop, and delivery is best-effort.
+        _ = _jobs.ScheduleAsync(() => Deliver(channel, templateId, recipient, model));
+    }
+
+    private void Deliver(
+        INotificationChannel channel,
+        string templateId,
+        NotificationRecipient recipient,
+        object model
+    )
+    {
+        if (Render(channel, templateId, model) is not { } content)
+        {
+            return;
+        }
+
+        for (var attempt = 1; attempt <= _config.MaxAttempts; attempt++)
+        {
+            try
+            {
+                channel.SendAsync(recipient, content).WaitSync();
+
+                return;
+            }
+            catch (Exception exception)
+            {
+                if (attempt >= _config.MaxAttempts)
+                {
+                    _logger.Error(
+                        exception,
+                        "Gave up delivering '{Template}' to {Address} on '{Channel}' after {Attempts} attempt(s)",
+                        templateId,
+                        recipient.Address,
+                        channel.Id,
+                        attempt
+                    );
+
+                    return;
+                }
+
+                _logger.Warning(
+                    exception,
+                    "Attempt {Attempt} to deliver '{Template}' on '{Channel}' failed; retrying",
+                    attempt,
+                    templateId,
+                    channel.Id
+                );
+
+                // Blocking a worker thread, not the loop: the job system exists for exactly this.
+                Thread.Sleep(TimeSpan.FromSeconds(_config.RetryDelaySeconds));
+            }
+        }
+    }
+
+    private NotificationContent? Render(INotificationChannel channel, string templateId, object model)
+    {
+        try
+        {
+            if (_templates.Render(channel.Id, templateId, model) is { } content)
+            {
+                return content;
+            }
+
+            _logger.Warning(
+                "No '{Template}' template for channel '{Channel}'; dropping",
+                templateId,
+                channel.Id
+            );
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(
+                exception,
+                "Rendering '{Template}' for channel '{Channel}' failed; dropping",
+                templateId,
+                channel.Id
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
+++ b/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
@@ -1,0 +1,72 @@
+using Moongate.Server.Abstractions.Data.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Scriban;
+using Scriban.Parsing;
+using Scriban.Runtime;
+
+namespace Moongate.Server.Services.Notifications;
+
+/// <summary>
+/// Scriban-backed template registry. Templates are parsed once at registration — the only place Scriban
+/// is allowed to fail — and rendering afterwards is pure.
+/// </summary>
+public sealed class NotificationTemplateService : INotificationTemplateService
+{
+    private const string SubjectVariable = "subject";
+    private const string FrontMatterMarker = "+++";
+
+    private readonly Dictionary<string, Template> _templates = new(StringComparer.OrdinalIgnoreCase);
+
+    public int Count => _templates.Count;
+
+    public void Register(string channelId, string templateId, string source)
+    {
+        // The mode is chosen from the source because FrontMatterAndContent *requires* the +++ block: a
+        // template without one fails to parse under it. Channels with no subject write no front matter,
+        // so both shapes have to be accepted.
+        var mode = source.TrimStart().StartsWith(FrontMatterMarker, StringComparison.Ordinal)
+                       ? ScriptMode.FrontMatterAndContent
+                       : ScriptMode.Default;
+
+        var template = Template.Parse(source, templateId, null, new LexerOptions { Mode = mode });
+
+        if (template.HasErrors)
+        {
+            throw new InvalidDataException(
+                $"Notification template '{channelId}/{templateId}' does not compile: " +
+                string.Join("; ", template.Messages.Select(message => message.ToString()))
+            );
+        }
+
+        _templates[Key(channelId, templateId)] = template;
+    }
+
+    public NotificationContent? Render(string channelId, string templateId, object model)
+    {
+        if (!_templates.TryGetValue(Key(channelId, templateId), out var template))
+        {
+            return null;
+        }
+
+        var globals = new ScriptObject();
+        globals.Import(model);
+
+        var context = new TemplateContext();
+        context.PushGlobal(globals);
+
+        // Evaluated explicitly so the subject is set whether or not rendering the page walks the front
+        // matter itself; the assignment is idempotent either way.
+        if (template.Page?.FrontMatter is { } frontMatter)
+        {
+            context.Evaluate(frontMatter);
+        }
+
+        var body = template.Render(context);
+        var subject = globals.TryGetValue(SubjectVariable, out var value) ? value?.ToString() : null;
+
+        return new(subject, body);
+    }
+
+    private static string Key(string channelId, string templateId)
+        => $"{channelId}/{templateId}";
+}

--- a/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
@@ -1,0 +1,59 @@
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Server;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Turns a pending web registration into a verification notification. Until an email channel exists this
+/// goes to the log, which is what makes the token reachable on a shard with no transport configured.
+/// </summary>
+public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
+{
+    private const string TemplateId = "account_verification";
+    private const string ChannelId = "log";
+
+    private readonly INotificationService _notifications;
+    private readonly IServerSettingsService _settings;
+    private readonly MoongateConfig _config;
+
+    public AccountRegistrationSubscriber(
+        INotificationService notifications,
+        IServerSettingsService settings,
+        MoongateConfig config
+    )
+    {
+        _notifications = notifications;
+        _settings = settings;
+        _config = config;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<AccountRegistrationRequestedEvent>(OnRegistrationRequested);
+
+    private Task OnRegistrationRequested(
+        AccountRegistrationRequestedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        // The verify URL is composed by the template, not here: its shape belongs to the website, and
+        // changing it should cost an edit rather than a release.
+        _notifications.Notify(
+            TemplateId,
+            new(ChannelId, message.Email),
+            new
+            {
+                message.Username,
+                message.Email,
+                message.Token,
+                Website = _settings.Get().Contacts.Website ?? string.Empty,
+                _config.ShardName
+            }
+        );
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
@@ -1,0 +1,42 @@
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Services.Notifications;
+using Moongate.Server.Services.Server;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Notifications;
+
+public sealed class AccountRegistrationSubscriberTests
+{
+    [Fact]
+    public async Task RegistrationEvent_SendsTheVerificationOnTheLogChannel()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register(
+            "log",
+            "account_verification",
+            "{{ username }}/{{ email }}/{{ token }}/{{ website }}/{{ shard_name }}"
+        );
+
+        var channel = new RecordingNotificationChannel("log");
+        var notifications = new NotificationService(templates, [channel], new StubJobSystem(), new());
+
+        var settings = new ServerSettingsService(new FakePersistenceService());
+        settings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+
+        var bus = new EventBusService();
+        new AccountRegistrationSubscriber(
+            notifications,
+            settings,
+            new() { ShardName = "Britannia", UltimaDirectory = "/tmp" }
+        ).Subscribe(bus);
+
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc123"));
+
+        var (recipient, content) = Assert.Single(channel.Sent);
+        Assert.Equal("tom@example.com", recipient.Address);
+        Assert.Equal("log", recipient.ChannelId);
+        Assert.Equal("tom/tom@example.com/abc123/https://shard.example/Britannia", content.Body.Trim());
+    }
+}

--- a/tests/Moongate.Tests/Server/Notifications/NotificationServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationServiceTests.cs
@@ -1,0 +1,111 @@
+using Moongate.Server.Services.Notifications;
+using Moongate.Server.Services.Notifications.Channels;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Notifications;
+
+public sealed class NotificationServiceTests
+{
+    [Fact]
+    public void Notify_RendersTheTemplateAndSendsItOnTheNamedChannel()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register("test", "greet", "Hello {{ username }}");
+        var channel = new RecordingNotificationChannel();
+        var jobs = new StubJobSystem();
+        var service = new NotificationService(templates, [channel], jobs, new());
+
+        service.Notify("greet", new("test", "tom@example.com"), new { Username = "tom" });
+
+        Assert.Equal(1, jobs.Scheduled);
+        var (recipient, content) = Assert.Single(channel.Sent);
+        Assert.Equal("tom@example.com", recipient.Address);
+        Assert.Equal("Hello tom", content.Body.Trim());
+    }
+
+    [Fact]
+    public void Notify_RoutesToTheChannelMatchingTheRecipient()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register("second", "greet", "hi");
+        var first = new RecordingNotificationChannel("first");
+        var second = new RecordingNotificationChannel("second");
+        var service = new NotificationService(templates, [first, second], new StubJobSystem(), new());
+
+        service.Notify("greet", new("second", "somewhere"), new { });
+
+        Assert.Empty(first.Sent);
+        Assert.Single(second.Sent);
+    }
+
+    [Fact]
+    public void Notify_UnknownChannel_DropsWithoutThrowingOrScheduling()
+    {
+        var templates = new NotificationTemplateService();
+        var channel = new RecordingNotificationChannel();
+        var jobs = new StubJobSystem();
+        var service = new NotificationService(templates, [channel], jobs, new());
+
+        // A notification is a side effect: an unregistered channel must not take down the caller.
+        service.Notify("greet", new("nope", "somewhere"), new { });
+
+        Assert.Equal(0, jobs.Scheduled);
+        Assert.Empty(channel.Sent);
+    }
+
+    [Fact]
+    public void Notify_MissingTemplate_DropsWithoutSending()
+    {
+        var templates = new NotificationTemplateService();
+        var channel = new RecordingNotificationChannel();
+        var service = new NotificationService(templates, [channel], new StubJobSystem(), new());
+
+        service.Notify("absent", new("test", "somewhere"), new { });
+
+        Assert.Equal(0, channel.Attempts);
+    }
+
+    [Fact]
+    public void Notify_RetriesUntilTheChannelSucceeds()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register("test", "greet", "hi");
+        var channel = new RecordingNotificationChannel(failuresBeforeSuccess: 2);
+        var service = new NotificationService(
+            templates,
+            [channel],
+            new StubJobSystem(),
+            new() { MaxAttempts = 3, RetryDelaySeconds = 0 }
+        );
+
+        service.Notify("greet", new("test", "somewhere"), new { });
+
+        Assert.Equal(3, channel.Attempts);
+        Assert.Single(channel.Sent);
+    }
+
+    [Fact]
+    public void Notify_GivesUpAfterMaxAttempts_WithoutThrowing()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register("test", "greet", "hi");
+        var channel = new RecordingNotificationChannel(failuresBeforeSuccess: 99);
+        var service = new NotificationService(
+            templates,
+            [channel],
+            new StubJobSystem(),
+            new() { MaxAttempts = 2, RetryDelaySeconds = 0 }
+        );
+
+        // The job runs inline here, so an escaping exception would fail this test — which is the point:
+        // on a real worker thread it would be an unobserved crash.
+        service.Notify("greet", new("test", "somewhere"), new { });
+
+        Assert.Equal(2, channel.Attempts);
+        Assert.Empty(channel.Sent);
+    }
+
+    [Fact]
+    public void LogChannel_IdentifiesItselfAsLog()
+        => Assert.Equal("log", new LogNotificationChannel().Id);
+}

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
@@ -1,0 +1,92 @@
+using Moongate.Server.Services.Notifications;
+
+namespace Moongate.Tests.Server.Notifications;
+
+public sealed class NotificationTemplateServiceTests
+{
+    [Fact]
+    public void Render_TakesTheSubjectFromFrontMatterAndTheBodyFromTheContent()
+    {
+        var service = new NotificationTemplateService();
+        service.Register(
+            "email",
+            "account_verification",
+            """
+            +++
+            subject = "Verify your " + shard_name + " account"
+            +++
+            Hello {{ username }}, token {{ token }}.
+            """
+        );
+
+        var content = service.Render(
+            "email",
+            "account_verification",
+            new { ShardName = "Britannia", Username = "tom", Token = "abc" }
+        );
+
+        Assert.Equal("Verify your Britannia account", content!.Subject);
+        Assert.Equal("Hello tom, token abc.", content.Body.Trim());
+
+        // The front matter must not leak into the body.
+        Assert.DoesNotContain("subject", content.Body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Render_WithoutFrontMatter_HasNoSubject()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "account_verification", "Token for {{ username }}: {{ token }}");
+
+        var content = service.Render("log", "account_verification", new { Username = "tom", Token = "abc" });
+
+        Assert.Null(content!.Subject);
+        Assert.Equal("Token for tom: abc", content.Body.Trim());
+    }
+
+    [Fact]
+    public void Register_ExposesModelMembersInSnakeCase()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "greet", "{{ shard_name }}");
+
+        var content = service.Render("log", "greet", new { ShardName = "Britannia" });
+
+        Assert.Equal("Britannia", content!.Body.Trim());
+    }
+
+    [Fact]
+    public void Render_UnknownTemplateOrChannel_IsNull()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "account_verification", "hello");
+
+        Assert.Null(service.Render("log", "nope", new { }));
+        Assert.Null(service.Render("email", "account_verification", new { }));
+    }
+
+    [Fact]
+    public void Register_BrokenSyntax_ThrowsNamingTheTemplate()
+    {
+        var service = new NotificationTemplateService();
+
+        // Compiling at registration is the whole point: a broken template must fail at load, not on the
+        // first notification months later.
+        var exception = Assert.Throws<InvalidDataException>(
+            () => service.Register("log", "broken", "{{ if }}")
+        );
+
+        Assert.Contains("broken", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, service.Count);
+    }
+
+    [Fact]
+    public void Count_ReportsRegisteredTemplates()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "one", "a");
+        service.Register("email", "one", "b");
+
+        Assert.Equal(2, service.Count);
+    }
+}

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
@@ -1,0 +1,95 @@
+using Moongate.Server.Loaders;
+using Moongate.Server.Services.Notifications;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Server.Notifications;
+
+public sealed class NotificationTemplatesLoaderTests
+{
+    [Fact]
+    public async Task LoadAsync_WhenMissing_SeedsTheDefaultsAndRegistersThem()
+    {
+        var root = NewRoot();
+        var directories = new DirectoriesConfig(root, Array.Empty<string>());
+        var templates = new NotificationTemplateService();
+        var loader = new NotificationTemplatesLoader(templates, directories);
+
+        try
+        {
+            await loader.LoadAsync();
+
+            var templatesDirectory = Path.Combine(directories.GetPath("notification"), "templates");
+
+            // Seeded as directories-per-channel, with the dot-free id intact.
+            Assert.True(File.Exists(Path.Combine(templatesDirectory, "log", "account_verification.mgtmpl")));
+            Assert.True(File.Exists(Path.Combine(templatesDirectory, "email", "account_verification.mgtmpl")));
+
+            Assert.Equal(2, templates.Count);
+            Assert.NotNull(
+                templates.Render("log", "account_verification", new { Username = "tom", Email = "t@x", Token = "abc" })
+            );
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_RegistersByDirectoryNameAndFileName()
+    {
+        var root = NewRoot();
+        var directories = new DirectoriesConfig(root, Array.Empty<string>());
+        var discord = Path.Combine(directories.RegisterDirectory("notification"), "templates", "discord");
+        Directory.CreateDirectory(discord);
+        File.WriteAllText(Path.Combine(discord, "shard_online.mgtmpl"), "{{ shard_name }} is up");
+
+        var templates = new NotificationTemplateService();
+        var loader = new NotificationTemplatesLoader(templates, directories);
+
+        try
+        {
+            await loader.LoadAsync();
+
+            // The directory is the channel id and the file name is the template id — no registry, no
+            // configuration: a plugin channel ships its own directory and is picked up.
+            var content = templates.Render("discord", "shard_online", new { ShardName = "Britannia" });
+            Assert.Equal("Britannia is up", content!.Body.Trim());
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_BrokenTemplate_IsReportedAndTheRestStillLoad()
+    {
+        var root = NewRoot();
+        var directories = new DirectoriesConfig(root, Array.Empty<string>());
+        var log = Path.Combine(directories.RegisterDirectory("notification"), "templates", "log");
+        Directory.CreateDirectory(log);
+        File.WriteAllText(Path.Combine(log, "broken.mgtmpl"), "{{ if }}");
+        File.WriteAllText(Path.Combine(log, "fine.mgtmpl"), "ok");
+
+        var templates = new NotificationTemplateService();
+        var loader = new NotificationTemplatesLoader(templates, directories);
+
+        try
+        {
+            // One bad file must not stop the shard from booting, nor hide the good templates.
+            await loader.LoadAsync();
+
+            Assert.Equal(1, templates.Count);
+            Assert.NotNull(templates.Render("log", "fine", new { }));
+            Assert.Null(templates.Render("log", "broken", new { }));
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    private static string NewRoot()
+        => Path.Combine(Path.GetTempPath(), "mg-notification-tests-" + Guid.NewGuid().ToString("N"));
+}

--- a/tests/Moongate.Tests/Support/RecordingNotificationChannel.cs
+++ b/tests/Moongate.Tests/Support/RecordingNotificationChannel.cs
@@ -1,0 +1,47 @@
+using Moongate.Server.Abstractions.Data.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// A channel that records what it was asked to deliver, and can be told to fail a given number of times
+/// first so retry behaviour can be observed.
+/// </summary>
+public sealed class RecordingNotificationChannel : INotificationChannel
+{
+    private int _failuresLeft;
+
+    public RecordingNotificationChannel(string id = "test", int failuresBeforeSuccess = 0)
+    {
+        Id = id;
+        _failuresLeft = failuresBeforeSuccess;
+    }
+
+    public string Id { get; }
+
+    /// <summary>Every delivery attempt that reached the channel, failed ones included.</summary>
+    public int Attempts { get; private set; }
+
+    /// <summary>What was successfully delivered.</summary>
+    public List<(NotificationRecipient Recipient, NotificationContent Content)> Sent { get; } = [];
+
+    public ValueTask SendAsync(
+        NotificationRecipient recipient,
+        NotificationContent content,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Attempts++;
+
+        if (_failuresLeft > 0)
+        {
+            _failuresLeft--;
+
+            throw new InvalidOperationException("channel unavailable");
+        }
+
+        Sent.Add((recipient, content));
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Moongate.Tests/Support/StubJobSystem.cs
+++ b/tests/Moongate.Tests/Support/StubJobSystem.cs
@@ -1,0 +1,38 @@
+using SquidStd.Core.Interfaces.Jobs;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// An <see cref="IJobSystem" /> that runs work inline on the calling thread, so a test can assert what
+/// the job did without waiting on a worker pool.
+/// </summary>
+public sealed class StubJobSystem : IJobSystem
+{
+    /// <summary>How many pieces of work were handed to the job system.</summary>
+    public int Scheduled { get; private set; }
+
+    public int WorkerCount => 1;
+
+    public int PendingCount => 0;
+
+    public int ActiveCount => 0;
+
+    public long CompletedCount => Scheduled;
+
+    public Task ScheduleAsync(Action work, CancellationToken cancellationToken = default)
+    {
+        Scheduled++;
+        work();
+
+        return Task.CompletedTask;
+    }
+
+    public Task<T> ScheduleAsync<T>(Func<T> work, CancellationToken cancellationToken = default)
+    {
+        Scheduled++;
+
+        return Task.FromResult(work());
+    }
+
+    public void Dispose() { }
+}


### PR DESCRIPTION
Closes #38.

Establishes the standard for sending a message out of the shard to a human. SMTP arrives later as one more channel, with no caller changing.

## The contract

In `Moongate.Server.Abstractions`, dependency-free:

- `INotificationService.Notify(templateId, recipient, model)` — the caller says *what* and *to whom*, never *how*.
- `INotificationChannel` — `Id` plus `SendAsync`; a channel receives text that is already rendered.
- `NotificationRecipient(ChannelId, Address)`, `NotificationContent(Subject, Body)`, `NotificationConfig`.
- `RegisterNotificationChannel<T>()` — a plugin adds a transport the same way it adds a data loader or an event subscriber.

Channels are identified by **string, not an enum**, so a plugin can add one without a core release. **Scriban is referenced from `Moongate.Server` only**: the contract assembly is published to NuGet and every plugin author would otherwise inherit the dependency.

## Templates

`root/notification/templates/<channel>/<id>.mgtmpl`, seeded from embedded assets on first boot. The directory name is the channel id, the file name is the template id — no registry to keep in sync. The subject lives in Scriban front matter, so one file carries both, and later `from` or `reply_to` without changing any type.

Template ids are snake_case and dot-free: embedded resource names use the dot as a directory separator, so `account.verification.mgtmpl` would seed to disk as `account/verification.mgtmpl`.

## Delivery

`Notify` hands the work to `IJobSystem` and returns, so neither the game loop nor a web request waits on a transport — `IEventBus.Publish` blocks until listeners complete, and registration events fire on an ASP.NET thread. Inside the job: render, send, retry up to `MaxAttempts`. Every failure path ends in a log line; nothing escapes into a worker thread, and a notification can never fail the operation that raised it.

## First consumer

`AccountRegistrationSubscriber` closes the seam left open by #35: `AccountRegistrationRequestedEvent` now renders `account_verification` and delivers it on the `log` channel, instead of the token being written to the log by hand. The verify URL is composed by the template, because its shape belongs to the website.

## Verification

- 1340 tests pass (17 new).
- `dotnet docfx docs/docfx.json --warningsAsErrors` at 0 warnings.
- Real boot: templates seeded to `notification/templates/{log,email}/account_verification.mgtmpl`, `POST /api/v1/register` answered 202, and the rendered verification appeared in the log with the real token. 0 errors in the boot log.

Docs: new "Notifications" page, plus a correction to the registration guide.