### PR TITLE
Raise every type size by one pixel

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -15,7 +15,7 @@ export function AppShell({ children }: { children: ReactNode }) {
     <div className="min-h-screen bg-page text-ink">
       <header className="flex h-[var(--mg-topbar-h)] items-center gap-3 border-b border-border-subtle bg-surface px-5">
         <img src={icon} alt="" className="size-[26px] rounded-control object-cover" />
-        <span className="font-display text-[15px] font-bold tracking-wider text-gold">{t('app.name')}</span>
+        <span className="font-display text-[16px] font-bold tracking-wider text-gold">{t('app.name')}</span>
         <div className="flex-1" />
         <span className="text-xs tracking-widest text-faint">{t('theme.label')}</span>
         <ThemeToggle />

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 // Faithful to mg-badge: 700 11px, radius 2px, padding 3px 10px, with the variant tinting text at full
 // colour, background at 10% and border at 40%. The staff variant is letter-spaced.
 const badgeVariants = cva(
-  'inline-flex items-center rounded-control border px-2.5 py-[3px] text-[11px] font-bold leading-none',
+  'inline-flex items-center rounded-control border px-2.5 py-[3px] text-[12px] font-bold leading-none',
   {
     variants: {
       variant: {

--- a/ui/src/components/ui/counter.tsx
+++ b/ui/src/components/ui/counter.tsx
@@ -6,7 +6,7 @@ export function Counter({ children, className }: { children: ReactNode; classNam
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-control bg-danger px-2 py-0.5 text-[11px] font-bold leading-none text-white',
+        'inline-flex items-center rounded-control bg-danger px-2 py-0.5 text-[12px] font-bold leading-none text-white',
         className,
       )}
     >

--- a/ui/src/components/ui/stat-card.tsx
+++ b/ui/src/components/ui/stat-card.tsx
@@ -17,8 +17,8 @@ export function StatCard({
 }) {
   return (
     <div className={cn('rounded-card border border-border-subtle bg-surface px-[18px] py-4', className)}>
-      <div className="mb-2 text-[11.5px] uppercase tracking-[0.1em] text-faint">{label}</div>
-      <div className={cn('font-mono text-[26px] font-bold text-ink', tone)}>{value ?? '—'}</div>
+      <div className="mb-2 text-[12.5px] uppercase tracking-[0.1em] text-faint">{label}</div>
+      <div className={cn('font-mono text-[27px] font-bold text-ink', tone)}>{value ?? '—'}</div>
       {sub !== undefined && <div className="mt-[3px] text-xs text-muted">{sub}</div>}
     </div>
   )

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-9 bg-deep px-3.5 text-left align-middle text-[11px] font-normal uppercase tracking-[0.12em] whitespace-nowrap text-faint [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-9 bg-deep px-3.5 text-left align-middle text-[12px] font-normal uppercase tracking-[0.12em] whitespace-nowrap text-faint [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/ui/src/routes/AdminScreen.tsx
+++ b/ui/src/routes/AdminScreen.tsx
@@ -17,7 +17,7 @@ export function AdminScreen() {
       <h1 className="font-display text-xl text-ink">{t('admin.title')}</h1>
 
       <section className="flex flex-col gap-3">
-        <h2 className="font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.status.title')}</h2>
+        <h2 className="font-display text-[14px] tracking-[0.08em] text-gold">{t('admin.status.title')}</h2>
         <div className="grid grid-cols-3 gap-4">
           <StatCard label={t('app.name')} value={status.data?.shardName} tone="text-gold" />
           <StatCard label={t('admin.status.build')} value={status.data?.version} />
@@ -26,7 +26,7 @@ export function AdminScreen() {
       </section>
 
       <section className="flex flex-col gap-3">
-        <h2 className="font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.stats.title')}</h2>
+        <h2 className="font-display text-[14px] tracking-[0.08em] text-gold">{t('admin.stats.title')}</h2>
         <div className="grid grid-cols-4 gap-4">
           <StatCard label={t('admin.stats.players')} value={stats.data?.players.online} tone="text-success" />
           <StatCard label={t('admin.stats.accounts')} value={stats.data?.accounts.total} />
@@ -36,7 +36,7 @@ export function AdminScreen() {
       </section>
 
       <Card className="p-5">
-        <h2 className="mb-3 font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.plugins.title')}</h2>
+        <h2 className="mb-3 font-display text-[14px] tracking-[0.08em] text-gold">{t('admin.plugins.title')}</h2>
         {plugins.isError && (
           <p role="alert" className="text-sm text-danger-text">
             {t('error.generic')}

--- a/ui/src/routes/DashboardScreen.tsx
+++ b/ui/src/routes/DashboardScreen.tsx
@@ -15,7 +15,7 @@ export function DashboardScreen() {
       </h1>
 
       <Card className="p-5">
-        <h2 className="mb-3 font-display text-[13px] tracking-widest text-gold">
+        <h2 className="mb-3 font-display text-[14px] tracking-widest text-gold">
           {t('dashboard.characters')}
         </h2>
 
@@ -44,7 +44,7 @@ export function DashboardScreen() {
       </Card>
 
       <Card className="p-5">
-        <h2 className="mb-3 font-display text-[13px] tracking-widest text-gold">{t('dashboard.shard')}</h2>
+        <h2 className="mb-3 font-display text-[14px] tracking-widest text-gold">{t('dashboard.shard')}</h2>
 
         {stats.isError && (
           <p role="alert" className="text-sm text-danger-text">
@@ -69,7 +69,7 @@ export function DashboardScreen() {
 function Figure({ label, value }: { label: string; value: number | undefined }) {
   return (
     <div>
-      <dt className="text-[11px] uppercase tracking-widest text-faint">{label}</dt>
+      <dt className="text-[12px] uppercase tracking-widest text-faint">{label}</dt>
       <dd className="font-mono text-2xl font-bold text-ink">{value ?? '—'}</dd>
     </div>
   )

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -58,7 +58,7 @@ export function LoginScreen() {
           />
         </div>
 
-        <p className="relative font-display text-[15px] text-gold">&ldquo;{t('login.quote')}&rdquo;</p>
+        <p className="relative font-display text-[16px] text-gold">&ldquo;{t('login.quote')}&rdquo;</p>
 
         {/* Real, and public: /api/v1/stats is anonymous, so the count is readable before anyone signs in.
             Rendered only once the reply lands — a zero here means an empty shard, which is worth saying,
@@ -71,7 +71,7 @@ export function LoginScreen() {
       </div>
 
       <form onSubmit={submit} className="flex w-full max-w-[420px] flex-col justify-center gap-4 px-12">
-        <h1 className="font-display text-[22px] font-bold tracking-wider text-gold">{t('login.title')}</h1>
+        <h1 className="font-display text-[23px] font-bold tracking-wider text-gold">{t('login.title')}</h1>
         <p className="text-sm text-muted">{t('login.subtitle')}</p>
 
         <div className="flex flex-col gap-1.5">

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -38,6 +38,16 @@
   --font-sans: var(--mg-font-body);
   --font-mono: var(--mg-font-mono);
 
+  /* Type scale, each step one pixel above Tailwind's default (12/14/16/18/20/24 → 13/15/17/19/21/25).
+     Line-heights stay on Tailwind's default ratios. The arbitrary text-[Npx] literals across the
+     components are bumped by the same +1px so every size grows together. */
+  --text-xs: 13px;
+  --text-sm: 15px;
+  --text-base: 17px;
+  --text-lg: 19px;
+  --text-xl: 21px;
+  --text-2xl: 25px;
+
   --radius-control: var(--mg-radius-control);
   --radius-card: var(--mg-radius-card);
 


### PR DESCRIPTION
Every font size up 1px, as requested.

- The Tailwind named scale via the `--text-*` theme variables:
  `xs/sm/base/lg/xl/2xl` → 13/15/17/19/21/25 (from 12/14/16/18/20/24).
- The arbitrary `text-[Npx]` literals across the components bumped by the same
  +1px (11→12, 11.5→12.5, 13→14, 15→16, 22→23, 26→27), so no size is left
  behind.

Line-heights stay on Tailwind's default ratios. The design's `tokens.css` holds
no sizes, so it is untouched.

52 UI tests pass. Verified in a headless browser, both themes: text reads a
touch larger across login, dashboard, the admin screen and the control kit,
with the layout intact and no overflow.