### PR TITLE
fix: refuse to send SMTP credentials over an unencrypted connection

### DIFF
--- a/docs/getting-started/notifications.md
+++ b/docs/getting-started/notifications.md
@@ -107,7 +107,7 @@ Email is delivered by `Moongate.Smtp.Plugin`, configured in
 |---|---|---|---|
 | `Host` | string | `''` | SMTP host. **Empty leaves the channel unregistered.** |
 | `Port` | int | `587` | Submission port. |
-| `Security` | enum | `Auto` | `None`, `StartTls`, `SslOnConnect`, or `Auto` — implicit TLS on 465, STARTTLS elsewhere when offered. |
+| `Security` | enum | `Auto` | `None`, `StartTls`, `SslOnConnect`, or `Auto`. See the warning below before relying on `Auto`. |
 | `Username` | string | `''` | Empty means no authentication, as a local relay usually wants. |
 | `Password` | string | `''` | See the note on secrets below. |
 | `FromAddress` | string | `''` | Sender. **Empty leaves the channel unregistered.** |
@@ -119,6 +119,15 @@ Email is delivered by `Moongate.Smtp.Plugin`, configured in
 > `notifications.AccountVerificationChannel` in `moongate.yaml` at `email` as
 > well. The server states which channel it will use at startup, and warns when
 > that channel is not registered — check the log if nothing arrives.
+
+> [!WARNING]
+> **`Auto` does not guarantee encryption.** It selects implicit TLS only on port 465; on every other
+> port it uses STARTTLS *when the server advertises it* and otherwise continues in plaintext. Use
+> `StartTls` on 587 or `SslOnConnect` on 465 whenever you configure a `Username`.
+>
+> As a backstop the plugin refuses to authenticate on a connection that never became encrypted,
+> logging `SMTP connection is not encrypted; not retrying` and dropping the message rather than
+> putting your password on the wire. A relay with no credentials is unaffected.
 
 ### Secrets
 

--- a/plugins/Moongate.Smtp.Plugin/Data/Exceptions/SmtpInsecureConnectionException.cs
+++ b/plugins/Moongate.Smtp.Plugin/Data/Exceptions/SmtpInsecureConnectionException.cs
@@ -1,0 +1,13 @@
+namespace Moongate.Smtp.Plugin.Data.Exceptions;
+
+/// <summary>
+/// Raised when credentials would be sent over a connection that never became encrypted. Its own type
+/// rather than a general-purpose exception, so the channel can classify it as permanent without
+/// swallowing unrelated failures.
+/// </summary>
+public sealed class SmtpInsecureConnectionException : Exception
+{
+    public SmtpInsecureConnectionException(string message) : base(message)
+    {
+    }
+}

--- a/plugins/Moongate.Smtp.Plugin/Services/MailKitSmtpTransport.cs
+++ b/plugins/Moongate.Smtp.Plugin/Services/MailKitSmtpTransport.cs
@@ -29,7 +29,13 @@ public sealed class MailKitSmtpTransport : ISmtpTransport
 
         await client.ConnectAsync(_config.Host, _config.Port, ToSocketOptions(_config.Security), cancellationToken);
 
-        if (!string.IsNullOrWhiteSpace(_config.Username))
+        // Checked after connecting, because whether the connection ended up encrypted is only known
+        // then: SecureSocketOptions.Auto resolves to StartTlsWhenAvailable on any port but the
+        // implicit-TLS one, and that proceeds in the clear when the server offers no STARTTLS.
+        var hasCredentials = !string.IsNullOrWhiteSpace(_config.Username);
+        SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials, client.IsSecure);
+
+        if (hasCredentials)
         {
             await client.AuthenticateAsync(_config.Username, _config.Password, cancellationToken);
         }

--- a/plugins/Moongate.Smtp.Plugin/Services/SmtpCredentialGuard.cs
+++ b/plugins/Moongate.Smtp.Plugin/Services/SmtpCredentialGuard.cs
@@ -1,0 +1,25 @@
+using Moongate.Smtp.Plugin.Data.Exceptions;
+
+namespace Moongate.Smtp.Plugin.Services;
+
+/// <summary>
+/// Keeps SMTP credentials off an unencrypted socket. Pure, so the rule can be tested without standing
+/// up a server that refuses STARTTLS.
+/// </summary>
+public static class SmtpCredentialGuard
+{
+    /// <summary>
+    /// Throws <see cref="SmtpInsecureConnectionException" /> when credentials are about to be presented
+    /// on a connection that is not encrypted. A connection with no credentials is left alone: a local
+    /// relay is a legitimate setup and has no secret to leak.
+    /// </summary>
+    public static void EnsureCredentialsAreProtected(bool hasCredentials, bool isSecure)
+    {
+        if (hasCredentials && !isSecure)
+        {
+            throw new SmtpInsecureConnectionException(
+                "Refusing to send SMTP credentials over an unencrypted connection. Security 'Auto' does not guarantee encryption — it falls back to plaintext when the server does not advertise STARTTLS. Set Security to StartTls (port 587) or SslOnConnect (port 465)."
+            );
+        }
+    }
+}

--- a/plugins/Moongate.Smtp.Plugin/Services/SmtpNotificationChannel.cs
+++ b/plugins/Moongate.Smtp.Plugin/Services/SmtpNotificationChannel.cs
@@ -7,6 +7,7 @@ using Moongate.Server.Abstractions.Data.Notifications;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Data.Exceptions;
 using Moongate.Smtp.Plugin.Interfaces;
 using Serilog;
 
@@ -63,6 +64,12 @@ public sealed class SmtpNotificationChannel : INotificationChannel
         {
             // Also permanent, and worse to retry: repeated bad credentials can trip a provider's limits.
             _logger.Error(exception, "SMTP authentication failed; not retrying");
+        }
+        catch (SmtpInsecureConnectionException exception)
+        {
+            // A misconfiguration, so permanent by definition: the connection will be just as unencrypted
+            // on the next attempt.
+            _logger.Error(exception, "SMTP connection is not encrypted; not retrying");
         }
     }
 

--- a/tests/Moongate.Tests/Smtp/SmtpCredentialGuardTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpCredentialGuardTests.cs
@@ -1,0 +1,30 @@
+using Moongate.Smtp.Plugin.Data.Exceptions;
+using Moongate.Smtp.Plugin.Services;
+
+namespace Moongate.Tests.Smtp;
+
+public sealed class SmtpCredentialGuardTests
+{
+    [Fact]
+    public void CredentialsOnAnUnencryptedConnection_Throws()
+    {
+        // Security: Auto resolves to StartTlsWhenAvailable on any port but the implicit-TLS one, and that
+        // proceeds in the clear when the server does not advertise STARTTLS. Authenticating there puts the
+        // password on the wire.
+        var exception = Assert.Throws<SmtpInsecureConnectionException>(
+            () => SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: true, isSecure: false)
+        );
+
+        Assert.Contains("unencrypted", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CredentialsOnAnEncryptedConnection_IsAllowed()
+        => SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: true, isSecure: true);
+
+    [Fact]
+    public void NoCredentialsOnAnUnencryptedConnection_IsAllowed()
+        // A local relay with no authentication is a legitimate setup, and nothing secret crosses the
+        // socket. Blocking it would be a broader change than the leak requires.
+        => SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: false, isSecure: false);
+}

--- a/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
@@ -4,6 +4,7 @@ using MimeKit;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Data.Exceptions;
 using Moongate.Smtp.Plugin.Services;
 using Moongate.Tests.Support;
 
@@ -92,6 +93,15 @@ public sealed class SmtpNotificationChannelTests
         );
 
         await Channel(new RecordingSmtpTransport(permanent))
+              .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+    }
+
+    [Fact]
+    public async Task SendAsync_InsecureConnection_DoesNotRethrow()
+    {
+        // A misconfiguration will not fix itself between attempts, so retrying it three times only
+        // delays the error in the log.
+        await Channel(new RecordingSmtpTransport(new SmtpInsecureConnectionException("unencrypted")))
               .SendAsync(new("email", "tom@example.com"), new("s", "b"));
     }
 


### PR DESCRIPTION
Closes #42.

`MoongateSmtpConfig.Security` defaults to `Auto`, which MailKit maps to `SslOnConnect` only on the implicit-TLS port; every other port gets `StartTlsWhenAvailable`, which proceeds in the clear when the server does not advertise STARTTLS. `MailKitSmtpTransport` authenticated regardless, so against a misconfigured server — or one where an active attacker strips the advertisement from the EHLO response — the SMTP AUTH exchange went out in cleartext, with nothing in the log to say the connection had been downgraded.

## The fix

Check `client.IsSecure` after connecting and before authenticating. The rule lives in `SmtpCredentialGuard`, a pure static, so it can be tested without standing up a server that refuses STARTTLS.

`SmtpInsecureConnectionException` gets its own type rather than reusing a general-purpose one, so `SmtpNotificationChannel` can classify it as **permanent** without swallowing unrelated failures. A misconfiguration will be just as unencrypted on the next attempt, so retrying three times only delays the error — this answers the open question left in #42.

A relay with no credentials is deliberately unaffected: it is a legitimate setup with no secret to leak. That is why the guard keys on credentials rather than on encryption alone.

## Verification

- 1360 tests pass (4 new: the three guard cases, plus the channel classifying the exception as permanent).
- DocFX at 0 warnings.
- Real boot against a sink advertising no STARTTLS, with a username configured: the send is refused, **0 retries** are logged, **nothing reaches the SMTP server**, and `POST /api/v1/register` still answers `202`. Before the fix the same configuration authenticated in plaintext and delivered.

Docs: the `Security` table row now points at a warning stating plainly that `Auto` does not guarantee encryption, and describing the backstop.