### PR TITLE
feat(persistence): move persisted entities to derived type ids

### DIFF
--- a/plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
+++ b/plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj
@@ -14,8 +14,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -41,8 +41,8 @@
         -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.15" />
-        <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj
+++ b/plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
+++ b/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
@@ -28,11 +28,7 @@ public sealed class MoongateNewsPlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
-        // Type id 100, not 4: the core entities in MoongatePersistencePlugin own the low ids, and 4 is
-        // already ServerSettingsEntity. External plugins take ids from 100 up, so a new core entity can
-        // never collide with one of theirs.
         container.RegisterPersistedEntity<NewsEntity, Serial>(
-            100,
             "news",
             1,
             entity => entity.Id,

--- a/plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj
+++ b/plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="MailKit" Version="4.17.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Core/Moongate.Core.csproj
+++ b/src/Moongate.Core/Moongate.Core.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Core" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Network/Moongate.Network.csproj
+++ b/src/Moongate.Network/Moongate.Network.csproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Network" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Network" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Persistence/Moongate.Persistence.csproj
+++ b/src/Moongate.Persistence/Moongate.Persistence.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Persistence" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Persistence" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Persistence.Abstractions" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Persistence.MessagePack" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -39,11 +39,9 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
         container.RegisterMessagePackSerializer();
         container.RegisterPersistence(persistenceConfig);
 
-        // Type ids are process-wide: registering one twice throws at startup. Core entities take 1-99 and
-        // are listed here; external plugins take 100 and up, so the two sets cannot collide as either
-        // side grows.
+        // No type ids here: SquidStd derives one from the store name, so nothing has to know which are
+        // taken and a plugin cannot collide with the host.
         container.RegisterPersistedEntity<AccountEntity, Serial>(
-            1,
             "accounts",
             1,
             entity => entity.Id,
@@ -52,7 +50,6 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
         );
 
         container.RegisterPersistedEntity<MobileEntity, Serial>(
-            2,
             "mobiles",
             1,
             entity => entity.Id,
@@ -60,7 +57,6 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
             new MobileSerialGenerator()
         );
         container.RegisterPersistedEntity<ItemEntity, Serial>(
-            3,
             "items",
             1,
             entity => entity.Id,
@@ -68,7 +64,6 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
             new ItemSerialGenerator()
         );
         container.RegisterPersistedEntity<ServerSettingsEntity, Serial>(
-            4,
             "server_settings",
             1,
             entity => entity.Id,

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Scripting.Lua" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -32,11 +32,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Scriban" Version="7.2.5"/>
-        <PackageReference Include="SquidStd.Abstractions" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Core" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Plugin" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.39.0"/>
-        <PackageReference Include="SquidStd.Services.Core" Version="0.39.0"/>
+        <PackageReference Include="SquidStd.Abstractions" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Core" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Plugin" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.40.0"/>
+        <PackageReference Include="SquidStd.Services.Core" Version="0.40.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Closes #45. Requires SquidStd 0.40.0 (tgiachi/squid-std#104).

The five persisted entities no longer carry a hand-picked `ushort`:

```csharp
container.RegisterPersistedEntity<AccountEntity, Serial>(
    "accounts", 1, entity => entity.Id, (entity, id) => entity.Id = id, new DefaultSerialGenerator()
);
```

SquidStd derives the id from the store name, which is already permanent because it is part of the snapshot file name. Nothing has to know which ids are taken, so the failure that produced this work — `NewsEntity` from a plugin and `ServerSettingsEntity` from the host both taking id 4 in parallel branches, leaving `develop` unbootable — cannot recur.

The reserved-range comments go with it. They described a convention that no longer exists, and leaving them would send the next reader hunting for a range to pick from.

**No `legacyTypeId`, no migration.** This shard has no save data worth keeping, so the entities simply start under their derived ids. A deployment that does have data would declare its previous id and let SquidStd rename the snapshot and translate the journal.

## Verification

- 1360 tests pass.
- Real boot: the server starts with zero errors and no `already registered`, and `POST /api/v1/auth/login` answers 200 — the whole persistence stack registered all five entities under derived ids.