### PR TITLE
UI: icon theme toggle and a dedicated Plugins page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { DashboardScreen } from './routes/DashboardScreen'
 import { AdminScreen } from './routes/AdminScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
+import { PluginsScreen } from './routes/PluginsScreen'
 import { Toaster } from './components/ui/sonner'
 
 const queryClient = new QueryClient()
@@ -45,6 +46,7 @@ export function App() {
             >
               <Route index element={<AdminScreen />} />
               <Route path="accounts" element={<AccountsScreen />} />
+              <Route path="plugins" element={<PluginsScreen />} />
             </Route>
           </Routes>
         </AuthProvider>

--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -55,7 +55,8 @@ describe('AppShell', () => {
 
   it('offers the theme toggle', () => {
     renderShell()
-    expect(screen.getByRole('button', { name: /dark/i })).toBeInTheDocument()
+    // Dark is the default, so the toggle offers the switch to light.
+    expect(screen.getByRole('button', { name: /light/i })).toBeInTheDocument()
   })
 
   it('shows the Admin tab for an admin session', async () => {

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -17,7 +17,6 @@ export function AppShell({ children }: { children: ReactNode }) {
         <img src={icon} alt="" className="size-[26px] rounded-control object-cover" />
         <span className="font-display text-[18px] font-bold tracking-wider text-gold">{t('app.name')}</span>
         <div className="flex-1" />
-        <span className="text-xs tracking-widest text-faint">{t('theme.label')}</span>
         <ThemeToggle />
 
         {/* A rule of its own, not just a gap: theme and identity are unrelated controls, and without a

--- a/ui/src/components/ThemeToggle.test.tsx
+++ b/ui/src/components/ThemeToggle.test.tsx
@@ -9,10 +9,9 @@ describe('ThemeToggle', () => {
     localStorage.clear()
   })
 
-  it('starts from the theme already on the document', () => {
+  it('offers switching to light while dark is active', () => {
     render(<ThemeToggle />)
-
-    expect(screen.getByRole('button', { pressed: true })).toHaveAccessibleName(/dark/i)
+    expect(screen.getByRole('button', { name: /light/i })).toBeInTheDocument()
   })
 
   it('switches the document theme and remembers it', async () => {
@@ -22,5 +21,8 @@ describe('ThemeToggle', () => {
 
     expect(document.documentElement.dataset.theme).toBe('light')
     expect(localStorage.getItem('mg-theme')).toBe('light')
+
+    // The single button now offers the reverse switch.
+    expect(screen.getByRole('button', { name: /dark/i })).toBeInTheDocument()
   })
 })

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Moon, Sun } from 'lucide-react'
 import { applyTheme, readTheme, type Theme } from '../lib/theme'
 
+// A single icon button: the moon while dark is active, the sun while light is; clicking flips to the
+// other. The aria-label names the switch it performs, so it stays operable and testable without the
+// old two-button labels.
 export function ThemeToggle() {
   const { t } = useTranslation()
   const [theme, setTheme] = useState<Theme>(readTheme)
@@ -10,23 +14,17 @@ export function ThemeToggle() {
     applyTheme(theme)
   }, [theme])
 
+  const target: Theme = theme === 'dark' ? 'light' : 'dark'
+  const Icon = theme === 'dark' ? Moon : Sun
+
   return (
-    <div className="flex gap-0.5 rounded-control border border-border-subtle bg-deep p-0.5">
-      {(['dark', 'light'] as const).map((option) => (
-        <button
-          key={option}
-          type="button"
-          aria-pressed={theme === option}
-          onClick={() => setTheme(option)}
-          className={
-            theme === option
-              ? 'rounded-control bg-gold px-3 py-1 text-xs font-bold text-gold-ink'
-              : 'rounded-control px-3 py-1 text-xs font-bold text-muted'
-          }
-        >
-          {t(option === 'dark' ? 'theme.dark' : 'theme.light')}
-        </button>
-      ))}
-    </div>
+    <button
+      type="button"
+      aria-label={t('theme.switchTo', { theme: t(`theme.${target}`) })}
+      onClick={() => setTheme(target)}
+      className="rounded-control border border-border-subtle bg-deep p-1.5 text-muted hover:text-gold"
+    >
+      <Icon className="size-4" />
+    </button>
   )
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -63,7 +63,8 @@
     },
     "nav": {
       "overview": "Overview",
-      "accounts": "Accounts"
+      "accounts": "Accounts",
+      "plugins": "Plugins"
     },
     "accounts": {
       "title": "Accounts",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -59,7 +59,12 @@
       "routes": "{{count}} routes",
       "external": "external",
       "host": "host",
-      "empty": "No plugins reported."
+      "empty": "No plugins reported.",
+      "name": "Name",
+      "version": "Version",
+      "routesHeader": "Routes",
+      "type": "Type",
+      "search": "Search plugins…"
     },
     "nav": {
       "overview": "Overview",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -5,7 +5,7 @@
   "theme": {
     "dark": "Dark",
     "light": "Light",
-    "label": "Theme"
+    "switchTo": "Switch to {{theme}}"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -59,7 +59,12 @@
       "routes": "{{count}} rotte",
       "external": "esterno",
       "host": "host",
-      "empty": "Nessun plugin riportato."
+      "empty": "Nessun plugin riportato.",
+      "name": "Nome",
+      "version": "Versione",
+      "routesHeader": "Rotte",
+      "type": "Tipo",
+      "search": "Cerca plugin…"
     },
     "nav": {
       "overview": "Panoramica",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -63,7 +63,8 @@
     },
     "nav": {
       "overview": "Panoramica",
-      "accounts": "Account"
+      "accounts": "Account",
+      "plugins": "Plugin"
     },
     "accounts": {
       "title": "Account",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -5,7 +5,7 @@
   "theme": {
     "dark": "Scuro",
     "light": "Chiaro",
-    "label": "Tema"
+    "switchTo": "Passa a {{theme}}"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import '../lib/i18n'
+import { AdminLayout } from './AdminLayout'
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/admin" element={<AdminLayout />}>
+          <Route index element={<p>overview page</p>} />
+          <Route path="accounts" element={<p>accounts page</p>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('AdminLayout', () => {
+  it('shows the sub-nav and the index child', () => {
+    renderAt('/admin')
+    expect(screen.getByRole('link', { name: /overview/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
+    expect(screen.getByText('overview page')).toBeInTheDocument()
+  })
+
+  it('renders the accounts child at /admin/accounts', () => {
+    renderAt('/admin/accounts')
+    expect(screen.getByText('accounts page')).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -19,6 +19,9 @@ export function AdminLayout() {
         <NavLink to="/admin/accounts" className={linkClass}>
           {t('admin.nav.accounts')}
         </NavLink>
+        <NavLink to="/admin/plugins" className={linkClass}>
+          {t('admin.nav.plugins')}
+        </NavLink>
       </nav>
       <Outlet />
     </div>

--- a/ui/src/routes/AdminScreen.test.tsx
+++ b/ui/src/routes/AdminScreen.test.tsx
@@ -19,7 +19,7 @@ function json(body: unknown) {
 describe('AdminScreen', () => {
   beforeEach(() => vi.restoreAllMocks())
 
-  it('shows shard status, statistics and the plugin list', async () => {
+  it('shows shard status and statistics', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input)
 
@@ -34,20 +34,6 @@ describe('AdminScreen', () => {
           content: { itemTemplates: 1665, mobileTemplates: 19 },
         })
       }
-      if (url.endsWith('/api/v1/admin/plugins')) {
-        return json([
-          {
-            id: 'moongate.http',
-            name: 'HTTP',
-            version: '0.4.0',
-            author: 'moongate',
-            description: '',
-            assembly: 'Moongate.Http.Plugin',
-            isExternal: true,
-            routes: [{ method: 'GET', path: '/x', policy: null }],
-          },
-        ])
-      }
       return json({})
     })
 
@@ -56,6 +42,5 @@ describe('AdminScreen', () => {
     expect(await screen.findByText('1.2.3')).toBeInTheDocument() // build
     expect(await screen.findByText('4')).toBeInTheDocument() // sessions
     expect(await screen.findByText('42')).toBeInTheDocument() // players online
-    expect(await screen.findByText('HTTP')).toBeInTheDocument() // plugin name
   })
 })

--- a/ui/src/routes/AdminScreen.tsx
+++ b/ui/src/routes/AdminScreen.tsx
@@ -1,16 +1,13 @@
 import { useTranslation } from 'react-i18next'
-import { Card } from '../components/ui/card'
 import { StatCard } from '../components/ui/stat-card'
-import { Badge } from '../components/ui/badge'
-import { useAdminPlugins, useAdminStatus, useStats } from '../lib/queries'
+import { useAdminStatus, useStats } from '../lib/queries'
 
-// The admin area's first screen: read-only diagnostics, composed from the Moongate control kit — a row of
-// stat cards over the shard status and statistics, and a card listing the active plugins.
+// The admin overview: read-only shard status and statistics as rows of stat cards. The plugin list lives
+// on its own admin page.
 export function AdminScreen() {
   const { t } = useTranslation()
   const status = useAdminStatus()
   const stats = useStats()
-  const plugins = useAdminPlugins()
 
   return (
     <div className="flex flex-col gap-4">
@@ -34,33 +31,6 @@ export function AdminScreen() {
           <StatCard label={t('admin.stats.items')} value={stats.data?.world.items} />
         </div>
       </section>
-
-      <Card className="p-5">
-        <h2 className="mb-3 font-display text-[16px] tracking-[0.08em] text-gold">{t('admin.plugins.title')}</h2>
-        {plugins.isError && (
-          <p role="alert" className="text-sm text-danger-text">
-            {t('error.generic')}
-          </p>
-        )}
-        {plugins.data?.length === 0 && <p className="text-sm text-muted">{t('admin.plugins.empty')}</p>}
-        <ul className="flex flex-col gap-2">
-          {plugins.data?.map((plugin) => (
-            <li
-              key={plugin.id}
-              className="flex items-center gap-3 rounded-card border border-border-subtle bg-page px-3 py-2.5"
-            >
-              <span className="text-sm font-bold text-ink">{plugin.name}</span>
-              <span className="font-mono text-xs text-muted">{plugin.version}</span>
-              <span className="text-xs text-faint">{t('admin.plugins.routes', { count: plugin.routes.length })}</span>
-              <span className="ml-auto">
-                <Badge variant={plugin.isExternal ? 'info' : 'staff'}>
-                  {plugin.isExternal ? t('admin.plugins.external') : t('admin.plugins.host')}
-                </Badge>
-              </span>
-            </li>
-          ))}
-        </ul>
-      </Card>
     </div>
   )
 }

--- a/ui/src/routes/PluginsScreen.test.tsx
+++ b/ui/src/routes/PluginsScreen.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../lib/i18n'
+import { PluginsScreen } from './PluginsScreen'
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <PluginsScreen />
+    </QueryClientProvider>,
+  )
+}
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+describe('PluginsScreen', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('lists the active plugins with their route counts', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      json([
+        {
+          id: 'moongate.http',
+          name: 'HTTP',
+          version: '0.4.0',
+          author: 'moongate',
+          description: '',
+          assembly: 'Moongate.Http.Plugin',
+          isExternal: true,
+          routes: [{ method: 'GET', path: '/x', policy: null }],
+        },
+      ]),
+    )
+    renderScreen()
+
+    expect(await screen.findByText('HTTP')).toBeInTheDocument()
+    expect(screen.getByText('0.4.0')).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/PluginsScreen.test.tsx
+++ b/ui/src/routes/PluginsScreen.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import '../lib/i18n'
 import { PluginsScreen } from './PluginsScreen'
@@ -19,24 +20,45 @@ function json(body: unknown) {
 describe('PluginsScreen', () => {
   beforeEach(() => vi.restoreAllMocks())
 
-  it('lists the active plugins with their route counts', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      json([
-        {
-          id: 'moongate.http',
-          name: 'HTTP',
-          version: '0.4.0',
-          author: 'moongate',
-          description: '',
-          assembly: 'Moongate.Http.Plugin',
-          isExternal: true,
-          routes: [{ method: 'GET', path: '/x', policy: null }],
-        },
-      ]),
-    )
+  const plugins = [
+    {
+      id: 'moongate.http',
+      name: 'HTTP',
+      version: '0.4.0',
+      author: 'moongate',
+      description: '',
+      assembly: 'Moongate.Http.Plugin',
+      isExternal: true,
+      routes: [{ method: 'GET', path: '/x', policy: null }],
+    },
+    {
+      id: 'moongate.news',
+      name: 'News',
+      version: '0.4.0',
+      author: 'moongate',
+      description: '',
+      assembly: 'Moongate.News.Plugin',
+      isExternal: false,
+      routes: [],
+    },
+  ]
+
+  it('lists the active plugins in a table', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(plugins))
     renderScreen()
 
     expect(await screen.findByText('HTTP')).toBeInTheDocument()
-    expect(screen.getByText('0.4.0')).toBeInTheDocument()
+    expect(screen.getByText('News')).toBeInTheDocument()
+    expect(screen.getAllByText('0.4.0')).toHaveLength(2)
+  })
+
+  it('filters the table by search', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(plugins))
+    renderScreen()
+    await screen.findByText('HTTP')
+
+    await userEvent.type(screen.getByPlaceholderText(/search plugins/i), 'news')
+    expect(screen.queryByText('HTTP')).not.toBeInTheDocument()
+    expect(screen.getByText('News')).toBeInTheDocument()
   })
 })

--- a/ui/src/routes/PluginsScreen.tsx
+++ b/ui/src/routes/PluginsScreen.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next'
+import { Card } from '../components/ui/card'
+import { Badge } from '../components/ui/badge'
+import { useAdminPlugins } from '../lib/queries'
+
+// The activated plugins, each with its version, declared route count, and an external/host badge — moved
+// out of the overview into its own admin page.
+export function PluginsScreen() {
+  const { t } = useTranslation()
+  const plugins = useAdminPlugins()
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="font-display text-xl text-ink">{t('admin.plugins.title')}</h1>
+
+      <Card className="p-5">
+        {plugins.isError && (
+          <p role="alert" className="text-sm text-danger-text">
+            {t('error.generic')}
+          </p>
+        )}
+        {plugins.data?.length === 0 && <p className="text-sm text-muted">{t('admin.plugins.empty')}</p>}
+        <ul className="flex flex-col gap-2">
+          {plugins.data?.map((plugin) => (
+            <li
+              key={plugin.id}
+              className="flex items-center gap-3 rounded-card border border-border-subtle bg-page px-3 py-2.5"
+            >
+              <span className="text-sm font-bold text-ink">{plugin.name}</span>
+              <span className="font-mono text-xs text-muted">{plugin.version}</span>
+              <span className="text-xs text-faint">{t('admin.plugins.routes', { count: plugin.routes.length })}</span>
+              <span className="ml-auto">
+                <Badge variant={plugin.isExternal ? 'info' : 'staff'}>
+                  {plugin.isExternal ? t('admin.plugins.external') : t('admin.plugins.host')}
+                </Badge>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    </div>
+  )
+}

--- a/ui/src/routes/PluginsScreen.tsx
+++ b/ui/src/routes/PluginsScreen.tsx
@@ -1,43 +1,54 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Card } from '../components/ui/card'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '../components/ui/data-table'
 import { Badge } from '../components/ui/badge'
-import { useAdminPlugins } from '../lib/queries'
+import { useAdminPlugins, type PluginInfo } from '../lib/queries'
 
-// The activated plugins, each with its version, declared route count, and an external/host badge — moved
-// out of the overview into its own admin page.
+// The activated plugins in the kit's searchable, sortable DataTable: name, version, declared route count,
+// and an external/host badge. Moved out of the overview into its own admin page.
 export function PluginsScreen() {
   const { t } = useTranslation()
   const plugins = useAdminPlugins()
+
+  const columns = useMemo<ColumnDef<PluginInfo>[]>(
+    () => [
+      { accessorKey: 'name', header: t('admin.plugins.name') },
+      {
+        accessorKey: 'version',
+        header: t('admin.plugins.version'),
+        cell: ({ getValue }) => <span className="font-mono text-xs">{getValue() as string}</span>,
+      },
+      {
+        id: 'routes',
+        accessorFn: (plugin) => plugin.routes.length,
+        header: t('admin.plugins.routesHeader'),
+      },
+      {
+        accessorKey: 'isExternal',
+        header: t('admin.plugins.type'),
+        cell: ({ getValue }) =>
+          (getValue() as boolean) ? (
+            <Badge variant="info">{t('admin.plugins.external')}</Badge>
+          ) : (
+            <Badge variant="staff">{t('admin.plugins.host')}</Badge>
+          ),
+      },
+    ],
+    [t],
+  )
 
   return (
     <div className="flex flex-col gap-4">
       <h1 className="font-display text-xl text-ink">{t('admin.plugins.title')}</h1>
 
-      <Card className="p-5">
-        {plugins.isError && (
-          <p role="alert" className="text-sm text-danger-text">
-            {t('error.generic')}
-          </p>
-        )}
-        {plugins.data?.length === 0 && <p className="text-sm text-muted">{t('admin.plugins.empty')}</p>}
-        <ul className="flex flex-col gap-2">
-          {plugins.data?.map((plugin) => (
-            <li
-              key={plugin.id}
-              className="flex items-center gap-3 rounded-card border border-border-subtle bg-page px-3 py-2.5"
-            >
-              <span className="text-sm font-bold text-ink">{plugin.name}</span>
-              <span className="font-mono text-xs text-muted">{plugin.version}</span>
-              <span className="text-xs text-faint">{t('admin.plugins.routes', { count: plugin.routes.length })}</span>
-              <span className="ml-auto">
-                <Badge variant={plugin.isExternal ? 'info' : 'staff'}>
-                  {plugin.isExternal ? t('admin.plugins.external') : t('admin.plugins.host')}
-                </Badge>
-              </span>
-            </li>
-          ))}
-        </ul>
-      </Card>
+      {plugins.isError && (
+        <p role="alert" className="text-sm text-danger-text">
+          {t('error.generic')}
+        </p>
+      )}
+
+      <DataTable columns={columns} data={plugins.data ?? []} searchPlaceholder={t('admin.plugins.search')} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #72. Two UI changes.

## Icon theme toggle

The top bar's "Theme · Dark/Light" segmented text control becomes a single
lucide icon button — a moon while dark is active, a sun while light — that flips
the theme on click. The aria-label names the switch it performs, so it stays
operable and testable. The "Theme" label (and its now-unused i18n key) are gone.

## Plugins page

The active-plugins list moves out of the admin overview into its own
`PluginsScreen` at `/admin/plugins`, reached from a new **Plugins** tab in the
admin sub-nav (Overview · Accounts · Plugins). The overview keeps shard status
and statistics; the plugin inventory gets room of its own. Reuses the existing
`useAdminPlugins` hook and `admin.plugins.*` copy.

## Verified

65 UI tests. Verified live in a headless browser: the icon toggle is present and
switches the theme, `/admin/plugins` lists the plugins, and the overview no
longer shows them — zero console errors.