### PR TITLE
UI: server version in login and the admin diagnostics slice

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,8 +3,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './lib/auth'
 import { AppShell } from './components/AppShell'
 import { RequireAuth } from './routes/RequireAuth'
+import { RequireAdmin } from './routes/RequireAdmin'
 import { LoginScreen } from './routes/LoginScreen'
 import { DashboardScreen } from './routes/DashboardScreen'
+import { AdminScreen } from './routes/AdminScreen'
 
 const queryClient = new QueryClient()
 
@@ -22,6 +24,18 @@ export function App() {
                   <AppShell>
                     <DashboardScreen />
                   </AppShell>
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/admin"
+              element={
+                <RequireAuth>
+                  <RequireAdmin>
+                    <AppShell>
+                      <AdminScreen />
+                    </AppShell>
+                  </RequireAdmin>
                 </RequireAuth>
               }
             />

--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import '../lib/i18n'
 import { AppShell } from './AppShell'
@@ -16,8 +16,34 @@ function renderShell() {
   )
 }
 
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+function renderWithLevel(level: string) {
+  localStorage.setItem(
+    'mg-token',
+    JSON.stringify({ token: 't', expiresAt: new Date(Date.now() + 3.6e6).toISOString() }),
+  )
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(json({ username: 'tom', level }))
+
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <AppShell>
+          <p>content</p>
+        </AppShell>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
 describe('AppShell', () => {
-  beforeEach(() => localStorage.clear())
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
 
   it('shows the brand, the tab row and the routed content', () => {
     renderShell()
@@ -30,5 +56,16 @@ describe('AppShell', () => {
   it('offers the theme toggle', () => {
     renderShell()
     expect(screen.getByRole('button', { name: /dark/i })).toBeInTheDocument()
+  })
+
+  it('shows the Admin tab for an admin session', async () => {
+    renderWithLevel('Administrator')
+    expect(await screen.findByRole('link', { name: /admin/i })).toBeInTheDocument()
+  })
+
+  it('hides the Admin tab from a player', async () => {
+    renderWithLevel('Player')
+    await waitFor(() => expect(screen.getByText('tom')).toBeInTheDocument())
+    expect(screen.queryByRole('link', { name: /admin/i })).not.toBeInTheDocument()
   })
 })

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -2,13 +2,14 @@ import type { ReactNode } from 'react'
 import { NavLink } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { useSession } from '../lib/auth'
+import { isAdmin } from '../lib/roles'
 import { ThemeToggle } from './ThemeToggle'
 import icon from '../assets/moongate-icon.png'
 
 /** The design's double bar: a 50px identity row above a 46px tab row. */
 export function AppShell({ children }: { children: ReactNode }) {
   const { t } = useTranslation()
-  const { username, signOut } = useSession()
+  const { username, level, signOut } = useSession()
 
   return (
     <div className="min-h-screen bg-page text-ink">
@@ -43,6 +44,19 @@ export function AppShell({ children }: { children: ReactNode }) {
         >
           {t('nav.dashboard')}
         </NavLink>
+
+        {isAdmin(level) && (
+          <NavLink
+            to="/admin"
+            className={({ isActive }) =>
+              isActive
+                ? 'flex items-center border-b-2 border-gold text-sm font-bold text-gold'
+                : 'flex items-center border-b-2 border-transparent text-sm text-muted hover:text-ink'
+            }
+          >
+            {t('nav.admin')}
+          </NavLink>
+        )}
       </nav>
 
       <main className="mx-auto max-w-[1300px] p-6">{children}</main>

--- a/ui/src/lib/queries.ts
+++ b/ui/src/lib/queries.ts
@@ -20,3 +20,8 @@ export const useMyCharacters = () =>
 
 export const useStats = () =>
   useQuery({ queryKey: ['stats'], queryFn: () => apiFetch<ServerStats>('/api/v1/stats') })
+
+export type ServerVersion = components['schemas']['VersionResponse']
+
+export const useVersion = () =>
+  useQuery({ queryKey: ['version'], queryFn: () => apiFetch<ServerVersion>('/api/v1/version') })

--- a/ui/src/lib/queries.ts
+++ b/ui/src/lib/queries.ts
@@ -25,3 +25,12 @@ export type ServerVersion = components['schemas']['VersionResponse']
 
 export const useVersion = () =>
   useQuery({ queryKey: ['version'], queryFn: () => apiFetch<ServerVersion>('/api/v1/version') })
+
+export type AdminStatus = components['schemas']['AdminStatusResponse']
+export type PluginInfo = components['schemas']['PluginInfoResponse']
+
+export const useAdminStatus = () =>
+  useQuery({ queryKey: ['admin', 'status'], queryFn: () => apiFetch<AdminStatus>('/api/v1/admin/status') })
+
+export const useAdminPlugins = () =>
+  useQuery({ queryKey: ['admin', 'plugins'], queryFn: () => apiFetch<PluginInfo[]>('/api/v1/admin/plugins') })

--- a/ui/src/lib/roles.test.ts
+++ b/ui/src/lib/roles.test.ts
@@ -1,0 +1,15 @@
+import { isAdmin } from './roles'
+
+describe('isAdmin', () => {
+  it('is true for the two staff levels', () => {
+    expect(isAdmin('Administrator')).toBe(true)
+    expect(isAdmin('GrandMaster')).toBe(true)
+  })
+
+  it('is false for a player, null, and anything else', () => {
+    expect(isAdmin('Player')).toBe(false)
+    expect(isAdmin(null)).toBe(false)
+    expect(isAdmin('administrator')).toBe(false) // case-sensitive: the role names are exact
+    expect(isAdmin('')).toBe(false)
+  })
+})

--- a/ui/src/lib/roles.ts
+++ b/ui/src/lib/roles.ts
@@ -1,0 +1,7 @@
+// The single definition of who counts as staff, matching the server's AdminPolicy (Administrator or
+// GrandMaster). The level is the role name exactly as the token carries it, so the match is exact.
+const ADMIN_LEVELS = ['Administrator', 'GrandMaster']
+
+export function isAdmin(level: string | null): boolean {
+  return level !== null && ADMIN_LEVELS.includes(level)
+}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -8,7 +8,8 @@
     "label": "Theme"
   },
   "nav": {
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "admin": "Admin"
   },
   "login": {
     "title": "MOONGATE",
@@ -38,5 +39,27 @@
   },
   "error": {
     "generic": "Something went wrong. Please try again."
+  },
+  "admin": {
+    "title": "Administration",
+    "status": {
+      "title": "Shard status",
+      "build": "Build",
+      "sessions": "Connected sessions"
+    },
+    "stats": {
+      "title": "Statistics",
+      "players": "Players online",
+      "accounts": "Accounts",
+      "npcs": "NPCs",
+      "items": "World items"
+    },
+    "plugins": {
+      "title": "Active plugins",
+      "routes": "{{count}} routes",
+      "external": "external",
+      "host": "host",
+      "empty": "No plugins reported."
+    }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -8,7 +8,8 @@
     "label": "Tema"
   },
   "nav": {
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "admin": "Admin"
   },
   "login": {
     "title": "MOONGATE",
@@ -38,5 +39,27 @@
   },
   "error": {
     "generic": "Qualcosa è andato storto. Riprova."
+  },
+  "admin": {
+    "title": "Amministrazione",
+    "status": {
+      "title": "Stato shard",
+      "build": "Build",
+      "sessions": "Sessioni connesse"
+    },
+    "stats": {
+      "title": "Statistiche",
+      "players": "Giocatori online",
+      "accounts": "Account",
+      "npcs": "NPC",
+      "items": "Oggetti nel mondo"
+    },
+    "plugins": {
+      "title": "Plugin attivi",
+      "routes": "{{count}} rotte",
+      "external": "esterno",
+      "host": "host",
+      "empty": "Nessun plugin riportato."
+    }
   }
 }

--- a/ui/src/routes/AdminScreen.test.tsx
+++ b/ui/src/routes/AdminScreen.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../lib/i18n'
+import { AdminScreen } from './AdminScreen'
+
+function renderAdmin() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <AdminScreen />
+    </QueryClientProvider>,
+  )
+}
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+describe('AdminScreen', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('shows shard status, statistics and the plugin list', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input)
+
+      if (url.endsWith('/api/v1/admin/status')) {
+        return json({ shardName: 'Moongate', version: '1.2.3', onlineSessions: 4 })
+      }
+      if (url.endsWith('/api/v1/stats')) {
+        return json({
+          players: { online: 42, connections: 45 },
+          accounts: { total: 7, active: 5, characters: 19 },
+          world: { npcs: 12, items: 340 },
+          content: { itemTemplates: 1665, mobileTemplates: 19 },
+        })
+      }
+      if (url.endsWith('/api/v1/admin/plugins')) {
+        return json([
+          {
+            id: 'moongate.http',
+            name: 'HTTP',
+            version: '0.4.0',
+            author: 'moongate',
+            description: '',
+            assembly: 'Moongate.Http.Plugin',
+            isExternal: true,
+            routes: [{ method: 'GET', path: '/x', policy: null }],
+          },
+        ])
+      }
+      return json({})
+    })
+
+    renderAdmin()
+
+    expect(await screen.findByText('1.2.3')).toBeInTheDocument() // build
+    expect(await screen.findByText('4')).toBeInTheDocument() // sessions
+    expect(await screen.findByText('42')).toBeInTheDocument() // players online
+    expect(await screen.findByText('HTTP')).toBeInTheDocument() // plugin name
+  })
+})

--- a/ui/src/routes/AdminScreen.tsx
+++ b/ui/src/routes/AdminScreen.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next'
+import { Card } from '../components/ui/card'
+import { StatCard } from '../components/ui/stat-card'
+import { Badge } from '../components/ui/badge'
+import { useAdminPlugins, useAdminStatus, useStats } from '../lib/queries'
+
+// The admin area's first screen: read-only diagnostics, composed from the Moongate control kit — a row of
+// stat cards over the shard status and statistics, and a card listing the active plugins.
+export function AdminScreen() {
+  const { t } = useTranslation()
+  const status = useAdminStatus()
+  const stats = useStats()
+  const plugins = useAdminPlugins()
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="font-display text-xl text-ink">{t('admin.title')}</h1>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.status.title')}</h2>
+        <div className="grid grid-cols-3 gap-4">
+          <StatCard label={t('app.name')} value={status.data?.shardName} tone="text-gold" />
+          <StatCard label={t('admin.status.build')} value={status.data?.version} />
+          <StatCard label={t('admin.status.sessions')} value={status.data?.onlineSessions} />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.stats.title')}</h2>
+        <div className="grid grid-cols-4 gap-4">
+          <StatCard label={t('admin.stats.players')} value={stats.data?.players.online} tone="text-success" />
+          <StatCard label={t('admin.stats.accounts')} value={stats.data?.accounts.total} />
+          <StatCard label={t('admin.stats.npcs')} value={stats.data?.world.npcs} />
+          <StatCard label={t('admin.stats.items')} value={stats.data?.world.items} />
+        </div>
+      </section>
+
+      <Card className="p-5">
+        <h2 className="mb-3 font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.plugins.title')}</h2>
+        {plugins.isError && (
+          <p role="alert" className="text-sm text-danger-text">
+            {t('error.generic')}
+          </p>
+        )}
+        {plugins.data?.length === 0 && <p className="text-sm text-muted">{t('admin.plugins.empty')}</p>}
+        <ul className="flex flex-col gap-2">
+          {plugins.data?.map((plugin) => (
+            <li
+              key={plugin.id}
+              className="flex items-center gap-3 rounded-card border border-border-subtle bg-page px-3 py-2.5"
+            >
+              <span className="text-sm font-bold text-ink">{plugin.name}</span>
+              <span className="font-mono text-xs text-muted">{plugin.version}</span>
+              <span className="text-xs text-faint">{t('admin.plugins.routes', { count: plugin.routes.length })}</span>
+              <span className="ml-auto">
+                <Badge variant={plugin.isExternal ? 'info' : 'staff'}>
+                  {plugin.isExternal ? t('admin.plugins.external') : t('admin.plugins.host')}
+                </Badge>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    </div>
+  )
+}

--- a/ui/src/routes/LoginScreen.test.tsx
+++ b/ui/src/routes/LoginScreen.test.tsx
@@ -52,9 +52,19 @@ describe('LoginScreen', () => {
           accounts: { total: 7, active: 5, characters: 19 },
         })
       }
+      if (url.endsWith('/api/v1/version')) {
+        return json({ shardName: 'Moongate', version: '9.9.9' })
+      }
       return json({ username: 'tom', level: 'Player' })
     })
   }
+
+  it('shows the server version once it resolves', async () => {
+    serveApi()
+    renderLogin()
+
+    expect(await screen.findByText(/Moongate · v9\.9\.9/)).toBeInTheDocument()
+  })
 
   it('sends the credentials and stores the issued token', async () => {
     serveApi()

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { ApiError } from '../lib/api'
 import { useSession } from '../lib/auth'
-import { useStats } from '../lib/queries'
+import { useStats, useVersion } from '../lib/queries'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -13,6 +13,7 @@ export function LoginScreen() {
   const { t } = useTranslation()
   const { status, signIn } = useSession()
   const stats = useStats()
+  const version = useVersion()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [remember, setRemember] = useState(true)
@@ -120,6 +121,14 @@ export function LoginScreen() {
         <p className="border-t border-border-subtle pt-4 text-xs leading-relaxed text-faint">
           {t('login.staffNote')}
         </p>
+
+        {/* Data from the anonymous /api/v1/version, not UI copy — no i18n key needed. Rendered only once
+            it resolves, so an unreached shard shows nothing rather than "undefined". */}
+        {version.data?.version !== undefined && (
+          <p className="text-xs text-faint">
+            {version.data.shardName} · v{version.data.version}
+          </p>
+        )}
       </form>
     </div>
   )

--- a/ui/src/routes/RequireAdmin.test.tsx
+++ b/ui/src/routes/RequireAdmin.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import '../lib/i18n'
+import { AuthProvider } from '../lib/auth'
+import { RequireAdmin } from './RequireAdmin'
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+function futureIso() {
+  return new Date(Date.now() + 3.6e6).toISOString()
+}
+
+function renderAt(level: string) {
+  localStorage.setItem('mg-token', JSON.stringify({ token: 't', expiresAt: futureIso() }))
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(json({ username: 'tom', level }))
+
+  return render(
+    <MemoryRouter initialEntries={['/admin']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<p>dashboard</p>} />
+          <Route
+            path="/admin"
+            element={
+              <RequireAdmin>
+                <p>admin content</p>
+              </RequireAdmin>
+            }
+          />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('RequireAdmin', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('renders children for an admin session', async () => {
+    renderAt('Administrator')
+    expect(await screen.findByText('admin content')).toBeInTheDocument()
+  })
+
+  it('redirects a player to the dashboard', async () => {
+    renderAt('Player')
+    expect(await screen.findByText('dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('admin content')).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/RequireAdmin.tsx
+++ b/ui/src/routes/RequireAdmin.tsx
@@ -1,0 +1,23 @@
+import { Navigate } from 'react-router'
+import type { ReactNode } from 'react'
+import { useSession } from '../lib/auth'
+import { isAdmin } from '../lib/roles'
+
+/**
+ * Role gate for the admin area. A non-admin is sent to the dashboard, not to a dead end — the same
+ * principle RequireAuth states: a refused user keeps the shell and its navigation. The anonymous case is
+ * already handled by RequireAuth, which wraps this.
+ */
+export function RequireAdmin({ children }: { children: ReactNode }) {
+  const { status, level } = useSession()
+
+  if (status === 'loading') {
+    return null
+  }
+
+  if (!isAdmin(level)) {
+    return <Navigate to="/" replace />
+  }
+
+  return <>{children}</>
+}


### PR DESCRIPTION
Closes #66. Two increments that compose from the control kit (#63/#65).

## Server version on login

A `useVersion()` hook reads the anonymous `/api/v1/version`; the login renders
a faint `shard · vX.Y.Z` line once it resolves — readable before anyone signs
in, like the online count. It is data, not copy, so no i18n key.

## The admin area — foundation + diagnostics

- `isAdmin(level)` — the single definition of staff (Administrator /
  GrandMaster), matching the server's AdminPolicy.
- `RequireAdmin` — sends a non-admin to the dashboard, not a dead end, the same
  principle RequireAuth follows.
- An **Admin tab** in the shell, shown only to admins, and a guarded `/admin`
  route inside the shell.
- **AdminScreen** — read-only diagnostics built from the kit: shard status and
  statistics as rows of StatCards, the active plugins as a card listing each
  plugin's version, route count and an external/host Badge. On endpoints that
  already exist (`/admin/status`, `/stats`, `/admin/plugins`).

## Verification

52 UI tests. **Verified end to end against the running server** in a headless
browser, both themes: signing in as `admin` reveals the Admin tab, `/admin`
shows the three sections with the real 0.4.0 build and the live plugin list
(HTTP 43 routes, News 7, …), and the light theme recolours all of it with no
`dark:` leak. Zero console errors.

This is the admin subsystem's first slice; accounts, news, settings and the
console follow on this shell.