### PR TITLE
fix(network): publish session lifecycle events on the game loop

### DIFF
--- a/src/Moongate.Server/Services/Network/NetworkService.cs
+++ b/src/Moongate.Server/Services/Network/NetworkService.cs
@@ -150,7 +150,11 @@ public sealed class NetworkService : INetworkService, ISquidStdService, IAsyncDi
     {
         var session = _sessions.GetOrCreate(e.Client);
         _logger.Information("Client connected: {SessionId}", e.Client.SessionId);
-        _eventBus.Publish(new SessionCreatedEvent(session));
+
+        // Session lifecycle subscribers mutate world state (the spatial index), so their event must be
+        // published on the game loop — like inbound packets (see OnDataReceived) — never on this
+        // transport thread.
+        _mainThreadDispatcher.Post(() => _eventBus.Publish(new SessionCreatedEvent(session)));
     }
 
     private void OnClientDisconnect(object? sender, SquidStdTcpClientEventArgs e)
@@ -158,7 +162,11 @@ public sealed class NetworkService : INetworkService, ISquidStdService, IAsyncDi
         if (_sessions.TryGet(e.Client.SessionId, out var session))
         {
             _sessions.Remove(e.Client.SessionId);
-            _eventBus.Publish(new SessionDestroyedEvent(session));
+
+            // Publish on the game loop, not this transport thread: SpatialSubscriber removes the character
+            // from the spatial index here, and that world mutation must be loop-affine to avoid racing the
+            // loop's own reads/writes (movement re-indexing, range queries).
+            _mainThreadDispatcher.Post(() => _eventBus.Publish(new SessionDestroyedEvent(session)));
         }
 
         _logger.Information("Client disconnected: {SessionId}", e.Client.SessionId);

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -60,6 +61,49 @@ public class LoginFlowIntegrationTests
 
         public void Post(Action action)
             => action();
+    }
+
+    // A stand-in game loop: drains posted work on one dedicated thread and exposes its id, so a test can
+    // prove that work meant for the loop actually ran there and not on the transport thread that posted it.
+    private sealed class LoopThreadDispatcher : IMainThreadDispatcher, IDisposable
+    {
+        private readonly BlockingCollection<Action> _queue = new();
+        private readonly Thread _thread;
+        private readonly ManualResetEventSlim _ready = new();
+
+        public int LoopThreadId { get; private set; }
+
+        public LoopThreadDispatcher()
+        {
+            _thread = new Thread(Run) { IsBackground = true, Name = "test-game-loop" };
+            _thread.Start();
+            _ready.Wait();
+        }
+
+        public int PendingCount => _queue.Count;
+
+        public int DrainPending(double? budgetMs = null)
+            => 0;
+
+        public void Post(Action action)
+            => _queue.Add(action);
+
+        private void Run()
+        {
+            LoopThreadId = Environment.CurrentManagedThreadId;
+            _ready.Set();
+
+            foreach (var action in _queue.GetConsumingEnumerable())
+            {
+                action();
+            }
+        }
+
+        public void Dispose()
+        {
+            _queue.CompleteAdding();
+            _thread.Join(TimeSpan.FromSeconds(2));
+        }
     }
 
     [Fact]
@@ -887,6 +931,46 @@ public class LoginFlowIntegrationTests
         }
     }
 
+    // A client disconnect is raised on the transport thread, but its SessionDestroyedEvent subscribers
+    // mutate world state (SpatialSubscriber removes the character from the spatial index), so they must
+    // run on the game loop — never on the transport thread. This drives a real connect/disconnect through
+    // a dedicated-loop dispatcher and asserts the event surfaces on the loop thread.
+    [Fact]
+    public async Task SessionDestroyed_IsPublishedOnTheGameLoopThread_NotTheTransportThread()
+    {
+        var config = LoopbackConfig();
+        var eventBus = new EventBusService();
+        using var loop = new LoopThreadDispatcher();
+
+        using var destroyed = new ManualResetEventSlim();
+        var subscriberThreadId = 0;
+        eventBus.Subscribe<SessionDestroyedEvent>(
+            (_, _) =>
+            {
+                subscriberThreadId = Environment.CurrentManagedThreadId;
+                destroyed.Set();
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var network = await StartServerAsync(config, eventBus, loop);
+
+        try
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket.Connect(IPAddress.Loopback, network.Port);
+            socket.Close();
+
+            Assert.True(destroyed.Wait(TimeSpan.FromSeconds(2)), "SessionDestroyedEvent was not published.");
+            Assert.Equal(loop.LoopThreadId, subscriberThreadId);
+        }
+        finally
+        {
+            await network.StopAsync(CancellationToken.None);
+        }
+    }
+
     /// <summary>
     /// End-to-end proof that the spatial index and its consumers work together: two real characters log
     /// in and enter the world (same default starting city, so they land on the same tile), the
@@ -1210,6 +1294,22 @@ public class LoginFlowIntegrationTests
 
     private static Task<NetworkService> StartServerAsync(MoongateConfig config)
         => StartServerAsync(config, new EventBusService());
+
+    /// <summary>
+    /// Minimal server (no packet handlers) started with a specific dispatcher — enough to exercise the
+    /// connect/disconnect lifecycle, where the session events are published, without a full login flow.
+    /// </summary>
+    private static async Task<NetworkService> StartServerAsync(
+        MoongateConfig config,
+        IEventBus eventBus,
+        IMainThreadDispatcher dispatcher
+    )
+    {
+        var network = new NetworkService(new SessionManager(), config, [], eventBus, dispatcher);
+        await network.StartAsync(CancellationToken.None);
+
+        return network;
+    }
 
     private static Task<NetworkService> StartServerAsync(MoongateConfig config, IEventBus eventBus)
         => StartServerAsync(config, eventBus, new StubCharacterService(), null);


### PR DESCRIPTION
## Bugs
1. `SpatialIndexService.Remove called off the game-loop thread` warning.
2. Player walks a few steps, then can no longer move.

## Root cause
`NetworkService.OnClientConnect`/`OnClientDisconnect` run on the transport thread and published `SessionCreatedEvent`/`SessionDestroyedEvent` **synchronously** there — unlike `OnDataReceived`, which marshals onto the game loop. `SpatialSubscriber.OnSessionDestroyed` then mutated the spatial index (`Remove`) off the loop, tripping the LoopGuard warning and **racing the loop's own spatial reads/writes during movement** (`GetItemsInRange`/`AddOrUpdate`). The index is plain `Dictionary`/`HashSet` (single-writer by design), so the race can corrupt it or throw — `TryMove` then propagates the exception, the dispatcher swallows it, no move-ack is sent, and the client freezes.

## Fix
Publish both lifecycle events through `IMainThreadDispatcher.Post`, mirroring `OnDataReceived`, so all world mutation is loop-affine.

## Test
New integration test `SessionDestroyed_IsPublishedOnTheGameLoopThread_NotTheTransportThread`: drives a real socket connect/disconnect through a dedicated-loop dispatcher and asserts the subscriber runs on the loop thread. It **fails before** the fix (subscriber ran on the transport thread — thread 13 vs loop thread 18) and passes after.

## Verification
- Full .NET suite green (1405), including the existing `SessionLifecycle`, `Movement_TurnThenStep` and `Spatial_TwoPlayers` integration tests — no regression.
- No packet classes changed (no packet-docs regen needed).

Closes #86.