### PR TITLE
feat: SMTP notification channel

### DIFF
--- a/Moongate.slnx
+++ b/Moongate.slnx
@@ -13,6 +13,7 @@
         <Project Path="plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj" />
         <Project Path="plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj" />
         <Project Path="plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj" />
+        <Project Path="plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj" />
     </Folder>
     <Folder Name="/tests/">
         <Project Path="tests/Moongate.Tests/Moongate.Tests.csproj" />

--- a/docs/getting-started/notifications.md
+++ b/docs/getting-started/notifications.md
@@ -49,6 +49,22 @@ Confirm your account:
 
 Channels without a subject simply omit the front matter block.
 
+Front matter also carries the **content type**. A template that renders HTML
+says so, and anything else — including omitting the line — is plain text:
+
+```
++++
+subject = "Verify your " + shard_name + " account"
+content_type = "html"
++++
+<p>Hello {{ username }},</p>
+```
+
+The rule is deliberately forgiving: only the exact value `html` selects HTML, so
+a mistyped `htlm` costs you a plain-text mail rather than a lost notification.
+An HTML mail is sent as a single HTML part, not as HTML with a plain-text
+alternative.
+
 Note that the verification URL is composed **here**, not in the server: its
 shape belongs to your website, so changing it costs an edit rather than a
 release.
@@ -64,11 +80,12 @@ it is unset the value is empty, and any link built from it will be broken.
 
 ## Channels
 
-`log` is the only channel shipped today: it writes the rendered notification to
-the server log, which is how the verification token is reachable on a shard with
-no transport configured. The `email/` templates ship ready for the SMTP channel
-that follows; addressing a channel that is not registered logs a warning and
-drops the notification.
+`log` writes the rendered notification to the server log. It always works, which
+makes it the channel a shard falls back on before a real transport is set up,
+and it is where the account verification token appears by default.
+
+`email` is provided by the SMTP plugin, described below. Addressing a channel
+that is not registered logs a warning and drops the notification.
 
 A plugin adds a transport by implementing `INotificationChannel` and registering
 it from its `Configure`:
@@ -81,12 +98,49 @@ The channel's `Id` is the only coordination point: notifications addressed to
 that id reach it, and it reads its templates from the directory of the same
 name.
 
+## Sending email
+
+Email is delivered by `Moongate.Smtp.Plugin`, configured in
+`<root>/plugins/configs/smtp.yaml`:
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `Host` | string | `''` | SMTP host. **Empty leaves the channel unregistered.** |
+| `Port` | int | `587` | Submission port. |
+| `Security` | enum | `Auto` | `None`, `StartTls`, `SslOnConnect`, or `Auto` — implicit TLS on 465, STARTTLS elsewhere when offered. |
+| `Username` | string | `''` | Empty means no authentication, as a local relay usually wants. |
+| `Password` | string | `''` | See the note on secrets below. |
+| `FromAddress` | string | `''` | Sender. **Empty leaves the channel unregistered.** |
+| `FromName` | string | `''` | Display name; falls back to the shard name. |
+| `TimeoutSeconds` | int | `30` | Connect and send timeout. |
+
+> [!IMPORTANT]
+> **Configuring SMTP is not enough to send verification mail.** Point
+> `notifications.AccountVerificationChannel` in `moongate.yaml` at `email` as
+> well. The server states which channel it will use at startup, and warns when
+> that channel is not registered — check the log if nothing arrives.
+
+### Secrets
+
+`MOONGATE_SMTP_PASSWORD` overrides `Password` when it is set, which is how a
+container deployment should supply it. When you do keep the password in the
+file, `chmod 600` it and keep it out of version control.
+
+### What is retried
+
+The channel decides. A timeout, an unreachable host or a `4xx` reply is
+transient, so it is retried up to `MaxAttempts`. An authentication failure or a
+`5xx` reply is permanent: it is logged once and not retried, because the answer
+will not change and repeatedly presenting bad credentials can trip a provider's
+rate limits.
+
 ## Configuration
 
 The `notifications` section of `moongate.yaml`:
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
+| `AccountVerificationChannel` | string | `log` | Which channel account verification is delivered on. |
 | `MaxAttempts` | int | `3` | Total delivery attempts per notification. |
 | `RetryDelaySeconds` | int | `5` | Wait between one attempt and the next. |
 

--- a/plugins/Moongate.Smtp.Plugin/Data/Config/MoongateSmtpConfig.cs
+++ b/plugins/Moongate.Smtp.Plugin/Data/Config/MoongateSmtpConfig.cs
@@ -1,0 +1,34 @@
+using Moongate.Smtp.Plugin.Types;
+
+namespace Moongate.Smtp.Plugin.Data.Config;
+
+/// <summary>
+/// SMTP settings, from <c>plugins/configs/smtp.yaml</c>. The channel is registered only when
+/// <see cref="Host" /> and <see cref="FromAddress" /> are both set.
+/// </summary>
+public sealed class MoongateSmtpConfig
+{
+    /// <summary>SMTP host. Empty leaves the email channel unregistered.</summary>
+    public string Host { get; set; } = string.Empty;
+
+    /// <summary>SMTP port. Default 587, the submission port.</summary>
+    public int Port { get; set; } = 587;
+
+    /// <summary>How the connection is secured.</summary>
+    public SmtpSecurityType Security { get; set; } = SmtpSecurityType.Auto;
+
+    /// <summary>Username. Empty means no authentication, as a local relay usually wants.</summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>Password. Overridden by the MOONGATE_SMTP_PASSWORD environment variable when that is set.</summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>Sender address. Empty leaves the email channel unregistered.</summary>
+    public string FromAddress { get; set; } = string.Empty;
+
+    /// <summary>Sender display name. Falls back to the shard name when empty.</summary>
+    public string FromName { get; set; } = string.Empty;
+
+    /// <summary>Connect and send timeout, in seconds.</summary>
+    public int TimeoutSeconds { get; set; } = 30;
+}

--- a/plugins/Moongate.Smtp.Plugin/Interfaces/ISmtpTransport.cs
+++ b/plugins/Moongate.Smtp.Plugin/Interfaces/ISmtpTransport.cs
@@ -1,0 +1,16 @@
+using MimeKit;
+
+namespace Moongate.Smtp.Plugin.Interfaces;
+
+/// <summary>
+/// Delivers one message over SMTP. The seam exists so building the message stays pure and testable, and
+/// everything that touches a socket lives behind a single method.
+/// </summary>
+public interface ISmtpTransport
+{
+    /// <summary>
+    /// Connects, authenticates if configured, sends and disconnects. Throws on failure; the caller
+    /// decides which failures are worth retrying.
+    /// </summary>
+    ValueTask SendAsync(MimeMessage message, CancellationToken cancellationToken = default);
+}

--- a/plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj
+++ b/plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Moongate.Server.Abstractions\Moongate.Server.Abstractions.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MailKit" Version="4.17.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/plugins/Moongate.Smtp.Plugin/MoongateSmtpPlugin.cs
+++ b/plugins/Moongate.Smtp.Plugin/MoongateSmtpPlugin.cs
@@ -1,0 +1,62 @@
+using DryIoc;
+using Moongate.Server.Abstractions.Extensions;
+using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Interfaces;
+using Moongate.Smtp.Plugin.Services;
+using Serilog;
+using SquidStd.Abstractions.Extensions.Config;
+using SquidStd.Core.Directories;
+using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Smtp.Plugin;
+
+/// <summary>Registers the email notification channel, when SMTP has been configured.</summary>
+public class MoongateSmtpPlugin : ISquidStdPlugin
+{
+    private const string PasswordEnvironmentVariable = "MOONGATE_SMTP_PASSWORD";
+
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.smtp.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateSmtpPlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate SMTP",
+            Description = "Email delivery for the notification pipeline"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        var directories = container.Resolve<DirectoriesConfig>();
+        container.RegisterConfigFile<MoongateSmtpConfig>("smtp", directories["plugins/configs"]);
+
+        var config = container.Resolve<MoongateSmtpConfig>();
+
+        // A container deployment supplies secrets as environment variables, not as a mounted file.
+        if (Environment.GetEnvironmentVariable(PasswordEnvironmentVariable) is { Length: > 0 } password)
+        {
+            config.Password = password;
+        }
+
+        var logger = Log.ForContext<MoongateSmtpPlugin>();
+
+        // Registering an unconfigured channel would be worse than registering none: every notification
+        // addressed to "email" would spend the pipeline's retries connecting to an empty host. Left
+        // unregistered, it produces one clear "no such channel" warning instead.
+        if (string.IsNullOrWhiteSpace(config.Host) || string.IsNullOrWhiteSpace(config.FromAddress))
+        {
+            logger.Warning(
+                "SMTP is not configured (Host and FromAddress are required in plugins/configs/smtp.yaml); the email notification channel is not registered"
+            );
+
+            return;
+        }
+
+        container.Register<ISmtpTransport, MailKitSmtpTransport>(Reuse.Singleton);
+        container.RegisterNotificationChannel<SmtpNotificationChannel>();
+
+        logger.Information("Email notifications will be sent through {Host}:{Port}", config.Host, config.Port);
+    }
+}

--- a/plugins/Moongate.Smtp.Plugin/Services/MailKitSmtpTransport.cs
+++ b/plugins/Moongate.Smtp.Plugin/Services/MailKitSmtpTransport.cs
@@ -1,0 +1,49 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Interfaces;
+using Moongate.Smtp.Plugin.Types;
+
+namespace Moongate.Smtp.Plugin.Services;
+
+/// <summary>
+/// The only code in Moongate that speaks MailKit. One connection per message: pooling would buy nothing
+/// at these volumes and would put shared state on the worker threads that deliver notifications.
+/// </summary>
+public sealed class MailKitSmtpTransport : ISmtpTransport
+{
+    private readonly MoongateSmtpConfig _config;
+
+    public MailKitSmtpTransport(MoongateSmtpConfig config)
+    {
+        _config = config;
+    }
+
+    public async ValueTask SendAsync(MimeMessage message, CancellationToken cancellationToken = default)
+    {
+        using var client = new SmtpClient
+        {
+            Timeout = _config.TimeoutSeconds * 1000
+        };
+
+        await client.ConnectAsync(_config.Host, _config.Port, ToSocketOptions(_config.Security), cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(_config.Username))
+        {
+            await client.AuthenticateAsync(_config.Username, _config.Password, cancellationToken);
+        }
+
+        await client.SendAsync(message, cancellationToken);
+        await client.DisconnectAsync(true, cancellationToken);
+    }
+
+    private static SecureSocketOptions ToSocketOptions(SmtpSecurityType security)
+        => security switch
+        {
+            SmtpSecurityType.None         => SecureSocketOptions.None,
+            SmtpSecurityType.StartTls     => SecureSocketOptions.StartTls,
+            SmtpSecurityType.SslOnConnect => SecureSocketOptions.SslOnConnect,
+            _                             => SecureSocketOptions.Auto
+        };
+}

--- a/plugins/Moongate.Smtp.Plugin/Services/SmtpNotificationChannel.cs
+++ b/plugins/Moongate.Smtp.Plugin/Services/SmtpNotificationChannel.cs
@@ -1,0 +1,87 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using MimeKit.Text;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Interfaces;
+using Serilog;
+
+namespace Moongate.Smtp.Plugin.Services;
+
+/// <summary>
+/// Delivers notifications as email. Building the message is all this class decides; the socket lives
+/// behind <see cref="ISmtpTransport" />.
+/// </summary>
+public sealed class SmtpNotificationChannel : INotificationChannel
+{
+    private readonly ILogger _logger = Log.ForContext<SmtpNotificationChannel>();
+    private readonly ISmtpTransport _transport;
+    private readonly MoongateSmtpConfig _config;
+    private readonly MoongateConfig _moongateConfig;
+
+    public SmtpNotificationChannel(
+        ISmtpTransport transport,
+        MoongateSmtpConfig config,
+        MoongateConfig moongateConfig
+    )
+    {
+        _transport = transport;
+        _config = config;
+        _moongateConfig = moongateConfig;
+    }
+
+    public string Id => "email";
+
+    public async ValueTask SendAsync(
+        NotificationRecipient recipient,
+        NotificationContent content,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var message = Build(recipient, content);
+
+        try
+        {
+            await _transport.SendAsync(message, cancellationToken);
+        }
+        catch (SmtpCommandException exception) when ((int)exception.StatusCode >= 500)
+        {
+            // Permanent: swallowing it tells the pipeline the delivery is finished, so it does not spend
+            // its retries on an answer that will not change.
+            _logger.Error(
+                exception,
+                "SMTP rejected the message for {Address} permanently ({Status}); not retrying",
+                recipient.Address,
+                exception.StatusCode
+            );
+        }
+        catch (AuthenticationException exception)
+        {
+            // Also permanent, and worse to retry: repeated bad credentials can trip a provider's limits.
+            _logger.Error(exception, "SMTP authentication failed; not retrying");
+        }
+    }
+
+    private MimeMessage Build(NotificationRecipient recipient, NotificationContent content)
+    {
+        var fromName = string.IsNullOrWhiteSpace(_config.FromName) ? _moongateConfig.ShardName : _config.FromName;
+
+        var message = new MimeMessage
+        {
+            Subject = content.Subject ?? string.Empty,
+            Body = new TextPart(content.ContentType == NotificationContentType.Html ? TextFormat.Html : TextFormat.Plain)
+            {
+                Text = content.Body
+            }
+        };
+
+        message.From.Add(new MailboxAddress(fromName, _config.FromAddress));
+        message.To.Add(MailboxAddress.Parse(recipient.Address));
+
+        return message;
+    }
+}

--- a/plugins/Moongate.Smtp.Plugin/Types/SmtpSecurityType.cs
+++ b/plugins/Moongate.Smtp.Plugin/Types/SmtpSecurityType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Smtp.Plugin.Types;
+
+/// <summary>How the SMTP connection is secured. Mapped onto MailKit's socket options by the transport.</summary>
+public enum SmtpSecurityType
+{
+    /// <summary>Let the transport choose from the port: implicit TLS on 465, STARTTLS elsewhere when offered.</summary>
+    Auto,
+
+    /// <summary>No encryption. Only sensible for a relay on localhost.</summary>
+    None,
+
+    /// <summary>Connect in the clear and upgrade with STARTTLS, failing if the server does not offer it.</summary>
+    StartTls,
+
+    /// <summary>Negotiate TLS immediately on connect, as port 465 expects.</summary>
+    SslOnConnect
+}

--- a/src/Moongate.Server.Abstractions/Data/Config/NotificationConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/NotificationConfig.cs
@@ -3,6 +3,12 @@ namespace Moongate.Server.Abstractions.Data.Config;
 /// <summary>Notification delivery settings, loaded from the <c>notifications</c> section of moongate.yaml.</summary>
 public sealed class NotificationConfig
 {
+    /// <summary>
+    /// Which channel account verification is delivered on. Defaults to <c>log</c>, the only channel a
+    /// bare shard has; point it at <c>email</c> once an SMTP transport is installed and configured.
+    /// </summary>
+    public string AccountVerificationChannel { get; set; } = "log";
+
     public int MaxAttempts { get; set; } = 3;
 
     public int RetryDelaySeconds { get; set; } = 5;

--- a/src/Moongate.Server.Abstractions/Data/Notifications/NotificationContent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Notifications/NotificationContent.cs
@@ -1,7 +1,19 @@
+using Moongate.Server.Abstractions.Types;
+
 namespace Moongate.Server.Abstractions.Data.Notifications;
 
 /// <summary>
 /// A rendered notification, ready to deliver. <see cref="Subject" /> is null for channels that have no
 /// concept of one.
 /// </summary>
-public sealed record NotificationContent(string? Subject, string Body);
+/// <param name="Subject">The subject line, or null when the channel has no notion of one.</param>
+/// <param name="Body">The rendered body.</param>
+/// <param name="ContentType">
+/// How to interpret <paramref name="Body" />. Defaulted rather than required: this assembly ships as a
+/// NuGet package, and a default keeps channels written against the two-parameter signature compiling.
+/// </param>
+public sealed record NotificationContent(
+    string? Subject,
+    string Body,
+    NotificationContentType ContentType = NotificationContentType.Text
+);

--- a/src/Moongate.Server.Abstractions/Types/NotificationContentType.cs
+++ b/src/Moongate.Server.Abstractions/Types/NotificationContentType.cs
@@ -1,0 +1,11 @@
+namespace Moongate.Server.Abstractions.Types;
+
+/// <summary>How a rendered notification body should be interpreted by the channel delivering it.</summary>
+public enum NotificationContentType
+{
+    /// <summary>Plain text. The default, and what every channel can handle.</summary>
+    Text,
+
+    /// <summary>An HTML document fragment. Channels that cannot render it should fall back to sending it as text.</summary>
+    Html
+}

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -18,6 +18,7 @@
         <ProjectReference Include="..\..\plugins\Moongate.Console.Admin.Plugin\Moongate.Console.Admin.Plugin.csproj"/>
         <ProjectReference Include="..\..\plugins\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
         <ProjectReference Include="..\..\plugins\Moongate.News.Plugin\Moongate.News.Plugin.csproj"/>
+        <ProjectReference Include="..\..\plugins\Moongate.Smtp.Plugin\Moongate.Smtp.Plugin.csproj"/>
         <ProjectReference Include="..\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\Moongate.Persistence\Moongate.Persistence.csproj"/>
         <ProjectReference Include="..\Moongate.Scripting\Moongate.Scripting.csproj"/>

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -31,6 +31,7 @@ using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Services.Notifications;
 using Moongate.Server.Services.Notifications.Channels;
 using Moongate.Server.Services.Server;
+using Moongate.Smtp.Plugin;
 using Moongate.Server.Services.World;
 using Serilog;
 using SquidStd.Abstractions.Extensions.Config;
@@ -133,6 +134,7 @@ await ConsoleApp.RunAsync(
 
                 builder.Add<MoongateConsolePlugin>();
                 builder.Add<MoongateNewsPlugin>();
+                builder.Add<MoongateSmtpPlugin>();
             }
         );
 

--- a/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
+++ b/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
@@ -1,5 +1,6 @@
 using Moongate.Server.Abstractions.Data.Notifications;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Abstractions.Types;
 using Scriban;
 using Scriban.Parsing;
 using Scriban.Runtime;
@@ -13,6 +14,8 @@ namespace Moongate.Server.Services.Notifications;
 public sealed class NotificationTemplateService : INotificationTemplateService
 {
     private const string SubjectVariable = "subject";
+    private const string ContentTypeVariable = "content_type";
+    private const string HtmlContentType = "html";
     private const string FrontMatterMarker = "+++";
 
     private readonly Dictionary<string, Template> _templates = new(StringComparer.OrdinalIgnoreCase);
@@ -64,7 +67,15 @@ public sealed class NotificationTemplateService : INotificationTemplateService
         var body = template.Render(context);
         var subject = globals.TryGetValue(SubjectVariable, out var value) ? value?.ToString() : null;
 
-        return new(subject, body);
+        // Anything that is not "html" is text, including a typo: a notification must never be lost to a
+        // mistyped piece of metadata.
+        var contentType =
+            globals.TryGetValue(ContentTypeVariable, out var declared) &&
+            string.Equals(declared?.ToString(), HtmlContentType, StringComparison.OrdinalIgnoreCase)
+                ? NotificationContentType.Html
+                : NotificationContentType.Text;
+
+        return new(subject, body, contentType);
     }
 
     private static string Key(string channelId, string templateId)

--- a/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
@@ -3,36 +3,60 @@ using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Events;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Abstractions.Interfaces.Server;
+using Serilog;
 using SquidStd.Core.Interfaces.Events;
 
 namespace Moongate.Server.Subscribers;
 
 /// <summary>
-/// Turns a pending web registration into a verification notification. Until an email channel exists this
-/// goes to the log, which is what makes the token reachable on a shard with no transport configured.
+/// Turns a pending web registration into a verification notification, on whichever channel
+/// <see cref="NotificationConfig.AccountVerificationChannel" /> names.
 /// </summary>
 public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
 {
     private const string TemplateId = "account_verification";
-    private const string ChannelId = "log";
 
+    private readonly ILogger _logger = Log.ForContext<AccountRegistrationSubscriber>();
     private readonly INotificationService _notifications;
+    private readonly IReadOnlyCollection<string> _channelIds;
     private readonly IServerSettingsService _settings;
     private readonly MoongateConfig _config;
+    private readonly string _channelId;
 
     public AccountRegistrationSubscriber(
         INotificationService notifications,
+        IEnumerable<INotificationChannel> channels,
         IServerSettingsService settings,
-        MoongateConfig config
+        MoongateConfig config,
+        NotificationConfig notificationConfig
     )
     {
         _notifications = notifications;
+        _channelIds = [.. channels.Select(channel => channel.Id)];
         _settings = settings;
         _config = config;
+        _channelId = notificationConfig.AccountVerificationChannel;
     }
 
     public void Subscribe(IEventBus eventBus)
-        => eventBus.Subscribe<AccountRegistrationRequestedEvent>(OnRegistrationRequested);
+    {
+        // Said out loud at startup, because the alternative is an operator installing a transport,
+        // forgetting to point the config at it, and finding out only when a player cannot register.
+        if (_channelIds.Contains(_channelId, StringComparer.OrdinalIgnoreCase))
+        {
+            _logger.Information("Account verification will be delivered on the '{Channel}' channel", _channelId);
+        }
+        else
+        {
+            _logger.Warning(
+                "Account verification is routed to the '{Channel}' channel, which is not registered; verification messages will be dropped. Registered channels: {Channels}",
+                _channelId,
+                _channelIds
+            );
+        }
+
+        eventBus.Subscribe<AccountRegistrationRequestedEvent>(OnRegistrationRequested);
+    }
 
     private Task OnRegistrationRequested(
         AccountRegistrationRequestedEvent message,
@@ -43,7 +67,7 @@ public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
         // changing it should cost an edit rather than a release.
         _notifications.Notify(
             TemplateId,
-            new(ChannelId, message.Email),
+            new(_channelId, message.Email),
             new
             {
                 message.Username,

--- a/tests/Moongate.Tests/Moongate.Tests.csproj
+++ b/tests/Moongate.Tests/Moongate.Tests.csproj
@@ -33,6 +33,7 @@
         <ProjectReference Include="..\..\src\Moongate.Core\Moongate.Core.csproj"/>
         <ProjectReference Include="..\..\plugins\Moongate.Http.Plugin\Moongate.Http.Plugin.csproj"/>
         <ProjectReference Include="..\..\plugins\Moongate.News.Plugin\Moongate.News.Plugin.csproj"/>
+        <ProjectReference Include="..\..\plugins\Moongate.Smtp.Plugin\Moongate.Smtp.Plugin.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Network\Moongate.Network.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Server\Moongate.Server.csproj"/>
         <ProjectReference Include="..\..\src\Moongate.Ultima\Moongate.Ultima.csproj"/>

--- a/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
@@ -10,16 +10,53 @@ namespace Moongate.Tests.Server.Notifications;
 public sealed class AccountRegistrationSubscriberTests
 {
     [Fact]
-    public async Task RegistrationEvent_SendsTheVerificationOnTheLogChannel()
+    public async Task RegistrationEvent_SendsTheVerificationOnTheConfiguredChannel()
+    {
+        var channel = new RecordingNotificationChannel("log");
+        var bus = Wire(channel, "log");
+
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc123"));
+
+        var (recipient, content) = Assert.Single(channel.Sent);
+        Assert.Equal("tom@example.com", recipient.Address);
+        Assert.Equal("log", recipient.ChannelId);
+        Assert.Equal("tom/tom@example.com/abc123/https://shard.example/Britannia", content.Body.Trim());
+    }
+
+    [Fact]
+    public async Task RegistrationEvent_HonoursAConfiguredEmailChannel()
+    {
+        var channel = new RecordingNotificationChannel("email");
+        var bus = Wire(channel, "email");
+
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc123"));
+
+        // Pointing the config at another channel is the whole switch: no code changes when SMTP lands.
+        Assert.Equal("email", Assert.Single(channel.Sent).Recipient.ChannelId);
+    }
+
+    [Fact]
+    public async Task UnregisteredChannel_DoesNotDeliver_AndDoesNotThrow()
+    {
+        var channel = new RecordingNotificationChannel("log");
+        var bus = Wire(channel, "email");
+
+        // Subscribing warns about this at startup; publishing must still be harmless.
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc123"));
+
+        Assert.Empty(channel.Sent);
+    }
+
+    /// <summary>Wires the subscriber over one channel, with the verification routed at <paramref name="routeTo" />.</summary>
+    private static EventBusService Wire(RecordingNotificationChannel channel, string routeTo)
     {
         var templates = new NotificationTemplateService();
         templates.Register(
-            "log",
+            channel.Id,
             "account_verification",
             "{{ username }}/{{ email }}/{{ token }}/{{ website }}/{{ shard_name }}"
         );
 
-        var channel = new RecordingNotificationChannel("log");
         var notifications = new NotificationService(templates, [channel], new StubJobSystem(), new());
 
         var settings = new ServerSettingsService(new FakePersistenceService());
@@ -28,15 +65,12 @@ public sealed class AccountRegistrationSubscriberTests
         var bus = new EventBusService();
         new AccountRegistrationSubscriber(
             notifications,
+            [channel],
             settings,
-            new() { ShardName = "Britannia", UltimaDirectory = "/tmp" }
+            new() { ShardName = "Britannia", UltimaDirectory = "/tmp" },
+            new() { AccountVerificationChannel = routeTo }
         ).Subscribe(bus);
 
-        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc123"));
-
-        var (recipient, content) = Assert.Single(channel.Sent);
-        Assert.Equal("tom@example.com", recipient.Address);
-        Assert.Equal("log", recipient.ChannelId);
-        Assert.Equal("tom/tom@example.com/abc123/https://shard.example/Britannia", content.Body.Trim());
+        return bus;
     }
 }

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
@@ -1,3 +1,4 @@
+using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.Notifications;
 
 namespace Moongate.Tests.Server.Notifications;
@@ -88,5 +89,55 @@ public sealed class NotificationTemplateServiceTests
         service.Register("email", "one", "b");
 
         Assert.Equal(2, service.Count);
+    }
+
+    [Fact]
+    public void Render_FrontMatterContentTypeHtml_MarksTheContentAsHtml()
+    {
+        var service = new NotificationTemplateService();
+        service.Register(
+            "email",
+            "fancy",
+            """
+            +++
+            content_type = "html"
+            +++
+            <p>Hello {{ username }}</p>
+            """
+        );
+
+        var content = service.Render("email", "fancy", new { Username = "tom" });
+
+        Assert.Equal(NotificationContentType.Html, content!.ContentType);
+        Assert.Equal("<p>Hello tom</p>", content.Body.Trim());
+    }
+
+    [Fact]
+    public void Render_WithoutContentType_IsText()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "plain", "hello");
+
+        Assert.Equal(NotificationContentType.Text, service.Render("log", "plain", new { })!.ContentType);
+    }
+
+    [Fact]
+    public void Render_UnknownContentType_FallsBackToText()
+    {
+        var service = new NotificationTemplateService();
+        service.Register(
+            "email",
+            "typo",
+            """
+            +++
+            content_type = "htlm"
+            +++
+            hello
+            """
+        );
+
+        // Deliberately forgiving: a mistyped content type must not cost the notification. Anything that
+        // is not "html" is text.
+        Assert.Equal(NotificationContentType.Text, service.Render("email", "typo", new { })!.ContentType);
     }
 }

--- a/tests/Moongate.Tests/Smtp/MoongateSmtpPluginTests.cs
+++ b/tests/Moongate.Tests/Smtp/MoongateSmtpPluginTests.cs
@@ -1,0 +1,59 @@
+using DryIoc;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Smtp.Plugin;
+using SquidStd.Core.Config;
+using SquidStd.Core.Directories;
+using SquidStd.Plugin.Abstractions.Data;
+
+namespace Moongate.Tests.Smtp;
+
+public sealed class MoongateSmtpPluginTests
+{
+    [Fact]
+    public void Metadata_IdentifiesThePlugin()
+        => Assert.Equal("moongate.smtp.plugin", new MoongateSmtpPlugin().Metadata.Id);
+
+    [Fact]
+    public void Configure_WithoutHost_RegistersNoChannel()
+    {
+        // Registering an unconfigured channel would burn the pipeline's retries connecting to nothing.
+        var container = Configured();
+
+        Assert.Empty(container.ResolveMany<INotificationChannel>());
+    }
+
+    [Fact]
+    public void Configure_WhenConfigured_RegistersTheEmailChannel()
+    {
+        var container = Configured(host: "localhost", from: "shard@example.com");
+
+        Assert.Equal("email", Assert.Single(container.ResolveMany<INotificationChannel>()).Id);
+    }
+
+    /// <summary>A container carrying what the real bootstrap supplies around the plugin.</summary>
+    private static IContainer Configured(string host = "", string from = "")
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-smtp-test-" + Guid.NewGuid().ToString("N"));
+
+        // Resolve the directory through DirectoriesConfig itself, so the file lands exactly where the
+        // plugin will look — the same reason ConsoleConfigFileTests does it this way rather than
+        // assuming how the path is transformed.
+        var directories = new DirectoriesConfig(root, ["plugins/configs"]);
+
+        // The section key matters: RegisterConfigFile binds the "smtp" section of smtp.yaml, not its root.
+        File.WriteAllText(
+            Path.Combine(directories["plugins/configs"], "smtp.yaml"),
+            $"smtp:\n  Host: '{host}'\n  FromAddress: '{from}'\n  Port: 2525\n  Security: None\n"
+        );
+
+        var container = new Container();
+        container.RegisterInstance(SquidStdConfig.Load("moongate", root));
+        container.RegisterInstance(directories);
+        container.RegisterInstance(new MoongateConfig { ShardName = "Britannia", UltimaDirectory = "/tmp" });
+
+        new MoongateSmtpPlugin().Configure(container, new PluginContext());
+
+        return container;
+    }
+}

--- a/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
@@ -1,0 +1,117 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Services;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Smtp;
+
+public sealed class SmtpNotificationChannelTests
+{
+    [Fact]
+    public void Id_IsEmail()
+        => Assert.Equal("email", Channel(new RecordingSmtpTransport()).Id);
+
+    [Fact]
+    public async Task SendAsync_BuildsTheMessageFromConfigAndContent()
+    {
+        var transport = new RecordingSmtpTransport();
+
+        await Channel(transport).SendAsync(new("email", "tom@example.com"), new("Verify", "hello"));
+
+        var message = Assert.Single(transport.Sent);
+        Assert.Equal("Verify", message.Subject);
+        Assert.Equal("shard@example.com", Assert.IsType<MailboxAddress>(Assert.Single(message.From)).Address);
+        Assert.Equal("tom@example.com", Assert.IsType<MailboxAddress>(Assert.Single(message.To)).Address);
+        Assert.Equal("hello", message.TextBody!.Trim());
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutFromName_UsesTheShardName()
+    {
+        var transport = new RecordingSmtpTransport();
+
+        await Channel(transport, fromName: string.Empty).SendAsync(new("email", "tom@example.com"), new("s", "b"));
+
+        var from = Assert.IsType<MailboxAddress>(Assert.Single(Assert.Single(transport.Sent).From));
+        Assert.Equal("Britannia", from.Name);
+    }
+
+    [Fact]
+    public async Task SendAsync_HtmlContent_SendsAnHtmlPart()
+    {
+        var transport = new RecordingSmtpTransport();
+
+        await Channel(transport).SendAsync(
+            new("email", "tom@example.com"),
+            new("Verify", "<p>hi</p>", NotificationContentType.Html)
+        );
+
+        var message = Assert.Single(transport.Sent);
+        Assert.Equal("<p>hi</p>", message.HtmlBody!.Trim());
+        Assert.Null(message.TextBody);
+    }
+
+    [Fact]
+    public async Task SendAsync_NullSubject_SendsAnEmptySubject()
+    {
+        var transport = new RecordingSmtpTransport();
+
+        await Channel(transport).SendAsync(new("email", "tom@example.com"), new(null, "body"));
+
+        Assert.Equal(string.Empty, Assert.Single(transport.Sent).Subject);
+    }
+
+    [Fact]
+    public async Task SendAsync_TransientFailure_Rethrows()
+    {
+        // A 4xx is the server saying "not now": the pipeline's retry is exactly the right response.
+        var transient = new SmtpCommandException(
+            SmtpErrorCode.MessageNotAccepted,
+            SmtpStatusCode.MailboxBusy,
+            "try later"
+        );
+
+        await Assert.ThrowsAsync<SmtpCommandException>(
+            async () => await Channel(new RecordingSmtpTransport(transient))
+                              .SendAsync(new("email", "tom@example.com"), new("s", "b"))
+        );
+    }
+
+    [Fact]
+    public async Task SendAsync_PermanentFailure_DoesNotRethrow()
+    {
+        // A 5xx will not improve on the third attempt; rethrowing would only delay the error in the log.
+        var permanent = new SmtpCommandException(
+            SmtpErrorCode.RecipientNotAccepted,
+            SmtpStatusCode.MailboxUnavailable,
+            "no such user"
+        );
+
+        await Channel(new RecordingSmtpTransport(permanent))
+              .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+    }
+
+    [Fact]
+    public async Task SendAsync_AuthenticationFailure_DoesNotRethrow()
+    {
+        // Retrying bad credentials can trip a provider's rate limits.
+        await Channel(new RecordingSmtpTransport(new AuthenticationException("bad credentials")))
+              .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+    }
+
+    private static SmtpNotificationChannel Channel(RecordingSmtpTransport transport, string fromName = "Shard Mail")
+        => new(
+            transport,
+            new MoongateSmtpConfig
+            {
+                Host = "localhost",
+                FromAddress = "shard@example.com",
+                FromName = fromName
+            },
+            new() { ShardName = "Britannia", UltimaDirectory = "/tmp" }
+        );
+}

--- a/tests/Moongate.Tests/Support/RecordingSmtpTransport.cs
+++ b/tests/Moongate.Tests/Support/RecordingSmtpTransport.cs
@@ -1,0 +1,33 @@
+using MimeKit;
+using Moongate.Smtp.Plugin.Interfaces;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// An <see cref="ISmtpTransport" /> that records what it was asked to send, or throws whatever a test
+/// hands it so failure classification can be observed.
+/// </summary>
+public sealed class RecordingSmtpTransport : ISmtpTransport
+{
+    private readonly Exception? _failure;
+
+    public RecordingSmtpTransport(Exception? failure = null)
+    {
+        _failure = failure;
+    }
+
+    /// <summary>Messages that were sent successfully.</summary>
+    public List<MimeMessage> Sent { get; } = [];
+
+    public ValueTask SendAsync(MimeMessage message, CancellationToken cancellationToken = default)
+    {
+        if (_failure is not null)
+        {
+            throw _failure;
+        }
+
+        Sent.Add(message);
+
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #40.

Delivers notifications by email, completing the pipeline shipped in #39.

## The plugin

`plugins/Moongate.Smtp.Plugin` implements the `email` channel. **MailKit is referenced from that project and nowhere else** — a check in the plan verifies `grep -rl MailKit --include=*.csproj` returns exactly one path, because `Moongate.Server.Abstractions` ships as a NuGet package and would otherwise push the dependency onto every plugin author.

Building the `MimeMessage` is pure logic in `SmtpNotificationChannel` and is tested against a fake transport; `MailKitSmtpTransport` is the only code that touches a socket, one connection per message.

**Registration is conditional on configuration.** With `Host` or `FromAddress` empty the plugin registers no channel and says so. An unconfigured channel would be worse than none: every notification addressed to `email` would spend the pipeline's retries connecting to an empty host.

## The channel decides what is retried

The pipeline retries any exception — right for an unreachable server, wrong for a permanent failure. A `4xx` rethrows so the retry does its job; a `5xx` or an authentication failure is logged and swallowed, because the answer will not change and repeatedly presenting bad credentials can trip a provider's rate limits. No core change: the distinction lives where the information to make it exists.

## Content type

`NotificationContent` gains a `NotificationContentType`, declared by a template through `content_type` in its Scriban front matter. The parameter is **defaulted**, so channels written against the two-parameter signature keep compiling. The rule is forgiving: only `html` selects HTML, so a mistyped `htlm` costs a plain-text mail rather than a lost notification. Sent as a single part, not `multipart/alternative`.

## Routing

`notifications.AccountVerificationChannel` (default `log`) decides where verification goes. The subscriber also takes the registered channel list so it can state the choice at startup and warn when that channel is not registered — otherwise "I installed the plugin and nothing is sent" is answered only by reading the log after a failed registration.

## Verification

- 1356 tests pass (17 new), including a clean-checkout run in Release.
- `dotnet docfx docs/docfx.json --warningsAsErrors` at 0 warnings.
- Real boot against a throwaway SMTP sink: registration produced a message with `From: Moongate <shard@example.com>` (the shard-name fallback), `Subject: Verify your Moongate account` and the verification link. Stopping the sink produced 3 attempts and `Gave up delivering`, while `POST /api/v1/register` still answered 202 — a broken transport must not fail a registration.