### PR TITLE
refactor(smtp): make the security mapping an extension method

### DIFF
--- a/plugins/Moongate.Smtp.Plugin/Extensions/SmtpSecurityTypeExtensions.cs
+++ b/plugins/Moongate.Smtp.Plugin/Extensions/SmtpSecurityTypeExtensions.cs
@@ -1,0 +1,26 @@
+using MailKit.Security;
+using Moongate.Smtp.Plugin.Types;
+
+namespace Moongate.Smtp.Plugin.Extensions;
+
+/// <summary>Maps the plugin's security setting onto the socket options MailKit expects.</summary>
+public static class SmtpSecurityTypeExtensions
+{
+    /// <summary>
+    /// Returns the MailKit socket options for <paramref name="security" />. An unrecognised value maps to
+    /// <see cref="SecureSocketOptions.Auto" />, which is also what the configuration defaults to.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SecureSocketOptions.Auto" /> does not guarantee encryption: it picks implicit TLS only
+    /// on the implicit-TLS port and otherwise upgrades with STARTTLS *when the server offers it*.
+    /// SmtpCredentialGuard is what stops credentials going out on a connection that stayed in the clear.
+    /// </remarks>
+    public static SecureSocketOptions ToSocketOptions(this SmtpSecurityType security)
+        => security switch
+        {
+            SmtpSecurityType.None         => SecureSocketOptions.None,
+            SmtpSecurityType.StartTls     => SecureSocketOptions.StartTls,
+            SmtpSecurityType.SslOnConnect => SecureSocketOptions.SslOnConnect,
+            _                             => SecureSocketOptions.Auto
+        };
+}

--- a/plugins/Moongate.Smtp.Plugin/Services/MailKitSmtpTransport.cs
+++ b/plugins/Moongate.Smtp.Plugin/Services/MailKitSmtpTransport.cs
@@ -1,9 +1,8 @@
 using MailKit.Net.Smtp;
-using MailKit.Security;
 using MimeKit;
 using Moongate.Smtp.Plugin.Data.Config;
+using Moongate.Smtp.Plugin.Extensions;
 using Moongate.Smtp.Plugin.Interfaces;
-using Moongate.Smtp.Plugin.Types;
 
 namespace Moongate.Smtp.Plugin.Services;
 
@@ -27,7 +26,7 @@ public sealed class MailKitSmtpTransport : ISmtpTransport
             Timeout = _config.TimeoutSeconds * 1000
         };
 
-        await client.ConnectAsync(_config.Host, _config.Port, ToSocketOptions(_config.Security), cancellationToken);
+        await client.ConnectAsync(_config.Host, _config.Port, _config.Security.ToSocketOptions(), cancellationToken);
 
         // Checked after connecting, because whether the connection ended up encrypted is only known
         // then: SecureSocketOptions.Auto resolves to StartTlsWhenAvailable on any port but the
@@ -43,13 +42,4 @@ public sealed class MailKitSmtpTransport : ISmtpTransport
         await client.SendAsync(message, cancellationToken);
         await client.DisconnectAsync(true, cancellationToken);
     }
-
-    private static SecureSocketOptions ToSocketOptions(SmtpSecurityType security)
-        => security switch
-        {
-            SmtpSecurityType.None         => SecureSocketOptions.None,
-            SmtpSecurityType.StartTls     => SecureSocketOptions.StartTls,
-            SmtpSecurityType.SslOnConnect => SecureSocketOptions.SslOnConnect,
-            _                             => SecureSocketOptions.Auto
-        };
 }

--- a/tests/Moongate.Tests/Smtp/SmtpSecurityTypeExtensionsTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpSecurityTypeExtensionsTests.cs
@@ -1,0 +1,26 @@
+using MailKit.Security;
+using Moongate.Smtp.Plugin.Extensions;
+using Moongate.Smtp.Plugin.Types;
+
+namespace Moongate.Tests.Smtp;
+
+public sealed class SmtpSecurityTypeExtensionsTests
+{
+    [Theory]
+    [InlineData(SmtpSecurityType.None, SecureSocketOptions.None)]
+    [InlineData(SmtpSecurityType.StartTls, SecureSocketOptions.StartTls)]
+    [InlineData(SmtpSecurityType.SslOnConnect, SecureSocketOptions.SslOnConnect)]
+    [InlineData(SmtpSecurityType.Auto, SecureSocketOptions.Auto)]
+    public void ToSocketOptions_MapsEveryDeclaredValue(SmtpSecurityType security, SecureSocketOptions expected)
+        => Assert.Equal(expected, security.ToSocketOptions());
+
+    [Fact]
+    public void ToSocketOptions_EveryEnumValueIsCovered()
+        // The mapping falls through to Auto, so a value added later would silently pick it up rather
+        // than being noticed. This fails the moment the enum grows without the theory above growing too.
+        => Assert.Equal(4, Enum.GetValues<SmtpSecurityType>().Length);
+
+    [Fact]
+    public void ToSocketOptions_AnUnrecognisedValue_FallsBackToAuto()
+        => Assert.Equal(SecureSocketOptions.Auto, ((SmtpSecurityType)99).ToSocketOptions());
+}


### PR DESCRIPTION
Pure refactor, no behaviour change. No issue: there is nothing to track beyond the diff.

`ToSocketOptions` moves out of `MailKitSmtpTransport` into `SmtpSecurityTypeExtensions`, so the call site reads:

```csharp
await client.ConnectAsync(_config.Host, _config.Port, _config.Security.ToSocketOptions(), cancellationToken);
```

The transport is then left holding only the code that talks to a socket, and `MailKit.Security` no longer needs to be imported there.

## Tests it did not have

The mapping was never covered. It now has one case per declared value, one pinning the fallback, and one asserting the enum still has four members — the switch falls through to `Auto`, so a value added later would silently inherit it rather than being noticed. That last test fails the moment the enum grows without the mapping growing too.

1366 tests pass.