### PR TITLE
feat(ui): show the shard's uploaded logo on the login screen

### DIFF
--- a/ui/src/lib/queries.ts
+++ b/ui/src/lib/queries.ts
@@ -21,6 +21,13 @@ export const useMyCharacters = () =>
 export const useStats = () =>
   useQuery({ queryKey: ['stats'], queryFn: () => apiFetch<ServerStats>('/api/v1/stats') })
 
+export type ServerInfo = components['schemas']['ServerInfoResponse']
+
+// Public and anonymous, like /stats and /version — the login screen reads it before anyone signs in,
+// to brand the page with the shard's own logo.
+export const useServerInfo = () =>
+  useQuery({ queryKey: ['server-info'], queryFn: () => apiFetch<ServerInfo>('/api/v1/server-info') })
+
 export type ServerVersion = components['schemas']['VersionResponse']
 
 export const useVersion = () =>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -22,7 +22,8 @@
     "quote": "Sosaria never sleeps.",
     "remember": "Remember me on this device",
     "online": "{{count}} adventurers online right now",
-    "artAlt": "The Moongate — a runic portal standing open"
+    "artAlt": "The Moongate — a runic portal standing open",
+    "logoAlt": "Shard logo"
   },
   "dashboard": {
     "welcome": "Welcome back, {{name}}",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -22,7 +22,8 @@
     "quote": "Sosaria non dorme mai.",
     "remember": "Ricordami su questo dispositivo",
     "online": "{{count}} avventurieri online in questo momento",
-    "artAlt": "Il Moongate — un portale runico aperto"
+    "artAlt": "Il Moongate — un portale runico aperto",
+    "logoAlt": "Logo dello shard"
   },
   "dashboard": {
     "welcome": "Bentornato, {{name}}",

--- a/ui/src/routes/LoginScreen.test.tsx
+++ b/ui/src/routes/LoginScreen.test.tsx
@@ -25,6 +25,7 @@ describe('LoginScreen', () => {
     localStorage.clear()
     sessionStorage.clear()
     vi.restoreAllMocks()
+    assets = {}
   })
 
   function json(body: unknown, status = 200) {
@@ -55,15 +56,44 @@ describe('LoginScreen', () => {
       if (url.endsWith('/api/v1/version')) {
         return json({ shardName: 'Moongate', version: '9.9.9' })
       }
+      if (url.endsWith('/api/v1/server-info')) {
+        return json({
+          shardName: 'Moongate',
+          contacts: { website: null, email: null, discord: null },
+          registrationEnabled: false,
+          assets,
+        })
+      }
       return json({ username: 'tom', level: 'Player' })
     })
   }
+
+  // The assets map the /server-info mock reports; tests override it before rendering.
+  let assets: Record<string, string> = {}
 
   it('shows the server version once it resolves', async () => {
     serveApi()
     renderLogin()
 
     expect(await screen.findByText(/Moongate · v9\.9\.9/)).toBeInTheDocument()
+  })
+
+  it('shows the shard logo when the server publishes one', async () => {
+    assets = { Logo: '/api/v1/server-info/assets/logo' }
+    serveApi()
+    renderLogin()
+
+    const logo = await screen.findByRole('img', { name: /shard logo/i })
+    expect(logo).toHaveAttribute('src', expect.stringContaining('/api/v1/server-info/assets/logo'))
+  })
+
+  it('shows no shard logo when the server has none', async () => {
+    serveApi()
+    renderLogin()
+
+    // The version resolving proves server-info also had time to; the logo is genuinely absent.
+    await screen.findByText(/Moongate · v9\.9\.9/)
+    expect(screen.queryByRole('img', { name: /shard logo/i })).not.toBeInTheDocument()
   })
 
   it('sends the credentials and stores the issued token', async () => {

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { ApiError } from '../lib/api'
 import { useSession } from '../lib/auth'
-import { useStats, useVersion } from '../lib/queries'
+import { useServerInfo, useStats, useVersion } from '../lib/queries'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -14,6 +14,10 @@ export function LoginScreen() {
   const { status, signIn } = useSession()
   const stats = useStats()
   const version = useVersion()
+  const serverInfo = useServerInfo()
+
+  // The assets map is keyed in PascalCase ("Logo") while the slot is lowercase — match case-insensitively.
+  const logoUrl = Object.entries(serverInfo.data?.assets ?? {}).find(([key]) => key.toLowerCase() === 'logo')?.[1]
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [remember, setRemember] = useState(true)
@@ -71,6 +75,12 @@ export function LoginScreen() {
       </div>
 
       <form onSubmit={submit} className="flex w-full max-w-[420px] flex-col justify-center gap-4 px-12">
+        {/* The shard's own logo, if it has uploaded one — public and anonymous, so it brands the page
+            before anyone signs in. Absent by default, so a fresh shard just shows the wordmark title. */}
+        {logoUrl !== undefined && (
+          <img src={logoUrl} alt={t('login.logoAlt')} className="mb-1 max-h-16 max-w-[220px] object-contain" />
+        )}
+
         <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">{t('login.title')}</h1>
         <p className="text-sm text-muted">{t('login.subtitle')}</p>
 


### PR DESCRIPTION
Consumes the logo asset made configurable in #75: the login page now brands itself with the shard's own logo.

## What
- New public hook `useServerInfo` (anonymous `GET /api/v1/server-info`, like `useStats`/`useVersion`).
- When the shard has uploaded a logo, the login renders it **above the sign-in form**; the decorative left artwork panel is unchanged. No logo → wordmark title only, so nothing changes by default.
- The assets map is PascalCase-keyed (`Logo`) while the slot is lowercase → case-insensitive lookup, matching the admin page.

## Verification
- 82 UI unit tests green (2 new: logo present → image, absent → none); production build clean.
- Live browser round-trip against the running server: uploaded a logo in admin, signed out, confirmed it renders above the login form; removed it and confirmed the fallback. No console errors.

Closes #76.