### PR TITLE
Admin account management: list, create, edit, suspend, delete

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,8 @@ import { RequireAdmin } from './routes/RequireAdmin'
 import { LoginScreen } from './routes/LoginScreen'
 import { DashboardScreen } from './routes/DashboardScreen'
 import { AdminScreen } from './routes/AdminScreen'
+import { AdminLayout } from './routes/AdminLayout'
+import { AccountsScreen } from './routes/AccountsScreen'
 
 const queryClient = new QueryClient()
 
@@ -33,12 +35,15 @@ export function App() {
                 <RequireAuth>
                   <RequireAdmin>
                     <AppShell>
-                      <AdminScreen />
+                      <AdminLayout />
                     </AppShell>
                   </RequireAdmin>
                 </RequireAuth>
               }
-            />
+            >
+              <Route index element={<AdminScreen />} />
+              <Route path="accounts" element={<AccountsScreen />} />
+            </Route>
           </Routes>
         </AuthProvider>
       </BrowserRouter>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,12 +9,14 @@ import { DashboardScreen } from './routes/DashboardScreen'
 import { AdminScreen } from './routes/AdminScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
+import { Toaster } from './components/ui/sonner'
 
 const queryClient = new QueryClient()
 
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <Toaster />
       <BrowserRouter>
         <AuthProvider>
           <Routes>

--- a/ui/src/lib/accounts.test.tsx
+++ b/ui/src/lib/accounts.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useAccounts, useCreateAccount, useDeleteAccount, useUpdateAccount } from './accounts'
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('accounts data module', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('useAccounts reads the list', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      json([{ username: 'tom', email: null, level: 'Player', isActive: true, characterCount: 2 }]),
+    )
+    const { result } = renderHook(() => useAccounts(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.data?.[0].username).toBe('tom'))
+  })
+
+  it('useCreateAccount POSTs the body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      json({ username: 'new', email: null, level: 'Player', isActive: true, characterCount: 0 }, 201),
+    )
+    const { result } = renderHook(() => useCreateAccount(), { wrapper: wrapper() })
+    await result.current.mutateAsync({ username: 'new', password: 'pw' })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/accounts')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({ username: 'new', password: 'pw' })
+  })
+
+  it('useUpdateAccount PATCHes the named account', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      json({ username: 'tom', email: null, level: 'Administrator', isActive: false, characterCount: 2 }),
+    )
+    const { result } = renderHook(() => useUpdateAccount(), { wrapper: wrapper() })
+    await result.current.mutateAsync({ username: 'tom', patch: { isActive: false } })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/accounts/tom')
+    expect((init as RequestInit).method).toBe('PATCH')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ isActive: false })
+  })
+
+  it('useDeleteAccount DELETEs the named account', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper: wrapper() })
+    await result.current.mutateAsync('tom')
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/accounts/tom')
+    expect((init as RequestInit).method).toBe('DELETE')
+  })
+})

--- a/ui/src/lib/accounts.ts
+++ b/ui/src/lib/accounts.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiFetch, apiPath } from './api'
+import type { components } from './api-types'
+
+export type Account = components['schemas']['AccountResponse']
+export type CreateAccount = components['schemas']['CreateAccountRequest']
+export type UpdateAccount = components['schemas']['UpdateAccountRequest']
+
+const LIST_KEY = ['admin', 'accounts']
+const ACCOUNT = '/api/v1/admin/accounts/{username}'
+
+export const useAccounts = () =>
+  useQuery({ queryKey: LIST_KEY, queryFn: () => apiFetch<Account[]>('/api/v1/admin/accounts') })
+
+export function useCreateAccount() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (body: CreateAccount) =>
+      apiFetch<Account>('/api/v1/admin/accounts', { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: () => client.invalidateQueries({ queryKey: LIST_KEY }),
+  })
+}
+
+export function useUpdateAccount() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: ({ username, patch }: { username: string; patch: UpdateAccount }) =>
+      apiFetch<Account>(apiPath(ACCOUNT, { username }), { method: 'PATCH', body: JSON.stringify(patch) }),
+    onSuccess: () => client.invalidateQueries({ queryKey: LIST_KEY }),
+  })
+}
+
+export function useDeleteAccount() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (username: string) => apiFetch<void>(apiPath(ACCOUNT, { username }), { method: 'DELETE' }),
+    onSuccess: () => client.invalidateQueries({ queryKey: LIST_KEY }),
+  })
+}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -87,7 +87,17 @@
         "Player": "Player",
         "GrandMaster": "GrandMaster",
         "Administrator": "Administrator"
-      }
+      },
+      "edit": "Manage {{username}}",
+      "suspendedLabel": "Suspended",
+      "newPassword": "New password",
+      "newPasswordHint": "Leave blank to keep the current password.",
+      "save": "Save",
+      "saved": "Account updated.",
+      "delete": "Delete account",
+      "deleteConfirm": "Delete {{username}} for good? This cannot be undone.",
+      "deleteYes": "Delete",
+      "deleted": "Account deleted."
     }
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -64,6 +64,20 @@
     "nav": {
       "overview": "Overview",
       "accounts": "Accounts"
+    },
+    "accounts": {
+      "title": "Accounts",
+      "new": "New account",
+      "search": "Search username, email…",
+      "username": "Username",
+      "email": "Email",
+      "level": "Level",
+      "status": "Status",
+      "characters": "Characters",
+      "active": "active",
+      "suspended": "suspended",
+      "manage": "Manage",
+      "none": "—"
     }
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -77,7 +77,17 @@
       "active": "active",
       "suspended": "suspended",
       "manage": "Manage",
-      "none": "—"
+      "none": "—",
+      "password": "Password",
+      "create": "Create",
+      "cancel": "Cancel",
+      "taken": "That username is already taken.",
+      "created": "Account created.",
+      "levels": {
+        "Player": "Player",
+        "GrandMaster": "GrandMaster",
+        "Administrator": "Administrator"
+      }
     }
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -60,6 +60,10 @@
       "external": "external",
       "host": "host",
       "empty": "No plugins reported."
+    },
+    "nav": {
+      "overview": "Overview",
+      "accounts": "Accounts"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -60,6 +60,10 @@
       "external": "esterno",
       "host": "host",
       "empty": "Nessun plugin riportato."
+    },
+    "nav": {
+      "overview": "Panoramica",
+      "accounts": "Account"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -64,6 +64,20 @@
     "nav": {
       "overview": "Panoramica",
       "accounts": "Account"
+    },
+    "accounts": {
+      "title": "Account",
+      "new": "Nuovo account",
+      "search": "Cerca username, email…",
+      "username": "Username",
+      "email": "Email",
+      "level": "Livello",
+      "status": "Stato",
+      "characters": "Personaggi",
+      "active": "attivo",
+      "suspended": "sospeso",
+      "manage": "Gestisci",
+      "none": "—"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -77,7 +77,17 @@
       "active": "attivo",
       "suspended": "sospeso",
       "manage": "Gestisci",
-      "none": "—"
+      "none": "—",
+      "password": "Password",
+      "create": "Crea",
+      "cancel": "Annulla",
+      "taken": "Questo username è già in uso.",
+      "created": "Account creato.",
+      "levels": {
+        "Player": "Player",
+        "GrandMaster": "GrandMaster",
+        "Administrator": "Administrator"
+      }
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -87,7 +87,17 @@
         "Player": "Player",
         "GrandMaster": "GrandMaster",
         "Administrator": "Administrator"
-      }
+      },
+      "edit": "Gestisci {{username}}",
+      "suspendedLabel": "Sospeso",
+      "newPassword": "Nuova password",
+      "newPasswordHint": "Lascia vuoto per non cambiarla.",
+      "save": "Salva",
+      "saved": "Account aggiornato.",
+      "delete": "Elimina account",
+      "deleteConfirm": "Eliminare {{username}} definitivamente? Non è reversibile.",
+      "deleteYes": "Elimina",
+      "deleted": "Account eliminato."
     }
   }
 }

--- a/ui/src/routes/AccountsScreen.tsx
+++ b/ui/src/routes/AccountsScreen.tsx
@@ -1,0 +1,4 @@
+// ui/src/routes/AccountsScreen.tsx — replaced in full by Task 3
+export function AccountsScreen() {
+  return null
+}

--- a/ui/src/routes/AccountsScreen.tsx
+++ b/ui/src/routes/AccountsScreen.tsx
@@ -1,4 +1,71 @@
-// ui/src/routes/AccountsScreen.tsx — replaced in full by Task 3
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '../components/ui/data-table'
+import { Badge } from '../components/ui/badge'
+import { Button } from '../components/ui/button'
+import { useAccounts, type Account } from '../lib/accounts'
+import { isAdmin } from '../lib/roles'
+import { NewAccountDialog } from './accounts/NewAccountDialog'
+import { EditAccountDialog } from './accounts/EditAccountDialog'
+
 export function AccountsScreen() {
-  return null
+  const { t } = useTranslation()
+  const accounts = useAccounts()
+  const [editing, setEditing] = useState<Account | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  const columns = useMemo<ColumnDef<Account>[]>(
+    () => [
+      { accessorKey: 'username', header: t('admin.accounts.username') },
+      {
+        accessorKey: 'email',
+        header: t('admin.accounts.email'),
+        cell: ({ getValue }) => (getValue() as string | null) ?? t('admin.accounts.none'),
+      },
+      {
+        accessorKey: 'level',
+        header: t('admin.accounts.level'),
+        cell: ({ getValue }) => {
+          const level = getValue() as string
+          return <Badge variant={isAdmin(level) ? 'staff' : 'info'}>{level}</Badge>
+        },
+      },
+      {
+        accessorKey: 'isActive',
+        header: t('admin.accounts.status'),
+        cell: ({ getValue }) =>
+          (getValue() as boolean) ? (
+            <Badge variant="success">{t('admin.accounts.active')}</Badge>
+          ) : (
+            <Badge variant="danger">{t('admin.accounts.suspended')}</Badge>
+          ),
+      },
+      { accessorKey: 'characterCount', header: t('admin.accounts.characters') },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <Button variant="default" className="px-3 py-1 text-xs" onClick={() => setEditing(row.original)}>
+            {t('admin.accounts.manage')}
+          </Button>
+        ),
+      },
+    ],
+    [t],
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-xl text-ink">{t('admin.accounts.title')}</h1>
+        <Button onClick={() => setCreating(true)}>{t('admin.accounts.new')}</Button>
+      </div>
+
+      <DataTable columns={columns} data={accounts.data ?? []} searchPlaceholder={t('admin.accounts.search')} />
+
+      <NewAccountDialog open={creating} onOpenChange={setCreating} />
+      <EditAccountDialog account={editing} onOpenChange={(open) => !open && setEditing(null)} />
+    </div>
+  )
 }

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -1,0 +1,26 @@
+import { NavLink, Outlet } from 'react-router'
+import { useTranslation } from 'react-i18next'
+
+const linkClass = ({ isActive }: { isActive: boolean }) =>
+  isActive
+    ? 'flex items-center border-b-2 border-gold py-2 text-sm font-bold text-gold'
+    : 'flex items-center border-b-2 border-transparent py-2 text-sm text-muted hover:text-ink'
+
+/** The admin area's own tab row, above whichever admin screen is routed below it. */
+export function AdminLayout() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col gap-5">
+      <nav className="flex gap-6 border-b border-border-subtle">
+        <NavLink to="/admin" end className={linkClass}>
+          {t('admin.nav.overview')}
+        </NavLink>
+        <NavLink to="/admin/accounts" className={linkClass}>
+          {t('admin.nav.accounts')}
+        </NavLink>
+      </nav>
+      <Outlet />
+    </div>
+  )
+}

--- a/ui/src/routes/accounts/EditAccountDialog.test.tsx
+++ b/ui/src/routes/accounts/EditAccountDialog.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../../lib/i18n'
+import { EditAccountDialog } from './EditAccountDialog'
+import type { Account } from '../../lib/accounts'
+
+const account: Account = { username: 'grimble', email: null, level: 'Player', isActive: true, characterCount: 1 }
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <EditAccountDialog account={account} onOpenChange={() => {}} />
+    </QueryClientProvider>,
+  )
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('EditAccountDialog', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('saves the suspended state via PATCH', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json({ ...account, isActive: false }))
+    renderDialog()
+
+    await userEvent.click(screen.getByRole('switch', { name: /suspended/i }))
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      const [url, init] = fetchSpy.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/accounts/grimble')
+      expect((init as RequestInit).method).toBe('PATCH')
+      expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({ isActive: false })
+    })
+  })
+
+  it('deletes after confirming', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+    renderDialog()
+
+    await userEvent.click(screen.getByRole('button', { name: /delete account/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => {
+      const [url, init] = fetchSpy.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/accounts/grimble')
+      expect((init as RequestInit).method).toBe('DELETE')
+    })
+  })
+})

--- a/ui/src/routes/accounts/EditAccountDialog.tsx
+++ b/ui/src/routes/accounts/EditAccountDialog.tsx
@@ -1,6 +1,140 @@
-// ui/src/routes/accounts/EditAccountDialog.tsx — replaced in full by Task 5
-import type { Account } from '../../lib/accounts'
+import { useEffect, useState, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDeleteAccount, useUpdateAccount, type Account, type UpdateAccount } from '../../lib/accounts'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/dialog'
+import { Input } from '../../components/ui/input'
+import { Label } from '../../components/ui/label'
+import { Button } from '../../components/ui/button'
+import { Switch } from '../../components/ui/switch'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui/select'
+import { toast } from '../../components/ui/sonner'
 
-export function EditAccountDialog({ account }: { account: Account | null; onOpenChange: (o: boolean) => void }) {
-  return account ? null : null
+const LEVELS = ['Player', 'GrandMaster', 'Administrator']
+
+export function EditAccountDialog({
+  account,
+  onOpenChange,
+}: {
+  account: Account | null
+  onOpenChange: (open: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const update = useUpdateAccount()
+  const remove = useDeleteAccount()
+
+  const [level, setLevel] = useState('Player')
+  const [suspended, setSuspended] = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+
+  // Reset the form whenever a different account opens the dialog.
+  useEffect(() => {
+    if (account) {
+      setLevel(account.level)
+      setSuspended(!account.isActive)
+      setPassword('')
+      setConfirmingDelete(false)
+    }
+  }, [account])
+
+  if (account === null) {
+    return null
+  }
+
+  async function save(event: FormEvent) {
+    event.preventDefault()
+    // Only the fields that actually changed, so a save never rewrites what it did not touch.
+    const patch: UpdateAccount = {}
+    if (level !== account!.level) patch.level = level
+    if (suspended === account!.isActive) patch.isActive = !suspended
+    if (password.length > 0) patch.password = password
+
+    try {
+      if (Object.keys(patch).length > 0) {
+        await update.mutateAsync({ username: account!.username, patch })
+      }
+      toast.success(t('admin.accounts.saved'))
+      onOpenChange(false)
+    } catch {
+      toast.error(t('error.generic'))
+    }
+  }
+
+  async function confirmDelete() {
+    try {
+      await remove.mutateAsync(account!.username)
+      toast.success(t('admin.accounts.deleted'))
+      onOpenChange(false)
+    } catch {
+      toast.error(t('error.generic'))
+    }
+  }
+
+  return (
+    <Dialog open={account !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={save} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>{t('admin.accounts.edit', { username: account.username })}</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>{t('admin.accounts.level')}</Label>
+            <Select value={level} onValueChange={setLevel}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {LEVELS.map((l) => (
+                  <SelectItem key={l} value={l}>
+                    {t(`admin.accounts.levels.${l}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Label className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={suspended}
+              onCheckedChange={setSuspended}
+              aria-label={t('admin.accounts.suspendedLabel')}
+            />
+            {t('admin.accounts.suspendedLabel')}
+          </Label>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-password">{t('admin.accounts.newPassword')}</Label>
+            <Input id="edit-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+            <p className="text-xs text-faint">{t('admin.accounts.newPasswordHint')}</p>
+          </div>
+
+          <DialogFooter className="flex items-center justify-between gap-2">
+            {confirmingDelete ? (
+              <span className="flex items-center gap-2">
+                <span className="text-sm text-danger-text">
+                  {t('admin.accounts.deleteConfirm', { username: account.username })}
+                </span>
+                <Button type="button" variant="destructive" onClick={confirmDelete} disabled={remove.isPending}>
+                  {t('admin.accounts.deleteYes')}
+                </Button>
+              </span>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-danger-text"
+                onClick={() => setConfirmingDelete(true)}
+              >
+                {t('admin.accounts.delete')}
+              </Button>
+            )}
+            <Button type="submit" disabled={update.isPending}>
+              {t('admin.accounts.save')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
 }

--- a/ui/src/routes/accounts/EditAccountDialog.tsx
+++ b/ui/src/routes/accounts/EditAccountDialog.tsx
@@ -1,0 +1,6 @@
+// ui/src/routes/accounts/EditAccountDialog.tsx — replaced in full by Task 5
+import type { Account } from '../../lib/accounts'
+
+export function EditAccountDialog({ account }: { account: Account | null; onOpenChange: (o: boolean) => void }) {
+  return account ? null : null
+}

--- a/ui/src/routes/accounts/NewAccountDialog.test.tsx
+++ b/ui/src/routes/accounts/NewAccountDialog.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../../lib/i18n'
+import { NewAccountDialog } from './NewAccountDialog'
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <NewAccountDialog open onOpenChange={() => {}} />
+    </QueryClientProvider>,
+  )
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('NewAccountDialog', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('posts the new account', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(json({ username: 'new', email: null, level: 'Player', isActive: true, characterCount: 0 }, 201))
+    renderDialog()
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'new')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith('/api/v1/admin/accounts', expect.objectContaining({ method: 'POST' })),
+    )
+  })
+
+  it('shows a message when the username is taken', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json({ title: 'Conflict' }, 409))
+    renderDialog()
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'tom')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    expect(await screen.findByText(/already taken/i)).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/accounts/NewAccountDialog.tsx
+++ b/ui/src/routes/accounts/NewAccountDialog.tsx
@@ -1,11 +1,96 @@
-// ui/src/routes/accounts/NewAccountDialog.tsx — replaced in full by Task 4
-import { Dialog, DialogContent, DialogTitle } from '../../components/ui/dialog'
+import { useState, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ApiError } from '../../lib/api'
+import { useCreateAccount } from '../../lib/accounts'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/dialog'
+import { Input } from '../../components/ui/input'
+import { Label } from '../../components/ui/label'
+import { Button } from '../../components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui/select'
+import { toast } from '../../components/ui/sonner'
 
-export function NewAccountDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+const LEVELS = ['Player', 'GrandMaster', 'Administrator']
+
+export function NewAccountDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  const { t } = useTranslation()
+  const create = useCreateAccount()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [email, setEmail] = useState('')
+  const [level, setLevel] = useState('Player')
+  const [error, setError] = useState<string | null>(null)
+
+  async function submit(event: FormEvent) {
+    event.preventDefault()
+    setError(null)
+    try {
+      await create.mutateAsync({ username, password, email: email || null, level })
+      toast.success(t('admin.accounts.created'))
+      onOpenChange(false)
+    } catch (caught) {
+      // 409 is the one failure worth naming inline; anything else is the generic toast.
+      if (caught instanceof ApiError && caught.status === 409) {
+        setError(t('admin.accounts.taken'))
+      } else {
+        toast.error(t('error.generic'))
+      }
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogTitle>New account</DialogTitle>
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>{t('admin.accounts.new')}</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-username">{t('admin.accounts.username')}</Label>
+            <Input id="new-username" value={username} onChange={(e) => setUsername(e.target.value)} required />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-password">{t('admin.accounts.password')}</Label>
+            <Input
+              id="new-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-email">{t('admin.accounts.email')}</Label>
+            <Input id="new-email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label>{t('admin.accounts.level')}</Label>
+            <Select value={level} onValueChange={setLevel}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {LEVELS.map((l) => (
+                  <SelectItem key={l} value={l}>
+                    {t(`admin.accounts.levels.${l}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error !== null && (
+            <p role="alert" className="text-sm text-danger-text">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button type="submit" disabled={create.isPending}>
+              {t('admin.accounts.create')}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/ui/src/routes/accounts/NewAccountDialog.tsx
+++ b/ui/src/routes/accounts/NewAccountDialog.tsx
@@ -1,0 +1,12 @@
+// ui/src/routes/accounts/NewAccountDialog.tsx — replaced in full by Task 4
+import { Dialog, DialogContent, DialogTitle } from '../../components/ui/dialog'
+
+export function NewAccountDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>New account</DialogTitle>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -10,6 +10,15 @@ if (!Element.prototype.hasPointerCapture) {
 }
 Element.prototype.scrollIntoView = () => {}
 
+// jsdom has no ResizeObserver, which the Radix Switch measures its thumb with.
+if (!('ResizeObserver' in globalThis)) {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
 // Pinned, not inherited. Assertions below match on rendered copy, so leaving the language to the app's
 // default would make every one of them a test of what that default happens to be — and they would all
 // break the day it changes, which is exactly what happened once already.


### PR DESCRIPTION
Closes #70. The admin subsystem's second slice, composed from the control kit.

## What it adds

- **Admin sub-nav** — an `AdminLayout` renders an Overview/Accounts tab row
  above an `<Outlet/>`; `/admin` becomes a parent route (diagnostics as index,
  accounts as a child). Keeps the top nav uncluttered as the admin area grows.
- **Accounts table** — a `DataTable` over `useAccounts()`: username, email,
  level and status `Badge`s, character count, client-side search, a Manage
  button per row.
- **Create dialog** — posts a new account; a 409 shows an inline "username
  taken" message; success toasts and closes.
- **Edit dialog** — change level (`Select`), toggle suspended (`Switch`), set a
  new password (blank keeps it), delete behind an inline confirm. Save patches
  only the changed fields.

A focused `accounts.ts` module owns the list query and the three mutations,
which invalidate the list on success. Every action reports through a sonner
toast, now mounted once at the app root.

## Verified

64 UI tests. **Verified end to end against the running server** in a headless
browser: signed in as `admin`, a throwaway account was created, suspended (its
badge flipped) and deleted (its row vanished) — with zero console errors. Both
themes render faithfully, no `dark:` leak.

## Not in this slice (stated in the design)

The account detail's IP / last login / hours / created fields — not in the API.
Server-side pagination; editing username or email. The other admin screens
(news, settings, console) — later slices on this sub-nav.