### PR TITLE
fix(docker): restore the full project graph before building

### DIFF
--- a/src/Moongate.Server/Dockerfile
+++ b/src/Moongate.Server/Dockerfile
@@ -12,15 +12,22 @@ WORKDIR /src
 COPY ["Directory.Build.props", "global.json", "./"]
 
 # Copy every referenced project file before restore: Moongate.Server pulls in the whole
-# graph (Network, Persistence, Scripting -> Core, UO.Data -> Ultima), so restore fails
-# unless all of them are present. Kept as a separate layer for dependency caching.
+# graph — the src libraries plus the four plugin projects it references. All twelve must be
+# here, because `dotnet restore` does NOT fail on a missing ProjectReference: it prints
+# "Skipping project ... because it was not found" and carries on, so an incomplete set
+# restores a partial graph, silently, and this layer stops being worth caching.
 COPY ["src/Moongate.Core/Moongate.Core.csproj", "src/Moongate.Core/"]
 COPY ["src/Moongate.Ultima/Moongate.Ultima.csproj", "src/Moongate.Ultima/"]
 COPY ["src/Moongate.UO.Data/Moongate.UO.Data.csproj", "src/Moongate.UO.Data/"]
 COPY ["src/Moongate.Network/Moongate.Network.csproj", "src/Moongate.Network/"]
 COPY ["src/Moongate.Persistence/Moongate.Persistence.csproj", "src/Moongate.Persistence/"]
 COPY ["src/Moongate.Scripting/Moongate.Scripting.csproj", "src/Moongate.Scripting/"]
+COPY ["src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj", "src/Moongate.Server.Abstractions/"]
 COPY ["src/Moongate.Server/Moongate.Server.csproj", "src/Moongate.Server/"]
+COPY ["plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj", "plugins/Moongate.Console.Admin.Plugin/"]
+COPY ["plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj", "plugins/Moongate.Http.Plugin/"]
+COPY ["plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj", "plugins/Moongate.News.Plugin/"]
+COPY ["plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj", "plugins/Moongate.Smtp.Plugin/"]
 RUN dotnet restore "src/Moongate.Server/Moongate.Server.csproj"
 
 COPY . .


### PR DESCRIPTION
Refs #50.

The restore layer copied 7 of the 12 project files `Moongate.Server` pulls in, leaving out `Moongate.Server.Abstractions` and all four plugin projects.

`dotnet restore` does not fail on a missing `ProjectReference` — it prints `Skipping project ... because it was not found` and carries on — so the layer succeeded while restoring a partial graph, and the implicit restore inside the later `dotnet build` silently made up the difference. **The published image was always correct**; what was broken is the point of the layer, which is to be a cacheable dependency step. Most of the restore work was being redone in the build layer on every source change.

## Verification

Two levels, because the fast one alone would not prove the `COPY` paths are valid in a real build context:

1. Reconstructed the pre-restore context by **parsing the `COPY` lines out of the Dockerfile itself**, so the check cannot drift from the file, and ran a real `dotnet restore` against it — 0 skipped projects.
2. Full `docker build --no-cache`: the restore layer now reports **12 projects restored and none skipped**, against 7 before.

No C# changed, so the test suite is untouched.