### PR TITLE
feat(ui): admin shard-settings page (general, contacts, assets)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,7 @@ import { AdminScreen } from './routes/AdminScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
+import { SettingsScreen } from './routes/SettingsScreen'
 import { Toaster } from './components/ui/sonner'
 
 const queryClient = new QueryClient()
@@ -47,6 +48,7 @@ export function App() {
               <Route index element={<AdminScreen />} />
               <Route path="accounts" element={<AccountsScreen />} />
               <Route path="plugins" element={<PluginsScreen />} />
+              <Route path="settings" element={<SettingsScreen />} />
             </Route>
           </Routes>
         </AuthProvider>

--- a/ui/src/components/settings/AssetSlotRow.test.tsx
+++ b/ui/src/components/settings/AssetSlotRow.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../../lib/i18n'
+import { AssetSlotRow } from './AssetSlotRow'
+
+function renderRow(url?: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <AssetSlotRow slot="logo" label="Logo" url={url} />
+    </QueryClientProvider>,
+  )
+}
+
+const settings = {
+  description: null,
+  contacts: { website: null, email: null, discord: null },
+  registrationEnabled: true,
+  assets: { logo: '/api/v1/server-info/assets/logo' },
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+describe('AssetSlotRow', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('previews an existing image and offers Remove', () => {
+    renderRow('/api/v1/server-info/assets/logo')
+    expect(screen.getByRole('img', { name: /logo/i })).toHaveAttribute(
+      'src',
+      expect.stringContaining('/api/v1/server-info/assets/logo'),
+    )
+    expect(screen.getByRole('button', { name: /remove/i })).toBeInTheDocument()
+  })
+
+  it('hides Remove when the slot is empty', () => {
+    renderRow(undefined)
+    expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument()
+  })
+
+  it('POSTs the chosen file to the slot', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    renderRow(undefined)
+
+    const file = new File(['x'], 'logo.png', { type: 'image/png' })
+    await userEvent.upload(screen.getByTestId('asset-input-logo'), file)
+
+    await waitFor(() => {
+      const [url, init] = fetchSpy.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/server-settings/assets/logo')
+      expect((init as RequestInit).method).toBe('POST')
+      expect((init as RequestInit).body).toBeInstanceOf(FormData)
+    })
+  })
+
+  it('DELETEs the slot on Remove', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+    renderRow('/api/v1/server-info/assets/logo')
+
+    await userEvent.click(screen.getByRole('button', { name: /remove/i }))
+
+    await waitFor(() => {
+      const [url, init] = fetchSpy.mock.calls[0]
+      expect(url).toBe('/api/v1/admin/server-settings/assets/logo')
+      expect((init as RequestInit).method).toBe('DELETE')
+    })
+  })
+})

--- a/ui/src/components/settings/AssetSlotRow.tsx
+++ b/ui/src/components/settings/AssetSlotRow.tsx
@@ -1,0 +1,89 @@
+import { useRef, useState, type ChangeEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Upload, X } from 'lucide-react'
+import { Button } from '../ui/button'
+import { toast } from '../ui/sonner'
+import { ApiError } from '../../lib/api'
+import { useDeleteAsset, useUploadAsset } from '../../lib/settings'
+
+interface AssetSlotRowProps {
+  slot: string
+  label: string
+  /** The public URL of the currently stored image, or undefined when the slot is empty. */
+  url?: string
+}
+
+export function AssetSlotRow({ slot, label, url }: AssetSlotRowProps) {
+  const { t } = useTranslation()
+  const upload = useUploadAsset()
+  const remove = useDeleteAsset()
+  const input = useRef<HTMLInputElement>(null)
+
+  // The public URL is stable per slot, so a re-upload keeps the same src; bump a counter to force the
+  // preview to reload the fresh bytes instead of the browser's cached copy.
+  const [reloads, setReloads] = useState(0)
+  const previewSrc = url ? `${url}?v=${reloads}` : undefined
+
+  function reportError(error: unknown) {
+    if (error instanceof ApiError && error.status === 415) toast.error(t('admin.settings.notImage'))
+    else if (error instanceof ApiError && error.status === 413) toast.error(t('admin.settings.tooLarge'))
+    else toast.error(t('error.generic'))
+  }
+
+  async function onFile(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0]
+    event.target.value = '' // let the same file be re-selected after a failure
+    if (!file) return
+    try {
+      await upload.mutateAsync({ slot, file })
+      setReloads((n) => n + 1)
+      toast.success(t('admin.settings.assetUpdated'))
+    } catch (error) {
+      reportError(error)
+    }
+  }
+
+  async function onRemove() {
+    try {
+      await remove.mutateAsync(slot)
+      toast.success(t('admin.settings.assetRemoved'))
+    } catch (error) {
+      reportError(error)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-control border border-border-subtle bg-deep">
+        {previewSrc ? (
+          <img src={previewSrc} alt={label} className="max-h-full max-w-full object-contain" />
+        ) : (
+          <span className="text-xs text-muted">—</span>
+        )}
+      </div>
+
+      <div className="flex-1">
+        <p className="text-sm font-bold text-ink">{label}</p>
+      </div>
+
+      <input
+        ref={input}
+        type="file"
+        accept="image/*"
+        onChange={onFile}
+        data-testid={`asset-input-${slot}`}
+        className="hidden"
+      />
+      <Button type="button" variant="outline" onClick={() => input.current?.click()} disabled={upload.isPending}>
+        <Upload className="size-4" />
+        {t('admin.settings.upload')}
+      </Button>
+      {url ? (
+        <Button type="button" variant="ghost" onClick={onRemove} disabled={remove.isPending}>
+          <X className="size-4" />
+          {t('admin.settings.remove')}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -49,4 +49,22 @@ describe('apiFetch', () => {
       '/api/v1/admin/accounts/bob%23x',
     )
   })
+
+  it('lets the browser set the content-type for a FormData body', async () => {
+    const fetchSpy = respond(200)
+    const form = new FormData()
+    form.append('file', new Blob(['x'], { type: 'image/png' }), 'logo.png')
+    await apiFetch('/api/v1/admin/server-settings/assets/logo', { method: 'POST', body: form })
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers)
+    expect(headers.has('content-type')).toBe(false)
+  })
+
+  it('still sets JSON content-type for a string body', async () => {
+    const fetchSpy = respond(200)
+    await apiFetch('/api/v1/x', { method: 'POST', body: JSON.stringify({ a: 1 }) })
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers)
+    expect(headers.get('content-type')).toBe('application/json')
+  })
 })

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -32,7 +32,9 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
   const headers = new Headers(init.headers)
   headers.set('accept', 'application/json')
 
-  if (init.body !== undefined && !headers.has('content-type')) {
+  // A FormData body must keep the content-type the browser assigns, boundary and all; only a
+  // hand-built (JSON) body gets the JSON type.
+  if (init.body !== undefined && !headers.has('content-type') && !(init.body instanceof FormData)) {
     headers.set('content-type', 'application/json')
   }
 

--- a/ui/src/lib/settings.test.tsx
+++ b/ui/src/lib/settings.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useDeleteAsset, useServerSettings, useUpdateSettings, useUploadAsset } from './settings'
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+const settings = {
+  description: 'A shard',
+  contacts: { website: null, email: null, discord: null },
+  registrationEnabled: true,
+  assets: {},
+}
+
+describe('settings data module', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('useServerSettings reads the settings', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    const { result } = renderHook(() => useServerSettings(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.data?.description).toBe('A shard'))
+  })
+
+  it('useUpdateSettings PUTs the body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    const { result } = renderHook(() => useUpdateSettings(), { wrapper: wrapper() })
+    await result.current.mutateAsync({ registrationEnabled: false })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/server-settings')
+    expect((init as RequestInit).method).toBe('PUT')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ registrationEnabled: false })
+  })
+
+  it('useUploadAsset posts a FormData to the slot', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    const { result } = renderHook(() => useUploadAsset(), { wrapper: wrapper() })
+    const file = new File(['x'], 'logo.png', { type: 'image/png' })
+    await result.current.mutateAsync({ slot: 'logo', file })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/server-settings/assets/logo')
+    expect((init as RequestInit).method).toBe('POST')
+    expect((init as RequestInit).body).toBeInstanceOf(FormData)
+  })
+
+  it('useDeleteAsset deletes the slot', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+    const { result } = renderHook(() => useDeleteAsset(), { wrapper: wrapper() })
+    await result.current.mutateAsync('favicon')
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/server-settings/assets/favicon')
+    expect((init as RequestInit).method).toBe('DELETE')
+  })
+})

--- a/ui/src/lib/settings.ts
+++ b/ui/src/lib/settings.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiFetch, apiPath } from './api'
+import type { components } from './api-types'
+
+export type ServerSettings = components['schemas']['ServerSettingsResponse']
+export type UpdateSettings = components['schemas']['UpdateServerSettingsRequest']
+export type Contacts = components['schemas']['ServerContactsResponse']
+
+const KEY = ['admin', 'server-settings']
+const ASSET = '/api/v1/admin/server-settings/assets/{slot}'
+
+export const useServerSettings = () =>
+  useQuery({ queryKey: KEY, queryFn: () => apiFetch<ServerSettings>('/api/v1/admin/server-settings') })
+
+export function useUpdateSettings() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (body: UpdateSettings) =>
+      apiFetch<ServerSettings>('/api/v1/admin/server-settings', { method: 'PUT', body: JSON.stringify(body) }),
+    onSuccess: () => client.invalidateQueries({ queryKey: KEY }),
+  })
+}
+
+export function useUploadAsset() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slot, file }: { slot: string; file: File }) => {
+      const form = new FormData()
+      form.append('file', file)
+      return apiFetch<ServerSettings>(apiPath(ASSET, { slot }), { method: 'POST', body: form })
+    },
+    onSuccess: () => client.invalidateQueries({ queryKey: KEY }),
+  })
+}
+
+export function useDeleteAsset() {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (slot: string) => apiFetch<void>(apiPath(ASSET, { slot }), { method: 'DELETE' }),
+    onSuccess: () => client.invalidateQueries({ queryKey: KEY }),
+  })
+}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -69,7 +69,8 @@
     "nav": {
       "overview": "Overview",
       "accounts": "Accounts",
-      "plugins": "Plugins"
+      "plugins": "Plugins",
+      "settings": "Settings"
     },
     "accounts": {
       "title": "Accounts",
@@ -104,6 +105,28 @@
       "deleteConfirm": "Delete {{username}} for good? This cannot be undone.",
       "deleteYes": "Delete",
       "deleted": "Account deleted."
+    },
+    "settings": {
+      "title": "Shard settings",
+      "general": "General",
+      "description": "Description",
+      "registration": "Web registration open",
+      "contacts": "Contacts",
+      "website": "Website",
+      "email": "Email",
+      "discord": "Discord",
+      "assets": "Assets",
+      "upload": "Upload",
+      "remove": "Remove",
+      "logo": "Logo",
+      "favicon": "Favicon",
+      "banner": "Banner",
+      "save": "Save",
+      "saved": "Settings saved.",
+      "assetUpdated": "Image updated.",
+      "assetRemoved": "Image removed.",
+      "notImage": "That file is not an image.",
+      "tooLarge": "That image is too large."
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -69,7 +69,8 @@
     "nav": {
       "overview": "Panoramica",
       "accounts": "Account",
-      "plugins": "Plugin"
+      "plugins": "Plugin",
+      "settings": "Impostazioni"
     },
     "accounts": {
       "title": "Account",
@@ -104,6 +105,28 @@
       "deleteConfirm": "Eliminare {{username}} definitivamente? Non è reversibile.",
       "deleteYes": "Elimina",
       "deleted": "Account eliminato."
+    },
+    "settings": {
+      "title": "Impostazioni shard",
+      "general": "Generale",
+      "description": "Descrizione",
+      "registration": "Registrazione web aperta",
+      "contacts": "Contatti",
+      "website": "Sito web",
+      "email": "Email",
+      "discord": "Discord",
+      "assets": "Asset",
+      "upload": "Carica",
+      "remove": "Rimuovi",
+      "logo": "Logo",
+      "favicon": "Favicon",
+      "banner": "Banner",
+      "save": "Salva",
+      "saved": "Impostazioni salvate.",
+      "assetUpdated": "Immagine aggiornata.",
+      "assetRemoved": "Immagine rimossa.",
+      "notImage": "Il file non è un'immagine.",
+      "tooLarge": "L'immagine è troppo grande."
     }
   }
 }

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -22,6 +22,7 @@ describe('AdminLayout', () => {
     expect(screen.getByRole('link', { name: /overview/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
     expect(screen.getByText('overview page')).toBeInTheDocument()
   })
 

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -22,6 +22,9 @@ export function AdminLayout() {
         <NavLink to="/admin/plugins" className={linkClass}>
           {t('admin.nav.plugins')}
         </NavLink>
+        <NavLink to="/admin/settings" className={linkClass}>
+          {t('admin.nav.settings')}
+        </NavLink>
       </nav>
       <Outlet />
     </div>

--- a/ui/src/routes/SettingsScreen.test.tsx
+++ b/ui/src/routes/SettingsScreen.test.tsx
@@ -45,6 +45,15 @@ describe('SettingsScreen', () => {
     expect(screen.getByTestId('asset-input-banner')).toBeInTheDocument()
   })
 
+  it('matches a stored asset to its slot regardless of key casing', async () => {
+    // The API keys the assets map in PascalCase ("Logo"); the slot is lowercase.
+    const withLogo = { ...settings, assets: { Logo: '/api/v1/server-info/assets/logo' } }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(withLogo))
+    renderScreen()
+
+    expect(await screen.findByRole('img', { name: /^logo$/i })).toBeInTheDocument()
+  })
+
   it('PUTs the current form state on Save', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
     renderScreen()

--- a/ui/src/routes/SettingsScreen.test.tsx
+++ b/ui/src/routes/SettingsScreen.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../lib/i18n'
+import { SettingsScreen } from './SettingsScreen'
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <SettingsScreen />
+    </QueryClientProvider>,
+  )
+}
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+const settings = {
+  description: 'The finest shard',
+  contacts: { website: 'https://x.io', email: null, discord: null },
+  registrationEnabled: true,
+  assets: {},
+}
+
+describe('SettingsScreen', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('shows the fetched settings', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    renderScreen()
+
+    expect(await screen.findByDisplayValue('The finest shard')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('https://x.io')).toBeInTheDocument()
+  })
+
+  it('PUTs the current form state on Save', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    renderScreen()
+
+    // The registration toggle is seeded on (from the fetched settings); flip it off and save.
+    const toggle = await screen.findByRole('switch', { name: /registration/i })
+    await userEvent.click(toggle)
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      const put = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PUT')!
+      expect(JSON.parse((put[1] as RequestInit).body as string)).toMatchObject({
+        registrationEnabled: false,
+        description: 'The finest shard',
+      })
+    })
+  })
+})

--- a/ui/src/routes/SettingsScreen.test.tsx
+++ b/ui/src/routes/SettingsScreen.test.tsx
@@ -35,6 +35,16 @@ describe('SettingsScreen', () => {
     expect(screen.getByDisplayValue('https://x.io')).toBeInTheDocument()
   })
 
+  it('renders an upload row for every asset slot', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    renderScreen()
+
+    await screen.findByDisplayValue('The finest shard')
+    expect(screen.getByTestId('asset-input-logo')).toBeInTheDocument()
+    expect(screen.getByTestId('asset-input-favicon')).toBeInTheDocument()
+    expect(screen.getByTestId('asset-input-banner')).toBeInTheDocument()
+  })
+
   it('PUTs the current form state on Save', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
     renderScreen()

--- a/ui/src/routes/SettingsScreen.tsx
+++ b/ui/src/routes/SettingsScreen.tsx
@@ -50,6 +50,11 @@ export function SettingsScreen() {
   const setContact = (key: keyof Contacts) => (value: string) =>
     setContacts((current) => ({ ...current, [key]: value || null }))
 
+  // The API keys the assets map in PascalCase ("Logo"), while the slot (and its upload path) is
+  // lowercase — match case-insensitively so the preview finds the stored image.
+  const assetUrl = (slot: string) =>
+    Object.entries(settings.data?.assets ?? {}).find(([key]) => key.toLowerCase() === slot)?.[1]
+
   return (
     <form onSubmit={save} className="flex flex-col gap-4">
       <h1 className="font-display text-xl text-ink">{t('admin.settings.title')}</h1>
@@ -99,12 +104,7 @@ export function SettingsScreen() {
       <Card className="flex flex-col gap-4 p-5">
         <h2 className="font-display text-[16px] tracking-[0.08em] text-gold">{t('admin.settings.assets')}</h2>
         {ASSET_SLOTS.map((slot) => (
-          <AssetSlotRow
-            key={slot}
-            slot={slot}
-            label={t(`admin.settings.${slot}`)}
-            url={settings.data?.assets[slot]}
-          />
+          <AssetSlotRow key={slot} slot={slot} label={t(`admin.settings.${slot}`)} url={assetUrl(slot)} />
         ))}
       </Card>
     </form>

--- a/ui/src/routes/SettingsScreen.tsx
+++ b/ui/src/routes/SettingsScreen.tsx
@@ -6,9 +6,11 @@ import { Label } from '../components/ui/label'
 import { Button } from '../components/ui/button'
 import { Switch } from '../components/ui/switch'
 import { toast } from '../components/ui/sonner'
+import { AssetSlotRow } from '../components/settings/AssetSlotRow'
 import { useServerSettings, useUpdateSettings, type Contacts } from '../lib/settings'
 
 const EMPTY_CONTACTS: Contacts = { website: null, email: null, discord: null }
+const ASSET_SLOTS = ['logo', 'favicon', 'banner'] as const
 
 export function SettingsScreen() {
   const { t } = useTranslation()
@@ -93,6 +95,18 @@ export function SettingsScreen() {
           {t('admin.settings.save')}
         </Button>
       </div>
+
+      <Card className="flex flex-col gap-4 p-5">
+        <h2 className="font-display text-[16px] tracking-[0.08em] text-gold">{t('admin.settings.assets')}</h2>
+        {ASSET_SLOTS.map((slot) => (
+          <AssetSlotRow
+            key={slot}
+            slot={slot}
+            label={t(`admin.settings.${slot}`)}
+            url={settings.data?.assets[slot]}
+          />
+        ))}
+      </Card>
     </form>
   )
 }

--- a/ui/src/routes/SettingsScreen.tsx
+++ b/ui/src/routes/SettingsScreen.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card } from '../components/ui/card'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { Button } from '../components/ui/button'
+import { Switch } from '../components/ui/switch'
+import { toast } from '../components/ui/sonner'
+import { useServerSettings, useUpdateSettings, type Contacts } from '../lib/settings'
+
+const EMPTY_CONTACTS: Contacts = { website: null, email: null, discord: null }
+
+export function SettingsScreen() {
+  const { t } = useTranslation()
+  const settings = useServerSettings()
+  const update = useUpdateSettings()
+
+  const [description, setDescription] = useState('')
+  const [registration, setRegistration] = useState(false)
+  const [contacts, setContacts] = useState<Contacts>(EMPTY_CONTACTS)
+
+  // Seed the form once, the first time the settings arrive. A later background refetch must not
+  // clobber edits the operator has already typed but not yet saved.
+  const seeded = useRef(false)
+  useEffect(() => {
+    if (settings.data && !seeded.current) {
+      seeded.current = true
+      setDescription(settings.data.description ?? '')
+      setRegistration(settings.data.registrationEnabled)
+      setContacts(settings.data.contacts ?? EMPTY_CONTACTS)
+    }
+  }, [settings.data])
+
+  async function save(event: FormEvent) {
+    event.preventDefault()
+    try {
+      await update.mutateAsync({
+        description: description || null,
+        registrationEnabled: registration,
+        contacts,
+      })
+      toast.success(t('admin.settings.saved'))
+    } catch {
+      toast.error(t('error.generic'))
+    }
+  }
+
+  const setContact = (key: keyof Contacts) => (value: string) =>
+    setContacts((current) => ({ ...current, [key]: value || null }))
+
+  return (
+    <form onSubmit={save} className="flex flex-col gap-4">
+      <h1 className="font-display text-xl text-ink">{t('admin.settings.title')}</h1>
+
+      <Card className="flex flex-col gap-4 p-5">
+        <h2 className="font-display text-[16px] tracking-[0.08em] text-gold">{t('admin.settings.general')}</h2>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="description">{t('admin.settings.description')}</Label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="rounded-control border border-border-subtle bg-deep px-3.5 py-2.5 text-sm text-ink outline-none focus-visible:border-gold"
+          />
+        </div>
+        <Label className="flex items-center gap-2 text-sm">
+          <Switch
+            checked={registration}
+            onCheckedChange={setRegistration}
+            aria-label={t('admin.settings.registration')}
+          />
+          {t('admin.settings.registration')}
+        </Label>
+      </Card>
+
+      <Card className="flex flex-col gap-4 p-5">
+        <h2 className="font-display text-[16px] tracking-[0.08em] text-gold">{t('admin.settings.contacts')}</h2>
+        {(['website', 'email', 'discord'] as const).map((key) => (
+          <div key={key} className="flex flex-col gap-1.5">
+            <Label htmlFor={`contact-${key}`}>{t(`admin.settings.${key}`)}</Label>
+            <Input
+              id={`contact-${key}`}
+              value={contacts[key] ?? ''}
+              onChange={(e) => setContact(key)(e.target.value)}
+            />
+          </div>
+        ))}
+      </Card>
+
+      <div>
+        <Button type="submit" disabled={update.isPending}>
+          {t('admin.settings.save')}
+        </Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
Adds the admin **Settings** page (`/admin/settings`), the fourth tab in the admin sub-navigation.

## What
- **General** card — shard description + web-registration toggle.
- **Contacts** card — website, email, Discord.
- **Assets** card — upload / preview / remove rows for the logo, favicon and banner slots.
- General + contacts save through a single `PUT`; each asset uploads via multipart `POST` and clears via `DELETE`.

## How
- `apiFetch` keeps a `FormData` body's browser-assigned content-type (boundary intact); only hand-built JSON bodies get `application/json`.
- New `lib/settings.ts` data module: `useServerSettings` / `useUpdateSettings` / `useUploadAsset` / `useDeleteAsset`, all invalidating the shared query on success.
- The form seeds once (ref-guarded) so a background refetch never wipes in-progress edits.
- Upload failures map **415 → not-an-image**, **413 → too-large**.
- The API keys the assets map in PascalCase (`Logo`) while the slot and its upload path are lowercase — the slot lookup is case-insensitive so a stored image previews and offers Remove.

## Verification
- 80 UI unit tests green; production build clean.
- Live browser round-trip against the running server in **both themes**: upload → preview → remove verified, no console errors.

Closes #74.