### PR TITLE
UI control kit: interactive controls and table

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "i18next": "^26.3.6",
+        "lucide-react": "^1.26.0",
         "radix-ui": "^1.6.4",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -6370,6 +6371,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.26.0.tgz",
+      "integrity": "sha512-raglYVR2+VkMfJL158krjVmE+rV5ST2lzA/KQm1FRSjMHT4MnWaegHxoVEpmc2So3nOEhp9oGejJwAPX8MoAjg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "i18next": "^26.3.6",
@@ -3270,6 +3271,39 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^19.2.8",
         "react-i18next": "^17.0.10",
         "react-router": "^8.2.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
@@ -7886,6 +7887,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.2.8",
     "react-i18next": "^17.0.10",
     "react-router": "^8.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^26.3.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^26.3.6",
+    "lucide-react": "^1.26.0",
     "radix-ui": "^1.6.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/ui/src/components/ui/checkbox.test.tsx
+++ b/ui/src/components/ui/checkbox.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Checkbox } from './checkbox'
+
+describe('Checkbox', () => {
+  it('toggles and reports the change', async () => {
+    const onCheckedChange = vi.fn()
+    render(<Checkbox aria-label="remember" onCheckedChange={onCheckedChange} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: 'remember' }))
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      // Faithful: off = border-strong; on = gold with the tick in gold-ink.
+      className={cn(
+        "peer size-[15px] shrink-0 rounded-control border border-border-strong outline-none focus-visible:border-gold focus-visible:ring-[3px] focus-visible:ring-gold/20 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-gold-hi data-[state=checked]:bg-gold data-[state=checked]:text-gold-ink",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/ui/src/components/ui/data-table.test.tsx
+++ b/ui/src/components/ui/data-table.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from './data-table'
+
+type Row = { name: string; level: string }
+
+const columns: ColumnDef<Row>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'level', header: 'Level' },
+]
+
+const rows: Row[] = [
+  { name: 'aelric', level: 'Player' },
+  { name: 'althea', level: 'GrandMaster' },
+]
+
+describe('DataTable', () => {
+  it('renders rows and filters them by the search box', async () => {
+    render(<DataTable columns={columns} data={rows} searchPlaceholder="Search" />)
+
+    expect(screen.getByText('aelric')).toBeInTheDocument()
+    expect(screen.getByText('althea')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'alth')
+
+    expect(screen.queryByText('aelric')).not.toBeInTheDocument()
+    expect(screen.getByText('althea')).toBeInTheDocument()
+  })
+
+  it('sorts when a header is clicked', async () => {
+    render(<DataTable columns={columns} data={rows} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /name/i }))
+    const cells = screen.getAllByRole('cell').map((c) => c.textContent)
+    // ascending by name puts aelric before althea
+    expect(cells.indexOf('aelric')).toBeLessThan(cells.indexOf('althea'))
+  })
+})

--- a/ui/src/components/ui/data-table.tsx
+++ b/ui/src/components/ui/data-table.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import {
+  type ColumnDef,
+  type SortingState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './table'
+import { Input } from './input'
+
+// A searchable, sortable table over the styled primitives. Search is a global filter; each header is a
+// button that toggles that column's sort. Behaviour comes from TanStack Table; the look from the tokens.
+export function DataTable<T>({
+  columns,
+  data,
+  searchPlaceholder,
+}: {
+  columns: ColumnDef<T>[]
+  data: T[]
+  searchPlaceholder?: string
+}) {
+  const [globalFilter, setGlobalFilter] = useState('')
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { globalFilter, sorting },
+    onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  return (
+    <div className="flex flex-col gap-3">
+      {searchPlaceholder !== undefined && (
+        <Input
+          value={globalFilter}
+          placeholder={searchPlaceholder}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="max-w-xs"
+        />
+      )}
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((group) => (
+            <TableRow key={group.id}>
+              {group.headers.map((header) => (
+                <TableHead key={header.id}>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 uppercase"
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    <span className="text-gold">
+                      {{ asc: '▲', desc: '▼' }[header.column.getIsSorted() as string] ?? ''}
+                    </span>
+                  </button>
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {cell.column.columnDef.cell
+                    ? flexRender(cell.column.columnDef.cell, cell.getContext())
+                    : String(cell.getValue() ?? '')}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/ui/src/components/ui/dialog.test.tsx
+++ b/ui/src/components/ui/dialog.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from './dialog'
+
+describe('Dialog', () => {
+  it('opens on the trigger and shows the title', async () => {
+    render(
+      <Dialog>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Suspend account</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    )
+
+    expect(screen.queryByText('Suspend account')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByText('Open'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Suspend account')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -1,0 +1,156 @@
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/60 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-card border border-border-subtle bg-surface p-5 text-ink shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("font-display text-lg leading-none font-bold text-gold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/ui/src/components/ui/select.test.tsx
+++ b/ui/src/components/ui/select.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
+
+describe('Select', () => {
+  it('opens and reports the chosen value', async () => {
+    const onValueChange = vi.fn()
+    render(
+      <Select onValueChange={onValueChange}>
+        <SelectTrigger aria-label="facet">
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="felucca">Felucca</SelectItem>
+          <SelectItem value="trammel">Trammel</SelectItem>
+        </SelectContent>
+      </Select>,
+    )
+
+    await userEvent.click(screen.getByLabelText('facet'))
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
+    expect(onValueChange).toHaveBeenCalledWith('trammel')
+  })
+})

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -1,0 +1,189 @@
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      // Faithful to mg-select: bg-deep, gold focus, caret in border-strong.
+      className={cn(
+        "flex w-full items-center justify-between gap-2 rounded-control border border-border-subtle bg-deep px-3.5 py-2.5 text-sm text-ink whitespace-nowrap outline-none focus-visible:border-gold focus-visible:ring-[3px] focus-visible:ring-gold/20 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-faint data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-border-strong",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-control border border-border-subtle bg-surface text-ink shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-control py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-raised focus:text-ink data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/ui/src/components/ui/sonner.test.tsx
+++ b/ui/src/components/ui/sonner.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { Toaster, toast } from './sonner'
+
+describe('Toaster', () => {
+  it('shows a toast message', async () => {
+    render(<Toaster />)
+    toast.success('Account suspended')
+    await waitFor(() => expect(screen.getByText('Account suspended')).toBeInTheDocument())
+  })
+})

--- a/ui/src/components/ui/sonner.tsx
+++ b/ui/src/components/ui/sonner.tsx
@@ -1,14 +1,24 @@
 import { Toaster as Sonner, toast } from 'sonner'
+import type { CSSProperties } from 'react'
 
-// A single Toaster mounted at the app root. Styled onto the surface tokens; sonner keeps the portal,
-// stacking and duration bar. Variants are reached through toast.success/error/warning/info.
+// A single Toaster mounted at the app root; sonner keeps the portal, stacking and duration bar. Its
+// colours come from its own CSS variables, which default to a light palette — so they are pointed at the
+// Moongate tokens here. Because the tokens themselves flip with `data-theme`, the toast follows the theme
+// with no `theme` prop and no `dark:`.
+const surfaceVars = {
+  '--normal-bg': 'var(--mg-surface)',
+  '--normal-text': 'var(--mg-text)',
+  '--normal-border': 'var(--mg-border)',
+  '--border-radius': 'var(--mg-radius-card)',
+} as CSSProperties
+
 export function Toaster() {
   return (
     <Sonner
       position="bottom-right"
+      style={surfaceVars}
       toastOptions={{
         classNames: {
-          toast: 'rounded-card border border-border-subtle bg-surface text-ink shadow-lg',
           description: 'text-muted',
           success: 'border-success/40',
           error: 'border-danger/40',

--- a/ui/src/components/ui/sonner.tsx
+++ b/ui/src/components/ui/sonner.tsx
@@ -1,0 +1,23 @@
+import { Toaster as Sonner, toast } from 'sonner'
+
+// A single Toaster mounted at the app root. Styled onto the surface tokens; sonner keeps the portal,
+// stacking and duration bar. Variants are reached through toast.success/error/warning/info.
+export function Toaster() {
+  return (
+    <Sonner
+      position="bottom-right"
+      toastOptions={{
+        classNames: {
+          toast: 'rounded-card border border-border-subtle bg-surface text-ink shadow-lg',
+          description: 'text-muted',
+          success: 'border-success/40',
+          error: 'border-danger/40',
+          warning: 'border-gold/40',
+          info: 'border-info/40',
+        },
+      }}
+    />
+  )
+}
+
+export { toast }

--- a/ui/src/components/ui/switch.test.tsx
+++ b/ui/src/components/ui/switch.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Switch } from './switch'
+
+describe('Switch', () => {
+  it('toggles and reports the change', async () => {
+    const onCheckedChange = vi.fn()
+    render(<Switch aria-label="live-tail" onCheckedChange={onCheckedChange} />)
+    await userEvent.click(screen.getByRole('switch', { name: 'live-tail' }))
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/ui/src/components/ui/switch.tsx
+++ b/ui/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-gold data-[state=unchecked]:bg-border",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 data-[state=checked]:bg-gold-ink"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-hidden rounded-card border border-border-subtle"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      // Faithful to mg-row: bordered, hover strengthens the border; selection = a gold border, no
+      // background change.
+      className={cn(
+        "border-b border-border-subtle transition-colors hover:border-border-strong data-[state=selected]:border-gold",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-9 bg-deep px-3.5 text-left align-middle text-[11px] font-normal uppercase tracking-[0.12em] whitespace-nowrap text-faint [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "px-3.5 py-2.5 align-middle whitespace-nowrap text-ink [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/ui/src/components/ui/tabs.test.tsx
+++ b/ui/src/components/ui/tabs.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs'
+
+describe('Tabs', () => {
+  it('switches the visible panel', async () => {
+    render(
+      <Tabs defaultValue="status">
+        <TabsList>
+          <TabsTrigger value="status">Status</TabsTrigger>
+          <TabsTrigger value="log">Log</TabsTrigger>
+        </TabsList>
+        <TabsContent value="status">status panel</TabsContent>
+        <TabsContent value="log">log panel</TabsContent>
+      </Tabs>,
+    )
+
+    expect(screen.getByText('status panel')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('tab', { name: 'Log' }))
+    expect(screen.getByText('log panel')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import { Tabs as TabsPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+// Faithful to mg-tabs: a flex row underlined by a border, each tab muted, the active one gold with a
+// 2px gold underline. Simplified from the shadcn scaffold's variant/orientation machinery, which the
+// design does not use.
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return <TabsPrimitive.Root data-slot="tabs" className={cn('flex flex-col gap-4', className)} {...props} />
+}
+
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn('flex gap-6 border-b border-border-subtle', className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        'border-b-2 border-transparent py-3 text-sm text-muted outline-none hover:text-ink disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-gold data-[state=active]:font-bold data-[state=active]:text-gold',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content data-slot="tabs-content" className={cn('outline-none', className)} {...props} />
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -1,6 +1,15 @@
 import '@testing-library/jest-dom/vitest'
 import i18n from './src/lib/i18n'
 
+// jsdom lacks the pointer-capture and scroll APIs the Radix primitives call (Select, Dialog, …). Stub
+// them so those components can be exercised under Vitest; without these, opening a Radix Select throws.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+  Element.prototype.setPointerCapture = () => {}
+  Element.prototype.releasePointerCapture = () => {}
+}
+Element.prototype.scrollIntoView = () => {}
+
 // Pinned, not inherited. Assertions below match on rendered copy, so leaving the language to the app's
 // default would make every one of them a test of what that default happens to be — and they would all
 // break the day it changes, which is exactly what happened once already.


### PR DESCRIPTION
Second half of the Moongate control kit (issue #64), faithful to
`Moongate Controls.dc.html`. Library-first, restyled onto the tokens:

- **Select / Checkbox / Switch** — Radix via shadcn: bg-deep surfaces, gold
  when active/checked.
- **Dialog** — darkened overlay (`bg-black/60`), mg-card window, gold Cinzel
  title.
- **Tabs** — simplified from the shadcn scaffold to the design's gold-underline;
  Radix keeps the keyboard/aria. For in-page panels — the shell keeps its
  router NavLinks.
- **Toast** — sonner; its CSS variables point at the `--mg-*` tokens so it
  follows the theme.
- **Table + DataTable** — styled primitives (bg-deep header, mg-row rows,
  selection = gold border, no background change) plus a TanStack Table wrapper
  wiring global search and column sorting.

Shared: jsdom pointer/scroll polyfills in `vitest.setup.ts` so the Radix
primitives can be tested; adds `lucide-react` (the icons the scaffolds import),
`sonner`, `@tanstack/react-table`.

**Verified in a headless browser, both themes** (throwaway gallery, not
committed): every control matches the design, and the light theme recolours all
of it with no `dark:` leak. **The visual check earned itself again** — it caught
the toast rendering white on the dark theme (sonner's light default), fixed by
mapping its CSS variables to the tokens.

44 UI tests pass.

Closes #64.