### PR TITLE
UI control kit: display components

### DIFF
--- a/ui/src/components/ui/alert.test.tsx
+++ b/ui/src/components/ui/alert.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { Alert, AlertDescription, AlertTitle } from './alert'
+
+describe('Alert', () => {
+  it('is an alert region carrying the variant class', () => {
+    render(
+      <Alert variant="danger">
+        <AlertTitle>Script error</AlertTitle>
+        <AlertDescription>spawn_orc_fort.lua:42</AlertDescription>
+      </Alert>,
+    )
+    const alert = screen.getByRole('alert')
+    expect(alert.className).toContain('text-danger-text')
+    expect(screen.getByText('Script error')).toBeInTheDocument()
+    expect(screen.getByText('spawn_orc_fort.lua:42')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/alert.tsx
+++ b/ui/src/components/ui/alert.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+// Faithful to mg-alert: a tinted card, background 8%, border 35%, text in the variant colour.
+const alertVariants = cva('rounded-card border p-4 text-sm', {
+  variants: {
+    variant: {
+      danger: 'border-danger/35 bg-danger/[0.08] text-danger-text',
+      warning: 'border-gold/35 bg-gold/[0.08] text-gold',
+      info: 'border-info/35 bg-info/[0.08] text-info',
+    },
+  },
+  defaultVariants: { variant: 'info' },
+})
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return <div role="alert" data-slot="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="alert-title" className={cn('mb-1 font-bold', className)} {...props} />
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="alert-description" className={cn('text-muted', className)} {...props} />
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/ui/src/components/ui/badge.test.tsx
+++ b/ui/src/components/ui/badge.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { Badge } from './badge'
+
+describe('Badge', () => {
+  it('renders its content', () => {
+    render(<Badge variant="success">ACTIVE</Badge>)
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+  })
+
+  it('carries the variant colour class', () => {
+    render(<Badge variant="danger">BANNED</Badge>)
+    expect(screen.getByText('BANNED').className).toContain('text-danger-text')
+  })
+
+  it('letter-spaces the staff variant', () => {
+    render(<Badge variant="staff">GM</Badge>)
+    expect(screen.getByText('GM').className).toContain('tracking-[0.14em]')
+  })
+})

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -1,48 +1,31 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
 
-import { cn } from "@/lib/utils"
-
+// Faithful to mg-badge: 700 11px, radius 2px, padding 3px 10px, with the variant tinting text at full
+// colour, background at 10% and border at 40%. The staff variant is letter-spaced.
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  'inline-flex items-center rounded-control border px-2.5 py-[3px] text-[11px] font-bold leading-none',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
-        outline:
-          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 [a&]:hover:underline",
+        success: 'text-success bg-success/10 border-success/40',
+        warning: 'text-gold bg-gold/10 border-gold/40',
+        danger: 'text-danger-text bg-danger/10 border-danger/40',
+        info: 'text-info bg-info/10 border-info/40',
+        staff: 'text-staff bg-staff/10 border-staff/40 tracking-[0.14em]',
       },
     },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
+    defaultVariants: { variant: 'info' },
+  },
 )
 
 function Badge({
   className,
-  variant = "default",
-  asChild = false,
+  variant,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span"
-
-  return (
-    <Comp
-      data-slot="badge"
-      data-variant={variant}
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  )
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
+  return <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
 }
 
 export { Badge, badgeVariants }

--- a/ui/src/components/ui/counter.test.tsx
+++ b/ui/src/components/ui/counter.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import { Counter, OnlineDot } from './counter'
+
+describe('Counter', () => {
+  it('renders the number', () => {
+    render(<Counter>8</Counter>)
+    expect(screen.getByText('8')).toBeInTheDocument()
+  })
+
+  it('OnlineDot has an accessible label', () => {
+    render(<OnlineDot />)
+    expect(screen.getByRole('img', { name: /online/i })).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/counter.tsx
+++ b/ui/src/components/ui/counter.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+/** The small danger-coloured count pill (mg-count). */
+export function Counter({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-control bg-danger px-2 py-0.5 text-[11px] font-bold leading-none text-white',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+/** The 7px success dot used next to online names. */
+export function OnlineDot({ className }: { className?: string }) {
+  return (
+    <span role="img" aria-label="online" className={cn('inline-block size-[7px] rounded-full bg-success', className)} />
+  )
+}

--- a/ui/src/components/ui/filter-pill.test.tsx
+++ b/ui/src/components/ui/filter-pill.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FilterPill } from './filter-pill'
+
+describe('FilterPill', () => {
+  it('reflects the active state through aria-pressed', () => {
+    render(<FilterPill active>Open · 8</FilterPill>)
+    expect(screen.getByRole('button', { pressed: true })).toHaveTextContent('Open · 8')
+  })
+
+  it('fires onClick', async () => {
+    const onClick = vi.fn()
+    render(<FilterPill onClick={onClick}>Mine · 3</FilterPill>)
+    await userEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/components/ui/filter-pill.tsx
+++ b/ui/src/components/ui/filter-pill.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+// Faithful to mg-pill: a bordered pill, muted by default; active turns gold with a 10% gold wash.
+export function FilterPill({
+  active = false,
+  className,
+  ...props
+}: React.ComponentProps<'button'> & { active?: boolean }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      className={cn(
+        'rounded-control border px-3 py-1 text-xs',
+        active
+          ? 'border-gold/35 bg-gold/10 font-bold text-gold'
+          : 'border-border-subtle text-muted hover:text-ink',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/ui/src/components/ui/stat-card.test.tsx
+++ b/ui/src/components/ui/stat-card.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { StatCard } from './stat-card'
+
+describe('StatCard', () => {
+  it('shows the label, value and sub', () => {
+    render(<StatCard label="Players online" value={42} sub="+5 today" />)
+    expect(screen.getByText('Players online')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('+5 today')).toBeInTheDocument()
+  })
+
+  it('renders an em dash for an undefined value', () => {
+    render(<StatCard label="TPS" value={undefined} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/stat-card.tsx
+++ b/ui/src/components/ui/stat-card.tsx
@@ -1,0 +1,25 @@
+import { cn } from '@/lib/utils'
+
+// Faithful to the design's statCard: a bordered surface holding an uppercase faint label, a mono value,
+// and an optional sub-line. `tone` colours the value (e.g. the gold or danger accents in the mock).
+export function StatCard({
+  label,
+  value,
+  sub,
+  tone,
+  className,
+}: {
+  label: string
+  value: string | number | undefined
+  sub?: string
+  tone?: string
+  className?: string
+}) {
+  return (
+    <div className={cn('rounded-card border border-border-subtle bg-surface px-[18px] py-4', className)}>
+      <div className="mb-2 text-[11.5px] uppercase tracking-[0.1em] text-faint">{label}</div>
+      <div className={cn('font-mono text-[26px] font-bold text-ink', tone)}>{value ?? '—'}</div>
+      {sub !== undefined && <div className="mt-[3px] text-xs text-muted">{sub}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
First half of the Moongate control kit (issue #62), faithful to
`Moongate Controls.dc.html`. The display components — no interactive behaviour:

- **Badge** — mg-badge, five semantic variants tinting text full / bg 10% /
  border 40%, staff letter-spaced. Replaces the unused generic shadcn badge.
- **StatCard**, **Counter**, **OnlineDot** — the stat row and count pills.
- **FilterPill** — gold when active, `aria-pressed`.
- **Alert** — danger/warning/info tinted cards (bg 8% / border 35%).

Library-first where a library helps; these five are thin styled components no
Radix primitive covers. All themed through the token bridge — no `dark:`.

**Verified in a headless browser, both themes** (throwaway gallery, not
committed): the badges tint correctly, the stat cards render mono values, the
filter pill and alerts match, and the light theme recolours everything with no
`dark:` leak.

36 UI tests pass. The interactive controls (select, checkbox, switch, dialog,
tabs, toast, table) follow in a second PR.

Closes #62.