### PR TITLE
feat(ui): admin web terminal (Console) onto the REST console

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
 import { SettingsScreen } from './routes/SettingsScreen'
+import { ConsoleScreen } from './routes/ConsoleScreen'
 import { Toaster } from './components/ui/sonner'
 
 const queryClient = new QueryClient()
@@ -49,6 +50,7 @@ export function App() {
               <Route path="accounts" element={<AccountsScreen />} />
               <Route path="plugins" element={<PluginsScreen />} />
               <Route path="settings" element={<SettingsScreen />} />
+              <Route path="console" element={<ConsoleScreen />} />
             </Route>
           </Routes>
         </AuthProvider>

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -1,4 +1,4 @@
-import { ApiError, apiFetch, apiPath, setAuthToken, setUnauthorizedHandler } from './api'
+import { ApiError, apiFetch, apiPath, apiStream, setAuthToken, setUnauthorizedHandler } from './api'
 
 describe('apiFetch', () => {
   beforeEach(() => {
@@ -66,5 +66,38 @@ describe('apiFetch', () => {
 
     const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers)
     expect(headers.get('content-type')).toBe('application/json')
+  })
+
+  it('treats 202 Accepted as an empty body', async () => {
+    // The console POST answers 202 with no body; parsing it as JSON would throw.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }))
+    await expect(apiFetch<void>('/api/v1/admin/console', { method: 'POST', body: '{}' })).resolves.toBeUndefined()
+  })
+
+  it('apiStream sends the bearer and event-stream accept, returning the response', async () => {
+    const streamResponse = new Response(new ReadableStream(), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(streamResponse)
+    setAuthToken('tok')
+
+    const response = await apiStream('/api/v1/admin/console/stream', new AbortController().signal)
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers)
+    expect(headers.get('accept')).toBe('text/event-stream')
+    expect(headers.get('authorization')).toBe('Bearer tok')
+    expect(response).toBe(streamResponse)
+  })
+
+  it('apiStream runs the unauthorized handler on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }))
+    const onUnauthorized = vi.fn()
+    setUnauthorizedHandler(onUnauthorized)
+
+    await expect(apiStream('/api/v1/admin/console/stream', new AbortController().signal)).rejects.toBeInstanceOf(
+      ApiError,
+    )
+    expect(onUnauthorized).toHaveBeenCalledOnce()
   })
 })

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -53,9 +53,35 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
     throw new ApiError(response.status, `${init.method ?? 'GET'} ${path} failed with ${response.status}`)
   }
 
-  if (response.status === 204) {
+  // 204 No Content and 202 Accepted (the console POST) have no JSON body to parse.
+  if (response.status === 204 || response.status === 202) {
     return undefined as T
   }
 
   return (await response.json()) as T
+}
+
+/**
+ * Opens an authenticated streaming GET (Server-Sent Events). EventSource can't send the bearer token,
+ * so the caller reads the frames off the returned Response's body itself. Shares the 401 handling with
+ * {@link apiFetch}; the caller aborts by passing a signal.
+ */
+export async function apiStream(path: string, signal: AbortSignal): Promise<Response> {
+  const headers = new Headers({ accept: 'text/event-stream' })
+  if (authToken !== null) {
+    headers.set('authorization', `Bearer ${authToken}`)
+  }
+
+  const response = await fetch(path, { headers, signal })
+
+  if (response.status === 401) {
+    onUnauthorized()
+    throw new ApiError(401, 'unauthorized')
+  }
+
+  if (!response.ok || response.body === null) {
+    throw new ApiError(response.status, `GET ${path} stream failed with ${response.status}`)
+  }
+
+  return response
 }

--- a/ui/src/lib/console.test.tsx
+++ b/ui/src/lib/console.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useConsole } from './console'
+
+// A stream that emits the given frames and then stays open, so the hook settles on 'connected' the way a
+// live console feed does (rather than ending and flipping to 'closed').
+function openStream(...frames: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(frame))
+    },
+  })
+}
+
+function serve(...frames: string[]) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url = String(input)
+    if (url.endsWith('/api/v1/admin/console/stream')) {
+      return new Response(openStream(...frames), { status: 200, headers: { 'content-type': 'text/event-stream' } })
+    }
+    if (url.endsWith('/api/v1/admin/console') && (init as RequestInit)?.method === 'POST') {
+      return new Response(null, { status: 202 })
+    }
+    return new Response('{}', { status: 200 })
+  })
+}
+
+describe('useConsole', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('connects and appends output lines from the stream', async () => {
+    serve('event: ready\ndata: conn-1\n\n', 'event: line\ndata: 2 players online\n\n')
+    const { result } = renderHook(() => useConsole())
+
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+    await waitFor(() =>
+      expect(result.current.lines.some((line) => line.kind === 'output' && line.text === '2 players online')).toBe(true),
+    )
+  })
+
+  it('echoes the command and POSTs it with the connection id', async () => {
+    const fetchSpy = serve('event: ready\ndata: conn-1\n\n')
+    const { result } = renderHook(() => useConsole())
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    await act(() => result.current.send('who'))
+
+    const post = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'POST')!
+    expect(JSON.parse((post[1] as RequestInit).body as string)).toEqual({ command: 'who', connectionId: 'conn-1' })
+    expect(result.current.lines.some((line) => line.kind === 'command' && line.text === 'who')).toBe(true)
+  })
+
+  it('clear empties the lines', async () => {
+    serve('event: ready\ndata: conn-1\n\n', 'event: line\ndata: hello\n\n')
+    const { result } = renderHook(() => useConsole())
+    await waitFor(() => expect(result.current.lines.length).toBeGreaterThan(0))
+
+    act(() => result.current.clear())
+    expect(result.current.lines).toHaveLength(0)
+  })
+})

--- a/ui/src/lib/console.ts
+++ b/ui/src/lib/console.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch, apiStream } from './api'
+import { readSseFrames } from './sse'
+
+export type ConsoleStatus = 'connecting' | 'connected' | 'closed'
+
+export interface ConsoleLine {
+  id: number
+  kind: 'command' | 'output'
+  text: string
+}
+
+const STREAM = '/api/v1/admin/console/stream'
+const SEND = '/api/v1/admin/console'
+
+/**
+ * Drives the admin web terminal: opens the authenticated SSE feed, exposes its output as a growing list
+ * of lines, and sends commands to the connection the feed reported. The feed is torn down on unmount.
+ */
+export function useConsole() {
+  const [status, setStatus] = useState<ConsoleStatus>('connecting')
+  const [lines, setLines] = useState<ConsoleLine[]>([])
+  const connectionId = useRef<string | null>(null)
+  const nextId = useRef(0)
+
+  const append = useCallback((kind: ConsoleLine['kind'], text: string) => {
+    setLines((current) => [...current, { id: nextId.current++, kind, text }])
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    async function pump() {
+      try {
+        const response = await apiStream(STREAM, controller.signal)
+        for await (const frame of readSseFrames(response.body!, controller.signal)) {
+          if (frame.event === 'ready') {
+            connectionId.current = frame.data
+            setStatus('connected')
+          } else if (frame.event === 'line') {
+            append('output', frame.data)
+          }
+          // 'done' marks a command's end; there is nothing to render for it in v1.
+        }
+      } catch {
+        // Aborted on unmount, or the feed dropped — either way there is nothing left to read.
+      } finally {
+        if (!controller.signal.aborted) setStatus('closed')
+      }
+    }
+
+    void pump()
+    return () => controller.abort()
+  }, [append])
+
+  const send = useCallback(
+    async (command: string) => {
+      const id = connectionId.current
+      if (id === null) return
+
+      append('command', command)
+      await apiFetch<void>(SEND, { method: 'POST', body: JSON.stringify({ command, connectionId: id }) })
+    },
+    [append],
+  )
+
+  const clear = useCallback(() => setLines([]), [])
+
+  return { status, lines, send, clear }
+}

--- a/ui/src/lib/sse.test.ts
+++ b/ui/src/lib/sse.test.ts
@@ -1,0 +1,46 @@
+import { parseSseFrame, readSseFrames } from './sse'
+
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function collect(stream: ReadableStream<Uint8Array>) {
+  const out: { event: string; data: string }[] = []
+  for await (const frame of readSseFrames(stream, new AbortController().signal)) out.push(frame)
+  return out
+}
+
+describe('parseSseFrame', () => {
+  it('reads the event type and data', () => {
+    expect(parseSseFrame('event: line\ndata: hello')).toEqual({ event: 'line', data: 'hello' })
+  })
+
+  it('joins multiple data lines with a newline', () => {
+    expect(parseSseFrame('event: line\ndata: a\ndata: b')).toEqual({ event: 'line', data: 'a\nb' })
+  })
+
+  it('defaults the event to "message" when none is given', () => {
+    expect(parseSseFrame('data: x')).toEqual({ event: 'message', data: 'x' })
+  })
+})
+
+describe('readSseFrames', () => {
+  it('yields one object per blank-line-separated frame', async () => {
+    const frames = await collect(streamOf('event: ready\ndata: conn-1\n\nevent: line\ndata: hi\n\n'))
+    expect(frames).toEqual([
+      { event: 'ready', data: 'conn-1' },
+      { event: 'line', data: 'hi' },
+    ])
+  })
+
+  it('reassembles a frame split across chunks', async () => {
+    const frames = await collect(streamOf('event: li', 'ne\ndata: split', '-line\n\n'))
+    expect(frames).toEqual([{ event: 'line', data: 'split-line' }])
+  })
+})

--- a/ui/src/lib/sse.ts
+++ b/ui/src/lib/sse.ts
@@ -1,0 +1,59 @@
+// A minimal Server-Sent-Events reader. The browser's EventSource can't carry an Authorization header,
+// so the console reads its stream over an authenticated fetch and parses the frames here instead.
+
+export interface SseFrame {
+  event: string
+  data: string
+}
+
+/** Parses one SSE frame (the text between blank lines) into its event type and joined data. */
+export function parseSseFrame(frame: string): SseFrame {
+  let event = 'message'
+  const data: string[] = []
+
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trim()
+    } else if (line.startsWith('data:')) {
+      // A single leading space after the colon is part of the SSE framing, not the payload.
+      data.push(line.slice('data:'.length).replace(/^ /, ''))
+    }
+  }
+
+  return { event, data: data.join('\n') }
+}
+
+/** Reads an SSE byte stream and yields one frame per blank-line-separated block until it ends or aborts. */
+export async function* readSseFrames(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): AsyncGenerator<SseFrame> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  // A pending read() does not observe the signal on its own; cancelling the reader unblocks it so the
+  // loop can exit promptly when the caller aborts (e.g. the console page unmounts).
+  const onAbort = () => reader.cancel().catch(() => {})
+  signal.addEventListener('abort', onAbort)
+
+  try {
+    while (!signal.aborted) {
+      const { value, done } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+
+      let boundary = buffer.indexOf('\n\n')
+      while (boundary !== -1) {
+        const frame = buffer.slice(0, boundary)
+        buffer = buffer.slice(boundary + 2)
+        if (frame.trim() !== '') yield parseSseFrame(frame)
+        boundary = buffer.indexOf('\n\n')
+      }
+    }
+  } finally {
+    signal.removeEventListener('abort', onAbort)
+    reader.cancel().catch(() => {})
+  }
+}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -71,7 +71,8 @@
       "overview": "Overview",
       "accounts": "Accounts",
       "plugins": "Plugins",
-      "settings": "Settings"
+      "settings": "Settings",
+      "console": "Console"
     },
     "accounts": {
       "title": "Accounts",
@@ -129,6 +130,22 @@
       "notImage": "That file is not an image.",
       "tooLarge": "That image is too large.",
       "tagline": "Tagline"
+    },
+    "console": {
+      "title": "Console",
+      "session": "Console · {{user}}",
+      "live": "Production",
+      "warning": "Commands run for real on the live server.",
+      "banner": "— session started",
+      "placeholder": "Type a command…",
+      "execute": "Run",
+      "clear": "Clear",
+      "connected": "connected",
+      "connecting": "connecting",
+      "closed": "disconnected",
+      "empty": "No output yet. Type a command to begin.",
+      "hint": "↑ / ↓ for history",
+      "snippets": "Quick commands"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -71,7 +71,8 @@
       "overview": "Panoramica",
       "accounts": "Account",
       "plugins": "Plugin",
-      "settings": "Impostazioni"
+      "settings": "Impostazioni",
+      "console": "Console"
     },
     "accounts": {
       "title": "Account",
@@ -129,6 +130,22 @@
       "notImage": "Il file non è un'immagine.",
       "tooLarge": "L'immagine è troppo grande.",
       "tagline": "Slogan"
+    },
+    "console": {
+      "title": "Console",
+      "session": "Console · {{user}}",
+      "live": "Produzione",
+      "warning": "I comandi girano davvero sul server in produzione.",
+      "banner": "— sessione avviata",
+      "placeholder": "Scrivi un comando…",
+      "execute": "Esegui",
+      "clear": "Pulisci",
+      "connected": "connesso",
+      "connecting": "connessione…",
+      "closed": "disconnesso",
+      "empty": "Nessun output. Scrivi un comando per iniziare.",
+      "hint": "↑ / ↓ per la cronologia",
+      "snippets": "Comandi rapidi"
     }
   }
 }

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -23,6 +23,7 @@ describe('AdminLayout', () => {
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /console/i })).toBeInTheDocument()
     expect(screen.getByText('overview page')).toBeInTheDocument()
   })
 

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -25,6 +25,9 @@ export function AdminLayout() {
         <NavLink to="/admin/settings" className={linkClass}>
           {t('admin.nav.settings')}
         </NavLink>
+        <NavLink to="/admin/console" className={linkClass}>
+          {t('admin.nav.console')}
+        </NavLink>
       </nav>
       <Outlet />
     </div>

--- a/ui/src/routes/ConsoleScreen.test.tsx
+++ b/ui/src/routes/ConsoleScreen.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '../lib/i18n'
+import type { ConsoleLine } from '../lib/console'
+import { ConsoleScreen } from './ConsoleScreen'
+
+const state = vi.hoisted(() => ({
+  status: 'connected' as 'connecting' | 'connected' | 'closed',
+  lines: [] as ConsoleLine[],
+  send: vi.fn(),
+  clear: vi.fn(),
+}))
+
+vi.mock('../lib/console', () => ({ useConsole: () => state }))
+vi.mock('../lib/auth', () => ({ useSession: () => ({ username: 'admin' }) }))
+
+describe('ConsoleScreen', () => {
+  beforeEach(() => {
+    state.status = 'connected'
+    state.lines = []
+    state.send = vi.fn()
+    state.clear = vi.fn()
+  })
+
+  it('renders the output lines', () => {
+    state.lines = [
+      { id: 0, kind: 'command', text: 'who' },
+      { id: 1, kind: 'output', text: '2 players online' },
+    ]
+    render(<ConsoleScreen />)
+
+    expect(screen.getByText('2 players online')).toBeInTheDocument()
+    expect(screen.getByText(/who/)).toBeInTheDocument()
+  })
+
+  it('sends the typed command on Enter and clears the input', async () => {
+    render(<ConsoleScreen />)
+    const input = screen.getByRole('textbox')
+
+    await userEvent.type(input, 'save{Enter}')
+
+    expect(state.send).toHaveBeenCalledWith('save')
+    expect(input).toHaveValue('')
+  })
+
+  it('recalls the previous command with ArrowUp', async () => {
+    render(<ConsoleScreen />)
+    const input = screen.getByRole('textbox')
+
+    await userEvent.type(input, 'who{Enter}')
+    await userEvent.type(input, '{ArrowUp}')
+
+    expect(input).toHaveValue('who')
+  })
+
+  it('runs the command with the Run button', async () => {
+    render(<ConsoleScreen />)
+    await userEvent.type(screen.getByRole('textbox'), 'broadcast hi')
+    await userEvent.click(screen.getByRole('button', { name: /run/i }))
+
+    expect(state.send).toHaveBeenCalledWith('broadcast hi')
+  })
+
+  it('fills the input from a quick-command snippet', async () => {
+    render(<ConsoleScreen />)
+    await userEvent.click(screen.getByRole('button', { name: /broadcast <message>/i }))
+
+    expect(screen.getByRole('textbox')).toHaveValue('broadcast <message>')
+  })
+
+  it('clears the output with the Clear button', async () => {
+    render(<ConsoleScreen />)
+
+    await userEvent.click(screen.getByRole('button', { name: /clear/i }))
+
+    expect(state.clear).toHaveBeenCalled()
+  })
+
+  it('disables input until connected', () => {
+    state.status = 'connecting'
+    render(<ConsoleScreen />)
+
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+})

--- a/ui/src/routes/ConsoleScreen.tsx
+++ b/ui/src/routes/ConsoleScreen.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Card } from '../components/ui/card'
+import { Button } from '../components/ui/button'
+import { Badge } from '../components/ui/badge'
+import { useSession } from '../lib/auth'
+import { useConsole, type ConsoleStatus } from '../lib/console'
+
+const PROMPT = 'moongate>'
+
+// The commands the REST console actually accepts today; clicking one pre-fills the input.
+const SNIPPETS = ['broadcast <message>', 'bc <message>']
+
+const DOT: Record<ConsoleStatus, string> = {
+  connected: 'bg-success shadow-[0_0_6px_rgba(111,201,141,0.7)]',
+  connecting: 'bg-gold',
+  closed: 'bg-danger-text',
+}
+
+const STATUS_BADGE: Record<ConsoleStatus, 'success' | 'warning' | 'danger'> = {
+  connected: 'success',
+  connecting: 'warning',
+  closed: 'danger',
+}
+
+export function ConsoleScreen() {
+  const { t } = useTranslation()
+  const { username } = useSession()
+  const { status, lines, send, clear } = useConsole()
+  const [input, setInput] = useState('')
+
+  // Submitted commands, newest last, plus a cursor into them for ↑/↓ recall (-1 = editing a fresh line).
+  const history = useRef<string[]>([])
+  const cursor = useRef(-1)
+  const output = useRef<HTMLDivElement>(null)
+  const field = useRef<HTMLInputElement>(null)
+
+  // Keep the newest line in view as output streams in.
+  useEffect(() => {
+    output.current?.scrollTo({ top: output.current.scrollHeight })
+  }, [lines])
+
+  function submit() {
+    const command = input.trim()
+    if (command === '') {
+      return
+    }
+    history.current = [...history.current, command]
+    cursor.current = -1
+    setInput('')
+    void send(command)
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    const past = history.current
+
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      submit()
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      if (past.length === 0) {
+        return
+      }
+      cursor.current = cursor.current === -1 ? past.length - 1 : Math.max(0, cursor.current - 1)
+      setInput(past[cursor.current])
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      if (cursor.current === -1) {
+        return
+      }
+      const next = cursor.current + 1
+      if (next >= past.length) {
+        cursor.current = -1
+        setInput('')
+      } else {
+        cursor.current = next
+        setInput(past[next])
+      }
+    }
+  }
+
+  function useSnippet(snippet: string) {
+    setInput(snippet)
+    field.current?.focus()
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="font-display text-xl text-ink">{t('admin.console.title')}</h1>
+
+      <div className="flex items-center gap-3">
+        <Badge variant="danger">{t('admin.console.live')}</Badge>
+        <span className="text-sm text-muted">{t('admin.console.warning')}</span>
+      </div>
+
+      <div className="overflow-hidden rounded-control border border-border-subtle bg-deep font-mono">
+        <div className="flex items-center gap-2 border-b border-border-subtle bg-surface px-3.5 py-2.5 text-[11.5px]">
+          <span className={`size-[7px] rounded-full ${DOT[status]}`} aria-hidden />
+          <span className="text-muted">{t('admin.console.session', { user: username ?? '' })}</span>
+          <span className="ml-auto flex items-center gap-2.5">
+            <Badge variant={STATUS_BADGE[status]}>{t(`admin.console.${status}`)}</Badge>
+            <button type="button" onClick={clear} className="text-xs text-muted hover:text-gold">
+              {t('admin.console.clear')}
+            </button>
+          </span>
+        </div>
+
+        <div ref={output} className="h-[360px] overflow-y-auto px-[18px] py-4 text-[13px] leading-[1.9]">
+          <div className="text-faint">{t('admin.console.banner')}</div>
+          {lines.map((line) =>
+            line.kind === 'command' ? (
+              <div key={line.id} className="whitespace-pre-wrap">
+                <span className="text-gold">{PROMPT} </span>
+                <span className="text-ink">{line.text}</span>
+              </div>
+            ) : (
+              <div key={line.id} className="whitespace-pre-wrap text-ink">
+                {line.text}
+              </div>
+            ),
+          )}
+        </div>
+
+        <div className="flex items-center gap-2.5 border-t border-border-subtle px-3.5 py-2.5">
+          <span className="text-[13px] text-gold" aria-hidden>
+            {PROMPT}
+          </span>
+          <input
+            ref={field}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            disabled={status !== 'connected'}
+            placeholder={t('admin.console.placeholder')}
+            autoComplete="off"
+            spellCheck={false}
+            className="flex-1 bg-transparent text-[13px] text-ink outline-none placeholder:text-faint disabled:opacity-50"
+          />
+          <span className="hidden text-xs text-faint sm:inline">{t('admin.console.hint')}</span>
+          <Button type="button" onClick={submit} disabled={status !== 'connected'} className="px-4 py-2 text-[11px]">
+            {t('admin.console.execute')}
+          </Button>
+        </div>
+      </div>
+
+      <Card className="flex flex-col gap-3 px-[18px] py-4">
+        <h2 className="font-display text-[13px] tracking-[0.08em] text-gold">{t('admin.console.snippets')}</h2>
+        <div className="flex flex-wrap gap-2.5 font-mono text-[12.5px]">
+          {SNIPPETS.map((snippet) => (
+            <button
+              key={snippet}
+              type="button"
+              onClick={() => useSnippet(snippet)}
+              className="rounded-control border border-border-subtle bg-page px-2.5 py-1.5 text-gold hover:border-gold"
+            >
+              {`› ${snippet}`}
+            </button>
+          ))}
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -9,6 +9,8 @@ if (!Element.prototype.hasPointerCapture) {
   Element.prototype.releasePointerCapture = () => {}
 }
 Element.prototype.scrollIntoView = () => {}
+// jsdom has no scrollTo either; the console pane calls it to keep the newest line in view.
+Element.prototype.scrollTo = () => {}
 
 // jsdom has no ResizeObserver, which the Radix Switch measures its thumb with.
 if (!('ResizeObserver' in globalThis)) {


### PR DESCRIPTION
Adds the **Console** admin page (`/admin/console`, 5th admin tab) — the web terminal from the `Moongate Portal.dc.html` design, driving the REST console shipped in #32.

## What
- Connects to the authenticated SSE feed, sends commands and streams their reply lines live; auto-scrolls, shows connection status, keeps ↑/↓ command history and a Clear button.
- Faithful to the design's web-terminal screen: deep terminal card, pulsing status dot, `moongate>` prompt, gold-prompt/ink-command lines, Run button, and a quick-command snippet row.

## How
- `apiStream()`: EventSource can't carry the bearer token, so the feed is read over an authenticated `fetch` streaming body; `apiFetch` now treats **202** (the console POST) as an empty body.
- `sse.ts`: a pure frame parser + a chunk-reassembling async reader (aborts cleanly on unmount).
- `useConsole()`: captures the `ready` connection id, accumulates output, posts commands, tears the feed down on unmount.
- Snippets list the commands the REST console actually accepts today (`broadcast`/`bc`) rather than the mockup's Lua examples.

## Verification
- 102 UI tests green (SSE parser, api 202/stream, useConsole lifecycle, ConsoleScreen interactions); build clean.
- Live browser round-trip in both themes: `nonsense-command` → "Unknown command.", `broadcast …` → "Broadcast sent.", streamed over SSE. No console errors.

Closes #84.