### PR TITLE
feat: configurable shard tagline shown on the login screen

### DIFF
--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerInfoResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerInfoResponse.cs
@@ -4,6 +4,7 @@ namespace Moongate.Http.Plugin.Data.Api.ServerInfo;
 public sealed record ServerInfoResponse(
     string ShardName,
     string? Description,
+    string? Tagline,
     ServerContactsResponse Contacts,
     bool RegistrationEnabled,
     IReadOnlyDictionary<string, string> Assets

--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerSettingsResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerSettingsResponse.cs
@@ -3,6 +3,7 @@ namespace Moongate.Http.Plugin.Data.Api.ServerInfo;
 /// <summary>The full settings view returned to staff (identical fields to the public info minus the shard name).</summary>
 public sealed record ServerSettingsResponse(
     string? Description,
+    string? Tagline,
     ServerContactsResponse Contacts,
     bool RegistrationEnabled,
     IReadOnlyDictionary<string, string> Assets

--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/UpdateServerSettingsRequest.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/UpdateServerSettingsRequest.cs
@@ -5,6 +5,8 @@ public sealed class UpdateServerSettingsRequest
 {
     public string? Description { get; set; }
 
+    public string? Tagline { get; set; }
+
     public ServerContactsResponse? Contacts { get; set; }
 
     public bool? RegistrationEnabled { get; set; }

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
@@ -52,6 +52,7 @@ public sealed class ServerInfoEndpoints : IApiEndpointRegistration
         return new(
             shardName,
             settings.Description,
+            settings.Tagline,
             new(settings.Contacts.Website, settings.Contacts.Email, settings.Contacts.Discord),
             settings.RegistrationEnabled,
             assets

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
@@ -49,6 +49,7 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
     internal static ServerSettingsResponse ToResponse(ServerSettingsEntity settings)
         => new(
             settings.Description,
+            settings.Tagline,
             new(settings.Contacts.Website, settings.Contacts.Email, settings.Contacts.Discord),
             settings.RegistrationEnabled,
             settings.Assets.Keys.ToDictionary(slot => slot, slot => $"/api/v1/server-info/assets/{slot.ToLowerInvariant()}")
@@ -65,6 +66,7 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
             new ServerSettingsUpdate
             {
                 Description = request.Description,
+                Tagline = request.Tagline,
                 RegistrationEnabled = request.RegistrationEnabled,
                 Contacts = request.Contacts is null
                                ? null

--- a/src/Moongate.Persistence/Entities/ServerSettingsEntity.cs
+++ b/src/Moongate.Persistence/Entities/ServerSettingsEntity.cs
@@ -9,6 +9,8 @@ public sealed class ServerSettingsEntity : ISerialIdEntity
 
     public string? Description { get; set; }
 
+    public string? Tagline { get; set; }
+
     public ServerContacts Contacts { get; set; } = new();
 
     public bool RegistrationEnabled { get; set; }

--- a/src/Moongate.Server.Abstractions/Data/ServerSettingsUpdate.cs
+++ b/src/Moongate.Server.Abstractions/Data/ServerSettingsUpdate.cs
@@ -7,6 +7,8 @@ public sealed class ServerSettingsUpdate
 {
     public string? Description { get; set; }
 
+    public string? Tagline { get; set; }
+
     public ServerContacts? Contacts { get; set; }
 
     public bool? RegistrationEnabled { get; set; }

--- a/src/Moongate.Server/Services/Server/ServerSettingsService.cs
+++ b/src/Moongate.Server/Services/Server/ServerSettingsService.cs
@@ -41,6 +41,11 @@ public sealed class ServerSettingsService : IServerSettingsService
             settings.Description = update.Description;
         }
 
+        if (update.Tagline is not null)
+        {
+            settings.Tagline = update.Tagline;
+        }
+
         if (update.Contacts is not null)
         {
             settings.Contacts = update.Contacts;

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
@@ -13,7 +13,9 @@ public sealed class ServerInfoEndpointsTests
     public async Task ServerInfo_IsPublic_AndReflectsSettings()
     {
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(new ServerSettingsUpdate { Description = "A fun shard", RegistrationEnabled = true });
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Description = "A fun shard", Tagline = "Sosaria never sleeps.", RegistrationEnabled = true }
+        );
 
         var response = await server.Client.GetAsync("/api/v1/server-info"); // no auth header
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -21,6 +23,7 @@ public sealed class ServerInfoEndpointsTests
         var info = await response.Content.ReadFromJsonAsync<ServerInfoResponse>();
         Assert.Equal("Moongate", info!.ShardName);
         Assert.Equal("A fun shard", info.Description);
+        Assert.Equal("Sosaria never sleeps.", info.Tagline);
         Assert.True(info.RegistrationEnabled);
     }
 

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
@@ -28,12 +28,13 @@ public sealed class ServerSettingsAdminEndpointsTests
 
         var response = await server.Client.PutAsJsonAsync(
             "/api/v1/admin/server-settings",
-            new UpdateServerSettingsRequest { RegistrationEnabled = true, Description = "Hi" }
+            new UpdateServerSettingsRequest { RegistrationEnabled = true, Description = "Hi", Tagline = "Welcome" }
         );
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         Assert.True(server.ServerSettings.Get().RegistrationEnabled);
         Assert.Equal("Hi", server.ServerSettings.Get().Description);
+        Assert.Equal("Welcome", server.ServerSettings.Get().Tagline);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Services/Server/ServerSettingsServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Server/ServerSettingsServiceTests.cs
@@ -46,6 +46,16 @@ public sealed class ServerSettingsServiceTests
     }
 
     [Fact]
+    public void Update_Tagline_RoundTrips()
+    {
+        var service = Create();
+
+        service.Update(new() { Tagline = "Sosaria never sleeps." });
+
+        Assert.Equal("Sosaria never sleeps.", service.Get().Tagline);
+    }
+
+    [Fact]
     public void SetAsset_ThenClear_RoundTrips()
     {
         var service = Create();

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2677,6 +2677,10 @@
             "type": "string",
             "nullable": true
           },
+          "tagline": {
+            "type": "string",
+            "nullable": true
+          },
           "contacts": {
             "$ref": "#/components/schemas/ServerContactsResponse"
           },
@@ -2702,6 +2706,10 @@
         "type": "object",
         "properties": {
           "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "tagline": {
             "type": "string",
             "nullable": true
           },
@@ -2881,6 +2889,10 @@
         "type": "object",
         "properties": {
           "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "tagline": {
             "type": "string",
             "nullable": true
           },

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -1318,6 +1318,7 @@ export interface components {
         ServerInfoResponse: {
             shardName: string;
             description?: string | null;
+            tagline?: string | null;
             contacts: components["schemas"]["ServerContactsResponse"];
             registrationEnabled: boolean;
             assets: {
@@ -1327,6 +1328,7 @@ export interface components {
         /** @description The full settings view returned to staff (identical fields to the public info minus the shard name). */
         ServerSettingsResponse: {
             description?: string | null;
+            tagline?: string | null;
             contacts: components["schemas"]["ServerContactsResponse"];
             registrationEnabled: boolean;
             assets: {
@@ -1393,6 +1395,7 @@ export interface components {
         /** @description A partial settings update: an omitted (null) field is left unchanged. */
         UpdateServerSettingsRequest: {
             description?: string | null;
+            tagline?: string | null;
             contacts?: components["schemas"]["ServerContactsResponse"];
             registrationEnabled?: boolean | null;
         };

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -127,7 +127,8 @@
       "assetUpdated": "Image updated.",
       "assetRemoved": "Image removed.",
       "notImage": "That file is not an image.",
-      "tooLarge": "That image is too large."
+      "tooLarge": "That image is too large.",
+      "tagline": "Tagline"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -127,7 +127,8 @@
       "assetUpdated": "Immagine aggiornata.",
       "assetRemoved": "Immagine rimossa.",
       "notImage": "Il file non è un'immagine.",
-      "tooLarge": "L'immagine è troppo grande."
+      "tooLarge": "L'immagine è troppo grande.",
+      "tagline": "Slogan"
     }
   }
 }

--- a/ui/src/routes/LoginScreen.test.tsx
+++ b/ui/src/routes/LoginScreen.test.tsx
@@ -26,6 +26,7 @@ describe('LoginScreen', () => {
     sessionStorage.clear()
     vi.restoreAllMocks()
     assets = {}
+    tagline = null
   })
 
   function json(body: unknown, status = 200) {
@@ -59,6 +60,7 @@ describe('LoginScreen', () => {
       if (url.endsWith('/api/v1/server-info')) {
         return json({
           shardName: 'Moongate',
+          tagline,
           contacts: { website: null, email: null, discord: null },
           registrationEnabled: false,
           assets,
@@ -68,8 +70,9 @@ describe('LoginScreen', () => {
     })
   }
 
-  // The assets map the /server-info mock reports; tests override it before rendering.
+  // What the /server-info mock reports; tests override these before rendering.
   let assets: Record<string, string> = {}
+  let tagline: string | null = null
 
   it('shows the server version once it resolves', async () => {
     serveApi()
@@ -94,6 +97,21 @@ describe('LoginScreen', () => {
     // The version resolving proves server-info also had time to; the logo is genuinely absent.
     await screen.findByText(/Moongate · v9\.9\.9/)
     expect(screen.queryByRole('img', { name: /shard logo/i })).not.toBeInTheDocument()
+  })
+
+  it('shows the shard tagline when the server sets one', async () => {
+    tagline = 'The moongates hum tonight.'
+    serveApi()
+    renderLogin()
+
+    expect(await screen.findByText(/The moongates hum tonight\./)).toBeInTheDocument()
+  })
+
+  it('falls back to the default quote without a tagline', async () => {
+    serveApi()
+    renderLogin()
+
+    expect(await screen.findByText(/Sosaria never sleeps\./)).toBeInTheDocument()
   })
 
   it('sends the credentials and stores the issued token', async () => {

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -56,7 +56,10 @@ export function LoginScreen() {
             them to stay legible. */}
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/85 via-black/35 to-transparent" />
 
-        <p className="relative font-display text-[18px] text-gold">&ldquo;{t('login.quote')}&rdquo;</p>
+        {/* The shard's own tagline when it has set one, otherwise the bundled default. */}
+        <p className="relative font-display text-[18px] text-gold">
+          &ldquo;{serverInfo.data?.tagline || t('login.quote')}&rdquo;
+        </p>
 
         {/* Real, and public: /api/v1/stats is anonymous, so the count is readable before anyone signs in.
             Rendered only once the reply lands — a zero here means an empty shard, which is worth saying,

--- a/ui/src/routes/SettingsScreen.test.tsx
+++ b/ui/src/routes/SettingsScreen.test.tsx
@@ -19,6 +19,7 @@ function json(body: unknown) {
 
 const settings = {
   description: 'The finest shard',
+  tagline: 'Sosaria never sleeps.',
   contacts: { website: 'https://x.io', email: null, discord: null },
   registrationEnabled: true,
   assets: {},
@@ -32,6 +33,7 @@ describe('SettingsScreen', () => {
     renderScreen()
 
     expect(await screen.findByDisplayValue('The finest shard')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Sosaria never sleeps.')).toBeInTheDocument()
     expect(screen.getByDisplayValue('https://x.io')).toBeInTheDocument()
   })
 
@@ -68,6 +70,7 @@ describe('SettingsScreen', () => {
       expect(JSON.parse((put[1] as RequestInit).body as string)).toMatchObject({
         registrationEnabled: false,
         description: 'The finest shard',
+        tagline: 'Sosaria never sleeps.',
       })
     })
   })

--- a/ui/src/routes/SettingsScreen.tsx
+++ b/ui/src/routes/SettingsScreen.tsx
@@ -18,6 +18,7 @@ export function SettingsScreen() {
   const update = useUpdateSettings()
 
   const [description, setDescription] = useState('')
+  const [tagline, setTagline] = useState('')
   const [registration, setRegistration] = useState(false)
   const [contacts, setContacts] = useState<Contacts>(EMPTY_CONTACTS)
 
@@ -28,6 +29,7 @@ export function SettingsScreen() {
     if (settings.data && !seeded.current) {
       seeded.current = true
       setDescription(settings.data.description ?? '')
+      setTagline(settings.data.tagline ?? '')
       setRegistration(settings.data.registrationEnabled)
       setContacts(settings.data.contacts ?? EMPTY_CONTACTS)
     }
@@ -38,6 +40,7 @@ export function SettingsScreen() {
     try {
       await update.mutateAsync({
         description: description || null,
+        tagline: tagline || null,
         registrationEnabled: registration,
         contacts,
       })
@@ -70,6 +73,10 @@ export function SettingsScreen() {
             rows={3}
             className="rounded-control border border-border-subtle bg-deep px-3.5 py-2.5 text-sm text-ink outline-none focus-visible:border-gold"
           />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="tagline">{t('admin.settings.tagline')}</Label>
+          <Input id="tagline" value={tagline} onChange={(e) => setTagline(e.target.value)} />
         </div>
         <Label className="flex items-center gap-2 text-sm">
           <Switch


### PR DESCRIPTION
Makes the login quote configurable from the admin settings instead of a hardcoded string — consumes the same public `server-info` surface used by the logo (#77).

## What
- New nullable `Tagline` on `ServerSettingsEntity`, threaded through `ServerSettingsUpdate`, the service, the admin `GET`/`PUT` and the public `server-info` response.
- Admin **Settings → General** gains a Tagline input, saved with the rest of the form.
- The login shows `server-info.tagline` in place of the bundled `Sosaria never sleeps.` quote, falling back to that default when unset.

## How
- backend: entity + update DTO + `ServerSettingsService` + response/request DTOs + both `ToResponse` mappers + admin `Update`.
- api: regenerated `openapi.json` and `api-types.ts` (`tagline` on the 3 schemas).
- Mirrors the existing `Description` partial-update convention (null = leave unchanged).

## Verification
- Full .NET suite green (1404); 84 UI tests green (new: service round-trip, server-info + admin PUT reflect tagline, login shows tagline / falls back to default).
- DocFX gate builds at 0 warnings.
- Live browser round-trip: set a tagline in admin → it appears on the login → cleared → default quote returns. No console errors.

Closes #80.