### PR TITLE
feat(plugins): report active plugins and their routes over REST

### DIFF
--- a/docs/contributing/toc.yml
+++ b/docs/contributing/toc.yml
@@ -18,3 +18,5 @@
       href: writing-plugins/data-loaders.md
     - name: Registration reference
       href: writing-plugins/registration.md
+    - name: Plugin diagnostics
+      href: writing-plugins/plugin-diagnostics.md

--- a/docs/contributing/writing-plugins/plugin-diagnostics.md
+++ b/docs/contributing/writing-plugins/plugin-diagnostics.md
@@ -1,0 +1,55 @@
+# Seeing which plugins are active
+
+`GET /api/v1/admin/plugins` reports every plugin the shard activated, each with the HTTP routes it
+declares. It requires a staff token: administrators and grand masters only.
+
+```json
+[
+  {
+    "id": "moongate.news.plugin",
+    "name": "Moongate News",
+    "version": "0.4.0",
+    "author": "squid",
+    "description": "Shard news",
+    "assembly": "Moongate.News.Plugin",
+    "isExternal": false,
+    "routes": [
+      { "method": "GET", "path": "/api/v1/news", "policy": null },
+      { "method": "POST", "path": "/api/v1/admin/news", "policy": "admin" }
+    ]
+  }
+]
+```
+
+## Reading the response
+
+`isExternal` says where the plugin came from. `false` means it was compiled into the server and
+registered in `Program.cs`. `true` means it was loaded from the `plugins` directory at startup — a DLL
+dropped in rather than built in.
+
+`policy` names the authorization policy guarding a route, and is `null` when the route is open to
+anonymous callers.
+
+`assembly` is how a route is tied to a plugin: each mapped route records the handler that serves it, and
+the assembly declaring that handler identifies the plugin. Nothing has to be declared for this to work,
+which is why adding an endpoint needs no extra registration to show up here.
+
+## The `moongate.host` entry
+
+The last entry is synthetic. It collects routes belonging to no plugin — the API reference served by
+Scalar, and anything the framework maps for itself. It exists so that everything the shard serves appears
+somewhere: a route that is live but absent from this list would be worse than an extra line.
+
+Note that `/health` is **not** in it. That route is declared inside the HTTP plugin, so it is reported
+against `moongate.http.plugin` along with the rest of that plugin's surface.
+
+## What the plugin list is not
+
+Attribution works at assembly granularity, and several plugins share one assembly: the plugin classes
+that live inside the server — script modules, data loaders, commands, packet handlers, event
+subscribers — all report `Moongate.Server`.
+
+None of them declares HTTP routes today, so each shows an empty list and nothing is ambiguous. Were
+`Moongate.Server` ever to declare routes directly, every plugin sharing that assembly would report the
+same full list, because nothing in the routing table says which of them owns a given route. Endpoints
+belong in a plugin of their own, which is what keeps this honest.

--- a/plugins/Moongate.Http.Plugin/Data/Api/Plugins/PluginInfoResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Plugins/PluginInfoResponse.cs
@@ -1,0 +1,18 @@
+namespace Moongate.Http.Plugin.Data.Api.Plugins;
+
+/// <summary>
+/// One activated plugin and everything it exposes over HTTP. <c>version</c> goes over the wire as a
+/// string, e.g. <c>"0.1.0"</c>.
+/// </summary>
+public record PluginInfoResponse(
+    string Id,
+    string Name,
+    // Qualified: Moongate.Http.Plugin.Data.Api.Version is a sibling namespace of this one, so an
+    // unqualified Version binds to it rather than to the type.
+    System.Version Version,
+    string Author,
+    string Description,
+    string Assembly,
+    bool IsExternal,
+    IReadOnlyList<PluginRouteResponse> Routes
+);

--- a/plugins/Moongate.Http.Plugin/Data/Api/Plugins/PluginRouteResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Plugins/PluginRouteResponse.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Plugins;
+
+/// <summary>One HTTP route a plugin declares. <c>policy</c> is null when the route is open.</summary>
+public record PluginRouteResponse(string Method, string Path, string? Policy);

--- a/plugins/Moongate.Http.Plugin/Data/Plugins/PluginRouteInfo.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Plugins/PluginRouteInfo.cs
@@ -1,0 +1,8 @@
+namespace Moongate.Http.Plugin.Data.Plugins;
+
+/// <summary>
+/// One mapped route, as the inspector reads it off the routing table. <see cref="Policy" /> is null when
+/// the route is open — either because nothing guards it, or because <c>AllowAnonymous</c> overrides what
+/// does.
+/// </summary>
+public record PluginRouteInfo(string Method, string Path, string? Policy);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Plugins/PluginAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Plugins/PluginAdminEndpoints.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data.Api.Plugins;
+using Moongate.Http.Plugin.Data.Plugins;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Plugins;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Server.Abstractions.Data.Plugins;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Http.Plugin.Endpoints.Plugins;
+
+/// <summary>Staff-only view of which plugins this shard activated and what each one serves.</summary>
+public sealed class PluginAdminEndpoints : IApiEndpointRegistration
+{
+    /// <summary>The synthetic entry carrying routes no plugin declares.</summary>
+    private const string HostId = "moongate.host";
+
+    private readonly IPluginCatalog _catalog;
+    private readonly IPluginRouteInspector _inspector;
+
+    public PluginAdminEndpoints(IPluginCatalog catalog, IPluginRouteInspector inspector)
+    {
+        _catalog = catalog;
+        _inspector = inspector;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+        => routes.MapGet("/api/v1/admin/plugins", Get)
+                 .WithName("GetAdminPlugins")
+                 .WithTags("admin")
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
+
+    /// <summary>Lists the plugins this shard activated, each with the HTTP routes it declares.</summary>
+    /// <remarks>
+    /// Routes belonging to no plugin — the API reference and framework middleware — are gathered under a
+    /// final synthetic entry with id <c>moongate.host</c>, so that everything the shard serves appears
+    /// somewhere. <c>policy</c> names the authorization policy guarding a route, and is null when the
+    /// route is open.
+    /// </remarks>
+
+    // EndpointDataSource arrives as a parameter rather than a constructor dependency: it does not exist in
+    // the container while plugins are being configured, only once the web application has been built.
+    private IResult Get(EndpointDataSource endpoints)
+    {
+        var byAssembly = _inspector.RoutesByAssembly(endpoints);
+        var catalogued = _catalog.Plugins.Select(plugin => plugin.AssemblyName).ToHashSet(StringComparer.Ordinal);
+
+        var plugins = _catalog.Plugins.Select(plugin => ToResponse(plugin, byAssembly)).ToList();
+
+        var unattributed = byAssembly.Where(entry => !catalogued.Contains(entry.Key))
+                                     .SelectMany(entry => entry.Value)
+                                     .Select(ToResponse)
+                                     .ToList();
+
+        plugins.Add(Host(unattributed));
+
+        return Results.Ok(plugins);
+    }
+
+    private static PluginInfoResponse ToResponse(
+        PluginDescriptor plugin,
+        IReadOnlyDictionary<string, IReadOnlyList<PluginRouteInfo>> byAssembly
+    )
+    {
+        var routes = byAssembly.TryGetValue(plugin.AssemblyName, out var declared)
+            ? declared.Select(ToResponse).ToList()
+            : [];
+
+        return new(
+            plugin.Id,
+            plugin.Name,
+            plugin.Version,
+            plugin.Author,
+            plugin.Description,
+            plugin.AssemblyName,
+            plugin.IsExternal,
+            routes
+        );
+    }
+
+    private static PluginRouteResponse ToResponse(PluginRouteInfo route)
+        => new(route.Method, route.Path, route.Policy);
+
+    /// <summary>
+    /// The catch-all entry. Its version is this plugin's own: there is no host assembly to read here,
+    /// because the HTTP plugin never references Moongate.Server.
+    /// </summary>
+
+    // System.Version is qualified because Moongate.Http.Plugin.Endpoints.Version is a sibling namespace of
+    // this one, and an unqualified Version binds to it rather than to the type.
+    private static PluginInfoResponse Host(IReadOnlyList<PluginRouteResponse> routes)
+        => new(
+            HostId,
+            "Host & framework",
+            typeof(PluginAdminEndpoints).Assembly.GetName().Version ?? new System.Version(0, 0),
+            "moongate",
+            "Routes no plugin declares: the API reference and framework middleware.",
+            string.Empty,
+            false,
+            routes
+        );
+}

--- a/plugins/Moongate.Http.Plugin/Interfaces/Plugins/IPluginRouteInspector.cs
+++ b/plugins/Moongate.Http.Plugin/Interfaces/Plugins/IPluginRouteInspector.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data.Plugins;
+
+namespace Moongate.Http.Plugin.Interfaces.Plugins;
+
+/// <summary>Reads the routing table and attributes every route to the assembly that declares it.</summary>
+public interface IPluginRouteInspector
+{
+    /// <summary>
+    /// The mapped routes, keyed by the simple name of the assembly declaring each handler. Routes whose
+    /// handler cannot be identified — the ones the framework maps for itself — are grouped under an empty
+    /// key rather than dropped.
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<PluginRouteInfo>> RoutesByAssembly(EndpointDataSource endpoints);
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -10,6 +10,7 @@ using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
 using Moongate.Http.Plugin.Endpoints.Mobiles;
 using Moongate.Http.Plugin.Endpoints.Players;
+using Moongate.Http.Plugin.Endpoints.Plugins;
 using Moongate.Http.Plugin.Endpoints.Registration;
 using Moongate.Http.Plugin.Endpoints.ServerInfo;
 using Moongate.Http.Plugin.Endpoints.Stats;
@@ -21,6 +22,7 @@ using Moongate.Http.Plugin.Interfaces.Console;
 using Moongate.Http.Plugin.Interfaces.Images;
 using Moongate.Http.Plugin.Interfaces.Maps;
 using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Plugins;
 using Moongate.Http.Plugin.Interfaces.Registration;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Services.Assets;
@@ -30,6 +32,7 @@ using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Services.Images;
 using Moongate.Http.Plugin.Services.Maps;
 using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Http.Plugin.Services.Plugins;
 using Moongate.Http.Plugin.Services.Registration;
 using Moongate.Http.Plugin.Services.Ultima;
 using Moongate.Ultima.Catalog;
@@ -138,6 +141,11 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<ServerSettingsAdminEndpoints>();
         container.RegisterApiEndpoint<RegistrationEndpoints>();
         container.RegisterApiEndpoint<StatsEndpoints>();
+
+        // Diagnostics for the staff console: which plugins are running and what each one serves. The
+        // catalogue itself is a server service — the composition root registers it.
+        container.Register<IPluginRouteInspector, EndpointPluginRouteInspector>(Reuse.Singleton);
+        container.RegisterApiEndpoint<PluginAdminEndpoints>();
 
         container.RegisterStdService<HttpServerService, HttpServerService>();
     }

--- a/plugins/Moongate.Http.Plugin/Services/Plugins/EndpointPluginRouteInspector.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Plugins/EndpointPluginRouteInspector.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data.Plugins;
+using Moongate.Http.Plugin.Interfaces.Plugins;
+
+namespace Moongate.Http.Plugin.Services.Plugins;
+
+/// <summary>
+/// Attributes routes to plugins through the routing table's own metadata.
+/// <para>
+/// Minimal APIs record the handler's <see cref="MethodInfo" /> against each endpoint, and the type
+/// declaring it names an assembly — which is enough to say which plugin a route belongs to without any
+/// endpoint having to declare an owner. It holds for lambda handlers too: the compiler puts the closure
+/// in the same assembly as the code that wrote it.
+/// </para>
+/// </summary>
+public sealed class EndpointPluginRouteInspector : IPluginRouteInspector
+{
+    /// <summary>Stands in for the verb when an endpoint declares none.</summary>
+    private const string AnyMethod = "*";
+
+    public IReadOnlyDictionary<string, IReadOnlyList<PluginRouteInfo>> RoutesByAssembly(EndpointDataSource endpoints)
+    {
+        var grouped = new Dictionary<string, List<PluginRouteInfo>>(StringComparer.Ordinal);
+
+        foreach (var endpoint in endpoints.Endpoints.OfType<RouteEndpoint>())
+        {
+            var assembly = endpoint.Metadata.GetMetadata<MethodInfo>()?.DeclaringType?.Assembly.GetName().Name
+                           ?? string.Empty;
+
+            if (!grouped.TryGetValue(assembly, out var routes))
+            {
+                routes = [];
+                grouped[assembly] = routes;
+            }
+
+            var path = "/" + (endpoint.RoutePattern.RawText ?? string.Empty).TrimStart('/');
+            var policy = PolicyOf(endpoint);
+
+            foreach (var method in MethodsOf(endpoint))
+            {
+                routes.Add(new(method, path, policy));
+            }
+        }
+
+        return grouped.ToDictionary(
+            entry => entry.Key,
+            entry => (IReadOnlyList<PluginRouteInfo>)entry.Value,
+            StringComparer.Ordinal
+        );
+    }
+
+    private static IEnumerable<string> MethodsOf(Endpoint endpoint)
+    {
+        var methods = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods;
+
+        return methods is null || methods.Count == 0 ? [AnyMethod] : methods;
+    }
+
+    /// <summary>
+    /// The policy guarding an endpoint, or null when it is open. <c>AllowAnonymous</c> is checked first
+    /// because it wins at runtime over any policy present alongside it.
+    /// </summary>
+    private static string? PolicyOf(Endpoint endpoint)
+    {
+        if (endpoint.Metadata.GetMetadata<IAllowAnonymous>() is not null)
+        {
+            return null;
+        }
+
+        return endpoint.Metadata
+                       .GetOrderedMetadata<IAuthorizeData>()
+                       .Select(data => data.Policy ?? data.Roles)
+                       .FirstOrDefault(value => !string.IsNullOrEmpty(value));
+    }
+}

--- a/src/Moongate.Server.Abstractions/Data/Plugins/PluginDescriptor.cs
+++ b/src/Moongate.Server.Abstractions/Data/Plugins/PluginDescriptor.cs
@@ -1,0 +1,16 @@
+namespace Moongate.Server.Abstractions.Data.Plugins;
+
+/// <summary>
+/// One plugin the bootstrap activated. <see cref="AssemblyName" /> is what joins a plugin to the HTTP
+/// routes it declares: an endpoint's handler names the type that declares it, and that type's assembly
+/// is matched against this.
+/// </summary>
+public record PluginDescriptor(
+    string Id,
+    string Name,
+    Version Version,
+    string Author,
+    string Description,
+    string AssemblyName,
+    bool IsExternal
+);

--- a/src/Moongate.Server.Abstractions/Interfaces/Plugins/IPluginCatalog.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Plugins/IPluginCatalog.cs
@@ -1,0 +1,18 @@
+using Moongate.Server.Abstractions.Data.Plugins;
+
+namespace Moongate.Server.Abstractions.Interfaces.Plugins;
+
+/// <summary>
+/// Every plugin the bootstrap actually activated.
+/// <para>
+/// SquidStd keeps no registry of its own — <c>PluginCollectionBuilder</c> consumes plugins and gives
+/// nothing back — so the catalogue is recorded where plugins are added rather than inferred by scanning
+/// loaded assemblies. That distinction is load-bearing: a plugin registered behind a configuration flag
+/// stays loaded in the process even when the flag switches it off, so a scan would report it as running.
+/// </para>
+/// </summary>
+public interface IPluginCatalog
+{
+    /// <summary>The activated plugins, in the order they were recorded.</summary>
+    IReadOnlyList<PluginDescriptor> Plugins { get; }
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -29,7 +29,9 @@ using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Network;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Services.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Services.Notifications.Channels;
+using Moongate.Server.Services.Plugins;
 using Moongate.Server.Services.Server;
 using Moongate.Smtp.Plugin;
 using Moongate.Server.Services.World;
@@ -41,6 +43,7 @@ using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Extensions.Directories;
 using SquidStd.Core.Interfaces.Events;
 using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
 using SquidStd.Plugin.Extensions;
 using SquidStd.Services.Core.Extensions;
 using SquidStd.Services.Core.Services.Bootstrap;
@@ -111,30 +114,45 @@ await ConsoleApp.RunAsync(
         // Safe with config-first: sections bind eagerly at registration, even after this call.
         stdBootstrap.ConfigureLogging();
 
+        // Built before the plugins are added and registered after, because the two halves happen in
+        // different bootstrap phases: activation here, container registration in ConfigureServices below.
+        var pluginCatalog = new PluginCatalog();
+
         stdBootstrap.UsePlugins(
             builder =>
             {
                 builder.FromDirectory("plugins");
-                builder.Add<MoongatePersistencePlugin>();
-                builder.Add<MoongateScriptingPlugin>();
-                builder.Add<MoongateScriptModulesPlugin>();
-                builder.Add<MoongateDataLoaderPlugin>();
-                builder.Add<MoongateCommandsPlugin>();
-                builder.Add<MoongatePacketHandlersPlugin>();
-                builder.Add<MoongateEventSubscribersPlugin>();
+
+                // Recorded at the point of activation rather than scanned for afterwards: MoongateHttpPlugin
+                // sits behind a flag, and its assembly stays loaded even when the flag switches it off.
+                void AddTracked<TPlugin>() where TPlugin : ISquidStdPlugin, new()
+                {
+                    var plugin = new TPlugin();
+
+                    pluginCatalog.Record(plugin, isExternal: false);
+                    builder.Add(plugin);
+                }
+
+                AddTracked<MoongatePersistencePlugin>();
+                AddTracked<MoongateScriptingPlugin>();
+                AddTracked<MoongateScriptModulesPlugin>();
+                AddTracked<MoongateDataLoaderPlugin>();
+                AddTracked<MoongateCommandsPlugin>();
+                AddTracked<MoongatePacketHandlersPlugin>();
+                AddTracked<MoongateEventSubscribersPlugin>();
 
                 if (!disableWebPlugin)
                 {
-                    builder.Add<MoongateHttpPlugin>();
+                    AddTracked<MoongateHttpPlugin>();
                 }
                 else
                 {
                     Log.Logger.Warning("HTTP is disabled");
                 }
 
-                builder.Add<MoongateConsolePlugin>();
-                builder.Add<MoongateNewsPlugin>();
-                builder.Add<MoongateSmtpPlugin>();
+                AddTracked<MoongateConsolePlugin>();
+                AddTracked<MoongateNewsPlugin>();
+                AddTracked<MoongateSmtpPlugin>();
             }
         );
 
@@ -144,6 +162,24 @@ await ConsoleApp.RunAsync(
                 // Binds the SAME cached instance mutated above; the file cannot clobber it.
                 container.RegisterConfigSection<MoongateConfig>("moongate");
                 container.RegisterConfigSection<NotificationConfig>("notifications");
+
+                // FromDirectory loads whatever it finds but hands back no list of it, so those plugins are
+                // recovered by elimination. Swept here rather than inside UsePlugins above because by now
+                // every plugin has certainly been loaded, and recorded after the explicit ones so that a
+                // duplicate id loses.
+                foreach (var type in PluginDiscovery.ExternalPluginTypes(
+                             typeof(Program).Assembly,
+                             AppDomain.CurrentDomain.GetAssemblies()
+                         ))
+                {
+                    if (Activator.CreateInstance(type) is ISquidStdPlugin external)
+                    {
+                        pluginCatalog.Record(external, isExternal: true);
+                    }
+                }
+
+                // The instance the plugin phase filled in, not a fresh one.
+                container.RegisterInstance<IPluginCatalog>(pluginCatalog);
 
                 container.Register<IAccountService, AccountService>(Reuse.Singleton);
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Plugins/PluginCatalog.cs
+++ b/src/Moongate.Server/Services/Plugins/PluginCatalog.cs
@@ -1,0 +1,42 @@
+using Moongate.Server.Abstractions.Data.Plugins;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Server.Services.Plugins;
+
+/// <summary>
+/// The catalogue the bootstrap fills in as it activates plugins. Written once during startup and read
+/// afterwards, so no synchronisation is needed.
+/// </summary>
+public sealed class PluginCatalog : IPluginCatalog
+{
+    private readonly List<PluginDescriptor> _plugins = [];
+
+    public IReadOnlyList<PluginDescriptor> Plugins => _plugins;
+
+    /// <summary>
+    /// Records a plugin as active. A second record of an id already held is ignored, which is what makes
+    /// the explicit registrations authoritative over the by-elimination sweep for directory-loaded ones.
+    /// </summary>
+    public void Record(ISquidStdPlugin plugin, bool isExternal)
+    {
+        var metadata = plugin.Metadata;
+
+        if (_plugins.Any(recorded => recorded.Id == metadata.Id))
+        {
+            return;
+        }
+
+        _plugins.Add(
+            new(
+                metadata.Id,
+                metadata.Name,
+                metadata.Version,
+                metadata.Author,
+                metadata.Description,
+                plugin.GetType().Assembly.GetName().Name ?? string.Empty,
+                isExternal
+            )
+        );
+    }
+}

--- a/src/Moongate.Server/Services/Plugins/PluginDiscovery.cs
+++ b/src/Moongate.Server/Services/Plugins/PluginDiscovery.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Server.Services.Plugins;
+
+/// <summary>
+/// Finds the plugins SquidStd loaded from the plugins directory.
+/// <para>
+/// <c>FromDirectory</c> reports nothing about what it loaded, so they are identified by elimination
+/// rather than by path: an assembly outside the server's compile-time graph was not shipped with the
+/// server, so it came from that directory. Testing the reference graph rather than the file location
+/// avoids guessing how the relative path was resolved, and — unlike a plain "does it implement
+/// ISquidStdPlugin" scan — never mistakes a first-party plugin that configuration switched off for an
+/// external one that is running.
+/// </para>
+/// </summary>
+public static class PluginDiscovery
+{
+    /// <summary>Whether <paramref name="candidate" /> lies outside the host's compile-time graph.</summary>
+    public static bool IsExternal(Assembly host, Assembly candidate)
+    {
+        var name = candidate.GetName().Name;
+
+        if (name == host.GetName().Name)
+        {
+            return false;
+        }
+
+        return !host.GetReferencedAssemblies().Any(reference => reference.Name == name);
+    }
+
+    /// <summary>Activatable plugin types found in assemblies outside the host's compile-time graph.</summary>
+    public static IEnumerable<Type> ExternalPluginTypes(Assembly host, IEnumerable<Assembly> loaded)
+        => loaded.Where(assembly => IsExternal(host, assembly))
+                 .SelectMany(LoadableTypes)
+                 .Where(
+                     type => type is { IsAbstract: false, IsInterface: false }
+                             && typeof(ISquidStdPlugin).IsAssignableFrom(type)
+                 );
+
+    /// <summary>
+    /// The types an assembly can actually give up. A plugin built against different dependency versions
+    /// throws on <c>GetTypes</c>; the types that did load are still usable, and one broken assembly must
+    /// not take down the whole sweep.
+    /// </summary>
+    private static IEnumerable<Type> LoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            return exception.Types.Where(type => type is not null)!;
+        }
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Plugins/PluginAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Plugins/PluginAdminEndpointsTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Net.Http.Json;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Api.Plugins;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http.Endpoints.Plugins;
+
+public class PluginAdminEndpointsTests
+{
+    private const string Route = "/api/v1/admin/plugins";
+    private const string HttpPluginId = "moongate.http.plugin";
+    private const string HostId = "moongate.host";
+
+    [Fact]
+    public async Task Plugins_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Plugins_WithPlayerToken_Is403()
+    {
+        await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Plugins_WithStaffToken_ListsTheActivatedPlugins()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var plugins = await GetPluginsAsync(server);
+
+        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
+
+        Assert.Equal("Moongate.Http.Plugin", http.Assembly);
+        Assert.False(http.IsExternal);
+    }
+
+    [Fact]
+    public async Task Plugins_ReportsRoutesWithTheirVerbAndPolicy()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var plugins = await GetPluginsAsync(server);
+        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
+
+        var status = Assert.Single(http.Routes, route => route.Path == "/api/v1/admin/status");
+
+        Assert.Equal("GET", status.Method);
+        Assert.Equal("admin", status.Policy);
+
+        var login = Assert.Single(http.Routes, route => route.Path == "/api/v1/auth/login");
+
+        Assert.Equal("POST", login.Method);
+        Assert.Null(login.Policy);
+    }
+
+    [Fact]
+    public async Task Plugins_AttributesHealthToTheHttpPluginNotToTheHost()
+    {
+        // /health is a lambda inside HttpServerService, so its closure lives in the HTTP plugin's assembly
+        // and the route belongs to that plugin. Getting this wrong is the easy mistake here.
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var plugins = await GetPluginsAsync(server);
+        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
+
+        Assert.Contains(http.Routes, route => route.Path == "/health");
+
+        var host = Assert.Single(plugins, plugin => plugin.Id == HostId);
+
+        Assert.DoesNotContain(host.Routes, route => route.Path == "/health");
+    }
+
+    [Fact]
+    public async Task Plugins_LeavesNoApiRouteUnattributed()
+    {
+        // The invariant that matters: every /api/ route belongs to a catalogued plugin. It breaks if
+        // endpoints are ever registered from an assembly nobody records, or if attribution stops working.
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var plugins = await GetPluginsAsync(server);
+        var host = Assert.Single(plugins, plugin => plugin.Id == HostId);
+
+        Assert.DoesNotContain(host.Routes, route => route.Path.StartsWith("/api/", StringComparison.Ordinal));
+    }
+
+    private static async Task<IReadOnlyList<PluginInfoResponse>> GetPluginsAsync(TestApiServer server)
+    {
+        var response = await server.Client.GetAsync(Route);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        return (await response.Content.ReadFromJsonAsync<List<PluginInfoResponse>>())!;
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -11,6 +11,7 @@ using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
 using Moongate.Http.Plugin.Endpoints.Mobiles;
 using Moongate.Http.Plugin.Endpoints.Players;
+using Moongate.Http.Plugin.Endpoints.Plugins;
 using Moongate.Http.Plugin.Endpoints.Registration;
 using Moongate.Http.Plugin.Endpoints.ServerInfo;
 using Moongate.Http.Plugin.Endpoints.Stats;
@@ -58,6 +59,7 @@ public class MoongateHttpPluginTests
                 typeof(MobileTemplateImageEndpoints),
                 typeof(PaperdollEndpoints),
                 typeof(PlayerEndpoints),
+                typeof(PluginAdminEndpoints),
                 typeof(RegistrationEndpoints),
                 typeof(ServerInfoEndpoints),
                 typeof(ServerSettingsAdminEndpoints),

--- a/tests/Moongate.Tests/Http/Services/Plugins/EndpointPluginRouteInspectorTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Plugins/EndpointPluginRouteInspectorTests.cs
@@ -1,0 +1,147 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Primitives;
+using Moongate.Http.Plugin.Data.Plugins;
+using Moongate.Http.Plugin.Services.Plugins;
+
+namespace Moongate.Tests.Http.Services.Plugins;
+
+public class EndpointPluginRouteInspectorTests
+{
+    private static readonly MethodInfo Handler =
+        typeof(EndpointPluginRouteInspectorTests).GetMethod(
+            nameof(SampleHandler),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    [Fact]
+    public void RoutesByAssembly_GroupsUnderTheAssemblyDeclaringTheHandler()
+    {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news", "GET")));
+
+        var assembly = typeof(EndpointPluginRouteInspectorTests).Assembly.GetName().Name!;
+        var routes = Assert.Contains(assembly, result);
+
+        Assert.Equal(new PluginRouteInfo("GET", "/api/v1/news", null), Assert.Single(routes));
+    }
+
+    [Fact]
+    public void RoutesByAssembly_ReportsTheAuthorizationPolicy()
+    {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(
+            new StubEndpointDataSource(Route("/api/v1/admin/news", "POST", policy: "admin"))
+        );
+
+        Assert.Equal("admin", Assert.Single(result.Values.Single()).Policy);
+    }
+
+    [Fact]
+    public void RoutesByAssembly_ReportsAllowAnonymousAsNoPolicy()
+    {
+        // AllowAnonymous wins at runtime over any policy also present, so it must win here too.
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(
+            new StubEndpointDataSource(Route("/api/v1/news", "GET", policy: "admin", allowAnonymous: true))
+        );
+
+        Assert.Null(Assert.Single(result.Values.Single()).Policy);
+    }
+
+    [Fact]
+    public void RoutesByAssembly_EmitsOneEntryPerVerb()
+    {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news", "GET", "HEAD")));
+
+        Assert.Equal(["GET", "HEAD"], result.Values.Single().Select(route => route.Method));
+    }
+
+    [Fact]
+    public void RoutesByAssembly_UsesAStarWhenNoVerbIsDeclared()
+    {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news")));
+
+        Assert.Equal("*", Assert.Single(result.Values.Single()).Method);
+    }
+
+    [Fact]
+    public void RoutesByAssembly_GroupsEndpointsWithoutAHandlerUnderAnEmptyKey()
+    {
+        // Swagger and Scalar map routes carrying no MethodInfo. They must not be dropped: the caller turns
+        // the empty key into the synthetic "host" entry.
+        var inspector = new EndpointPluginRouteInspector();
+
+        var endpoint = new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("/scalar/v1"),
+            0,
+            new(new HttpMethodMetadata(["GET"])),
+            "/scalar/v1"
+        );
+
+        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(endpoint));
+
+        Assert.Equal("/scalar/v1", Assert.Single(result[string.Empty]).Path);
+    }
+
+    private static void SampleHandler()
+    {
+    }
+
+    private static RouteEndpoint Route(
+        string pattern,
+        string? method = null,
+        string? secondMethod = null,
+        string? policy = null,
+        bool allowAnonymous = false
+    )
+    {
+        var metadata = new List<object> { Handler };
+
+        if (method is not null)
+        {
+            // Typed as List<string> rather than inferred: an inferred array would come out string?[] from
+            // the nullable parameters and would not bind to HttpMethodMetadata.
+            List<string> verbs = secondMethod is null ? [method] : [method, secondMethod];
+
+            metadata.Add(new HttpMethodMetadata(verbs));
+        }
+
+        if (policy is not null)
+        {
+            metadata.Add(new AuthorizeAttribute(policy));
+        }
+
+        if (allowAnonymous)
+        {
+            metadata.Add(new AllowAnonymousAttribute());
+        }
+
+        return new(_ => Task.CompletedTask, RoutePatternFactory.Parse(pattern), 0, new(metadata), pattern);
+    }
+
+    private sealed class StubEndpointDataSource : EndpointDataSource
+    {
+        private readonly IReadOnlyList<Endpoint> _endpoints;
+
+        public StubEndpointDataSource(params Endpoint[] endpoints)
+        {
+            _endpoints = endpoints;
+        }
+
+        public override IReadOnlyList<Endpoint> Endpoints => _endpoints;
+
+        public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
+    }
+}

--- a/tests/Moongate.Tests/Server/Plugins/AbstractPlugin.cs
+++ b/tests/Moongate.Tests/Server/Plugins/AbstractPlugin.cs
@@ -1,0 +1,13 @@
+using DryIoc;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Tests.Server.Plugins;
+
+/// <summary>Proves the sweep skips types it could never activate.</summary>
+public abstract class AbstractPlugin : ISquidStdPlugin
+{
+    public abstract PluginMetadata Metadata { get; }
+
+    public abstract void Configure(IContainer container, PluginContext context);
+}

--- a/tests/Moongate.Tests/Server/Plugins/DiscoverablePlugin.cs
+++ b/tests/Moongate.Tests/Server/Plugins/DiscoverablePlugin.cs
@@ -1,0 +1,23 @@
+using DryIoc;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Tests.Server.Plugins;
+
+/// <summary>Stands in for a plugin DLL dropped into <c>plugins/</c> — discovered, never referenced.</summary>
+public sealed class DiscoverablePlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "discoverable.plugin",
+            Name = "Discoverable",
+            Version = new(1, 0, 0),
+            Author = "squid",
+            Description = "found by elimination"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+    }
+}

--- a/tests/Moongate.Tests/Server/Plugins/PluginCatalogTests.cs
+++ b/tests/Moongate.Tests/Server/Plugins/PluginCatalogTests.cs
@@ -1,0 +1,90 @@
+using DryIoc;
+using Moongate.Server.Services.Plugins;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Tests.Server.Plugins;
+
+public class PluginCatalogTests
+{
+    [Fact]
+    public void Record_KeepsTheMetadataAndTheDeclaringAssembly()
+    {
+        var catalog = new PluginCatalog();
+
+        catalog.Record(new FakePlugin("fake.one", "Fake One"), isExternal: false);
+
+        var plugin = Assert.Single(catalog.Plugins);
+
+        Assert.Equal("fake.one", plugin.Id);
+        Assert.Equal("Fake One", plugin.Name);
+        Assert.Equal(new Version(2, 3, 4), plugin.Version);
+        Assert.Equal("squid", plugin.Author);
+        Assert.Equal("a fake", plugin.Description);
+        Assert.False(plugin.IsExternal);
+
+        // The assembly name is the join key the route inspector uses; it must come from the plugin's own
+        // type, not from anything the plugin declares about itself.
+        Assert.Equal(typeof(PluginCatalogTests).Assembly.GetName().Name, plugin.AssemblyName);
+    }
+
+    [Fact]
+    public void Record_MarksExternalPluginsAsSuch()
+    {
+        var catalog = new PluginCatalog();
+
+        catalog.Record(new FakePlugin("fake.external", "External"), isExternal: true);
+
+        Assert.True(Assert.Single(catalog.Plugins).IsExternal);
+    }
+
+    [Fact]
+    public void Record_IgnoresASecondRecordOfTheSameId()
+    {
+        // FromDirectory-loaded plugins are found by elimination after the explicit ones are recorded, so
+        // the same plugin reaching Record twice is a real path, not a hypothetical.
+        var catalog = new PluginCatalog();
+
+        catalog.Record(new FakePlugin("fake.one", "First"), isExternal: false);
+        catalog.Record(new FakePlugin("fake.one", "Second"), isExternal: true);
+
+        var plugin = Assert.Single(catalog.Plugins);
+
+        Assert.Equal("First", plugin.Name);
+        Assert.False(plugin.IsExternal);
+    }
+
+    [Fact]
+    public void Plugins_KeepsTheOrderTheyWereRecordedIn()
+    {
+        var catalog = new PluginCatalog();
+
+        catalog.Record(new FakePlugin("fake.one", "One"), isExternal: false);
+        catalog.Record(new FakePlugin("fake.two", "Two"), isExternal: false);
+
+        Assert.Equal(["fake.one", "fake.two"], catalog.Plugins.Select(plugin => plugin.Id));
+    }
+
+    private sealed class FakePlugin : ISquidStdPlugin
+    {
+        private readonly PluginMetadata _metadata;
+
+        public FakePlugin(string id, string name)
+        {
+            _metadata = new()
+            {
+                Id = id,
+                Name = name,
+                Version = new(2, 3, 4),
+                Author = "squid",
+                Description = "a fake"
+            };
+        }
+
+        public PluginMetadata Metadata => _metadata;
+
+        public void Configure(IContainer container, PluginContext context)
+        {
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/Plugins/PluginDiscoveryTests.cs
+++ b/tests/Moongate.Tests/Server/Plugins/PluginDiscoveryTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
+using Moongate.Server.Services.Plugins;
+
+namespace Moongate.Tests.Server.Plugins;
+
+public class PluginDiscoveryTests
+{
+    private static readonly Assembly Tests = typeof(PluginDiscoveryTests).Assembly;
+    private static readonly Assembly Abstractions = typeof(IPluginCatalog).Assembly;
+
+    [Fact]
+    public void IsExternal_IsFalseForTheHostItself()
+    {
+        Assert.False(PluginDiscovery.IsExternal(Tests, Tests));
+    }
+
+    [Fact]
+    public void IsExternal_IsFalseForAnAssemblyTheHostReferences()
+    {
+        // Moongate.Tests references Moongate.Server.Abstractions transitively and directly enough to appear
+        // in its reference list: anything in the compile-time graph was shipped with the server.
+        Assert.False(PluginDiscovery.IsExternal(Tests, Abstractions));
+    }
+
+    [Fact]
+    public void IsExternal_IsTrueForAnAssemblyOutsideTheHostGraph()
+    {
+        // Reversing the roles gives a genuine outsider: Moongate.Server.Abstractions cannot reference the
+        // test project, so from its point of view the tests are an externally loaded assembly. This is the
+        // same shape as a DLL dropped into plugins/.
+        Assert.True(PluginDiscovery.IsExternal(Abstractions, Tests));
+    }
+
+    [Fact]
+    public void ExternalPluginTypes_FindsPluginTypesOnlyOutsideTheHostGraph()
+    {
+        var found = PluginDiscovery.ExternalPluginTypes(Abstractions, [Tests]).ToList();
+
+        Assert.Contains(typeof(DiscoverablePlugin), found);
+    }
+
+    [Fact]
+    public void ExternalPluginTypes_SkipsAssembliesInsideTheHostGraph()
+    {
+        // The host's own plugins are recorded explicitly at activation; sweeping them up here would
+        // resurrect the very plugin a configuration flag switched off.
+        Assert.Empty(PluginDiscovery.ExternalPluginTypes(Tests, [Tests]));
+    }
+
+    [Fact]
+    public void ExternalPluginTypes_SkipsAbstractTypesAndInterfaces()
+    {
+        var found = PluginDiscovery.ExternalPluginTypes(Abstractions, [Tests]).ToList();
+
+        Assert.DoesNotContain(typeof(AbstractPlugin), found);
+    }
+}

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using DryIoc;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Types;
+using Moongate.Http.Plugin;
 using Moongate.Http.Plugin.Data;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Endpoints.Accounts;
@@ -9,6 +10,7 @@ using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Players;
+using Moongate.Http.Plugin.Endpoints.Plugins;
 using Moongate.Http.Plugin.Endpoints.Registration;
 using Moongate.Http.Plugin.Endpoints.ServerInfo;
 using Moongate.Http.Plugin.Endpoints.Stats;
@@ -18,11 +20,14 @@ using Moongate.Http.Plugin.Interfaces.Auth;
 using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Http.Plugin.Services.Auth;
 using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Http.Plugin.Services.Plugins;
 using Moongate.Http.Plugin.Services.Registration;
 using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Server;
 using Moongate.Server.Services.Accounts;
+using Moongate.Server.Services.Plugins;
 using Moongate.Server.Services.Server;
 using SquidStd.Core.Interfaces.Config;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
@@ -170,6 +175,16 @@ public sealed class TestApiServer : IAsyncDisposable
         var stats = new StubServerStatsService();
         container.RegisterInstance<IServerStatsService>(stats);
         container.RegisterApiEndpointInstance(new StatsEndpoints(stats, moongateConfig));
+
+        // The fixture's endpoints all live in Moongate.Http.Plugin, so recording that plugin is what makes
+        // their routes attributable — the same join the real bootstrap makes.
+        var pluginCatalog = new PluginCatalog();
+        pluginCatalog.Record(new MoongateHttpPlugin(), isExternal: false);
+
+        container.RegisterInstance<IPluginCatalog>(pluginCatalog);
+        container.RegisterApiEndpointInstance(
+            new PluginAdminEndpoints(pluginCatalog, new EndpointPluginRouteInspector())
+        );
 
         // Lets a test add endpoint groups this fixture cannot know about — the ones the HTTP plugin owns.
         configure?.Invoke(container);


### PR DESCRIPTION
Adds `GET /api/v1/admin/plugins`, a staff-only endpoint listing every activated plugin together with the HTTP routes it declares.

Refs #48.

## How it works

SquidStd keeps no registry of loaded plugins — `PluginCollectionBuilder` consumes them and hands nothing back — so `Program.cs` records them as it activates them. Deliberately not by scanning loaded assemblies: `MoongateHttpPlugin` sits behind a config flag, and its assembly stays loaded even when the flag switches it off, so a scan would report it as running.

Routes are attributed by reading each endpoint's handler `MethodInfo` and taking the declaring type's assembly, so **no existing endpoint changed**. This works for lambda handlers too: the compiler puts the closure in the assembly that declared it.

Plugins loaded from the `plugins` directory are recovered by elimination — an assembly outside the server's compile-time graph came from there. Testing the reference graph rather than the file path avoids guessing how the relative path was resolved.

Routes belonging to no plugin (Scalar's reference pages) are gathered under a synthetic `moongate.host` entry rather than dropped: a route that is live but absent from the list would be a worse diagnostic than an extra line.

## Verification

Checked on a **real boot**, not only against the test fixture — the fixture builds its catalogue by hand, while production goes through `Program.cs`:

- 11 plugins catalogued, including the conditionally registered HTTP plugin
- 43 routes attributed to the HTTP plugin, 7 to News, 0 to plugins that expose none
- only Scalar's 4 routes under `moongate.host`; **zero** `/api/` routes unattributed
- `/health` attributed to `moongate.http.plugin`, not to the host — it is a lambda declared inside `HttpServerService`

1388 tests passing (22 new). DocFX builds at 0 warnings. No new build warnings.

## Known limitation, documented

Attribution is per assembly, and the plugin classes living inside the server all report `Moongate.Server`. None declares HTTP routes today, so nothing is ambiguous; were the server ever to declare routes directly, every plugin sharing that assembly would report the same list. This is written up in the docs page rather than left implicit.

## Not in scope

The Dockerfile's restore layer copies neither the plugin `.csproj` files nor `Moongate.Server.Abstractions.csproj`, though `Moongate.Server` references all of them. `dotnet restore` skips missing project references silently, so the layer succeeds on an incomplete graph and the later `dotnet build` repairs it with an implicit restore. CI is green and the image is correct; the cost is a largely wasted cache layer. Worth a separate fix.