### PR TITLE
Attach server zips to releases and fix empty release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,3 +477,67 @@ jobs:
               --api-key "${{ github.token }}" \
               --skip-duplicate
           done
+
+  publish_release_assets:
+    name: Publish release zips
+    needs:
+      - gate
+      - verify
+      - semantic_release
+      - reconcile_release
+    if: >-
+      always() &&
+      needs.gate.outputs.should_release == 'true' &&
+      needs.verify.result == 'success' &&
+      (needs.semantic_release.result == 'success' || needs.semantic_release.result == 'skipped') &&
+      (needs.reconcile_release.result == 'success' || needs.reconcile_release.result == 'skipped') &&
+      (needs.semantic_release.outputs.version != '' || needs.gate.outputs.version != '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        rid:
+          - linux-x64
+          - win-x64
+          - linux-arm64
+    env:
+      RELEASE_VERSION: ${{ needs.semantic_release.outputs.version || needs.gate.outputs.version }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: v${{ env.RELEASE_VERSION }}
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: global.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.10.0
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Build the portal
+        run: |
+          npm ci --prefix ui
+          npm --prefix ui run build
+
+      - name: Package ${{ matrix.rid }}
+        run: |
+          scripts/package_release.sh \
+            --rid "${{ matrix.rid }}" \
+            --version "${RELEASE_VERSION}" \
+            --ui-dist ui/dist \
+            --out ./artifacts
+
+      - name: Upload to the release
+        run: gh release upload "v${RELEASE_VERSION}" ./artifacts/*.zip --clobber

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,13 +7,13 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits"
+        "preset": "angular"
       }
     ],
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits"
+        "preset": "angular"
       }
     ],
     [

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Assembles one platform's release zip: the self-contained single-file server, the built portal beside it
+# (which the server finds and serves), and the top-level README and LICENSE. CI calls this per RID; it also
+# runs locally. One place owns how a release zip is shaped.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RID=""
+VERSION=""
+UI_DIST=""
+OUT_DIR="$REPO_ROOT/artifacts"
+
+SUPPORTED_RIDS=("linux-x64" "win-x64" "linux-arm64")
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") --rid <rid> --version <version> [options]
+
+Build one self-contained server zip: executable + portal + README + LICENSE.
+
+Required:
+  -r, --rid <rid>          Target runtime: ${SUPPORTED_RIDS[*]}
+  -v, --version <version>  Version string used in the zip name (e.g. 0.5.0)
+
+Options:
+      --ui-dist <path>     Prebuilt portal directory to bundle. If omitted, the
+                           script builds it from ui/ with npm.
+      --out <dir>          Output directory (default: ./artifacts)
+  -h, --help               Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -r | --rid)
+    RID="$2"
+    shift 2
+    ;;
+  -v | --version)
+    VERSION="$2"
+    shift 2
+    ;;
+  --ui-dist)
+    UI_DIST="$2"
+    shift 2
+    ;;
+  --out)
+    OUT_DIR="$2"
+    shift 2
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+if [[ -z "$RID" || -z "$VERSION" ]]; then
+  echo "Both --rid and --version are required." >&2
+  usage
+  exit 1
+fi
+
+is_supported="false"
+for candidate in "${SUPPORTED_RIDS[@]}"; do
+  [[ "$candidate" == "$RID" ]] && is_supported="true"
+done
+if [[ "$is_supported" != "true" ]]; then
+  echo "Unsupported rid: $RID (expected one of: ${SUPPORTED_RIDS[*]})" >&2
+  exit 1
+fi
+
+# The portal is platform-independent. Prefer a path the caller already built (CI builds it once); fall back
+# to a fresh build so a local run with no prior build still works.
+if [[ -z "$UI_DIST" ]]; then
+  if [[ -f "$REPO_ROOT/ui/dist/index.html" ]]; then
+    UI_DIST="$REPO_ROOT/ui/dist"
+  else
+    echo "No portal build found; building it from ui/"
+    npm --prefix "$REPO_ROOT/ui" ci
+    npm --prefix "$REPO_ROOT/ui" run build
+    UI_DIST="$REPO_ROOT/ui/dist"
+  fi
+fi
+
+if [[ ! -f "$UI_DIST/index.html" ]]; then
+  echo "Portal build has no index.html: $UI_DIST" >&2
+  exit 1
+fi
+
+PKG_NAME="moongate-server-${VERSION}-${RID}"
+PKG_DIR="$OUT_DIR/$PKG_NAME"
+
+rm -rf "$PKG_DIR"
+mkdir -p "$PKG_DIR"
+
+echo "Publishing $RID (self-contained, single file)"
+dotnet publish "$REPO_ROOT/src/Moongate.Server/Moongate.Server.csproj" \
+  -c Release -r "$RID" \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -p:DebugType=embedded \
+  -p:GenerateDocumentationFile=false \
+  -o "$PKG_DIR"
+
+# Portal beside the executable, then the top-level docs. The parent ui/ is created first so that
+# `cp -r <src> <dest>` — with dest absent — copies the portal's contents into a fresh ui/dist.
+mkdir -p "$PKG_DIR/ui"
+cp -r "$UI_DIST" "$PKG_DIR/ui/dist"
+cp "$REPO_ROOT/README.md" "$REPO_ROOT/LICENSE" "$PKG_DIR/"
+
+ZIP_PATH="$OUT_DIR/$PKG_NAME.zip"
+rm -f "$ZIP_PATH"
+(cd "$OUT_DIR" && zip -r -q "$PKG_NAME.zip" "$PKG_NAME")
+
+# Leave only the zip.
+rm -rf "$PKG_DIR"
+
+echo "$ZIP_PATH"


### PR DESCRIPTION
Closes #60. Two halves that make a release complete: downloadable server
packages, and notes that list what changed.

## Server zips

Three self-contained, single-file zips attached to each GitHub release —
`linux-x64`, `win-x64`, `linux-arm64`. Each carries the executable, `ui/dist`
beside it (the portal, which the server finds and serves), README and LICENSE.
No .NET install needed to run them.

`scripts/package_release.sh` is the single source of truth for how a zip is
shaped — runnable locally, called per-RID by a new matrix job
`publish_release_assets`. The job shares the gate of the existing publish jobs,
so it fires on both the normal push release and the manual `workflow_dispatch`
recovery, and uploads with `--clobber` so a re-run replaces rather than fails.

**Verified locally:**
- linux-x64 zip unpacks to a server that, launched from its own directory,
  serves the bundled portal at `/` (`Serving the portal from …/ui/dist`) and
  answers a real request. The launch-from-its-own-dir detail matters: run from
  the repo root, the server would serve the repo's `ui/dist` and never exercise
  the zip's copy.
- win-x64 and linux-arm64 cross-publish from Linux and produce their zips with
  the portal (win as `Moongate.Server.exe`).

## Readable notes

Switch the semantic-release preset from `conventionalcommits` to `angular` in
`commit-analyzer` and `release-notes-generator`. Proven by reproducing note
generation on the real `v0.3.0..v0.4.0` range with the installed toolchain:
conventionalcommits renders 0 commit lines, angular renders 23. Version bumps
are unchanged (feat minor, fix patch, breaking major). The old empty changelog
entries are left as history; the next release is the first with a populated
body.

## Note on CI

The release workflow runs only on push to `main` / `workflow_dispatch`, not on
PRs into `develop`, so the new job is not exercised by this PR's checks. It was
verified locally (script end-to-end) and by validating the workflow parses and
the job is wired with the shared gate and matrix. It first runs on the next
release.