### PR TITLE
feat(world): mobile sector-transition events with Lua hooks

### DIFF
--- a/docs/scripting/reference/events.md
+++ b/docs/scripting/reference/events.md
@@ -53,7 +53,25 @@ end)
 | Event | Fired | Payload |
 |---|---|---|
 | `world_ready` | Once, on the game-loop thread, after the world is loaded and ready. | none (empty table) |
+| `mobile_entered_sector` | When a mobile enters a spatial sector — appearing in the world, or crossing into it from another sector. Boundary-only (never per tile), mobiles only. | `mobile`, `map_id`, `sector_x`, `sector_y` |
+| `mobile_left_sector` | When a mobile leaves a spatial sector — being removed from the world, or crossing out of it into another. Boundary-only, mobiles only. | `mobile`, `map_id`, `sector_x`, `sector_y` |
+| `mobile_changed_sector` | When a mobile moves from one sector to another. Fires alongside `mobile_left_sector` (old) and `mobile_entered_sector` (new); never on spawn or removal. | `mobile`, `from_map_id`, `from_sector_x`, `from_sector_y`, `to_map_id`, `to_sector_x`, `to_sector_y` |
 
 `world_ready` is the recommended hook for bootstrap spawns: the handler runs on
 the loop, so it can create and place mobiles and items directly without
 `game.post`.
+
+The `mobile_*_sector` events fire on the game loop as mobiles cross the spatial
+index's 16-tile sector grid — a coarse "region" signal for waking NPC AI, arming
+spawners, or reacting to who is nearby, without polling. Sectors are `world
+coordinate >> 4`, so `sector_x = x / 16`. A step that stays inside the same
+sector fires nothing.
+
+**Example**
+
+```lua
+events.on("mobile_entered_sector", function(e)
+  log.debug("mobile " .. tostring(e.mobile) .. " entered sector "
+    .. e.map_id .. ":" .. e.sector_x .. "," .. e.sector_y)
+end)
+```

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileChangedSectorEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileChangedSectorEvent.cs
@@ -1,0 +1,22 @@
+using Moongate.Core.Primitives;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>
+/// Raised when a mobile moves from one spatial-index sector to another (never on spawn or removal — those
+/// are covered by <see cref="MobileEnteredSectorEvent" /> and <see cref="MobileLeftSectorEvent" />, both
+/// of which also fire alongside this one on a move). Carries the full source and target sector keys so a
+/// map change is unambiguous. Auto-exposed to Lua as <c>events.on("mobile_changed_sector", ...)</c>, with
+/// a table carrying <c>mobile</c>, <c>from_map_id</c>, <c>from_sector_x</c>, <c>from_sector_y</c>,
+/// <c>to_map_id</c>, <c>to_sector_x</c> and <c>to_sector_y</c>.
+/// </summary>
+public sealed record MobileChangedSectorEvent(
+    Serial Mobile,
+    int FromMapId,
+    int FromSectorX,
+    int FromSectorY,
+    int ToMapId,
+    int ToSectorX,
+    int ToSectorY
+) : IEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileEnteredSectorEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileEnteredSectorEvent.cs
@@ -1,0 +1,12 @@
+using Moongate.Core.Primitives;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>
+/// Raised when a mobile enters a spatial-index sector — either appearing in the world or crossing a
+/// sector boundary from another one. Fires only on sector boundaries, never per tile, and only for
+/// mobiles (not items). Auto-exposed to Lua as <c>events.on("mobile_entered_sector", ...)</c>, with a
+/// table carrying <c>mobile</c>, <c>map_id</c>, <c>sector_x</c> and <c>sector_y</c>.
+/// </summary>
+public sealed record MobileEnteredSectorEvent(Serial Mobile, int MapId, int SectorX, int SectorY) : IEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileLeftSectorEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileLeftSectorEvent.cs
@@ -1,0 +1,12 @@
+using Moongate.Core.Primitives;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>
+/// Raised when a mobile leaves a spatial-index sector — either being removed from the world or crossing
+/// a sector boundary into another one. Fires only on sector boundaries, never per tile, and only for
+/// mobiles (not items). Auto-exposed to Lua as <c>events.on("mobile_left_sector", ...)</c>, with a table
+/// carrying <c>mobile</c>, <c>map_id</c>, <c>sector_x</c> and <c>sector_y</c>.
+/// </summary>
+public sealed record MobileLeftSectorEvent(Serial Mobile, int MapId, int SectorX, int SectorY) : IEvent;

--- a/src/Moongate.Server/Services/World/SpatialIndexService.cs
+++ b/src/Moongate.Server/Services/World/SpatialIndexService.cs
@@ -2,9 +2,12 @@ using Moongate.Core.Geometry;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Data.Internal.World;
 using Moongate.Server.Scripting;
+using Serilog;
+using SquidStd.Core.Interfaces.Events;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.Server.Services.World;
@@ -18,17 +21,21 @@ public sealed class SpatialIndexService : ISpatialIndexService
     // 16-tile sectors: sector coordinates are world coordinates >> 4.
     private const int SectorShift = 4;
 
+    private readonly ILogger _logger = Log.ForContext<SpatialIndexService>();
+
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
     private readonly IEntityStore<ItemEntity, Serial> _items;
     private readonly ILoopThread _loopThread;
+    private readonly IEventBus _eventBus;
     private readonly Dictionary<(int MapId, int SectorX, int SectorY), Sector> _sectors = [];
     private readonly Dictionary<Serial, (int MapId, int SectorX, int SectorY)> _locations = [];
 
-    public SpatialIndexService(IPersistenceService persistenceService, ILoopThread loopThread)
+    public SpatialIndexService(IPersistenceService persistenceService, ILoopThread loopThread, IEventBus eventBus)
     {
         _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
         _items = persistenceService.GetStore<ItemEntity, Serial>();
         _loopThread = loopThread;
+        _eventBus = eventBus;
     }
 
     public void AddOrUpdate(MobileEntity mobile)
@@ -98,7 +105,10 @@ public sealed class SpatialIndexService : ISpatialIndexService
 
     private void Place(Serial serial, int mapId, Point3D position, bool isMobile)
     {
-        var key = (mapId, position.X >> SectorShift, position.Y >> SectorShift);
+        var key = (MapId: mapId, SectorX: position.X >> SectorShift, SectorY: position.Y >> SectorShift);
+
+        var moved = false;
+        (int MapId, int SectorX, int SectorY) from = default;
 
         if (_locations.TryGetValue(serial, out var current))
         {
@@ -107,7 +117,9 @@ public sealed class SpatialIndexService : ISpatialIndexService
                 return;
             }
 
-            RemoveCore(serial);
+            from = current;
+            moved = true;
+            RemoveCore(serial); // publishes the "left" event for the old sector, if this is a mobile
         }
 
         if (!_sectors.TryGetValue(key, out var sector))
@@ -126,6 +138,33 @@ public sealed class SpatialIndexService : ISpatialIndexService
         }
 
         _locations[serial] = key;
+
+        // Sector transitions are a mobile-only, boundary-only signal: never for items, and never for a
+        // step that stays inside the same sector (handled by the same-key early return above).
+        if (!isMobile)
+        {
+            return;
+        }
+
+        _logger.Debug("Mobile {Mobile} entered sector {MapId}:{SectorX},{SectorY}", serial, key.MapId, key.SectorX, key.SectorY);
+        _eventBus.Publish(new MobileEnteredSectorEvent(serial, key.MapId, key.SectorX, key.SectorY));
+
+        if (moved)
+        {
+            _logger.Debug(
+                "Mobile {Mobile} changed sector {FromMapId}:{FromSectorX},{FromSectorY} -> {ToMapId}:{ToSectorX},{ToSectorY}",
+                serial,
+                from.MapId,
+                from.SectorX,
+                from.SectorY,
+                key.MapId,
+                key.SectorX,
+                key.SectorY
+            );
+            _eventBus.Publish(
+                new MobileChangedSectorEvent(serial, from.MapId, from.SectorX, from.SectorY, key.MapId, key.SectorX, key.SectorY)
+            );
+        }
     }
 
     private void RemoveCore(Serial serial)
@@ -137,12 +176,20 @@ public sealed class SpatialIndexService : ISpatialIndexService
 
         if (_sectors.TryGetValue(key, out var sector))
         {
-            sector.Mobiles.Remove(serial);
+            // HashSet.Remove returns whether the serial was present, which is exactly "was this a mobile in
+            // this sector" — the gate for emitting the mobile-only "left" signal.
+            var wasMobile = sector.Mobiles.Remove(serial);
             sector.Items.Remove(serial);
 
             if (sector.IsEmpty)
             {
                 _sectors.Remove(key);
+            }
+
+            if (wasMobile)
+            {
+                _logger.Debug("Mobile {Mobile} left sector {MapId}:{SectorX},{SectorY}", serial, key.MapId, key.SectorX, key.SectorY);
+                _eventBus.Publish(new MobileLeftSectorEvent(serial, key.MapId, key.SectorX, key.SectorY));
             }
         }
     }

--- a/tests/Moongate.Tests/Server/ItemServiceTests.cs
+++ b/tests/Moongate.Tests/Server/ItemServiceTests.cs
@@ -329,7 +329,7 @@ public class ItemServiceTests
         var persistence = new FakePersistenceService();
         var marker = new LoopThreadMarker();
         marker.Capture();
-        var spatial = new SpatialIndexService(persistence, marker);
+        var spatial = new SpatialIndexService(persistence, marker, new StubEventBus());
 
         return (new(persistence, null, spatial), spatial, persistence);
     }

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -753,7 +753,7 @@ public class LoginFlowIntegrationTests
 
             var loopThread = new LoopThreadMarker();
             loopThread.Capture();
-            var spatial = new SpatialIndexService(persistence, loopThread);
+            var spatial = new SpatialIndexService(persistence, loopThread, eventBus);
             new SpatialSubscriber(spatial, persistence).Subscribe(eventBus);
 
             var mapTiles = new MapTileService(mapProvider);
@@ -995,7 +995,7 @@ public class LoginFlowIntegrationTests
 
         var loopThread = new LoopThreadMarker();
         loopThread.Capture();
-        var spatial = new SpatialIndexService(persistence, loopThread);
+        var spatial = new SpatialIndexService(persistence, loopThread, eventBus);
         new SpatialSubscriber(spatial, persistence).Subscribe(eventBus);
 
         var world = new WorldService(

--- a/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
@@ -59,7 +59,7 @@ public class SpatialSubscriberTests
         var persistence = new FakePersistenceService();
         var marker = new LoopThreadMarker();
         marker.Capture();
-        var spatial = new SpatialIndexService(persistence, marker);
+        var spatial = new SpatialIndexService(persistence, marker, new StubEventBus());
 
         return (new(spatial, persistence), spatial, persistence);
     }

--- a/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
@@ -1,5 +1,6 @@
 using Moongate.Core.Extensions;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.Game;
 using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
@@ -136,13 +137,101 @@ public class SpatialIndexServiceTests
         index.Remove(new(0xDEAD));
     }
 
+    [Fact]
+    public void AddOrUpdate_NewMobile_PublishesEnteredSectorOnly()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+
+        index.AddOrUpdate(SeedMobile(persistence, 0x1, 0, 100, 100)); // sector (6, 6)
+
+        var entered = Assert.Single(bus.Published.OfType<MobileEnteredSectorEvent>());
+        Assert.Equal(new(0x1), entered.Mobile);
+        Assert.Equal((0, 6, 6), (entered.MapId, entered.SectorX, entered.SectorY));
+        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
+    }
+
+    [Fact]
+    public void AddOrUpdate_MoveAcrossSectors_PublishesLeftEnteredAndChanged()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var mobile = SeedMobile(persistence, 0x1, 0, 15, 0); // sector (0, 0)
+        index.AddOrUpdate(mobile);
+
+        mobile.Position = new(400, 400, 0); // sector (25, 25)
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+        index.AddOrUpdate(mobile);
+
+        // Left and Changed are unique to the move; Entered also fired once on the initial spawn, so the
+        // move's entry is the later of the two.
+        var left = Assert.Single(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Equal((0, 0, 0), (left.MapId, left.SectorX, left.SectorY));
+
+        var entered = bus.Published.OfType<MobileEnteredSectorEvent>().Last();
+        Assert.Equal((0, 25, 25), (entered.MapId, entered.SectorX, entered.SectorY));
+
+        var changed = Assert.Single(bus.Published.OfType<MobileChangedSectorEvent>());
+        Assert.Equal((0, 0, 0), (changed.FromMapId, changed.FromSectorX, changed.FromSectorY));
+        Assert.Equal((0, 25, 25), (changed.ToMapId, changed.ToSectorX, changed.ToSectorY));
+    }
+
+    [Fact]
+    public void AddOrUpdate_SameSector_PublishesNoFurtherSectorEvents()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var mobile = SeedMobile(persistence, 0x1, 0, 100, 100);
+
+        index.AddOrUpdate(mobile);
+        index.AddOrUpdate(mobile); // same tile, same sector
+
+        Assert.Single(bus.Published.OfType<MobileEnteredSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
+    }
+
+    [Fact]
+    public void Remove_Mobile_PublishesLeftSector()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var mobile = SeedMobile(persistence, 0x1, 0, 100, 100);
+        index.AddOrUpdate(mobile);
+
+        index.Remove(mobile.Id);
+
+        var left = Assert.Single(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Equal(new(0x1), left.Mobile);
+        Assert.Equal((0, 6, 6), (left.MapId, left.SectorX, left.SectorY));
+    }
+
+    [Fact]
+    public void Items_ProduceNoSectorEvents()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var item = SeedItem(persistence, 0x40000001, 0, 50, 50);
+
+        index.AddOrUpdate(item);
+        index.Remove(item.Id);
+
+        Assert.Empty(bus.Published.OfType<MobileEnteredSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
+    }
+
     private static (SpatialIndexService Index, FakePersistenceService Persistence) Build()
     {
+        var (index, persistence, _) = BuildWithBus();
+
+        return (index, persistence);
+    }
+
+    private static (SpatialIndexService Index, FakePersistenceService Persistence, StubEventBus Bus) BuildWithBus()
+    {
         var persistence = new FakePersistenceService();
+        var bus = new StubEventBus();
         var marker = new LoopThreadMarker();
         marker.Capture();
 
-        return (new(persistence, marker), persistence);
+        return (new(persistence, marker, bus), persistence, bus);
     }
 
     private static ItemEntity SeedItem(FakePersistenceService persistence, uint serial, int mapId, int x, int y)


### PR DESCRIPTION
Adds domain events fired when a mobile crosses the spatial index's 16-tile sector grid, with automatic Lua hooks and Serilog Debug logging.

## What
- `SpatialIndexService` publishes `MobileEnteredSectorEvent` / `MobileLeftSectorEvent` / `MobileChangedSectorEvent` on **boundary crossings only** (never per tile), for **mobiles only** (items produce nothing), logging each at `Log.Debug`.
- A move fires **Left(old) + Entered(new) + Changed(old→new)**; a spawn fires only **Entered**; a removal only **Left**; a same-sector step fires **nothing**.
- Auto-exposed to Lua by the event-bus→Lua bridge: `events.on("mobile_entered_sector"|"mobile_left_sector"|"mobile_changed_sector", ...)`, snake_case payload fields (`mobile`, `map_id`, `sector_x`, `sector_y`, and the `from_*`/`to_*` pair for changed).
- Emitted **on the game loop** (the index is loop-affine after #87), so subscribers and Lua handlers can touch world state directly.

## How
Events emitted from `Place` (Entered/Changed) and `RemoveCore` (Left); the mobile-vs-item gate uses the sector's `Mobiles` set membership. `SpatialIndexService` gains an `IEventBus` dependency.

## Tests / docs
- 5 new `SpatialIndexServiceTests` (new mobile → Entered; move → Left+Entered+Changed; same sector → nothing; remove → Left; items → nothing). Full .NET suite green (1410).
- Documented in `docs/scripting/reference/events.md`; DocFX builds at 0 warnings.
- No packet classes changed.

## Note
Debug lines show only with `logger.MinimumLevel: Debug` in `moongate.yaml` (default is `Information`).

Closes #88.