### PR TITLE
chore(format): reformat the C# codebase with jb (ReSharper)

### DIFF
--- a/plugins/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
+++ b/plugins/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
@@ -62,7 +62,12 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
         }
         catch (Exception ex) when (ex is SocketException or FormatException)
         {
-            _logger.Error(ex, "Admin console failed to bind {Address}:{Port}; console unavailable", _config.Address, _config.Port);
+            _logger.Error(
+                ex,
+                "Admin console failed to bind {Address}:{Port}; console unavailable",
+                _config.Address,
+                _config.Port
+            );
             _listener = null;
 
             return ValueTask.CompletedTask;
@@ -111,8 +116,12 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
                 );
             }
         }
-        catch (OperationCanceledException) { }
-        catch (ObjectDisposedException) { }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
     private static async Task RejectAsync(TcpClient client)

--- a/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
@@ -36,14 +36,14 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/accounts")
-                          .WithTags("accounts")
-                          .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithTags("accounts")
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapGet("/", List).WithName("ListAccounts").Produces<IReadOnlyList<AccountResponse>>();
         group.MapGet("/{username}", Get).WithName("GetAccount").Produces<AccountResponse>();
         group.MapPost("/", Create)
-             .WithName("CreateAccount")
-             .Produces<AccountResponse>(StatusCodes.Status201Created);
+            .WithName("CreateAccount")
+            .Produces<AccountResponse>(StatusCodes.Status201Created);
         group.MapPatch("/{username}", Update).WithName("UpdateAccount").Produces<AccountResponse>();
         group.MapDelete("/{username}", Delete).WithName("DeleteAccount").Produces(StatusCodes.Status204NoContent);
     }
@@ -191,8 +191,8 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// <remarks>Answers 404 when no account carries that username.</remarks>
     private IResult Get(string username)
         => _accounts.GetByUsername(username) is { } account
-               ? Results.Ok(ToResponse(account))
-               : NotFound(username);
+            ? Results.Ok(ToResponse(account))
+            : NotFound(username);
 
     /// <summary>Lists every account on the shard.</summary>
     /// <remarks>Passwords are never returned, by any account route.</remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Admin/AdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Admin/AdminEndpoints.cs
@@ -24,10 +24,10 @@ public sealed class AdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/status", Status)
-                 .WithName("GetAdminStatus")
-                 .WithTags("admin")
-                 .Produces<AdminStatusResponse>()
-                 .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("GetAdminStatus")
+            .WithTags("admin")
+            .Produces<AdminStatusResponse>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Reports the shard's name, build and how many sessions are connected.</summary>
     /// <remarks>A snapshot taken when the request is served, not a live figure.</remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Auth/AuthEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Auth/AuthEndpoints.cs
@@ -39,16 +39,16 @@ public sealed class AuthEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapPost("/api/v1/auth/login", Login)
-              .WithName("Login")
-              .WithTags("auth")
-              .Produces<ApiTokenResult>()
-              .AllowAnonymous();
+            .WithName("Login")
+            .WithTags("auth")
+            .Produces<ApiTokenResult>()
+            .AllowAnonymous();
 
         routes.MapPost("/api/v1/auth/renew", Renew)
-              .WithName("RenewToken")
-              .WithTags("auth")
-              .Produces<ApiTokenResult>()
-              .RequireAuthorization(HttpServerService.PlayerPolicy);
+            .WithName("RenewToken")
+            .WithTags("auth")
+            .Produces<ApiTokenResult>()
+            .RequireAuthorization(HttpServerService.PlayerPolicy);
     }
 
     /// <summary>Trades account credentials for a bearer token.</summary>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterAdminEndpoints.cs
@@ -21,10 +21,10 @@ public sealed class CharacterAdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/characters", List)
-                 .WithName("ListCharacters")
-                 .WithTags("characters")
-                 .Produces<PagedResponse<CharacterResponse>>()
-                 .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("ListCharacters")
+            .WithTags("characters")
+            .Produces<PagedResponse<CharacterResponse>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Every player character on the shard, paged.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterEndpoints.cs
@@ -29,10 +29,10 @@ public sealed class CharacterEndpoints : IApiEndpointRegistration
         // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
         // has none — the route would document itself blank.
         => routes.MapGet("/api/v1/player/me/characters", GetMine)
-                 .WithName("GetMyCharacters")
-                 .WithTags("player")
-                 .Produces<IReadOnlyList<CharacterResponse>>()
-                 .RequireAuthorization(HttpServerService.PlayerPolicy);
+            .WithName("GetMyCharacters")
+            .WithTags("player")
+            .Produces<IReadOnlyList<CharacterResponse>>()
+            .RequireAuthorization(HttpServerService.PlayerPolicy);
 
     /// <summary>
     /// Reads the account id the token was issued with. JwtTokenService writes it into <c>sub</c>, but
@@ -84,7 +84,7 @@ public sealed class CharacterEndpoints : IApiEndpointRegistration
 
         return Results.Ok(
             _characters.GetPlayerCharacters(accountId)
-                       .Select(mobile => CharacterResponse.From(mobile, null))
+                .Select(mobile => CharacterResponse.From(mobile, null))
         );
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
@@ -34,19 +34,19 @@ public sealed class ConsoleEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/admin/console/stream", Stream)
-              .WithName("StreamConsole")
-              .WithTags("console")
+            .WithName("StreamConsole")
+            .WithTags("console")
 
-              // An event stream, not JSON: the frames have no schema a generated client could bind to,
-              // only a content type worth stating.
-              .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+            // An event stream, not JSON: the frames have no schema a generated client could bind to,
+            // only a content type worth stating.
+            .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         routes.MapPost("/api/v1/admin/console", Send)
-              .WithName("SendConsoleCommand")
-              .WithTags("console")
-              .Produces(StatusCodes.Status202Accepted)
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("SendConsoleCommand")
+            .WithTags("console")
+            .Produces(StatusCodes.Status202Accepted)
+            .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     /// <summary>Opens a per-connection SSE feed; its first event carries the connection id to POST with.</summary>
@@ -85,8 +85,7 @@ public sealed class ConsoleEndpoints : IApiEndpointRegistration
             line => writer.TryWrite(new ConsoleStreamEvent("line", line))
         );
 
-        _dispatcher.Post(
-            () =>
+        _dispatcher.Post(() =>
             {
                 _commands.Execute(invocation);
                 writer.TryWrite(new ConsoleStreamEvent("done", request.Command));

--- a/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageAdminEndpoints.cs
@@ -23,12 +23,12 @@ public sealed class ItemImageAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/images/items")
-                          .WithTags("images")
-                          .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithTags("images")
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapPost("/", Start)
-             .WithName("StartItemImageExport")
-             .Produces<ItemImageExportStatus>(StatusCodes.Status202Accepted);
+            .WithName("StartItemImageExport")
+            .Produces<ItemImageExportStatus>(StatusCodes.Status202Accepted);
         group.MapGet("/", GetStatus).WithName("GetItemImageExportStatus").Produces<ItemImageExportStatus>();
     }
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageEndpoints.cs
@@ -25,10 +25,10 @@ public sealed class ItemImageEndpoints : IApiEndpointRegistration
         // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
         // has none — the route would document itself blank.
         => routes.MapGet("/api/v1/images/items/{id}.png", Get)
-                 .WithName("GetItemImage")
-                 .WithTags("images")
-                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
-                 .AllowAnonymous();
+            .WithName("GetItemImage")
+            .WithTags("images")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
+            .AllowAnonymous();
 
     /// <summary>
     /// Hex, with or without the prefix. A bare "1234" is hex too: the route is documented as 0xITEM_ID,
@@ -110,10 +110,10 @@ public sealed class ItemImageEndpoints : IApiEndpointRegistration
         var path = await _images.GetOrCreateAsync(itemId, hueValue, cancellationToken);
 
         return path is null
-                   ? Results.Problem(
-                       $"No art for item 0x{itemId:x4}.",
-                       statusCode: StatusCodes.Status404NotFound
-                   )
-                   : Results.File(path, "image/png");
+            ? Results.Problem(
+                $"No art for item 0x{itemId:x4}.",
+                statusCode: StatusCodes.Status404NotFound
+            )
+            : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Items/ItemTemplateEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Items/ItemTemplateEndpoints.cs
@@ -23,16 +23,16 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/admin/items/templates", List)
-              .WithName("ListItemTemplates")
-              .WithTags("items")
-              .Produces<PagedResponse<ItemTemplateSummaryResponse>>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("ListItemTemplates")
+            .WithTags("items")
+            .Produces<PagedResponse<ItemTemplateSummaryResponse>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         routes.MapGet("/api/v1/admin/items/templates/{id}", Get)
-              .WithName("GetItemTemplate")
-              .WithTags("items")
-              .Produces<ItemTemplateResponse>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("GetItemTemplate")
+            .WithTags("items")
+            .Produces<ItemTemplateResponse>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     private static List<ItemTemplate> Filter(IReadOnlyList<ItemTemplate> all, string? search)
@@ -44,12 +44,11 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
 
         return
         [
-            .. all.Where(
-                template =>
-                    Matches(template.Id, search) ||
-                    Matches(template.Name, search) ||
-                    Matches(template.Category, search) ||
-                    template.Tags.Any(tag => Matches(tag, search))
+            .. all.Where(template =>
+                Matches(template.Id, search) ||
+                Matches(template.Name, search) ||
+                Matches(template.Category, search) ||
+                template.Tags.Any(tag => Matches(tag, search))
             )
         ];
     }
@@ -61,8 +60,8 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
         var template = _templates.GetById(id);
 
         return template is null
-                   ? Results.Problem($"No item template with id '{id}'.", statusCode: StatusCodes.Status404NotFound)
-                   : Results.Ok(ItemTemplateResponse.From(template));
+            ? Results.Problem($"No item template with id '{id}'.", statusCode: StatusCodes.Status404NotFound)
+            : Results.Ok(ItemTemplateResponse.From(template));
     }
 
     /// <summary>Every item template, paged.</summary>
@@ -83,9 +82,9 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
         IReadOnlyList<ItemTemplateSummaryResponse> items =
         [
             .. matched.OrderBy(template => template.Id, StringComparer.OrdinalIgnoreCase)
-                      .Skip(request.Skip)
-                      .Take(request.PageSize)
-                      .Select(ItemTemplateSummaryResponse.From)
+                .Skip(request.Skip)
+                .Take(request.PageSize)
+                .Select(ItemTemplateSummaryResponse.From)
         ];
 
         return Results.Ok(PagedResponse<ItemTemplateSummaryResponse>.From(items, matched.Count, request));

--- a/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageAdminEndpoints.cs
@@ -23,12 +23,12 @@ public sealed class MapImageAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/images/maps")
-                          .WithTags("images")
-                          .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithTags("images")
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapPost("/", Start)
-             .WithName("StartMapImageExport")
-             .Produces<MapImageExportStatus>(StatusCodes.Status202Accepted);
+            .WithName("StartMapImageExport")
+            .Produces<MapImageExportStatus>(StatusCodes.Status202Accepted);
         group.MapGet("/", GetStatus).WithName("GetMapImageExportStatus").Produces<MapImageExportStatus>();
     }
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
@@ -27,23 +27,23 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
         // Method groups, not lambdas: Swashbuckle reads the /// off the handler's method, and a lambda has
         // none — the route would document itself blank.
         routes.MapGet("/api/v1/images/maps", List)
-              .WithName("ListMaps")
-              .WithTags("images")
-              .Produces<IReadOnlyList<MapFacetInfo>>()
-              .AllowAnonymous();
+            .WithName("ListMaps")
+            .WithTags("images")
+            .Produces<IReadOnlyList<MapFacetInfo>>()
+            .AllowAnonymous();
 
         // Before the tile route, so "full" is never read as a zoom.
         routes.MapGet("/api/v1/images/maps/{map}/full.png", GetFull)
-              .WithName("GetFullMapImage")
-              .WithTags("images")
-              .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
-              .AllowAnonymous();
+            .WithName("GetFullMapImage")
+            .WithTags("images")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
+            .AllowAnonymous();
 
         routes.MapGet("/api/v1/images/maps/{map}/{z}/{x}/{y}.png", GetTile)
-              .WithName("GetMapTile")
-              .WithTags("images")
-              .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
-              .AllowAnonymous();
+            .WithName("GetMapTile")
+            .WithTags("images")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
+            .AllowAnonymous();
     }
 
     /// <summary>A whole facet as one PNG.</summary>
@@ -73,8 +73,8 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
         var path = await _maps.GetFullAsync(facet, renderStyle, cancellationToken);
 
         return path is null
-                   ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)
-                   : Results.File(path, "image/png");
+            ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
     }
 
     /// <summary>One map tile.</summary>
@@ -137,11 +137,11 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
         var path = await _maps.GetTileAsync(facet, renderStyle, zoom, x, y, cancellationToken);
 
         return path is null
-                   ? Results.Problem(
-                       $"No tile {x},{y} at zoom {zoom} for {facet}.",
-                       statusCode: StatusCodes.Status404NotFound
-                   )
-                   : Results.File(path, "image/png");
+            ? Results.Problem(
+                $"No tile {x},{y} at zoom {zoom} for {facet}.",
+                statusCode: StatusCodes.Status404NotFound
+            )
+            : Results.File(path, "image/png");
     }
 
     private static IResult InvalidFacet(string name)
@@ -170,24 +170,23 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
 
         return Results.Ok(
             _provider.Facets
-                     .Select(facet => (Facet: facet, Map: _provider.Get(facet)))
-                     .Where(entry => entry.Map is not null)
-                     .Select(
-                         entry =>
-                         {
-                             var maxZoom = _maps.MaxZoomFor(entry.Facet);
+                .Select(facet => (Facet: facet, Map: _provider.Get(facet)))
+                .Where(entry => entry.Map is not null)
+                .Select(entry =>
+                    {
+                        var maxZoom = _maps.MaxZoomFor(entry.Facet);
 
-                             return new MapFacetInfo(
-                                 entry.Facet.ToString(),
-                                 entry.Map!.Width,
-                                 entry.Map.Height,
-                                 maxZoom,
-                                 MapTileGeometry.TileSize,
-                                 MapTileGeometry.TilesAcross(entry.Map.Width, maxZoom, maxZoom),
-                                 MapTileGeometry.TilesDown(entry.Map.Height, maxZoom, maxZoom)
-                             );
-                         }
-                     )
+                        return new MapFacetInfo(
+                            entry.Facet.ToString(),
+                            entry.Map!.Width,
+                            entry.Map.Height,
+                            maxZoom,
+                            MapTileGeometry.TileSize,
+                            MapTileGeometry.TilesAcross(entry.Map.Width, maxZoom, maxZoom),
+                            MapTileGeometry.TilesDown(entry.Map.Height, maxZoom, maxZoom)
+                        );
+                    }
+                )
         );
     }
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/BodyImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/BodyImageEndpoints.cs
@@ -18,9 +18,9 @@ public sealed class BodyImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/bodies/{body}.png", Get)
-                 .WithName("GetBodyImage")
-                 .WithTags("mobiles")
-                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+            .WithName("GetBodyImage")
+            .WithTags("mobiles")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves a body's idle, front-facing frame as PNG.</summary>
     /// <remarks>
@@ -38,7 +38,7 @@ public sealed class BodyImageEndpoints : IApiEndpointRegistration
         var path = await _bodies.GetOrCreateAsync(bodyId, hue.GetValueOrDefault(), cancellationToken);
 
         return path is null
-                   ? Results.Problem($"No animation for body {bodyId}.", statusCode: StatusCodes.Status404NotFound)
-                   : Results.File(path, "image/png");
+            ? Results.Problem($"No animation for body {bodyId}.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/HairImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/HairImageEndpoints.cs
@@ -20,9 +20,9 @@ public sealed class HairImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/hair/{style}.png", Get)
-                 .WithName("GetHairImage")
-                 .WithTags("mobiles")
-                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+            .WithName("GetHairImage")
+            .WithTags("mobiles")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves a hair (or facial-hair) style as PNG, rendered over a reference body.</summary>
     /// <remarks>
@@ -39,15 +39,15 @@ public sealed class HairImageEndpoints : IApiEndpointRegistration
 
         var referenceBody = body is > 0 ? body.Value : DefaultReferenceBody;
         var path = await _hair.GetOrCreateAsync(
-                       styleId,
-                       hue.GetValueOrDefault(),
-                       referenceBody,
-                       facial.GetValueOrDefault(),
-                       cancellationToken
-                   );
+            styleId,
+            hue.GetValueOrDefault(),
+            referenceBody,
+            facial.GetValueOrDefault(),
+            cancellationToken
+        );
 
         return path is null
-                   ? Results.Problem($"Nothing decodes for style {styleId}.", statusCode: StatusCodes.Status404NotFound)
-                   : Results.File(path, "image/png");
+            ? Results.Problem($"Nothing decodes for style {styleId}.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileImageAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileImageAdminEndpoints.cs
@@ -33,25 +33,25 @@ public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var export = routes.MapGroup("/api/v1/admin/images/bodies")
-                           .WithTags("mobiles")
-                           .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithTags("mobiles")
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         export.MapPost("/", Start)
-              .WithName("StartBodyImageExport")
-              .Produces<BodyImageExportStatus>(StatusCodes.Status202Accepted);
+            .WithName("StartBodyImageExport")
+            .Produces<BodyImageExportStatus>(StatusCodes.Status202Accepted);
         export.MapGet("/", GetStatus).WithName("GetBodyImageExportStatus").Produces<BodyImageExportStatus>();
 
         routes.MapGet("/api/v1/admin/bodies", ListBodies)
-              .WithName("ListBodies")
-              .WithTags("mobiles")
-              .Produces<PagedResponse<BodySummary>>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("ListBodies")
+            .WithTags("mobiles")
+            .Produces<PagedResponse<BodySummary>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         routes.MapGet("/api/v1/admin/hair-styles", ListHairStyles)
-              .WithName("ListHairStyles")
-              .WithTags("mobiles")
-              .Produces<PagedResponse<HairStyleSummary>>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("ListHairStyles")
+            .WithTags("mobiles")
+            .Produces<PagedResponse<HairStyleSummary>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     /// <summary>Reports how far the body image export has got.</summary>
@@ -72,16 +72,16 @@ public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
         }
 
         var classified = _catalog.ClassifiedBodies
-                                 .Where(entry => entry.Type != MobType.Equipment)
-                                 .Where(entry => Matches(entry.Body, request.Search))
-                                 .OrderBy(entry => entry.Body)
-                                 .ToArray();
+            .Where(entry => entry.Type != MobType.Equipment)
+            .Where(entry => Matches(entry.Body, request.Search))
+            .OrderBy(entry => entry.Body)
+            .ToArray();
 
         IReadOnlyList<BodySummary> items =
         [
             .. classified.Skip(request.Skip)
-                         .Take(request.PageSize)
-                         .Select(entry => BodySummary.From(entry.Body, entry.Type))
+                .Take(request.PageSize)
+                .Select(entry => BodySummary.From(entry.Body, entry.Type))
         ];
 
         return Results.Ok(PagedResponse<BodySummary>.From(items, classified.Length, request));
@@ -98,11 +98,10 @@ public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
 
         var source = facial.GetValueOrDefault() ? HairStyleCatalog.Facial : HairStyleCatalog.Hair;
         var matched = source
-                      .Where(
-                          entry => request.Search is null ||
-                                   entry.Name.Contains(request.Search, StringComparison.OrdinalIgnoreCase)
-                      )
-                      .ToArray();
+            .Where(entry => request.Search is null ||
+                            entry.Name.Contains(request.Search, StringComparison.OrdinalIgnoreCase)
+            )
+            .ToArray();
 
         IReadOnlyList<HairStyleSummary> items =
         [

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateImageEndpoints.cs
@@ -18,9 +18,9 @@ public sealed class MobileTemplateImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/mobiles/templates/{id}.png", Get)
-                 .WithName("GetMobileTemplateImage")
-                 .WithTags("mobiles")
-                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+            .WithName("GetMobileTemplateImage")
+            .WithTags("mobiles")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves a mobile template's dressed figure as PNG: body, hair and worn equipment.</summary>
     /// <remarks>
@@ -32,7 +32,7 @@ public sealed class MobileTemplateImageEndpoints : IApiEndpointRegistration
         var path = await _figures.GetOrCreateAsync(id, cancellationToken);
 
         return path is null
-                   ? Results.Problem($"No renderable figure for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
-                   : Results.File(path, "image/png");
+            ? Results.Problem($"No renderable figure for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/PaperdollEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/PaperdollEndpoints.cs
@@ -18,9 +18,9 @@ public sealed class PaperdollEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/mobiles/templates/{id}/paperdoll.png", Get)
-                 .WithName("GetMobileTemplatePaperdoll")
-                 .WithTags("mobiles")
-                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+            .WithName("GetMobileTemplatePaperdoll")
+            .WithTags("mobiles")
+            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves the template's classic client paperdoll as PNG: background, body, hair, equipment.</summary>
     /// <remarks>
@@ -33,7 +33,7 @@ public sealed class PaperdollEndpoints : IApiEndpointRegistration
         var path = await _paperdolls.GetOrCreateAsync(id, background.GetValueOrDefault(true), cancellationToken);
 
         return path is null
-                   ? Results.Problem($"No paperdoll for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
-                   : Results.File(path, "image/png");
+            ? Results.Problem($"No paperdoll for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
+            : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Players/PlayerEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Players/PlayerEndpoints.cs
@@ -16,10 +16,10 @@ public sealed class PlayerEndpoints : IApiEndpointRegistration
     // generated types have no shape to bind to.
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/player/me", Me)
-                 .WithName("GetPlayerMe")
-                 .WithTags("player")
-                 .Produces<PlayerMeResponse>()
-                 .RequireAuthorization(HttpServerService.PlayerPolicy);
+            .WithName("GetPlayerMe")
+            .WithTags("player")
+            .Produces<PlayerMeResponse>()
+            .RequireAuthorization(HttpServerService.PlayerPolicy);
 
     /// <summary>Reports the account the bearer token belongs to.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Plugins/PluginAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Plugins/PluginAdminEndpoints.cs
@@ -29,10 +29,10 @@ public sealed class PluginAdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/plugins", Get)
-                 .WithName("GetAdminPlugins")
-                 .WithTags("admin")
-                 .Produces<IReadOnlyList<PluginInfoResponse>>()
-                 .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithName("GetAdminPlugins")
+            .WithTags("admin")
+            .Produces<IReadOnlyList<PluginInfoResponse>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Lists the plugins this shard activated, each with the HTTP routes it declares.</summary>
     /// <remarks>
@@ -57,9 +57,9 @@ public sealed class PluginAdminEndpoints : IApiEndpointRegistration
         var plugins = _catalog.Plugins.Select(plugin => ToResponse(plugin, byAssembly)).ToList();
 
         var unattributed = byAssembly.Where(entry => !catalogued.Contains(entry.Key))
-                                     .SelectMany(entry => entry.Value)
-                                     .Select(ToResponse)
-                                     .ToList();
+            .SelectMany(entry => entry.Value)
+            .Select(ToResponse)
+            .ToList();
 
         plugins.Add(Host(unattributed));
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Registration/RegistrationEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Registration/RegistrationEndpoints.cs
@@ -17,7 +17,9 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
     private readonly IServerSettingsService _settings;
     private readonly IRegistrationRateLimiter _rateLimiter;
 
-    public RegistrationEndpoints(IAccountService accounts, IServerSettingsService settings, IRegistrationRateLimiter rateLimiter)
+    public RegistrationEndpoints(
+        IAccountService accounts, IServerSettingsService settings, IRegistrationRateLimiter rateLimiter
+    )
     {
         _accounts = accounts;
         _settings = settings;
@@ -27,15 +29,15 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapPost("/api/v1/register", RegisterAccount)
-              .WithName("RegisterAccount")
-              .Produces(StatusCodes.Status202Accepted)
-              .WithTags("registration")
-              .AllowAnonymous();
+            .WithName("RegisterAccount")
+            .Produces(StatusCodes.Status202Accepted)
+            .WithTags("registration")
+            .AllowAnonymous();
         routes.MapPost("/api/v1/register/verify", Verify)
-              .WithName("VerifyRegistration")
-              .WithTags("registration")
-              .Produces(StatusCodes.Status200OK)
-              .AllowAnonymous();
+            .WithName("VerifyRegistration")
+            .WithTags("registration")
+            .Produces(StatusCodes.Status200OK)
+            .AllowAnonymous();
     }
 
     /// <summary>Registers a new account when web registration is open.</summary>

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
@@ -28,18 +28,18 @@ public sealed class ServerInfoEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/server-info", Get)
-              .WithName("GetServerInfo")
-              .WithTags("server-info")
-              .Produces<ServerInfoResponse>()
-              .AllowAnonymous();
+            .WithName("GetServerInfo")
+            .WithTags("server-info")
+            .Produces<ServerInfoResponse>()
+            .AllowAnonymous();
         routes.MapGet("/api/v1/server-info/assets/{slot}", GetAsset)
-              .WithName("GetServerAsset")
-              .WithTags("server-info")
+            .WithName("GetServerAsset")
+            .WithTags("server-info")
 
-              // Binary, but no content type stated: the slot decides it. An operator's logo may be a PNG,
-              // an SVG or an ICO, and naming one here would document a promise the route does not make.
-              .Produces<byte[]>(StatusCodes.Status200OK)
-              .AllowAnonymous();
+            // Binary, but no content type stated: the slot decides it. An operator's logo may be a PNG,
+            // an SVG or an ICO, and naming one here would document a promise the route does not make.
+            .Produces<byte[]>(StatusCodes.Status200OK)
+            .AllowAnonymous();
     }
 
     internal static ServerInfoResponse ToResponse(string shardName, ServerSettingsEntity settings)

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
@@ -22,7 +22,9 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
     private readonly IServerAssetFileStore _assets;
     private readonly MoongateHttpConfig _config;
 
-    public ServerSettingsAdminEndpoints(IServerSettingsService settings, IServerAssetFileStore assets, MoongateHttpConfig config)
+    public ServerSettingsAdminEndpoints(
+        IServerSettingsService settings, IServerAssetFileStore assets, MoongateHttpConfig config
+    )
     {
         _settings = settings;
         _assets = assets;
@@ -32,18 +34,18 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/server-settings")
-                          .WithTags("server-settings")
-                          .RequireAuthorization(HttpServerService.AdminPolicy);
+            .WithTags("server-settings")
+            .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapGet("/", Get).WithName("GetServerSettings").Produces<ServerSettingsResponse>();
         group.MapPut("/", Update).WithName("UpdateServerSettings").Produces<ServerSettingsResponse>();
         group.MapPost("/assets/{slot}", UploadAsset)
-             .WithName("UploadServerAsset")
-             .DisableAntiforgery()
-             .Produces<ServerSettingsResponse>();
+            .WithName("UploadServerAsset")
+            .DisableAntiforgery()
+            .Produces<ServerSettingsResponse>();
         group.MapDelete("/assets/{slot}", DeleteAsset)
-             .WithName("DeleteServerAsset")
-             .Produces(StatusCodes.Status204NoContent);
+            .WithName("DeleteServerAsset")
+            .Produces(StatusCodes.Status204NoContent);
     }
 
     internal static ServerSettingsResponse ToResponse(ServerSettingsEntity settings)
@@ -69,13 +71,13 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
                 Tagline = request.Tagline,
                 RegistrationEnabled = request.RegistrationEnabled,
                 Contacts = request.Contacts is null
-                               ? null
-                               : new ServerContacts
-                               {
-                                   Website = request.Contacts.Website,
-                                   Email = request.Contacts.Email,
-                                   Discord = request.Contacts.Discord
-                               }
+                    ? null
+                    : new ServerContacts
+                    {
+                        Website = request.Contacts.Website,
+                        Email = request.Contacts.Email,
+                        Discord = request.Contacts.Discord
+                    }
             }
         );
 
@@ -96,8 +98,8 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
         if (!validation.Ok)
         {
             return validation.Error == AssetValidationError.TooLarge
-                       ? Results.Problem("Asset exceeds the maximum upload size.", statusCode: StatusCodes.Status413PayloadTooLarge)
-                       : Results.Problem("Unsupported asset content-type.", statusCode: StatusCodes.Status415UnsupportedMediaType);
+                ? Results.Problem("Asset exceeds the maximum upload size.", statusCode: StatusCodes.Status413PayloadTooLarge)
+                : Results.Problem("Unsupported asset content-type.", statusCode: StatusCodes.Status415UnsupportedMediaType);
         }
 
         await using (var stream = file.OpenReadStream())
@@ -105,7 +107,10 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
             await _assets.SaveAsync(parsed, validation.Extension!, stream);
         }
 
-        _settings.SetAsset(parsed, new ServerAssetMeta { FileName = $"{parsed}.{validation.Extension}", ContentType = file.ContentType });
+        _settings.SetAsset(
+            parsed,
+            new ServerAssetMeta { FileName = $"{parsed}.{validation.Extension}", ContentType = file.ContentType }
+        );
 
         return Results.Ok(ToResponse(_settings.Get()));
     }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Stats/StatsEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Stats/StatsEndpoints.cs
@@ -23,10 +23,10 @@ public sealed class StatsEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/stats", Get)
-                 .WithName("GetServerStats")
-                 .WithTags("stats")
-                 .Produces<ServerStatsResponse>()
-                 .AllowAnonymous();
+            .WithName("GetServerStats")
+            .WithTags("stats")
+            .Produces<ServerStatsResponse>()
+            .AllowAnonymous();
 
     internal static ServerStatsResponse ToResponse(ServerStatsSnapshot snapshot)
         => new(

--- a/plugins/Moongate.Http.Plugin/Endpoints/Version/VersionEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Version/VersionEndpoints.cs
@@ -26,10 +26,10 @@ public sealed class VersionEndpoints : IApiEndpointRegistration
         // A method group rather than a lambda: Swashbuckle reads the /// off the handler's method, and a
         // lambda has no method to read it from — the route would document itself as blank.
         => routes.MapGet("/api/v1/version", Version)
-                 .WithName("GetVersion")
-                 .WithTags("version")
-                 .Produces<VersionResponse>()
-                 .AllowAnonymous();
+            .WithName("GetVersion")
+            .WithTags("version")
+            .Produces<VersionResponse>()
+            .AllowAnonymous();
 
     /// <summary>Reports the shard's name and build.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Services/Assets/ServerAssetFileStore.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Assets/ServerAssetFileStore.cs
@@ -32,8 +32,8 @@ public sealed class ServerAssetFileStore : IServerAssetFileStore
         var path = Path.Combine(_directory, fileName);
 
         return File.Exists(path)
-                   ? (File.OpenRead(path), fileName)
-                   : null;
+            ? (File.OpenRead(path), fileName)
+            : null;
     }
 
     public void Delete(string fileName)

--- a/plugins/Moongate.Http.Plugin/Services/Hosting/HttpServerService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Hosting/HttpServerService.cs
@@ -86,8 +86,7 @@ public sealed class HttpServerService : ISquidStdService
 
         builder.Services.AddProblemDetails();
         builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen(
-            options =>
+        builder.Services.AddSwaggerGen(options =>
             {
                 // Every DTO here is a record of non-nullable properties, but by default Swashbuckle marks
                 // nothing required — so a generated client has to treat every field as possibly absent and
@@ -108,38 +107,37 @@ public sealed class HttpServerService : ISquidStdService
         // camelCase over the wire while the DTOs stay PascalCase in C#. ASP.NET already defaults to this,
         // but the wire format is a contract clients are written against: stated here it cannot be changed
         // by a default shifting under us.
-        builder.Services.ConfigureHttpJsonOptions(
-            options => options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        builder.Services.ConfigureHttpJsonOptions(options =>
+            options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         );
 
         builder.Services
-               .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-               .AddJwtBearer(
-                   options =>
-                   {
-                       options.TokenValidationParameters = new()
-                       {
-                           ValidateIssuer = true,
-                           ValidIssuer = _config.Jwt.Issuer,
-                           ValidateAudience = true,
-                           ValidAudience = _config.Jwt.Issuer,
-                           ValidateIssuerSigningKey = true,
-                           IssuerSigningKey = signingKey,
-                           ValidateLifetime = true
-                       };
-                   }
-               );
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+                {
+                    options.TokenValidationParameters = new()
+                    {
+                        ValidateIssuer = true,
+                        ValidIssuer = _config.Jwt.Issuer,
+                        ValidateAudience = true,
+                        ValidAudience = _config.Jwt.Issuer,
+                        ValidateIssuerSigningKey = true,
+                        IssuerSigningKey = signingKey,
+                        ValidateLifetime = true
+                    };
+                }
+            );
 
         builder.Services
-               .AddAuthorizationBuilder()
-               .AddPolicy(
-                   AdminPolicy,
-                   policy => policy.RequireRole(
-                       nameof(AccountLevelType.Administrator),
-                       nameof(AccountLevelType.GrandMaster)
-                   )
-               )
-               .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
+            .AddAuthorizationBuilder()
+            .AddPolicy(
+                AdminPolicy,
+                policy => policy.RequireRole(
+                    nameof(AccountLevelType.Administrator),
+                    nameof(AccountLevelType.GrandMaster)
+                )
+            )
+            .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
 
         _app = builder.Build();
 
@@ -177,8 +175,7 @@ public sealed class HttpServerService : ISquidStdService
         _app.UseAuthorization();
 
         _app.UseSwagger();
-        _app.MapScalarApiReference(
-            options =>
+        _app.MapScalarApiReference(options =>
             {
                 options.WithOpenApiRoutePattern(SwaggerRoutePattern);
                 options.AddDocument(DocumentName);
@@ -206,12 +203,13 @@ public sealed class HttpServerService : ISquidStdService
         {
             var indexPath = Path.Combine(uiDist, "index.html");
 
-            _app.MapFallback(
-                async context =>
+            _app.MapFallback(async context =>
                 {
                     var path = context.Request.Path;
-                    var reserved = ReservedPrefixes.Any(
-                        prefix => path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase)
+                    var reserved = ReservedPrefixes.Any(prefix => path.StartsWithSegments(
+                            prefix,
+                            StringComparison.OrdinalIgnoreCase
+                        )
                     );
 
                     if (!HttpMethods.IsGet(context.Request.Method) || reserved)
@@ -269,12 +267,12 @@ public sealed class HttpServerService : ISquidStdService
     /// </summary>
     private IEnumerable<string> EndpointXmlDocumentationPaths()
         => _container.GetServiceRegistrations()
-                     .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
-                     .Select(registration => registration.ImplementationType?.Assembly)
-                     .Where(assembly => assembly is not null)
-                     .Select(assembly => Path.Combine(AppContext.BaseDirectory, $"{assembly!.GetName().Name}.xml"))
-                     .Distinct()
-                     .Where(File.Exists);
+            .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+            .Select(registration => registration.ImplementationType?.Assembly)
+            .Where(assembly => assembly is not null)
+            .Select(assembly => Path.Combine(AppContext.BaseDirectory, $"{assembly!.GetName().Name}.xml"))
+            .Distinct()
+            .Where(File.Exists);
 
     /// <summary>
     /// Mints a signing key for a server that has not configured one, and writes it to moongate.yaml.
@@ -329,8 +327,8 @@ public sealed class HttpServerService : ISquidStdService
         // index.html rather than the directory: a directory that exists but holds no entry point would pass
         // the check and then serve nothing.
         return Candidates()
-              .Select(Path.GetFullPath)
-              .FirstOrDefault(candidate => File.Exists(Path.Combine(candidate, "index.html")));
+            .Select(Path.GetFullPath)
+            .FirstOrDefault(candidate => File.Exists(Path.Combine(candidate, "index.html")));
     }
 
     /// <summary>

--- a/plugins/Moongate.Http.Plugin/Services/Images/ItemImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Images/ItemImageService.cs
@@ -34,23 +34,23 @@ public sealed class ItemImageService : IItemImageService
 
     public async Task<IReadOnlyList<uint>> GetArtItemIdsAsync(CancellationToken cancellationToken = default)
         => await _gate.ReadAsync(
-               () =>
-               {
-                   var ids = new List<uint>();
-                   var max = Art.GetMaxItemId();
+            () =>
+            {
+                var ids = new List<uint>();
+                var max = Art.GetMaxItemId();
 
-                   for (var id = 0; id <= max; id++)
-                   {
-                       if (Art.IsValidStatic(id))
-                       {
-                           ids.Add((uint)id);
-                       }
-                   }
+                for (var id = 0; id <= max; id++)
+                {
+                    if (Art.IsValidStatic(id))
+                    {
+                        ids.Add((uint)id);
+                    }
+                }
 
-                   return (IReadOnlyList<uint>)ids;
-               },
-               cancellationToken
-           );
+                return (IReadOnlyList<uint>)ids;
+            },
+            cancellationToken
+        );
 
     public async Task<string?> GetOrCreateAsync(
         uint itemId,
@@ -70,9 +70,9 @@ public sealed class ItemImageService : IItemImageService
         // Re-checked inside the gate, because another request may have produced it while this one waited.
         // The decode is all that needs the gate — the write is ordinary file I/O and is done outside it.
         var png = await _gate.ReadAsync(
-                      () => File.Exists(path) ? null : _catalog.GetItemImage(itemId, hue),
-                      cancellationToken
-                  );
+            () => File.Exists(path) ? null : _catalog.GetItemImage(itemId, hue),
+            cancellationToken
+        );
 
         // Null means two different things here: another request won the race, or the item has no art.
         // The file is what tells them apart — returning null blindly would turn a cache race into a 404.

--- a/plugins/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
@@ -66,19 +66,19 @@ public sealed class MapImageService : IMapImageService
         // A facet-sized bitmap, unavoidably: the output is that image. The gate makes concurrent first
         // requests queue rather than each allocating their own, and the re-check means only the first pays.
         using var image = await _gate.ReadAsync(
-                              () =>
-                              {
-                                  if (File.Exists(path))
-                                  {
-                                      return null;
-                                  }
+            () =>
+            {
+                if (File.Exists(path))
+                {
+                    return null;
+                }
 
-                                  using var bitmap = RenderBlocks(map, style, 0, 0, Blocks(map.Width), Blocks(map.Height));
+                using var bitmap = RenderBlocks(map, style, 0, 0, Blocks(map.Width), Blocks(map.Height));
 
-                                  return bitmap.ToImage();
-                              },
-                              cancellationToken
-                          );
+                return bitmap.ToImage();
+            },
+            cancellationToken
+        );
 
         if (image is null)
         {
@@ -126,8 +126,8 @@ public sealed class MapImageService : IMapImageService
         }
 
         using var tile = zoom == maxZoom
-                             ? await RenderNativeAsync(map, style, x, y, cancellationToken)
-                             : await ComposeAsync(facet, style, zoom, x, y, cancellationToken);
+            ? await RenderNativeAsync(map, style, x, y, cancellationToken)
+            : await ComposeAsync(facet, style, zoom, x, y, cancellationToken);
 
         await WriteAtomicallyAsync(path, tile, cancellationToken);
 
@@ -195,8 +195,8 @@ public sealed class MapImageService : IMapImageService
         int height
     )
         => style == MapRenderStyleType.Relief
-               ? map.GetImageWithAltitude(x, y, width, height, true, MapAltitudeModeType.NormalWithAltitude)
-               : map.GetImage(x, y, width, height, true);
+            ? map.GetImageWithAltitude(x, y, width, height, true, MapAltitudeModeType.NormalWithAltitude)
+            : map.GetImage(x, y, width, height, true);
 
     /// <summary>
     /// One GetImage of exactly 32 blocks, clipped at the facet's edge. The remainder of an edge tile is
@@ -216,14 +216,14 @@ public sealed class MapImageService : IMapImageService
         var height = Math.Min(MapTileGeometry.BlocksPerTile, Blocks(map.Height) - blockY);
 
         var rendered = await _gate.ReadAsync(
-                           () =>
-                           {
-                               using var bitmap = RenderBlocks(map, style, blockX, blockY, width, height);
+            () =>
+            {
+                using var bitmap = RenderBlocks(map, style, blockX, blockY, width, height);
 
-                               return bitmap.ToImage();
-                           },
-                           cancellationToken
-                       );
+                return bitmap.ToImage();
+            },
+            cancellationToken
+        );
 
         if (rendered.Width == MapTileGeometry.TileSize && rendered.Height == MapTileGeometry.TileSize)
         {
@@ -241,9 +241,9 @@ public sealed class MapImageService : IMapImageService
 
     private string StyleDirectory(MapType facet, MapRenderStyleType style)
         => Directory.CreateDirectory(
-                        Path.Combine(_cachePath, facet.ToString().ToLowerInvariant(), style.ToString().ToLowerInvariant())
-                    )
-                    .FullName;
+                Path.Combine(_cachePath, facet.ToString().ToLowerInvariant(), style.ToString().ToLowerInvariant())
+            )
+            .FullName;
 
     private string TilePath(MapType facet, MapRenderStyleType style, int zoom, int x, int y)
     {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageExportJob.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageExportJob.cs
@@ -70,9 +70,9 @@ public sealed class BodyImageExportJob : IBodyImageExportJob
         try
         {
             var bodies = _catalog.ClassifiedBodies
-                                 .Where(entry => entry.Type != MobType.Equipment)
-                                 .Select(entry => entry.Body)
-                                 .ToArray();
+                .Where(entry => entry.Type != MobType.Equipment)
+                .Select(entry => entry.Body)
+                .ToArray();
 
             lock (_sync)
             {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageService.cs
@@ -35,9 +35,9 @@ public sealed class BodyImageService : IBodyImageService
         }
 
         var frame = await _gate.ReadAsync(
-                        () => File.Exists(path) ? null : _catalog.GetFrame(body, 0, 1, 0, hue),
-                        cancellationToken
-                    );
+            () => File.Exists(path) ? null : _catalog.GetFrame(body, 0, 1, 0, hue),
+            cancellationToken
+        );
 
         if (frame is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/HairImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/HairImageService.cs
@@ -37,21 +37,21 @@ public sealed class HairImageService : IHairImageService
         }
 
         var figure = await _gate.ReadAsync(
-                         () => File.Exists(path)
-                                   ? null
-                                   : _renderer.Render(
-                                       new(
-                                           referenceBody,
-                                           0,
-                                           facial ? 0 : style,
-                                           facial ? 0 : hue,
-                                           facial ? style : 0,
-                                           facial ? hue : 0,
-                                           []
-                                       )
-                                   ),
-                         cancellationToken
-                     );
+            () => File.Exists(path)
+                ? null
+                : _renderer.Render(
+                    new(
+                        referenceBody,
+                        0,
+                        facial ? 0 : style,
+                        facial ? 0 : hue,
+                        facial ? style : 0,
+                        facial ? hue : 0,
+                        []
+                    )
+                ),
+            cancellationToken
+        );
 
         if (figure is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileTemplateImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileTemplateImageService.cs
@@ -60,9 +60,9 @@ public sealed class MobileTemplateImageService : IMobileTemplateImageService
         );
 
         var figure = await _gate.ReadAsync(
-                         () => File.Exists(path) ? null : _renderer.Render(request),
-                         cancellationToken
-                     );
+            () => File.Exists(path) ? null : _renderer.Render(request),
+            cancellationToken
+        );
 
         if (figure is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/PaperdollImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/PaperdollImageService.cs
@@ -68,9 +68,9 @@ public sealed class PaperdollImageService : IPaperdollImageService
         );
 
         var doll = await _gate.ReadAsync(
-                       () => File.Exists(path) ? null : _renderer.Render(request),
-                       cancellationToken
-                   );
+            () => File.Exists(path) ? null : _renderer.Render(request),
+            cancellationToken
+        );
 
         if (doll is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Plugins/EndpointPluginRouteInspector.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Plugins/EndpointPluginRouteInspector.cs
@@ -72,8 +72,8 @@ public sealed class EndpointPluginRouteInspector : IPluginRouteInspector
         }
 
         return endpoint.Metadata
-                       .GetOrderedMetadata<IAuthorizeData>()
-                       .Select(data => data.Policy ?? data.Roles)
-                       .FirstOrDefault(value => !string.IsNullOrEmpty(value));
+            .GetOrderedMetadata<IAuthorizeData>()
+            .Select(data => data.Policy ?? data.Roles)
+            .FirstOrDefault(value => !string.IsNullOrEmpty(value));
     }
 }

--- a/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationRateLimiter.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationRateLimiter.cs
@@ -25,8 +25,8 @@ public sealed class RegistrationRateLimiter : IRegistrationRateLimiter
             clientKey,
             _ => new Window(now, 1),
             (_, current) => now - current.Start >= _window
-                                ? new Window(now, 1)
-                                : current with { Count = current.Count + 1 }
+                ? new Window(now, 1)
+                : current with { Count = current.Count + 1 }
         );
 
         return updated.Count <= _permitPerWindow;

--- a/plugins/Moongate.News.Plugin/Endpoints/NewsAdminEndpoints.cs
+++ b/plugins/Moongate.News.Plugin/Endpoints/NewsAdminEndpoints.cs
@@ -22,26 +22,31 @@ public sealed class NewsAdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
     {
-        routes.MapPost("/api/v1/admin/news", Create).WithName("CreateNews")
-              .WithTags("news")
-              .Produces<NewsResponse>(StatusCodes.Status201Created)
-              .RequireAuthorization(HttpServerService.AdminPolicy);
-        routes.MapGet("/api/v1/admin/news", ListAll).WithName("ListAllNews")
-              .WithTags("news")
-              .Produces<IReadOnlyList<NewsResponse>>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
-        routes.MapGet("/api/v1/admin/news/{id}", GetOne).WithName("GetNewsAdmin")
-              .WithTags("news")
-              .Produces<NewsResponse>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
-        routes.MapPut("/api/v1/admin/news/{id}", Update).WithName("UpdateNews")
-              .WithTags("news")
-              .Produces<NewsResponse>()
-              .RequireAuthorization(HttpServerService.AdminPolicy);
-        routes.MapDelete("/api/v1/admin/news/{id}", Delete).WithName("DeleteNews")
-              .WithTags("news")
-              .Produces(StatusCodes.Status204NoContent)
-              .RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapPost("/api/v1/admin/news", Create)
+            .WithName("CreateNews")
+            .WithTags("news")
+            .Produces<NewsResponse>(StatusCodes.Status201Created)
+            .RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapGet("/api/v1/admin/news", ListAll)
+            .WithName("ListAllNews")
+            .WithTags("news")
+            .Produces<IReadOnlyList<NewsResponse>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapGet("/api/v1/admin/news/{id}", GetOne)
+            .WithName("GetNewsAdmin")
+            .WithTags("news")
+            .Produces<NewsResponse>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapPut("/api/v1/admin/news/{id}", Update)
+            .WithName("UpdateNews")
+            .WithTags("news")
+            .Produces<NewsResponse>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
+        routes.MapDelete("/api/v1/admin/news/{id}", Delete)
+            .WithName("DeleteNews")
+            .WithTags("news")
+            .Produces(StatusCodes.Status204NoContent)
+            .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     /// <summary>Creates a news entry, authored by the calling staff member.</summary>

--- a/plugins/Moongate.News.Plugin/Endpoints/NewsEndpoints.cs
+++ b/plugins/Moongate.News.Plugin/Endpoints/NewsEndpoints.cs
@@ -21,13 +21,13 @@ public sealed class NewsEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/news", List)
-              .WithName("ListNews")
-              .WithTags("news")
-              .Produces<IReadOnlyList<NewsResponse>>();
+            .WithName("ListNews")
+            .WithTags("news")
+            .Produces<IReadOnlyList<NewsResponse>>();
         routes.MapGet("/api/v1/news/{id}", GetOne)
-              .WithName("GetNews")
-              .WithTags("news")
-              .Produces<NewsResponse>();
+            .WithName("GetNews")
+            .WithTags("news")
+            .Produces<NewsResponse>();
     }
 
     /// <summary>Lists published news, newest first.</summary>
@@ -36,5 +36,7 @@ public sealed class NewsEndpoints : IApiEndpointRegistration
 
     /// <summary>Returns one published news entry; 404 if it is missing or a draft.</summary>
     private IResult GetOne(uint id)
-        => _news.Get(new Serial(id)) is { IsPublished: true } news ? TypedResults.Ok(NewsResponse.From(news)) : TypedResults.NotFound();
+        => _news.Get(new Serial(id)) is { IsPublished: true } news
+            ? TypedResults.Ok(NewsResponse.From(news))
+            : TypedResults.NotFound();
 }

--- a/plugins/Moongate.News.Plugin/Interfaces/INewsService.cs
+++ b/plugins/Moongate.News.Plugin/Interfaces/INewsService.cs
@@ -7,10 +7,14 @@ namespace Moongate.News.Plugin.Interfaces;
 public interface INewsService
 {
     /// <summary>Creates a news entry; the store assigns its id. Timestamps are set to now.</summary>
-    ValueTask<NewsEntity> CreateAsync(string title, string body, string author, bool isPublished, CancellationToken ct = default);
+    ValueTask<NewsEntity> CreateAsync(
+        string title, string body, string author, bool isPublished, CancellationToken ct = default
+    );
 
     /// <summary>Updates an entry's title/body/published state and its <c>UpdatedAt</c>; null if not found.</summary>
-    ValueTask<NewsEntity?> UpdateAsync(Serial id, string title, string body, bool isPublished, CancellationToken ct = default);
+    ValueTask<NewsEntity?> UpdateAsync(
+        Serial id, string title, string body, bool isPublished, CancellationToken ct = default
+    );
 
     /// <summary>Deletes an entry; false if it did not exist.</summary>
     ValueTask<bool> DeleteAsync(Serial id, CancellationToken ct = default);

--- a/plugins/Moongate.News.Plugin/Services/NewsService.cs
+++ b/plugins/Moongate.News.Plugin/Services/NewsService.cs
@@ -15,7 +15,9 @@ public sealed class NewsService : INewsService
         _store = persistence.GetStore<NewsEntity, Serial>();
     }
 
-    public async ValueTask<NewsEntity> CreateAsync(string title, string body, string author, bool isPublished, CancellationToken ct = default)
+    public async ValueTask<NewsEntity> CreateAsync(
+        string title, string body, string author, bool isPublished, CancellationToken ct = default
+    )
     {
         var now = DateTime.UtcNow;
         var news = new NewsEntity
@@ -32,7 +34,9 @@ public sealed class NewsService : INewsService
         return news;
     }
 
-    public async ValueTask<NewsEntity?> UpdateAsync(Serial id, string title, string body, bool isPublished, CancellationToken ct = default)
+    public async ValueTask<NewsEntity?> UpdateAsync(
+        Serial id, string title, string body, bool isPublished, CancellationToken ct = default
+    )
     {
         if (_store.GetById(id) is not { } news)
         {

--- a/src/Moongate.Network/Exceptions/UoFramingException.cs
+++ b/src/Moongate.Network/Exceptions/UoFramingException.cs
@@ -7,5 +7,7 @@ namespace Moongate.Network.Exceptions;
 /// </summary>
 public sealed class UoFramingException : Exception
 {
-    public UoFramingException(string message) : base(message) { }
+    public UoFramingException(string message) : base(message)
+    {
+    }
 }

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -70,8 +70,7 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
             (entity, id) => entity.Id = id,
             new DefaultSerialGenerator()
         );
-        container.RegisterPersistenceSeeder(
-            async (service, token) =>
+        container.RegisterPersistenceSeeder(async (service, token) =>
             {
                 var accountStore = service.GetStore<AccountEntity, Serial>();
 

--- a/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
+++ b/src/Moongate.Server.Abstractions/Types/CommandSourceType.cs
@@ -7,7 +7,7 @@ namespace Moongate.Server.Abstractions.Types;
 [Flags]
 public enum CommandSourceType : byte
 {
-    InGame  = 1 << 0,
+    InGame = 1 << 0,
     Console = 1 << 1,
-    Rest    = 1 << 2
+    Rest = 1 << 2
 }

--- a/src/Moongate.Server/Data/Exceptions/UODirectoryNotValidException.cs
+++ b/src/Moongate.Server/Data/Exceptions/UODirectoryNotValidException.cs
@@ -2,11 +2,17 @@ namespace Moongate.Server.Data.Exceptions;
 
 public class UODirectoryNotValidException : Exception
 {
-    public UODirectoryNotValidException() { }
+    public UODirectoryNotValidException()
+    {
+    }
 
     public UODirectoryNotValidException(string message)
-        : base(message) { }
+        : base(message)
+    {
+    }
 
     public UODirectoryNotValidException(string message, Exception inner)
-        : base(message, inner) { }
+        : base(message, inner)
+    {
+    }
 }

--- a/src/Moongate.Server/Extensions/DataLoaderServiceRegistrationExtensions.cs
+++ b/src/Moongate.Server/Extensions/DataLoaderServiceRegistrationExtensions.cs
@@ -26,10 +26,10 @@ public static class DataLoaderServiceRegistrationExtensions
                 var recorded = resolver.Resolve<List<DataLoaderRegistration>>(IfUnresolved.ReturnDefault);
 
                 return recorded is null
-                           ? []
-                           : recorded.OrderBy(registration => registration.Priority)
-                                     .Select(registration => registration.Resolve(resolver))
-                                     .ToList();
+                    ? []
+                    : recorded.OrderBy(registration => registration.Priority)
+                        .Select(registration => registration.Resolve(resolver))
+                        .ToList();
             },
             Reuse.Singleton
         );

--- a/src/Moongate.Server/Handlers/DeleteCharacterHandler.cs
+++ b/src/Moongate.Server/Handlers/DeleteCharacterHandler.cs
@@ -34,8 +34,8 @@ public sealed class DeleteCharacterHandler : IPacketHandler<DeleteCharacterPacke
         }
 
         var characters = _characterService.GetPlayerCharacters(context.Session.AccountId)
-                                          .Select(character => character.Name)
-                                          .ToList();
+            .Select(character => character.Name)
+            .ToList();
 
         context.Session.Send(new CharacterListUpdatePacket(characters, CharacterSlots));
     }

--- a/src/Moongate.Server/Internal/EmbeddedResourceDirectorySeeder.cs
+++ b/src/Moongate.Server/Internal/EmbeddedResourceDirectorySeeder.cs
@@ -18,13 +18,12 @@ internal static class EmbeddedResourceDirectorySeeder
         var temporaryDirectory = Path.Combine(parentDirectory, $".{directoryName}-{Guid.NewGuid():N}.tmp");
         var temporaryPrefix = temporaryDirectory + Path.DirectorySeparatorChar;
         var resources = ResourceUtils.GetEmbeddedResourceNames(assembly, embeddedDirectory)
-                                     .Where(
-                                         resourceName => resourceName.StartsWith(
-                                             embeddedNamespace + ".",
-                                             StringComparison.Ordinal
-                                         )
-                                     )
-                                     .OrderBy(name => name, StringComparer.OrdinalIgnoreCase);
+            .Where(resourceName => resourceName.StartsWith(
+                    embeddedNamespace + ".",
+                    StringComparison.Ordinal
+                )
+            )
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase);
 
         Directory.CreateDirectory(parentDirectory);
 

--- a/src/Moongate.Server/Loaders/ItemTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/ItemTemplatesLoader.cs
@@ -53,8 +53,8 @@ public sealed class ItemTemplatesLoader : IDataLoader
         }
 
         var files = Directory.GetFiles(itemsDirectory, "*.yaml", SearchOption.AllDirectories)
-                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-                             .ToArray();
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         if (files.Length == 0)
         {

--- a/src/Moongate.Server/Loaders/LootTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/LootTemplatesLoader.cs
@@ -46,8 +46,8 @@ public sealed class LootTemplatesLoader : IDataLoader
         }
 
         var files = Directory.GetFiles(lootDirectory, "*.yaml", SearchOption.AllDirectories)
-                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-                             .ToArray();
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         if (files.Length == 0)
         {

--- a/src/Moongate.Server/Loaders/MobileTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/MobileTemplatesLoader.cs
@@ -46,8 +46,8 @@ public sealed class MobileTemplatesLoader : IDataLoader
         }
 
         var files = Directory.GetFiles(mobilesDirectory, "*.yaml", SearchOption.AllDirectories)
-                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-                             .ToArray();
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
         if (files.Length == 0)
         {

--- a/src/Moongate.Server/Loaders/NotificationTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/NotificationTemplatesLoader.cs
@@ -52,12 +52,12 @@ public sealed class NotificationTemplatesLoader : IDataLoader
         var failed = 0;
 
         foreach (var channelDirectory in Directory.GetDirectories(templatesDirectory)
-                                                  .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+                     .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
         {
             var channelId = Path.GetFileName(channelDirectory);
 
             foreach (var file in Directory.GetFiles(channelDirectory, Extension, SearchOption.TopDirectoryOnly)
-                                          .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+                         .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
             {
                 var templateId = Path.GetFileNameWithoutExtension(file);
 

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -118,8 +118,7 @@ await ConsoleApp.RunAsync(
         // different bootstrap phases: activation here, container registration in ConfigureServices below.
         var pluginCatalog = new PluginCatalog();
 
-        stdBootstrap.UsePlugins(
-            builder =>
+        stdBootstrap.UsePlugins(builder =>
             {
                 builder.FromDirectory("plugins");
 
@@ -156,8 +155,7 @@ await ConsoleApp.RunAsync(
             }
         );
 
-        stdBootstrap.ConfigureServices(
-            container =>
+        stdBootstrap.ConfigureServices(container =>
             {
                 // Binds the SAME cached instance mutated above; the file cannot clobber it.
                 container.RegisterConfigSection<MoongateConfig>("moongate");
@@ -246,16 +244,14 @@ await ConsoleApp.RunAsync(
 
                 var eventBus = container.Resolve<IEventBus>();
 
-                eventBus.Subscribe<EngineStartedEvent>(
-                    (_, _) =>
+                eventBus.Subscribe<EngineStartedEvent>((_, _) =>
                     {
                         container.Resolve<TimerAutostartService>().InitDefaultTimers();
 
                         var loop = container.Resolve<IGameLoopContext>();
                         var marker = container.Resolve<ILoopThread>();
 
-                        loop.Post(
-                            () =>
+                        loop.Post(() =>
                             {
                                 marker.Capture();
                                 _ = eventBus.PublishAsync(new WorldReadyEvent());

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -40,8 +40,8 @@ public class AccountService : IAccountService
     public AccountAuthResult Authenticate(string username, string password)
     {
         var account = _accountStore
-                      .Query()
-                      .FirstOrDefault(s => s.Username == username && HashUtils.VerifyPassword(password, s.PasswordHash));
+            .Query()
+            .FirstOrDefault(s => s.Username == username && HashUtils.VerifyPassword(password, s.PasswordHash));
 
         if (account == null)
         {
@@ -144,8 +144,8 @@ public class AccountService : IAccountService
         }
 
         var account = _accountStore
-                      .Query()
-                      .FirstOrDefault(a => !string.IsNullOrEmpty(a.ActivationToken) && a.ActivationToken == token);
+            .Query()
+            .FirstOrDefault(a => !string.IsNullOrEmpty(a.ActivationToken) && a.ActivationToken == token);
 
         if (account is null)
         {

--- a/src/Moongate.Server/Services/Accounts/CharacterService.cs
+++ b/src/Moongate.Server/Services/Accounts/CharacterService.cs
@@ -226,13 +226,13 @@ public class CharacterService : ICharacterService
     private void GiveStartingItems(MobileEntity mobile, ItemEntity backpack, CharacterCreationPacket packet)
     {
         var topSkillNames = packet.Skills
-                                  .Where(skill => skill.Value > 0)
-                                  .OrderByDescending(skill => skill.Value)
-                                  .Take(3)
-                                  .Select(skill => _skills.GetById(skill.SkillId)?.Name)
-                                  .Where(name => name is not null)
-                                  .Select(name => name!)
-                                  .ToList();
+            .Where(skill => skill.Value > 0)
+            .OrderByDescending(skill => skill.Value)
+            .Take(3)
+            .Select(skill => _skills.GetById(skill.SkillId)?.Name)
+            .Where(name => name is not null)
+            .Select(name => name!)
+            .ToList();
 
         var kit = _startingItems.Resolve(packet.Race, packet.Gender, topSkillNames);
 

--- a/src/Moongate.Server/Services/Commands/CommandService.cs
+++ b/src/Moongate.Server/Services/Commands/CommandService.cs
@@ -30,7 +30,9 @@ public sealed class CommandService : ICommandService
     private readonly IResolverContext _resolver;
     private readonly IAccountService _accounts;
 
-    public CommandService(IReadOnlyList<CommandRegistration> registrations, IResolverContext resolver, IAccountService accounts)
+    public CommandService(
+        IReadOnlyList<CommandRegistration> registrations, IResolverContext resolver, IAccountService accounts
+    )
     {
         _registry = BuildRegistry(registrations);
         _resolver = resolver;
@@ -102,16 +104,15 @@ public sealed class CommandService : ICommandService
 
     public IReadOnlyList<CommandDescriptor> ListCommands(CommandSourceType source)
         => _registry.Values
-                    .Where(registration => registration.Sources.HasFlag(source))
-                    .Distinct()
-                    .Select(
-                        registration => new CommandDescriptor(
-                            registration.Name.Split('|')[0],
-                            registration.MinLevel,
-                            registration.Description
-                        )
-                    )
-                    .ToList();
+            .Where(registration => registration.Sources.HasFlag(source))
+            .Distinct()
+            .Select(registration => new CommandDescriptor(
+                    registration.Name.Split('|')[0],
+                    registration.MinLevel,
+                    registration.Description
+                )
+            )
+            .ToList();
 
     public static bool IsAuthorized(AccountLevelType actorLevel, AccountLevelType minLevel)
         => actorLevel >= minLevel;

--- a/src/Moongate.Server/Services/Items/ItemFactoryService.cs
+++ b/src/Moongate.Server/Services/Items/ItemFactoryService.cs
@@ -20,14 +20,13 @@ public sealed class ItemFactoryService : IItemFactoryService
     public IReadOnlyList<ItemEntity> CreateByCategory(string category, int count = 1, int amount = 1, Hue? hue = null)
     {
         var matches = _templates.All
-                                .Where(
-                                    template => string.Equals(
-                                        template.Category,
-                                        category,
-                                        StringComparison.OrdinalIgnoreCase
-                                    )
-                                )
-                                .ToList();
+            .Where(template => string.Equals(
+                    template.Category,
+                    category,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+            .ToList();
 
         return CreateFromPool(matches, count, amount, hue);
     }
@@ -35,8 +34,8 @@ public sealed class ItemFactoryService : IItemFactoryService
     public IReadOnlyList<ItemEntity> CreateByTag(string tag, int count = 1, int amount = 1, Hue? hue = null)
     {
         var matches = _templates.All
-                                .Where(template => template.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
-                                .ToList();
+            .Where(template => template.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+            .ToList();
 
         return CreateFromPool(matches, count, amount, hue);
     }

--- a/src/Moongate.Server/Services/Items/ItemTemplateYamlDeserializer.cs
+++ b/src/Moongate.Server/Services/Items/ItemTemplateYamlDeserializer.cs
@@ -34,9 +34,9 @@ internal static class ItemTemplateYamlDeserializer
     };
 
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-                                                         .WithDuplicateKeyChecking()
-                                                         .WithEnforceNullability()
-                                                         .Build();
+        .WithDuplicateKeyChecking()
+        .WithEnforceNullability()
+        .Build();
 
     public static ItemTemplate[] DeserializeFromFile(string file, string relativePath)
     {

--- a/src/Moongate.Server/Services/Items/ItemTemplateYamlSerializer.cs
+++ b/src/Moongate.Server/Services/Items/ItemTemplateYamlSerializer.cs
@@ -7,13 +7,13 @@ namespace Moongate.Server.Services.Items;
 public static class ItemTemplateYamlSerializer
 {
     private static readonly ISerializer Serializer = new SerializerBuilder()
-                                                     .ConfigureDefaultValuesHandling(
-                                                         DefaultValuesHandling.OmitNull |
-                                                         DefaultValuesHandling.OmitDefaults |
-                                                         DefaultValuesHandling.OmitEmptyCollections
-                                                     )
-                                                     .DisableAliases()
-                                                     .Build();
+        .ConfigureDefaultValuesHandling(
+            DefaultValuesHandling.OmitNull |
+            DefaultValuesHandling.OmitDefaults |
+            DefaultValuesHandling.OmitEmptyCollections
+        )
+        .DisableAliases()
+        .Build();
 
     public static void SerializeToFile(string file, IReadOnlyList<ItemTemplate> templates)
     {

--- a/src/Moongate.Server/Services/Items/LootService.cs
+++ b/src/Moongate.Server/Services/Items/LootService.cs
@@ -64,8 +64,8 @@ public sealed class LootService : ILootService
     private IReadOnlyList<ItemEntity> Materialize(LootTemplateEntry entry)
     {
         var amount = entry is { AmountMin: { } low, AmountMax: { } high }
-                         ? _random.Next(low, high + 1)
-                         : entry.Amount ?? 1;
+            ? _random.Next(low, high + 1)
+            : entry.Amount ?? 1;
 
         var hasId = !string.IsNullOrWhiteSpace(entry.ItemTemplateId);
         var hasTag = !string.IsNullOrWhiteSpace(entry.ItemTag);
@@ -78,8 +78,8 @@ public sealed class LootService : ILootService
         }
 
         return hasId
-                   ? _itemFactory.CreateFromTemplate(entry.ItemTemplateId!, amount: amount)
-                   : _itemFactory.CreateByTag(entry.ItemTag!, amount: amount);
+            ? _itemFactory.CreateFromTemplate(entry.ItemTemplateId!, amount: amount)
+            : _itemFactory.CreateByTag(entry.ItemTag!, amount: amount);
     }
 
     private LootTemplateEntry? PickWeighted(LootTemplate template)

--- a/src/Moongate.Server/Services/Items/LootTemplateYamlDeserializer.cs
+++ b/src/Moongate.Server/Services/Items/LootTemplateYamlDeserializer.cs
@@ -15,9 +15,9 @@ internal static class LootTemplateYamlDeserializer
     };
 
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-                                                         .WithDuplicateKeyChecking()
-                                                         .WithEnforceNullability()
-                                                         .Build();
+        .WithDuplicateKeyChecking()
+        .WithEnforceNullability()
+        .Build();
 
     public static LootTemplate[] DeserializeFromFile(string file, string relativePath)
     {

--- a/src/Moongate.Server/Services/Mobiles/MobileTemplateYamlDeserializer.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileTemplateYamlDeserializer.cs
@@ -7,8 +7,8 @@ namespace Moongate.Server.Services.Mobiles;
 internal static class MobileTemplateYamlDeserializer
 {
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-                                                         .WithDuplicateKeyChecking()
-                                                         .Build();
+        .WithDuplicateKeyChecking()
+        .Build();
 
     public static MobileTemplate[] DeserializeFromFile(string file, string relativePath)
     {

--- a/src/Moongate.Server/Services/Network/NetworkService.cs
+++ b/src/Moongate.Server/Services/Network/NetworkService.cs
@@ -68,12 +68,12 @@ public sealed class NetworkService : INetworkService, ISquidStdService, IAsyncDi
         }
 
         _handlers[opCode] = (session, packet) =>
-                            {
-                                var reader = new SpanReader(packet);
-                                var decoded = TPacket.Read(ref reader);
+        {
+            var reader = new SpanReader(packet);
+            var decoded = TPacket.Read(ref reader);
 
-                                handler.Handle(decoded, new(session));
-                            };
+            handler.Handle(decoded, new(session));
+        };
     }
 
     public async ValueTask StartAsync(CancellationToken cancellationToken = default)

--- a/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
+++ b/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
@@ -28,8 +28,8 @@ public sealed class NotificationTemplateService : INotificationTemplateService
         // template without one fails to parse under it. Channels with no subject write no front matter,
         // so both shapes have to be accepted.
         var mode = source.TrimStart().StartsWith(FrontMatterMarker, StringComparison.Ordinal)
-                       ? ScriptMode.FrontMatterAndContent
-                       : ScriptMode.Default;
+            ? ScriptMode.FrontMatterAndContent
+            : ScriptMode.Default;
 
         var template = Template.Parse(source, templateId, null, new LexerOptions { Mode = mode });
 

--- a/src/Moongate.Server/Services/Plugins/PluginDiscovery.cs
+++ b/src/Moongate.Server/Services/Plugins/PluginDiscovery.cs
@@ -32,11 +32,10 @@ public static class PluginDiscovery
     /// <summary>Activatable plugin types found in assemblies outside the host's compile-time graph.</summary>
     public static IEnumerable<Type> ExternalPluginTypes(Assembly host, IEnumerable<Assembly> loaded)
         => loaded.Where(assembly => IsExternal(host, assembly))
-                 .SelectMany(LoadableTypes)
-                 .Where(
-                     type => type is { IsAbstract: false, IsInterface: false }
-                             && typeof(ISquidStdPlugin).IsAssignableFrom(type)
-                 );
+            .SelectMany(LoadableTypes)
+            .Where(type => type is { IsAbstract: false, IsInterface: false }
+                           && typeof(ISquidStdPlugin).IsAssignableFrom(type)
+            );
 
     /// <summary>
     /// The types an assembly can actually give up. A plugin built against different dependency versions

--- a/src/Moongate.Server/Services/Server/ServerStatsService.cs
+++ b/src/Moongate.Server/Services/Server/ServerStatsService.cs
@@ -105,8 +105,7 @@ public sealed class ServerStatsService : IServerStatsService, ISquidStdService
         // for a whole interval. The event fires on the loop once the world is loaded, which is both the
         // earliest correct moment and the right thread. Refreshing inline here is not an option — StartAsync
         // runs off the loop, and reading the world stores from there is what this snapshot exists to avoid.
-        _eventBus.Subscribe<WorldReadyEvent>(
-            (_, _) =>
+        _eventBus.Subscribe<WorldReadyEvent>((_, _) =>
             {
                 Refresh();
 

--- a/src/Moongate.Server/Services/World/OplService.cs
+++ b/src/Moongate.Server/Services/World/OplService.cs
@@ -114,7 +114,7 @@ public sealed class OplService : IOplService
 
     private static string FirstNonEmpty(string? first, string? second, string fallback)
         => !string.IsNullOrWhiteSpace(first) ? first :
-           !string.IsNullOrWhiteSpace(second) ? second : fallback;
+            !string.IsNullOrWhiteSpace(second) ? second : fallback;
 
     private static int Fnv1a(string text)
     {

--- a/src/Moongate.Server/Services/World/SpatialIndexService.cs
+++ b/src/Moongate.Server/Services/World/SpatialIndexService.cs
@@ -146,7 +146,13 @@ public sealed class SpatialIndexService : ISpatialIndexService
             return;
         }
 
-        _logger.Debug("Mobile {Mobile} entered sector {MapId}:{SectorX},{SectorY}", serial, key.MapId, key.SectorX, key.SectorY);
+        _logger.Debug(
+            "Mobile {Mobile} entered sector {MapId}:{SectorX},{SectorY}",
+            serial,
+            key.MapId,
+            key.SectorX,
+            key.SectorY
+        );
         _eventBus.Publish(new MobileEnteredSectorEvent(serial, key.MapId, key.SectorX, key.SectorY));
 
         if (moved)
@@ -162,7 +168,15 @@ public sealed class SpatialIndexService : ISpatialIndexService
                 key.SectorY
             );
             _eventBus.Publish(
-                new MobileChangedSectorEvent(serial, from.MapId, from.SectorX, from.SectorY, key.MapId, key.SectorX, key.SectorY)
+                new MobileChangedSectorEvent(
+                    serial,
+                    from.MapId,
+                    from.SectorX,
+                    from.SectorY,
+                    key.MapId,
+                    key.SectorX,
+                    key.SectorY
+                )
             );
         }
     }
@@ -188,7 +202,13 @@ public sealed class SpatialIndexService : ISpatialIndexService
 
             if (wasMobile)
             {
-                _logger.Debug("Mobile {Mobile} left sector {MapId}:{SectorX},{SectorY}", serial, key.MapId, key.SectorX, key.SectorY);
+                _logger.Debug(
+                    "Mobile {Mobile} left sector {MapId}:{SectorX},{SectorY}",
+                    serial,
+                    key.MapId,
+                    key.SectorX,
+                    key.SectorY
+                );
                 _eventBus.Publish(new MobileLeftSectorEvent(serial, key.MapId, key.SectorX, key.SectorY));
             }
         }

--- a/src/Moongate.UO.Data/Mobiles/Templates/HueSpec.cs
+++ b/src/Moongate.UO.Data/Mobiles/Templates/HueSpec.cs
@@ -29,8 +29,8 @@ public static partial class HueSpec
         }
 
         return ushort.TryParse(spec, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
-                   ? value
-                   : (ushort)0;
+            ? value
+            : (ushort)0;
     }
 
     [GeneratedRegex(@"^hue\(\s*(\d+)\s*:\s*(\d+)\s*\)$", RegexOptions.IgnoreCase)]

--- a/src/Moongate.Ultima/Animation/AnimationEdit.cs
+++ b/src/Moongate.Ultima/Animation/AnimationEdit.cs
@@ -35,7 +35,7 @@ public sealed class AnimationEdit
                 bin.Write((short)6);
                 var animLength = Animations.GetAnimLength(body, fileType);
                 var currType = animLength == 22 ? 0 :
-                               animLength == 13 ? 1 : 2;
+                    animLength == 13 ? 1 : 2;
                 bin.Write((short)currType);
                 var indexPos = bin.BaseStream.Position;
                 var animPos = bin.BaseStream.Position + 12 * animLength * 5;

--- a/src/Moongate.Ultima/Animation/AnimationsUopLoader.cs
+++ b/src/Moongate.Ultima/Animation/AnimationsUopLoader.cs
@@ -46,8 +46,8 @@ internal static class AnimationsUopLoader
 
     public static IEnumerable<int> GetAllUopBodyIds()
         => MobTypes.GetDefinedBodies()
-                   .Where(id => (MobTypes.GetFlags(id) & 0x10000u) != 0)
-                   .OrderBy(id => id);
+            .Where(id => (MobTypes.GetFlags(id) & 0x10000u) != 0)
+            .OrderBy(id => id);
 
     public static AnimationFrame[] GetAnimation(
         int body,
@@ -114,8 +114,8 @@ internal static class AnimationsUopLoader
         }
 
         var result = firstFrame && frames.Length > 1
-                         ? new[] { frames[0] }
-                         : frames;
+            ? new[] { frames[0] }
+            : frames;
 
         Animations.Cache.Set(cacheKey, result);
 

--- a/src/Moongate.Ultima/Animation/Animdata.cs
+++ b/src/Moongate.Ultima/Animation/Animdata.cs
@@ -23,7 +23,9 @@ public sealed class Animdata
         public byte FrameStart { get; set; }
 
         // Empty constructor needed for deserialization.
-        public AnimdataEntry() { }
+        public AnimdataEntry()
+        {
+        }
 
         public AnimdataEntry(sbyte[] frame, byte unk, byte frameCount, byte frameInterval, byte frameStart)
         {

--- a/src/Moongate.Ultima/Audio/WaveFormatException.cs
+++ b/src/Moongate.Ultima/Audio/WaveFormatException.cs
@@ -2,9 +2,15 @@ namespace Moongate.Ultima.Audio;
 
 public class WaveFormatException : Exception
 {
-    public WaveFormatException() { }
+    public WaveFormatException()
+    {
+    }
 
-    public WaveFormatException(string message) : base(message) { }
+    public WaveFormatException(string message) : base(message)
+    {
+    }
 
-    public WaveFormatException(string message, Exception innerException) : base(message, innerException) { }
+    public WaveFormatException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }

--- a/src/Moongate.Ultima/Graphics/Art.cs
+++ b/src/Moongate.Ultima/Graphics/Art.cs
@@ -493,8 +493,8 @@ public static class Art
                             // GetLand / GetStatic transparently check _replaced
                             // first, then the LRU cache, then decode from disk.
                             var bmp = index < 0x4000
-                                          ? GetLand(index)
-                                          : GetStatic(index - 0x4000, false);
+                                ? GetLand(index)
+                                : GetStatic(index - 0x4000, false);
 
                             if (bmp == null || _removed[index])
                             {

--- a/src/Moongate.Ultima/Graphics/Gumps.cs
+++ b/src/Moongate.Ultima/Graphics/Gumps.cs
@@ -141,7 +141,7 @@ public sealed class Gumps
                         var pPixelEnd = pPixel + width;
 
                         ushort color,
-                               count;
+                            count;
 
                         if (onlyHueGrayPixels)
                         {

--- a/src/Moongate.Ultima/Helpers/MapHelper.cs
+++ b/src/Moongate.Ultima/Helpers/MapHelper.cs
@@ -24,14 +24,14 @@ public sealed class MapHelper
         if (Files.GetFilePath("map1.mul") != null || Files.GetFilePath("map1legacymul.uop") != null)
         {
             Map.Trammel = Map.Trammel.Width == 7168
-                              ? new(1, 1, 7168, 4096)
-                              : new Map(1, 1, 6144, 4096);
+                ? new(1, 1, 7168, 4096)
+                : new Map(1, 1, 6144, 4096);
         }
         else
         {
             Map.Trammel = Map.Trammel.Width == 7168
-                              ? new(0, 1, 7168, 4096)
-                              : new Map(0, 1, 6144, 4096);
+                ? new(0, 1, 7168, 4096)
+                : new Map(0, 1, 6144, 4096);
         }
     }
 }

--- a/src/Moongate.Ultima/Helpers/MythicDecompress.cs
+++ b/src/Moongate.Ultima/Helpers/MythicDecompress.cs
@@ -65,7 +65,7 @@ public static class MythicDecompress
         var output = new byte[input.Length + nonZeroCount + 1024];
 
         for (int i = 0,
-                 m = 0;
+             m = 0;
              i < nonZeroCount;
              ++i)
         {
@@ -117,7 +117,7 @@ public static class MythicDecompress
         } while (count >= 0);
 
         for (int i = 0,
-                 m = 0;
+             m = 0;
              i < nonZeroCount;
              ++i)
         {
@@ -285,7 +285,7 @@ public static class MythicDecompress
             Frequency(partialInput, frequency);
 
             for (int i = 0,
-                     m = 0;
+                 m = 0;
                  i < nonZeroCount;
                  ++i)
             {

--- a/src/Moongate.Ultima/Helpers/UopUtils.cs
+++ b/src/Moongate.Ultima/Helpers/UopUtils.cs
@@ -70,11 +70,11 @@ public static class UopUtils
     public static ulong HashFileName(string s)
     {
         uint eax,
-             ecx,
-             edx,
-             ebx,
-             esi,
-             edi;
+            ecx,
+            edx,
+            ebx,
+            esi,
+            edi;
 
         eax = ecx = edx = ebx = esi = edi = 0;
         ebx = edi = esi = (uint)s.Length + 0xDEADBEEF;

--- a/src/Moongate.Ultima/Imaging/UltimaBitmap.cs
+++ b/src/Moongate.Ultima/Imaging/UltimaBitmap.cs
@@ -148,8 +148,7 @@ public sealed unsafe class UltimaBitmap : IDisposable
         ArgumentNullException.ThrowIfNull(source);
 
         var result = new UltimaBitmap(source.Width, source.Height);
-        source.ProcessPixelRows(
-            accessor =>
+        source.ProcessPixelRows(accessor =>
             {
                 for (var y = 0; y < accessor.Height; y++)
                 {
@@ -187,8 +186,7 @@ public sealed unsafe class UltimaBitmap : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         var image = new Image<Bgra32>(Width, Height);
-        image.ProcessPixelRows(
-            accessor =>
+        image.ProcessPixelRows(accessor =>
             {
                 for (var y = 0; y < accessor.Height; y++)
                 {

--- a/src/Moongate.Ultima/Io/FileIndex.cs
+++ b/src/Moongate.Ultima/Io/FileIndex.cs
@@ -31,7 +31,9 @@ public sealed class FileIndex : IDisposable
         ".dat",
         -1,
         false
-    ) { }
+    )
+    {
+    }
 
     public FileIndex(
         string idxFile,

--- a/src/Moongate.Ultima/Localization/SpeechEntry.cs
+++ b/src/Moongate.Ultima/Localization/SpeechEntry.cs
@@ -7,8 +7,7 @@ public sealed class SpeechEntry
     public short Id { get; }
     public string KeyWord { get; set; }
 
-    [Browsable(false)]
-    public int Order { get; }
+    [Browsable(false)] public int Order { get; }
 
     public SpeechEntry(short id, string keyword, int order)
     {

--- a/src/Moongate.Ultima/Localization/StringList.cs
+++ b/src/Moongate.Ultima/Localization/StringList.cs
@@ -133,8 +133,8 @@ public sealed class StringList
 
         public int Compare(StringEntry x, StringEntry y)
             => _sortDescending
-                   ? string.CompareOrdinal(y.Text, x.Text)
-                   : string.CompareOrdinal(x.Text, y.Text);
+                ? string.CompareOrdinal(y.Text, x.Text)
+                : string.CompareOrdinal(x.Text, y.Text);
     }
 
     public StringEntry GetEntry(int number)

--- a/src/Moongate.Ultima/Maps/Map.cs
+++ b/src/Moongate.Ultima/Maps/Map.cs
@@ -514,7 +514,7 @@ public sealed class Map
         var pStart = (byte*)bmp.Scan0;
 
         for (int oy = 0,
-                 by = y;
+             by = y;
              oy < height;
              ++oy, ++by, pStart += blockStride)
         {
@@ -528,7 +528,7 @@ public sealed class Map
             var pRow7 = (int*)(pStart + 7 * stride);
 
             for (int ox = 0,
-                     bx = x;
+                 bx = x;
                  ox < width;
                  ++ox, ++bx)
             {
@@ -594,7 +594,7 @@ public sealed class Map
         var pStart = (byte*)bmp.Scan0;
 
         for (int oy = 0,
-                 by = y;
+             by = y;
              oy < height;
              ++oy, ++by, pStart += blockStride)
         {
@@ -604,7 +604,7 @@ public sealed class Map
             var pRow3 = (int*)(pStart + 3 * stride);
 
             for (int ox = 0,
-                     bx = x;
+                 bx = x;
                  ox < width;
                  ++ox, ++bx)
             {
@@ -639,7 +639,7 @@ public sealed class Map
         var pStart = (byte*)bmp.Scan0;
 
         for (int oy = 0,
-                 by = y;
+             by = y;
              oy < height;
              ++oy, ++by, pStart += blockStride)
         {
@@ -647,7 +647,7 @@ public sealed class Map
             var pRow1 = (int*)(pStart + 1 * stride);
 
             for (int ox = 0,
-                     bx = x;
+                 bx = x;
                  ox < width;
                  ++ox, ++bx)
             {
@@ -1505,7 +1505,7 @@ public sealed class Map
         return data;
     }
 
-#region Altitude Map Rendering
+    #region Altitude Map Rendering
 
     /// <summary>
     /// Returns Bitmap with altitude rendering mode support
@@ -1562,7 +1562,7 @@ public sealed class Map
         {
             // Grayscale altitude mode (formerly 8bpp indexed with a gray palette)
             for (int oy = 0,
-                     by = y;
+                 by = y;
                  oy < height;
                  ++oy, ++by, pStart += blockStride)
             {
@@ -1576,7 +1576,7 @@ public sealed class Map
                 var pRow7 = (ushort*)(pStart + 7 * stride);
 
                 for (int ox = 0,
-                         bx = x;
+                     bx = x;
                      ox < width;
                      ++ox, ++bx)
                 {
@@ -1635,7 +1635,7 @@ public sealed class Map
             var withAltitude = altitudeMode == MapAltitudeModeType.NormalWithAltitude;
 
             for (int oy = 0,
-                     by = y;
+                 by = y;
                  oy < height;
                  ++oy, ++by, pStart += blockStride)
             {
@@ -1649,13 +1649,13 @@ public sealed class Map
                 var pRow7 = (ushort*)(pStart + 7 * stride);
 
                 for (int ox = 0,
-                         bx = x;
+                     bx = x;
                      ox < width;
                      ++ox, ++bx)
                 {
                     var colorData = withAltitude
-                                        ? GetLitBlock(bx, by, statics)
-                                        : GetRenderedBlock(bx, by, statics);
+                        ? GetLitBlock(bx, by, statics)
+                        : GetRenderedBlock(bx, by, statics);
 
                     fixed (ushort* pData = colorData)
                     {
@@ -1827,8 +1827,8 @@ public sealed class Map
     {
         // Get current shading settings based on preset
         var settings = ShadingPreset == AltitudeShadingPresetType.Custom
-                           ? CustomShadingSettings
-                           : AltitudeShadingSettings.GetPreset(ShadingPreset);
+            ? CustomShadingSettings
+            : AltitudeShadingSettings.GetPreset(ShadingPreset);
 
         // Use configurable intensity (lower = more contrast, higher = softer)
         var maxSlope = Math.Clamp(AltitudeIntensity, 1, 20);
@@ -1929,5 +1929,5 @@ public sealed class Map
         return (ushort)(OpaqueBit | (red << 10) | (green << 5) | blue);
     }
 
-#endregion
+    #endregion
 }

--- a/src/Moongate.Ultima/Maps/TileMatrix.cs
+++ b/src/Moongate.Ultima/Maps/TileMatrix.cs
@@ -383,8 +383,8 @@ public sealed class TileMatrix : IDisposable
         if (_map?.CanRead != true || !_map.CanSeek)
         {
             _map = _mapPath == null
-                       ? null
-                       : new FileStream(_mapPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                ? null
+                : new FileStream(_mapPath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
             if (IsUOPFormat && _mapPath != null && !IsUOPAlreadyRead)
             {
@@ -427,8 +427,8 @@ public sealed class TileMatrix : IDisposable
         if (_statics?.CanRead != true || !_statics.CanSeek)
         {
             _statics = _staticsPath == null
-                           ? null
-                           : new FileStream(_staticsPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                ? null
+                : new FileStream(_staticsPath, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
         if (_statics == null)

--- a/src/Moongate.Ultima/Maps/TileMatrixPatch.cs
+++ b/src/Moongate.Ultima/Maps/TileMatrixPatch.cs
@@ -23,7 +23,7 @@ public sealed class TileMatrixPatch
 
         LandBlocksCount = StaticBlocksCount = 0;
         string mapDataPath,
-               mapIndexPath;
+            mapIndexPath;
 
         if (path == null)
         {
@@ -54,8 +54,8 @@ public sealed class TileMatrixPatch
         }
 
         string staDataPath,
-               staIndexPath,
-               staLookupPath;
+            staIndexPath,
+            staLookupPath;
 
         if (path == null)
         {
@@ -217,7 +217,7 @@ public sealed class TileMatrixPatch
                 using (var fsLookup = new FileStream(lookupPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     using (BinaryReader indexReader = new(fsIndex),
-                                        lookupReader = new(fsLookup))
+                           lookupReader = new(fsLookup))
                     {
                         var count = Math.Min(
                             (int)(indexReader.BaseStream.Length / 4),

--- a/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
@@ -25,7 +25,9 @@ public class ConsoleAdminIntegrationTests
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        {
+        }
     }
 
     private static (ConsoleServerService Service, RecordingChatService Chat) Build(SeededAccountService accounts)
@@ -36,7 +38,8 @@ public class ConsoleAdminIntegrationTests
             AccountLevelType.GrandMaster,
             "Sends a server-wide system message.",
             CommandSourceType.InGame | CommandSourceType.Console,
-            _ => new BroadcastCommand(chat));
+            _ => new BroadcastCommand(chat)
+        );
         var commands = new CommandService([registration], new Container(), accounts);
         var config = new MoongateConsoleConfig { Enabled = true, Address = "127.0.0.1", Port = 0, MaxSessions = 4 };
         var service = new ConsoleServerService(config, commands, accounts, new InlineMainThreadDispatcher());

--- a/tests/Moongate.Tests/Console/ConsoleAuthTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAuthTests.cs
@@ -15,23 +15,27 @@ public class ConsoleAuthTests
     public void Evaluate_SuccessAtOrAboveMinLevel_IsAllowed()
         => Assert.Equal(
             ConsoleAuthResultType.Allowed,
-            ConsoleAuth.Evaluate(Ok(), AccountLevelType.GrandMaster, AccountLevelType.GrandMaster));
+            ConsoleAuth.Evaluate(Ok(), AccountLevelType.GrandMaster, AccountLevelType.GrandMaster)
+        );
 
     [Fact]
     public void Evaluate_SuccessBelowMinLevel_IsInsufficientPrivileges()
         => Assert.Equal(
             ConsoleAuthResultType.InsufficientPrivileges,
-            ConsoleAuth.Evaluate(Ok(), AccountLevelType.Player, AccountLevelType.GrandMaster));
+            ConsoleAuth.Evaluate(Ok(), AccountLevelType.Player, AccountLevelType.GrandMaster)
+        );
 
     [Fact]
     public void Evaluate_AuthFailure_IsLoginFailed()
         => Assert.Equal(
             ConsoleAuthResultType.LoginFailed,
-            ConsoleAuth.Evaluate(Denied(), null, AccountLevelType.GrandMaster));
+            ConsoleAuth.Evaluate(Denied(), null, AccountLevelType.GrandMaster)
+        );
 
     [Fact]
     public void Evaluate_SuccessButUnknownAccount_IsLoginFailed()
         => Assert.Equal(
             ConsoleAuthResultType.LoginFailed,
-            ConsoleAuth.Evaluate(Ok(), null, AccountLevelType.GrandMaster));
+            ConsoleAuth.Evaluate(Ok(), null, AccountLevelType.GrandMaster)
+        );
 }

--- a/tests/Moongate.Tests/Console/ConsoleConfigFileTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleConfigFileTests.cs
@@ -19,7 +19,10 @@ public class ConsoleConfigFileTests
             // Use DirectoriesConfig itself to resolve (and create) the dir, so the file lands exactly
             // where the plugin will look — no assumption about the snake-case path transform.
             var directories = new DirectoriesConfig(root, ["plugins/configs"]);
-            File.WriteAllText(Path.Combine(directories["plugins/configs"], "console.yaml"), "console:\n  Enabled: true\n  Port: 9999\n");
+            File.WriteAllText(
+                Path.Combine(directories["plugins/configs"], "console.yaml"),
+                "console:\n  Enabled: true\n  Port: 9999\n"
+            );
 
             using var container = new Container();
             container.RegisterInstance(SquidStdConfig.Load("moongate", root));

--- a/tests/Moongate.Tests/Data/FlippableTemplatesTests.cs
+++ b/tests/Moongate.Tests/Data/FlippableTemplatesTests.cs
@@ -19,8 +19,8 @@ public class FlippableTemplatesTests
             await new ItemTemplatesLoader(templates, directories).LoadAsync();
 
             var withFlip = templates.All
-                                    .Where(t => t.FlippableItemIds is { Count: > 0 })
-                                    .ToList();
+                .Where(t => t.FlippableItemIds is { Count: > 0 })
+                .ToList();
 
             // The port added flip data well beyond the 3 hand-authored files.
             Assert.True(withFlip.Count > 20, $"Expected many flippable templates, got {withFlip.Count}");

--- a/tests/Moongate.Tests/Data/ItemTemplateSplitDataTests.cs
+++ b/tests/Moongate.Tests/Data/ItemTemplateSplitDataTests.cs
@@ -35,8 +35,8 @@ public class ItemTemplateSplitDataTests
         var repositoryRoot = FindRepositoryRoot();
         var splitRoot = Path.Combine(repositoryRoot, "src", "Moongate.Server", "Assets", "Templates", "Items");
         var splitFiles = Directory.GetFiles(splitRoot, "*.yaml", SearchOption.AllDirectories)
-                                  .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-                                  .ToArray();
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
         var splitByFile = splitFiles.ToDictionary(
             path => Path.GetRelativePath(splitRoot, path).Replace(Path.DirectorySeparatorChar, '/'),
             path => YamlUtils.DeserializeFromFile<ItemTemplate[]>(path) ?? [],

--- a/tests/Moongate.Tests/Data/StartingItemsDataTests.cs
+++ b/tests/Moongate.Tests/Data/StartingItemsDataTests.cs
@@ -33,12 +33,12 @@ public class StartingItemsDataTests
 
             var data = LoadData();
             var referenced = data.All
-                                 .Equip
-                                 .Concat(data.All.Pack)
-                                 .Concat(data.ByBody.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
-                                 .Concat(data.BySkill.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
-                                 .Select(entry => entry.Item)
-                                 .Distinct();
+                .Equip
+                .Concat(data.All.Pack)
+                .Concat(data.ByBody.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
+                .Concat(data.BySkill.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
+                .Select(entry => entry.Item)
+                .Distinct();
 
             foreach (var id in referenced)
             {

--- a/tests/Moongate.Tests/Http/ApiEndpointRegistrationExtensionsTests.cs
+++ b/tests/Moongate.Tests/Http/ApiEndpointRegistrationExtensionsTests.cs
@@ -9,12 +9,16 @@ public class ApiEndpointRegistrationExtensionsTests
 {
     private sealed class FirstEndpoints : IApiEndpointRegistration
     {
-        public void Register(IEndpointRouteBuilder routes) { }
+        public void Register(IEndpointRouteBuilder routes)
+        {
+        }
     }
 
     private sealed class SecondEndpoints : IApiEndpointRegistration
     {
-        public void Register(IEndpointRouteBuilder routes) { }
+        public void Register(IEndpointRouteBuilder routes)
+        {
+        }
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/ContainerSharingTests.cs
+++ b/tests/Moongate.Tests/Http/ContainerSharingTests.cs
@@ -44,13 +44,12 @@ public class ContainerSharingTests
     [Fact]
     public async Task Endpoint_ServesMutationsMadeThroughTheGameContainerAfterStartup()
     {
-        await using var server = await TestHttpServer.StartAsync(
-                                     container =>
-                                     {
-                                         container.Register<GameSingleton>(Reuse.Singleton);
-                                         container.RegisterApiEndpoint<SingletonProbeEndpoints>();
-                                     }
-                                 );
+        await using var server = await TestHttpServer.StartAsync(container =>
+            {
+                container.Register<GameSingleton>(Reuse.Singleton);
+                container.RegisterApiEndpoint<SingletonProbeEndpoints>();
+            }
+        );
 
         // Mutated after the routes are mapped, through the container rather than the endpoint: the marker
         // only comes back changed if the endpoint holds the game's own instance and reads it live. This is

--- a/tests/Moongate.Tests/Http/Endpoints/Accounts/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Accounts/AccountEndpointsTests.cs
@@ -16,9 +16,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/admin/accounts",
-                           new { username, password }
-                       );
+            "/api/v1/admin/accounts",
+            new { username, password }
+        );
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -30,9 +30,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/admin/accounts",
-                           new { username = "alice", password = "secret", email = "a@b.c", level = "Player" }
-                       );
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret", email = "a@b.c", level = "Player" }
+        );
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal("/api/v1/admin/accounts/alice", response.Headers.Location?.ToString());
@@ -61,9 +61,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/admin/accounts",
-                           new { username = "tom", password = "secret" }
-                       );
+            "/api/v1/admin/accounts",
+            new { username = "tom", password = "secret" }
+        );
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -76,9 +76,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/admin/accounts",
-                           new { username = "alice", password = "secret", level = "Wizard" }
-                       );
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret", level = "Wizard" }
+        );
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Null(server.Accounts.GetByUsername("alice"));
@@ -117,9 +117,9 @@ public class AccountEndpointsTests
     public async Task Delete_LoopNeverAnswers_Is503()
     {
         await using var server = await TestApiServer.StartAsync(
-                                     loop: new StubGameLoopContext(false),
-                                     deleteTimeout: TimeSpan.FromMilliseconds(50)
-                                 );
+            loop: new StubGameLoopContext(false),
+            deleteTimeout: TimeSpan.FromMilliseconds(50)
+        );
         await server.AuthenticateAsync();
 
         var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
@@ -240,9 +240,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
-                           "/api/v1/admin/accounts/tom",
-                           new { isActive = false }
-                       );
+            "/api/v1/admin/accounts/tom",
+            new { isActive = false }
+        );
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -285,9 +285,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
-                           "/api/v1/admin/accounts/nobody",
-                           new { isActive = false }
-                       );
+            "/api/v1/admin/accounts/nobody",
+            new { isActive = false }
+        );
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -299,9 +299,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
-                           "/api/v1/admin/accounts/tom",
-                           new { level = "Wizard", isActive = false }
-                       );
+            "/api/v1/admin/accounts/tom",
+            new { level = "Wizard", isActive = false }
+        );
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 

--- a/tests/Moongate.Tests/Http/Endpoints/Auth/AuthEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Auth/AuthEndpointsTests.cs
@@ -16,9 +16,9 @@ public class AuthEndpointsTests
         server.Accounts.SetActive("tom", false);
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/auth/login",
-                           new { username = "tom", password = "secret" }
-                       );
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.DoesNotContain("block", await response.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
@@ -30,9 +30,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/auth/login",
-                           new { username = "tom", password = "secret" }
-                       );
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -48,9 +48,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/auth/login",
-                           new { username = "tom", password = "secret" }
-                       );
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
 
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("\"expiresAt\"", body, StringComparison.Ordinal);
@@ -63,9 +63,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/auth/login",
-                           new { username = "nobody", password = "secret" }
-                       );
+            "/api/v1/auth/login",
+            new { username = "nobody", password = "secret" }
+        );
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -76,9 +76,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-                           "/api/v1/auth/login",
-                           new { username = "tom", password = "wrong" }
-                       );
+            "/api/v1/auth/login",
+            new { username = "tom", password = "wrong" }
+        );
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }

--- a/tests/Moongate.Tests/Http/Endpoints/Auth/AuthRenewEndpointTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Auth/AuthRenewEndpointTests.cs
@@ -53,7 +53,7 @@ public class AuthRenewEndpointTests
         clock.Advance(TimeSpan.FromMinutes(45));
 
         var renewed = (await (await server.Client.PostAsync(Route, null)).Content
-                          .ReadFromJsonAsync<ApiTokenResult>()).Token;
+            .ReadFromJsonAsync<ApiTokenResult>()).Token;
 
         Assert.Equal(loginAuthTime, AuthTimeOf(renewed));
     }

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterAdminEndpointsTests.cs
@@ -156,13 +156,13 @@ public class CharacterAdminEndpointsTests
 
     private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
         => await TestApiServer.StartAsync(
-               level,
-               configure: container =>
-                          {
-                              container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
-                              container.RegisterApiEndpointInstance(
-                                  new CharacterAdminEndpoints(container.Resolve<ICharacterQueryService>())
-                              );
-                          }
-           );
+            level,
+            configure: container =>
+            {
+                container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new CharacterAdminEndpoints(container.Resolve<ICharacterQueryService>())
+                );
+            }
+        );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterEndpointsTests.cs
@@ -19,8 +19,8 @@ public class CharacterEndpointsTests
         // Every NPC on a real shard looks like this in the store: a mobile no account lists.
         await using var server = await TestApiServer.StartAsync();
         await server.Persistence
-                    .Store<MobileEntity>()
-                    .UpsertAsync(new() { Name = "a wandering healer" });
+            .Store<MobileEntity>()
+            .UpsertAsync(new() { Name = "a wandering healer" });
         await server.AuthenticateAsync();
 
         var characters = await server.Client.GetFromJsonAsync<List<CharacterResponse>>(Route);

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
@@ -24,9 +24,13 @@ public class ConsoleEndpointsTests
 {
     private sealed class RecordingChat : IChatService
     {
-        public void Broadcast(string text, Hue? hue = null) { }
+        public void Broadcast(string text, Hue? hue = null)
+        {
+        }
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        {
+        }
     }
 
     // Wires the real ConsoleEndpoints (over real HTTP) against the given registry, an inline dispatcher
@@ -41,13 +45,16 @@ public class ConsoleEndpointsTests
                     AccountLevelType.GrandMaster,
                     "Sends a server-wide system message.",
                     CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
-                    _ => new BroadcastCommand(new RecordingChat()));
+                    _ => new BroadcastCommand(new RecordingChat())
+                );
                 var commands = new CommandService([registration], container, container.Resolve<IAccountService>());
 
                 container.RegisterInstance<IConsoleStreamRegistry>(registry);
                 container.RegisterApiEndpointInstance(
-                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher()));
-            });
+                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher())
+                );
+            }
+        );
 
     [Fact]
     public async Task Post_with_unknown_connection_returns_404()
@@ -57,7 +64,9 @@ public class ConsoleEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/console", new { command = "broadcast hi", connectionId = "nope" });
+            "/api/v1/admin/console",
+            new { command = "broadcast hi", connectionId = "nope" }
+        );
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -71,7 +80,9 @@ public class ConsoleEndpointsTests
         var (id, reader) = registry.Open();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/console", new { command = "broadcast hi", connectionId = id });
+            "/api/v1/admin/console",
+            new { command = "broadcast hi", connectionId = id }
+        );
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         registry.Close(id); // inline dispatch already ran the command; complete the channel so we can drain it

--- a/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
@@ -29,7 +29,9 @@ public class RestConsoleIntegrationTests
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        {
+        }
     }
 
     [Fact]
@@ -46,19 +48,25 @@ public class RestConsoleIntegrationTests
                     AccountLevelType.GrandMaster,
                     "Sends a server-wide system message.",
                     CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
-                    _ => new BroadcastCommand(chat));
+                    _ => new BroadcastCommand(chat)
+                );
                 var commands = new CommandService([registration], container, container.Resolve<IAccountService>());
 
                 container.RegisterInstance<IConsoleStreamRegistry>(registry);
                 container.RegisterApiEndpointInstance(
-                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher()));
-            });
+                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher())
+                );
+            }
+        );
         await server.AuthenticateAsync();
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
 
         using var streamResponse = await server.Client.GetAsync(
-            "/api/v1/admin/console/stream", HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+            "/api/v1/admin/console/stream",
+            HttpCompletionOption.ResponseHeadersRead,
+            timeout.Token
+        );
         Assert.Equal("text/event-stream", streamResponse.Content.Headers.ContentType?.MediaType);
 
         await using var body = await streamResponse.Content.ReadAsStreamAsync(timeout.Token);
@@ -71,7 +79,8 @@ public class RestConsoleIntegrationTests
         var post = await server.Client.PostAsJsonAsync(
             "/api/v1/admin/console",
             new { command = "broadcast hello world", connectionId },
-            timeout.Token);
+            timeout.Token
+        );
         Assert.Equal(HttpStatusCode.Accepted, post.StatusCode);
 
         Assert.True(await events.MoveNextAsync());

--- a/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageAdminEndpointsTests.cs
@@ -55,19 +55,19 @@ public class ItemImageAdminEndpointsTests
 
     private static async Task<TestApiServer> StartAsync(ItemImageFixture fixture)
         => await TestApiServer.StartAsync(
-               configure: container =>
-                          {
-                              container.RegisterInstance(fixture.Directories);
-                              container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
-                              container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-                              container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
-                              container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
-                              container.RegisterApiEndpointInstance(
-                                  new ItemImageAdminEndpoints(
-                                      container.Resolve<IItemImageExportJob>(),
-                                      container.Resolve<IItemImageService>()
-                                  )
-                              );
-                          }
-           );
+            configure: container =>
+            {
+                container.RegisterInstance(fixture.Directories);
+                container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+                container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new ItemImageAdminEndpoints(
+                        container.Resolve<IItemImageExportJob>(),
+                        container.Resolve<IItemImageService>()
+                    )
+                );
+            }
+        );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageEndpointsTests.cs
@@ -24,8 +24,8 @@ public class ItemImageEndpointsTests
 
         var plain = await server.Client.GetByteArrayAsync($"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png");
         var hued = await server.Client.GetByteArrayAsync(
-                       $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x{ItemImageFixture.Hue:x4}"
-                   );
+            $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x{ItemImageFixture.Hue:x4}"
+        );
 
         using var plainImage = Image.Load<Bgra32>(plain);
         using var huedImage = Image.Load<Bgra32>(hued);
@@ -108,14 +108,13 @@ public class ItemImageEndpointsTests
     }
 
     private static async Task<TestHttpServer> StartAsync(ItemImageFixture fixture)
-        => await TestHttpServer.StartAsync(
-               container =>
-               {
-                   container.RegisterInstance(fixture.Directories);
-                   container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
-                   container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-                   container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
-                   container.RegisterApiEndpointInstance(new ItemImageEndpoints(container.Resolve<IItemImageService>()));
-               }
-           );
+        => await TestHttpServer.StartAsync(container =>
+            {
+                container.RegisterInstance(fixture.Directories);
+                container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(new ItemImageEndpoints(container.Resolve<IItemImageService>()));
+            }
+        );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Items/ItemTemplateEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Items/ItemTemplateEndpointsTests.cs
@@ -90,8 +90,8 @@ public class ItemTemplateEndpointsTests
         await server.AuthenticateAsync();
 
         var page = await server.Client.GetFromJsonAsync<PagedResponse<ItemTemplateSummaryResponse>>(
-                       $"{Route}?search=nothing"
-                   );
+            $"{Route}?search=nothing"
+        );
 
         Assert.Equal(0, page!.Total);
         Assert.Empty(page.Items);
@@ -122,26 +122,26 @@ public class ItemTemplateEndpointsTests
 
     private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
         => await TestApiServer.StartAsync(
-               level,
-               configure: container =>
-                          {
-                              var templates = new ItemTemplateService();
-                              templates.Register(Template("katana", "a katana", "weapons", 0x13FF, ["weapon", "sword"]));
-                              templates.Register(Template("bread", "a bread loaf", "food", 0x103B, ["food"]));
-                              templates.Register(
-                                  Template(
-                                      "elder_katana",
-                                      "an elder katana",
-                                      "weapons",
-                                      0x13FF,
-                                      ["weapon", "sword"],
-                                      ItemRarityType.Legendary
-                                  )
-                              );
-                              container.RegisterInstance<IItemTemplateService>(templates);
-                              container.RegisterApiEndpointInstance(new ItemTemplateEndpoints(templates));
-                          }
-           );
+            level,
+            configure: container =>
+            {
+                var templates = new ItemTemplateService();
+                templates.Register(Template("katana", "a katana", "weapons", 0x13FF, ["weapon", "sword"]));
+                templates.Register(Template("bread", "a bread loaf", "food", 0x103B, ["food"]));
+                templates.Register(
+                    Template(
+                        "elder_katana",
+                        "an elder katana",
+                        "weapons",
+                        0x13FF,
+                        ["weapon", "sword"],
+                        ItemRarityType.Legendary
+                    )
+                );
+                container.RegisterInstance<IItemTemplateService>(templates);
+                container.RegisterApiEndpointInstance(new ItemTemplateEndpoints(templates));
+            }
+        );
 
     private static ItemTemplate Template(
         string id,
@@ -163,7 +163,7 @@ public class ItemTemplateEndpointsTests
             Rarity = rarity,
             Tags = [.. tags],
             Params = id == "katana"
-                         ? new() { ["durability"] = new() { Type = "int", Value = "100" } }
-                         : null
+                ? new() { ["durability"] = new() { Type = "int", Value = "100" } }
+                : null
         };
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
@@ -139,19 +139,18 @@ public class MapImageEndpointsTests
     }
 
     private static async Task<TestHttpServer> StartAsync(MapImageFixture fixture)
-        => await TestHttpServer.StartAsync(
-               container =>
-               {
-                   container.RegisterInstance(fixture.Directories);
-                   container.RegisterInstance(fixture.Provider);
-                   container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-                   container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
-                   container.RegisterApiEndpointInstance(
-                       new MapImageEndpoints(
-                           container.Resolve<IMapImageService>(),
-                           container.Resolve<IUltimaMapProvider>()
-                       )
-                   );
-               }
-           );
+        => await TestHttpServer.StartAsync(container =>
+            {
+                container.RegisterInstance(fixture.Directories);
+                container.RegisterInstance(fixture.Provider);
+                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
+                container.RegisterApiEndpointInstance(
+                    new MapImageEndpoints(
+                        container.Resolve<IMapImageService>(),
+                        container.Resolve<IUltimaMapProvider>()
+                    )
+                );
+            }
+        );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileImageEndpointsTests.cs
@@ -49,8 +49,8 @@ public sealed class MobileImageEndpointsTests : IDisposable
 
         var hair = await server.Client.GetFromJsonAsync<PagedResponse<HairStyleSummary>>("/api/v1/admin/hair-styles");
         var facial = await server.Client.GetFromJsonAsync<PagedResponse<HairStyleSummary>>(
-                         "/api/v1/admin/hair-styles?facial=true"
-                     );
+            "/api/v1/admin/hair-styles?facial=true"
+        );
 
         Assert.Equal(10, hair!.Total);
         Assert.Equal(7, facial!.Total);
@@ -164,41 +164,41 @@ public sealed class MobileImageEndpointsTests : IDisposable
         templates.Register(new() { Id = "villager", Appearance = new() { Body = 400 } });
 
         return await TestApiServer.StartAsync(
-                   level,
-                   configure: container =>
-                              {
-                                  var gate = new StubUltimaReadGate();
-                                  var directories = new DirectoriesConfig(_root, Array.Empty<string>());
-                                  var bodies = new BodyImageService(catalog, directories, gate);
-                                  var renderer = new MobileFigureRenderer(catalog, new ItemTemplateService());
+            level,
+            configure: container =>
+            {
+                var gate = new StubUltimaReadGate();
+                var directories = new DirectoriesConfig(_root, Array.Empty<string>());
+                var bodies = new BodyImageService(catalog, directories, gate);
+                var renderer = new MobileFigureRenderer(catalog, new ItemTemplateService());
 
-                                  container.RegisterApiEndpointInstance(new BodyImageEndpoints(bodies));
-                                  container.RegisterApiEndpointInstance(
-                                      new HairImageEndpoints(new HairImageService(renderer, directories, gate))
-                                  );
-                                  container.RegisterApiEndpointInstance(
-                                      new MobileTemplateImageEndpoints(
-                                          new MobileTemplateImageService(renderer, templates, directories, gate)
-                                      )
-                                  );
-                                  container.RegisterApiEndpointInstance(
-                                      new MobileImageAdminEndpoints(catalog, new BodyImageExportJob(bodies, catalog), bodies)
-                                  );
+                container.RegisterApiEndpointInstance(new BodyImageEndpoints(bodies));
+                container.RegisterApiEndpointInstance(
+                    new HairImageEndpoints(new HairImageService(renderer, directories, gate))
+                );
+                container.RegisterApiEndpointInstance(
+                    new MobileTemplateImageEndpoints(
+                        new MobileTemplateImageService(renderer, templates, directories, gate)
+                    )
+                );
+                container.RegisterApiEndpointInstance(
+                    new MobileImageAdminEndpoints(catalog, new BodyImageExportJob(bodies, catalog), bodies)
+                );
 
-                                  var gumps = new FakeGumpCatalog();
-                                  gumps.Gumps[(0x000C, 0)] = (W: 40, H: 100); // male body gump
+                var gumps = new FakeGumpCatalog();
+                gumps.Gumps[(0x000C, 0)] = (W: 40, H: 100); // male body gump
 
-                                  container.RegisterApiEndpointInstance(
-                                      new PaperdollEndpoints(
-                                          new PaperdollImageService(
-                                              new PaperdollRenderer(gumps, catalog, new ItemTemplateService()),
-                                              templates,
-                                              directories,
-                                              gate
-                                          )
-                                      )
-                                  );
-                              }
-               );
+                container.RegisterApiEndpointInstance(
+                    new PaperdollEndpoints(
+                        new PaperdollImageService(
+                            new PaperdollRenderer(gumps, catalog, new ItemTemplateService()),
+                            templates,
+                            directories,
+                            gate
+                        )
+                    )
+                );
+            }
+        );
     }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
@@ -14,7 +14,8 @@ public sealed class ServerInfoEndpointsTests
     {
         await using var server = await TestApiServer.StartAsync();
         server.ServerSettings.Update(
-            new ServerSettingsUpdate { Description = "A fun shard", Tagline = "Sosaria never sleeps.", RegistrationEnabled = true }
+            new ServerSettingsUpdate
+                { Description = "A fun shard", Tagline = "Sosaria never sleeps.", RegistrationEnabled = true }
         );
 
         var response = await server.Client.GetAsync("/api/v1/server-info"); // no auth header

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -34,11 +34,11 @@ public class MoongateHttpPluginTests
         // Registrations rather than instances: the game-facing groups need services this bare
         // container has no reason to hold; what the plugin is responsible for is the registering.
         var registered = Configured()
-                         .GetServiceRegistrations()
-                         .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
-                         .Select(registration => registration.ImplementationType)
-                         .OrderBy(type => type!.Name)
-                         .ToArray();
+            .GetServiceRegistrations()
+            .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+            .Select(registration => registration.ImplementationType)
+            .OrderBy(type => type!.Name)
+            .ToArray();
 
         Assert.Equal(
             [

--- a/tests/Moongate.Tests/Http/Services/Auth/JwtTokenServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Auth/JwtTokenServiceTests.cs
@@ -35,8 +35,7 @@ public class JwtTokenServiceTests
         // HS256 needs at least 32 bytes. Failing loudly beats minting tokens nobody can verify.
         var service = Service(signingKey);
 
-        Assert.Throws<InvalidOperationException>(
-            () => service.Issue(new(5), "tom", AccountLevelType.Player, SessionStart)
+        Assert.Throws<InvalidOperationException>(() => service.Issue(new(5), "tom", AccountLevelType.Player, SessionStart)
         );
     }
 

--- a/tests/Moongate.Tests/Http/Services/Hosting/HttpServerServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Hosting/HttpServerServiceTests.cs
@@ -65,9 +65,9 @@ public class HttpServerServiceTests
     [Fact]
     public async Task StartAsync_MapsRegisteredEndpointGroups()
     {
-        await using var server = await TestHttpServer.StartAsync(
-                                     container => container.RegisterApiEndpointInstance(new ProbeEndpoints())
-                                 );
+        await using var server =
+            await TestHttpServer.StartAsync(container => container.RegisterApiEndpointInstance(new ProbeEndpoints())
+            );
 
         Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/probe")).StatusCode);
     }
@@ -128,9 +128,10 @@ public class HttpServerServiceTests
         // The whole point of the /// on the endpoint handlers: without the XML wired in, the document
         // still serves and Scalar still renders — just with every description blank. Nothing else here
         // would notice, which is why this asserts on the prose rather than on a 200.
-        await using var server = await TestHttpServer.StartAsync(
-                                     container => container.RegisterApiEndpointInstance(new DocumentedProbeEndpoints())
-                                 );
+        await using var server =
+            await TestHttpServer.StartAsync(container =>
+                container.RegisterApiEndpointInstance(new DocumentedProbeEndpoints())
+            );
 
         var document = await server.Client.GetStringAsync(HttpServerService.SwaggerDocumentRoute);
 
@@ -189,9 +190,9 @@ public class HttpServerServiceTests
         // throw away the key the operator chose.
         var configManager = new StubConfigManagerService();
 
-        await using var server = await TestHttpServer.StartAsync(
-                                     container => container.RegisterInstance<IConfigManagerService>(configManager)
-                                 );
+        await using var server =
+            await TestHttpServer.StartAsync(container => container.RegisterInstance<IConfigManagerService>(configManager)
+            );
 
         Assert.Equal(TestHttpServer.SigningKey, server.Container.Resolve<MoongateHttpConfig>().Jwt.SigningKey);
         Assert.Equal(0, configManager.SaveCount);
@@ -203,9 +204,9 @@ public class HttpServerServiceTests
         // The web app runs on the game's container, so disposing the WebApplication disposes that
         // container's singletons — the game's, not the API's. They would go down while the game is still
         // running, and its own StopAsync would then fail on objects already disposed.
-        var server = await TestHttpServer.StartAsync(
-                         container => container.Register<DisposableGameSingleton>(Reuse.Singleton)
-                     );
+        var server = await TestHttpServer.StartAsync(container =>
+            container.Register<DisposableGameSingleton>(Reuse.Singleton)
+        );
         var singleton = server.Container.Resolve<DisposableGameSingleton>();
 
         await server.DisposeAsync();

--- a/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
@@ -52,9 +52,9 @@ public class MapImageServiceTests
         var zoom = service.MaxZoomFor(MapType.Felucca);
 
         var paths = await Task.WhenAll(
-                        Enumerable.Range(0, 4)
-                                  .Select(x => service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, x, 0))
-                    );
+            Enumerable.Range(0, 4)
+                .Select(x => service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, x, 0))
+        );
 
         Assert.All(paths, path => Assert.True(File.Exists(path)));
     }
@@ -82,12 +82,12 @@ public class MapImageServiceTests
         var service = Service(fixture);
 
         var path = await service.GetTileAsync(
-                       MapType.Felucca,
-                       MapRenderStyleType.Flat,
-                       service.MaxZoomFor(MapType.Felucca),
-                       0,
-                       0
-                   );
+            MapType.Felucca,
+            MapRenderStyleType.Flat,
+            service.MaxZoomFor(MapType.Felucca),
+            0,
+            0
+        );
 
         Assert.NotNull(path);
 
@@ -107,12 +107,12 @@ public class MapImageServiceTests
         var service = Service(fixture);
 
         var path = await service.GetTileAsync(
-                       MapType.Felucca,
-                       MapRenderStyleType.Flat,
-                       service.MaxZoomFor(MapType.Felucca),
-                       0,
-                       0
-                   );
+            MapType.Felucca,
+            MapRenderStyleType.Flat,
+            service.MaxZoomFor(MapType.Felucca),
+            0,
+            0
+        );
 
         using var image = await Image.LoadAsync<Bgra32>(path!);
         var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];
@@ -138,12 +138,12 @@ public class MapImageServiceTests
         var service = Service(fixture);
 
         var path = await service.GetTileAsync(
-                       MapType.Felucca,
-                       MapRenderStyleType.Relief,
-                       service.MaxZoomFor(MapType.Felucca),
-                       0,
-                       0
-                   );
+            MapType.Felucca,
+            MapRenderStyleType.Relief,
+            service.MaxZoomFor(MapType.Felucca),
+            0,
+            0
+        );
 
         using var image = await Image.LoadAsync<Bgra32>(path!);
         var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];

--- a/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
+++ b/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
@@ -8,19 +8,18 @@ namespace Moongate.Tests.Network;
 public class PacketDocumentationTests
 {
     private static readonly List<Type> PacketTypes = typeof(IOutgoingPacket).Assembly
-                                                                            .GetTypes()
-                                                                            .Where(
-                                                                                t => t is
-                                                                                    {
-                                                                                        IsValueType: true,
-                                                                                        Namespace: not null
-                                                                                    } &&
-                                                                                    t.Namespace.StartsWith(
-                                                                                        "Moongate.Network.Packets.",
-                                                                                        StringComparison.Ordinal
-                                                                                    )
-                                                                            )
-                                                                            .ToList();
+        .GetTypes()
+        .Where(t => t is
+                    {
+                        IsValueType: true,
+                        Namespace: not null
+                    } &&
+                    t.Namespace.StartsWith(
+                        "Moongate.Network.Packets.",
+                        StringComparison.Ordinal
+                    )
+        )
+        .ToList();
 
     [Fact]
     public void AllPacketTypes_AreDiscovered()

--- a/tests/Moongate.Tests/News/NewsEndpointsTests.cs
+++ b/tests/Moongate.Tests/News/NewsEndpointsTests.cs
@@ -24,7 +24,8 @@ public class NewsEndpointsTests
                 var news = container.Resolve<INewsService>();
                 container.RegisterApiEndpointInstance(new NewsAdminEndpoints(news));
                 container.RegisterApiEndpointInstance(new NewsEndpoints(news));
-            });
+            }
+        );
 
     [Fact]
     public async Task Admin_can_create_then_read_it_back()
@@ -33,7 +34,9 @@ public class NewsEndpointsTests
         await server.AuthenticateAsync();
 
         var create = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/news", new CreateNewsRequest("Patch 1", "notes", IsPublished: true));
+            "/api/v1/admin/news",
+            new CreateNewsRequest("Patch 1", "notes", IsPublished: true)
+        );
         Assert.Equal(HttpStatusCode.Created, create.StatusCode);
         var created = await create.Content.ReadFromJsonAsync<NewsResponse>();
         Assert.Equal("Patch 1", created!.Title);
@@ -60,7 +63,9 @@ public class NewsEndpointsTests
         await server.AuthenticateAsync();
 
         var put = await server.Client.PutAsJsonAsync(
-            "/api/v1/admin/news/999999", new UpdateNewsRequest("x", "y", true));
+            "/api/v1/admin/news/999999",
+            new UpdateNewsRequest("x", "y", true)
+        );
         Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
 
         var del = await server.Client.DeleteAsync("/api/v1/admin/news/999999");
@@ -86,7 +91,9 @@ public class NewsEndpointsTests
         await using var server = await StartAsync();
         await server.AuthenticateAsync();
         var draft = await (await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/news", new CreateNewsRequest("draft", "b", false))).Content.ReadFromJsonAsync<NewsResponse>();
+            "/api/v1/admin/news",
+            new CreateNewsRequest("draft", "b", false)
+        )).Content.ReadFromJsonAsync<NewsResponse>();
 
         var res = await server.Client.GetAsync($"/api/v1/news/{draft!.Id}");
 

--- a/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
+++ b/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
@@ -22,8 +22,7 @@ public class GameLoopModuleTests
 
         var bootstrap = SquidStdBootstrap.Create(new SquidStdOptions { ConfigName = "moongate", RootDirectory = root });
 
-        bootstrap.ConfigureServices(
-            container =>
+        bootstrap.ConfigureServices(container =>
             {
                 // RegisterCoreServices already provides IMainThreadDispatcher and ITimerService.
                 container.RegisterCoreServices();

--- a/tests/Moongate.Tests/Server/CharacterServiceTests.cs
+++ b/tests/Moongate.Tests/Server/CharacterServiceTests.cs
@@ -84,8 +84,7 @@ public class CharacterServiceTests
 
         var eventBus = new EventBusService();
         CharacterCreatedEvent? published = null;
-        eventBus.Subscribe<CharacterCreatedEvent>(
-            (evt, _) =>
+        eventBus.Subscribe<CharacterCreatedEvent>((evt, _) =>
             {
                 published = evt;
 
@@ -124,8 +123,7 @@ public class CharacterServiceTests
         var eventBus = new EventBusService();
 
         CharacterReadyEvent? ready = null;
-        eventBus.Subscribe<CharacterReadyEvent>(
-            (evt, _) =>
+        eventBus.Subscribe<CharacterReadyEvent>((evt, _) =>
             {
                 ready = evt;
 
@@ -206,8 +204,7 @@ public class CharacterServiceTests
 
         var eventBus = new EventBusService();
         CharacterDeletedEvent? published = null;
-        eventBus.Subscribe<CharacterDeletedEvent>(
-            (evt, _) =>
+        eventBus.Subscribe<CharacterDeletedEvent>((evt, _) =>
             {
                 published = evt;
 
@@ -239,8 +236,7 @@ public class CharacterServiceTests
 
         var eventBus = new EventBusService();
         var published = 0;
-        eventBus.Subscribe<CharacterDeletedEvent>(
-            (_, _) =>
+        eventBus.Subscribe<CharacterDeletedEvent>((_, _) =>
             {
                 published++;
 

--- a/tests/Moongate.Tests/Server/CommandRestSourceTests.cs
+++ b/tests/Moongate.Tests/Server/CommandRestSourceTests.cs
@@ -21,7 +21,12 @@ public class CommandRestSourceTests
     private static ICommandService Build(CommandSourceType sources)
     {
         var registration = new CommandRegistration(
-            "echo", AccountLevelType.GrandMaster, "Echo.", sources, _ => new Echo());
+            "echo",
+            AccountLevelType.GrandMaster,
+            "Echo.",
+            sources,
+            _ => new Echo()
+        );
 
         return new CommandService([registration], new Container(), new SeededAccountService());
     }

--- a/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
@@ -17,7 +17,9 @@ public class BroadcastCommandTests
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        {
+        }
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
@@ -102,8 +102,15 @@ public class CommandServiceTests
         var command = new RecordingCommand();
         var service = Service(Registration("test|t", CommandSourceType.Console, AccountLevelType.GrandMaster, command));
 
-        service.Execute(new CommandInvocation(
-            CommandSourceType.Console, AccountLevelType.GrandMaster, null, "test a b", _ => { }));
+        service.Execute(
+            new CommandInvocation(
+                CommandSourceType.Console,
+                AccountLevelType.GrandMaster,
+                null,
+                "test a b",
+                _ => { }
+            )
+        );
 
         Assert.NotNull(command.LastContext);
         Assert.Equal(["a", "b"], command.LastContext!.Value.Arguments);
@@ -116,8 +123,15 @@ public class CommandServiceTests
         var replies = new List<string>();
         var service = Service(Registration("test", CommandSourceType.Console));
 
-        service.Execute(new CommandInvocation(
-            CommandSourceType.Console, AccountLevelType.Administrator, null, "nope", replies.Add));
+        service.Execute(
+            new CommandInvocation(
+                CommandSourceType.Console,
+                AccountLevelType.Administrator,
+                null,
+                "nope",
+                replies.Add
+            )
+        );
 
         Assert.Equal("Unknown command.", Assert.Single(replies));
     }
@@ -128,8 +142,15 @@ public class CommandServiceTests
         var replies = new List<string>();
         var service = Service(Registration("test", CommandSourceType.InGame)); // in-game only
 
-        service.Execute(new CommandInvocation(
-            CommandSourceType.Console, AccountLevelType.Administrator, null, "test", replies.Add));
+        service.Execute(
+            new CommandInvocation(
+                CommandSourceType.Console,
+                AccountLevelType.Administrator,
+                null,
+                "test",
+                replies.Add
+            )
+        );
 
         Assert.Equal("Unknown command.", Assert.Single(replies));
     }
@@ -140,8 +161,15 @@ public class CommandServiceTests
         var replies = new List<string>();
         var service = Service(Registration("test", CommandSourceType.Console, AccountLevelType.GrandMaster));
 
-        service.Execute(new CommandInvocation(
-            CommandSourceType.Console, AccountLevelType.Player, null, "test", replies.Add));
+        service.Execute(
+            new CommandInvocation(
+                CommandSourceType.Console,
+                AccountLevelType.Player,
+                null,
+                "test",
+                replies.Add
+            )
+        );
 
         Assert.Equal("Unknown command.", Assert.Single(replies));
     }
@@ -153,7 +181,8 @@ public class CommandServiceTests
     {
         var service = Service(
             Registration("broadcast|bc", CommandSourceType.InGame | CommandSourceType.Console),
-            Registration("ingameonly", CommandSourceType.InGame));
+            Registration("ingameonly", CommandSourceType.InGame)
+        );
 
         var console = service.ListCommands(CommandSourceType.Console);
 

--- a/tests/Moongate.Tests/Server/Handlers/MegaClilocHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/MegaClilocHandlerTests.cs
@@ -30,8 +30,8 @@ public class MegaClilocHandlerTests
         var second = NewItem(items, "a katana");
 
         var responses = MegaClilocHandler
-                        .BuildResponses([first.Id, new(0x40009999), second.Id], opl)
-                        .ToList();
+            .BuildResponses([first.Id, new(0x40009999), second.Id], opl)
+            .ToList();
 
         Assert.Equal(2, responses.Count);
         Assert.Equal(first.Id, responses[0].Serial);

--- a/tests/Moongate.Tests/Server/ItemTemplateSeedingCollection.cs
+++ b/tests/Moongate.Tests/Server/ItemTemplateSeedingCollection.cs
@@ -1,4 +1,6 @@
 namespace Moongate.Tests.Server;
 
 [CollectionDefinition("ItemTemplateSeeding", DisableParallelization = true)]
-public sealed class ItemTemplateSeedingCollection { }
+public sealed class ItemTemplateSeedingCollection
+{
+}

--- a/tests/Moongate.Tests/Server/ItemTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/ItemTemplatesLoaderTests.cs
@@ -140,10 +140,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("collections.yaml", exception.Message);
             Assert.Contains("'item'", exception.Message);
@@ -168,10 +167,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("b.yaml", exception.Message);
             Assert.Contains("DUPLICATE", exception.Message);
@@ -242,10 +240,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("strict-null.yaml", exception.Message);
             Assert.Contains("'item'", exception.Message);
@@ -273,10 +270,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("validation.yaml", exception.Message);
             Assert.Contains(templateId, exception.Message);
@@ -327,10 +323,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("b-invalid.yaml", exception.Message);
             Assert.Contains("invalid", exception.Message);
@@ -362,10 +357,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("params.yaml", exception.Message);
             Assert.Contains("Params[broken]", exception.Message);
@@ -389,10 +383,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains("non-finite-weight.yaml", exception.Message);
             Assert.Contains("'item'", exception.Message);
@@ -416,10 +409,9 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(
-                                async () =>
-                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
-                            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await new ItemTemplatesLoader(service, directories).LoadAsync()
+            );
 
             Assert.Contains(Path.Combine("nested", "schema.yaml"), exception.Message);
             Assert.NotNull(exception.InnerException);

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -146,8 +146,7 @@ public class LoginFlowIntegrationTests
 
         using var aliceEntered = new ManualResetEventSlim();
         using var bobEntered = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>(
-            (e, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
             {
                 if (e.Mobile.Name == "Alice")
                 {
@@ -263,27 +262,27 @@ public class LoginFlowIntegrationTests
         var config = LoopbackConfig();
         var persistence = new FakePersistenceService();
         await persistence.Store<AccountEntity>()
-                         .UpsertAsync(
-                             new()
-                             {
-                                 Id = (Serial)1,
-                                 Username = "gm",
-                                 PasswordHash = HashUtils.HashPassword("secret"),
-                                 IsActive = true,
-                                 AccountLevel = AccountLevelType.GrandMaster
-                             }
-                         );
+            .UpsertAsync(
+                new()
+                {
+                    Id = (Serial)1,
+                    Username = "gm",
+                    PasswordHash = HashUtils.HashPassword("secret"),
+                    IsActive = true,
+                    AccountLevel = AccountLevelType.GrandMaster
+                }
+            );
         await persistence.Store<AccountEntity>()
-                         .UpsertAsync(
-                             new()
-                             {
-                                 Id = (Serial)2,
-                                 Username = "player",
-                                 PasswordHash = HashUtils.HashPassword("secret"),
-                                 IsActive = true,
-                                 AccountLevel = AccountLevelType.Player
-                             }
-                         );
+            .UpsertAsync(
+                new()
+                {
+                    Id = (Serial)2,
+                    Username = "player",
+                    PasswordHash = HashUtils.HashPassword("secret"),
+                    IsActive = true,
+                    AccountLevel = AccountLevelType.Player
+                }
+            );
 
         var eventBus = new EventBusService();
         var opl = new OplService(persistence, new ItemTemplateService());
@@ -334,8 +333,7 @@ public class LoginFlowIntegrationTests
 
         using var gmEntered = new ManualResetEventSlim();
         using var playerEntered = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>(
-            (e, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
             {
                 if (e.Mobile.Name == "GM")
                 {
@@ -351,16 +349,16 @@ public class LoginFlowIntegrationTests
         );
 
         var network = await StartServerWithCommandsAsync(
-                          config,
-                          eventBus,
-                          characters,
-                          world,
-                          chat,
-                          commands,
-                          accounts,
-                          opl,
-                          sessions
-                      );
+            config,
+            eventBus,
+            characters,
+            world,
+            chat,
+            commands,
+            accounts,
+            opl,
+            sessions
+        );
 
         try
         {
@@ -423,8 +421,7 @@ public class LoginFlowIntegrationTests
         var eventBus = new EventBusService();
 
         using var dispatched = new ManualResetEventSlim();
-        eventBus.Subscribe<PacketDispatchedEvent>(
-            (e, _) =>
+        eventBus.Subscribe<PacketDispatchedEvent>((e, _) =>
             {
                 if (e.OpCode == 0x80)
                 {
@@ -466,8 +463,7 @@ public class LoginFlowIntegrationTests
 
         var eventBus = new EventBusService();
         using var enteredWorld = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>(
-            (_, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>((_, _) =>
             {
                 enteredWorld.Set();
 
@@ -527,8 +523,8 @@ public class LoginFlowIntegrationTests
             // The response holds the 1050045 name line with "Freydis" in the UTF-16LE arguments.
             var nameArgs = Encoding.Unicode.GetBytes(" \tFreydis\t ");
             var megaClilocPattern = new byte[] { 0x00, 0x10, 0x05, 0xBD, 0x00, (byte)nameArgs.Length }
-                                    .Concat(nameArgs)
-                                    .ToArray();
+                .Concat(nameArgs)
+                .ToArray();
             Assert.True(
                 PollUntil(socket, compressed, megaClilocPattern),
                 "No MegaCliloc (0xD6) response carrying the name line arrived."
@@ -631,8 +627,7 @@ public class LoginFlowIntegrationTests
 
         var eventBus = new EventBusService();
         using var enteredWorld = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>(
-            (_, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>((_, _) =>
             {
                 enteredWorld.Set();
 
@@ -791,8 +786,7 @@ public class LoginFlowIntegrationTests
 
             using var aliceEntered = new ManualResetEventSlim();
             using var bobEntered = new ManualResetEventSlim();
-            eventBus.Subscribe<PlayerEnteredWorldEvent>(
-                (e, _) =>
+            eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
                 {
                     if (e.Mobile.Name == "Alice")
                     {
@@ -895,16 +889,14 @@ public class LoginFlowIntegrationTests
 
         using var created = new ManualResetEventSlim();
         using var destroyed = new ManualResetEventSlim();
-        eventBus.Subscribe<SessionCreatedEvent>(
-            (_, _) =>
+        eventBus.Subscribe<SessionCreatedEvent>((_, _) =>
             {
                 created.Set();
 
                 return Task.CompletedTask;
             }
         );
-        eventBus.Subscribe<SessionDestroyedEvent>(
-            (_, _) =>
+        eventBus.Subscribe<SessionDestroyedEvent>((_, _) =>
             {
                 destroyed.Set();
 
@@ -944,8 +936,7 @@ public class LoginFlowIntegrationTests
 
         using var destroyed = new ManualResetEventSlim();
         var subscriberThreadId = 0;
-        eventBus.Subscribe<SessionDestroyedEvent>(
-            (_, _) =>
+        eventBus.Subscribe<SessionDestroyedEvent>((_, _) =>
             {
                 subscriberThreadId = Environment.CurrentManagedThreadId;
                 destroyed.Set();
@@ -1011,8 +1002,7 @@ public class LoginFlowIntegrationTests
 
         using var aliceEntered = new ManualResetEventSlim();
         using var bobEntered = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>(
-            (e, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
             {
                 if (e.Mobile.Name == "Alice")
                 {

--- a/tests/Moongate.Tests/Server/LootTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/LootTemplatesLoaderTests.cs
@@ -28,8 +28,7 @@ public class LootTemplatesLoaderTests
             var seedAtomic = seederType.GetMethod("SeedAtomic");
             Assert.NotNull(seedAtomic);
 
-            var exception = Assert.Throws<TargetInvocationException>(
-                () => seedAtomic.Invoke(
+            var exception = Assert.Throws<TargetInvocationException>(() => seedAtomic.Invoke(
                     null,
                     [
                         typeof(LootTemplatesLoader).Assembly,

--- a/tests/Moongate.Tests/Server/MobileFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/MobileFactoryServiceTests.cs
@@ -83,8 +83,8 @@ public class MobileFactoryServiceTests
         var factory = Factory(templates);
 
         var genders = Enumerable.Range(0, 40)
-                                .Select(_ => factory.CreateFromTemplate("any", 1, new(0, 0, 0))!.Mobile.Gender)
-                                .ToHashSet();
+            .Select(_ => factory.CreateFromTemplate("any", 1, new(0, 0, 0))!.Mobile.Gender)
+            .ToHashSet();
 
         Assert.Contains(GenderType.Male, genders);
         Assert.Contains(GenderType.Female, genders);
@@ -180,8 +180,8 @@ public class MobileFactoryServiceTests
         var factory = Factory(templates);
 
         var loots = Enumerable.Range(0, 40)
-                              .Select(_ => factory.CreateFromTemplate("guard", 1, new(0, 0, 0))!.Mobile.LootTableId)
-                              .ToHashSet();
+            .Select(_ => factory.CreateFromTemplate("guard", 1, new(0, 0, 0))!.Mobile.LootTableId)
+            .ToHashSet();
 
         Assert.Contains("guard.rich", loots); // variant override wins
         Assert.Contains("guard.base", loots); // variant without loot inherits the template

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
@@ -73,8 +73,7 @@ public sealed class NotificationTemplateServiceTests
 
         // Compiling at registration is the whole point: a broken template must fail at load, not on the
         // first notification months later.
-        var exception = Assert.Throws<InvalidDataException>(
-            () => service.Register("log", "broken", "{{ if }}")
+        var exception = Assert.Throws<InvalidDataException>(() => service.Register("log", "broken", "{{ if }}")
         );
 
         Assert.Contains("broken", exception.Message, StringComparison.Ordinal);

--- a/tests/Moongate.Tests/Server/Scripting/AccountModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/AccountModuleTests.cs
@@ -78,7 +78,10 @@ public class AccountModuleTests
         var (module, _) = Build();
         module.Create("tom", "secret", null, "Player");
 
-        Assert.DoesNotContain(module.Get("tom")!.ToDictionary().Keys, key => key.Contains("password", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            module.Get("tom")!.ToDictionary().Keys,
+            key => key.Contains("password", StringComparison.OrdinalIgnoreCase)
+        );
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Scripting/LoopAffineInvokeMarshallerTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/LoopAffineInvokeMarshallerTests.cs
@@ -16,7 +16,9 @@ public class LoopAffineInvokeMarshallerTests
 
         public bool IsOnLoopThread { get; }
 
-        public void Capture() { }
+        public void Capture()
+        {
+        }
     }
 
     [Fact]
@@ -26,8 +28,7 @@ public class LoopAffineInvokeMarshallerTests
         var marshaller = new LoopAffineInvokeMarshaller(new StubLoopThread(false), dispatcher);
         var ran = false;
 
-        var result = marshaller.Invoke(
-            () =>
+        var result = marshaller.Invoke(() =>
             {
                 ran = true;
 
@@ -51,8 +52,7 @@ public class LoopAffineInvokeMarshallerTests
         var marshaller = new LoopAffineInvokeMarshaller(new StubLoopThread(true), dispatcher);
         var ran = false;
 
-        var result = marshaller.Invoke(
-            () =>
+        var result = marshaller.Invoke(() =>
             {
                 ran = true;
 

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -40,8 +40,7 @@ public sealed class AccountRegistrationTests
     {
         var (accounts, bus) = Create();
         AccountRegistrationRequestedEvent? seen = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>(
-            (e, _) =>
+        bus.Subscribe<AccountRegistrationRequestedEvent>((e, _) =>
             {
                 seen = e;
 

--- a/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
@@ -32,8 +32,8 @@ public class SpatialSubscriberTests
         persistence.Store<MobileEntity>().UpsertAsync(npc).WaitSync();
         persistence.Store<MobileEntity>().UpsertAsync(character).WaitSync();
         persistence.Store<AccountEntity>()
-                   .UpsertAsync(new() { Id = new(0x999), Username = "bob", MobileIds = [character.Id] })
-                   .WaitSync();
+            .UpsertAsync(new() { Id = new(0x999), Username = "bob", MobileIds = [character.Id] })
+            .WaitSync();
 
         // A ground item and a contained item: only the ground one must be indexed.
         var ground = new ItemEntity { Id = new(0x40000001), MapId = 0, Position = new(100, 100, 0) };

--- a/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
@@ -23,7 +23,9 @@ public class WorldServiceTests
     // because there are no sessions.
     private sealed class NoopPacket : IOutgoingPacket
     {
-        public void Write(ref SpanWriter writer) { }
+        public void Write(ref SpanWriter writer)
+        {
+        }
     }
 
     [Fact]
@@ -38,12 +40,11 @@ public class WorldServiceTests
     public void BuildSequence_EmitsExpectedOrderedOpcodes()
     {
         var opcodes = Service(new([]))
-                      .BuildSequence(Player())
-                      .Select(packet => Serialize(packet)[0])
-                      .ToArray();
+            .BuildSequence(Player())
+            .Select(packet => Serialize(packet)[0])
+            .ToArray();
 
         Assert.Equal(
-
             // The second 0x11 neighbour is 0xBF/0x19, the stat lock state paired with the status.
             new byte[] { 0x1B, 0xBF, 0xBF, 0xBC, 0xB9, 0x20, 0x4F, 0x4E, 0x78, 0x11, 0xBF, 0x3A, 0x72, 0x55, 0x5B },
             opcodes

--- a/tests/Moongate.Tests/Smtp/SmtpCredentialGuardTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpCredentialGuardTests.cs
@@ -11,8 +11,8 @@ public sealed class SmtpCredentialGuardTests
         // Security: Auto resolves to StartTlsWhenAvailable on any port but the implicit-TLS one, and that
         // proceeds in the clear when the server does not advertise STARTTLS. Authenticating there puts the
         // password on the wire.
-        var exception = Assert.Throws<SmtpInsecureConnectionException>(
-            () => SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: true, isSecure: false)
+        var exception = Assert.Throws<SmtpInsecureConnectionException>(() =>
+            SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: true, isSecure: false)
         );
 
         Assert.Contains("unencrypted", exception.Message, StringComparison.OrdinalIgnoreCase);

--- a/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
@@ -46,10 +46,11 @@ public sealed class SmtpNotificationChannelTests
     {
         var transport = new RecordingSmtpTransport();
 
-        await Channel(transport).SendAsync(
-            new("email", "tom@example.com"),
-            new("Verify", "<p>hi</p>", NotificationContentType.Html)
-        );
+        await Channel(transport)
+            .SendAsync(
+                new("email", "tom@example.com"),
+                new("Verify", "<p>hi</p>", NotificationContentType.Html)
+            );
 
         var message = Assert.Single(transport.Sent);
         Assert.Equal("<p>hi</p>", message.HtmlBody!.Trim());
@@ -76,9 +77,8 @@ public sealed class SmtpNotificationChannelTests
             "try later"
         );
 
-        await Assert.ThrowsAsync<SmtpCommandException>(
-            async () => await Channel(new RecordingSmtpTransport(transient))
-                              .SendAsync(new("email", "tom@example.com"), new("s", "b"))
+        await Assert.ThrowsAsync<SmtpCommandException>(async () => await Channel(new RecordingSmtpTransport(transient))
+            .SendAsync(new("email", "tom@example.com"), new("s", "b"))
         );
     }
 
@@ -93,7 +93,7 @@ public sealed class SmtpNotificationChannelTests
         );
 
         await Channel(new RecordingSmtpTransport(permanent))
-              .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+            .SendAsync(new("email", "tom@example.com"), new("s", "b"));
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public sealed class SmtpNotificationChannelTests
         // A misconfiguration will not fix itself between attempts, so retrying it three times only
         // delays the error in the log.
         await Channel(new RecordingSmtpTransport(new SmtpInsecureConnectionException("unencrypted")))
-              .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+            .SendAsync(new("email", "tom@example.com"), new("s", "b"));
     }
 
     [Fact]
@@ -110,7 +110,7 @@ public sealed class SmtpNotificationChannelTests
     {
         // Retrying bad credentials can trip a provider's rate limits.
         await Channel(new RecordingSmtpTransport(new AuthenticationException("bad credentials")))
-              .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+            .SendAsync(new("email", "tom@example.com"), new("s", "b"));
     }
 
     private static SmtpNotificationChannel Channel(RecordingSmtpTransport transport, string fromName = "Shard Mail")

--- a/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
+++ b/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
@@ -56,8 +56,8 @@ public sealed class InMemoryEntityStore<TEntity> : IEntityStore<TEntity, Serial>
         var matched = filter is null ? _items.Values.ToList() : _items.Values.Where(filter).ToList();
 
         var ordered = descending
-                          ? matched.OrderByDescending(orderBy).ThenByDescending(entity => entity.Id)
-                          : matched.OrderBy(orderBy).ThenBy(entity => entity.Id);
+            ? matched.OrderByDescending(orderBy).ThenByDescending(entity => entity.Id)
+            : matched.OrderBy(orderBy).ThenBy(entity => entity.Id);
 
         IReadOnlyList<TEntity> page = [.. ordered.Skip(skip).Take(take)];
 

--- a/tests/Moongate.Tests/Support/SeededAccountService.cs
+++ b/tests/Moongate.Tests/Support/SeededAccountService.cs
@@ -37,7 +37,8 @@ public sealed class SeededAccountService : IAccountService
         {
             if (account.Id == accountId)
             {
-                return new AccountEntity { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true };
+                return new AccountEntity
+                    { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true };
             }
         }
 

--- a/tests/Moongate.Tests/Support/StubEventBus.cs
+++ b/tests/Moongate.Tests/Support/StubEventBus.cs
@@ -16,7 +16,9 @@ public sealed class StubEventBus : IEventBus
     {
         public static readonly NoopDisposable Instance = new();
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+        }
     }
 
     public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent

--- a/tests/Moongate.Tests/Support/StubJobSystem.cs
+++ b/tests/Moongate.Tests/Support/StubJobSystem.cs
@@ -34,5 +34,7 @@ public sealed class StubJobSystem : IJobSystem
         return Task.FromResult(work());
     }
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+    }
 }

--- a/tests/Moongate.Tests/Support/StubLoopThread.cs
+++ b/tests/Moongate.Tests/Support/StubLoopThread.cs
@@ -12,5 +12,7 @@ public sealed class StubLoopThread : ILoopThread
 
     public bool IsOnLoopThread { get; }
 
-    public void Capture() { }
+    public void Capture()
+    {
+    }
 }

--- a/tests/Moongate.Tests/Support/StubServerStatsService.cs
+++ b/tests/Moongate.Tests/Support/StubServerStatsService.cs
@@ -11,5 +11,7 @@ public sealed class StubServerStatsService : IServerStatsService
 {
     public ServerStatsSnapshot Current { get; set; } = ServerStatsSnapshot.Empty;
 
-    public void Refresh() { }
+    public void Refresh()
+    {
+    }
 }

--- a/tests/Moongate.Tests/Support/StubSessionManager.cs
+++ b/tests/Moongate.Tests/Support/StubSessionManager.cs
@@ -34,7 +34,9 @@ public sealed class StubSessionManager : ISessionManager
     public bool IsCharacterPlayed(Serial mobileId)
         => Played.Contains(mobileId);
 
-    public void Remove(long sessionId) { }
+    public void Remove(long sessionId)
+    {
+    }
 
     public bool TryGet(long sessionId, out PlayerSession session)
     {

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -94,9 +94,9 @@ public sealed class TestApiServer : IAsyncDisposable
     public async Task AuthenticateAsync()
     {
         var response = await Client.PostAsJsonAsync(
-                           "/api/v1/auth/login",
-                           new { username = "tom", password = "secret" }
-                       );
+            "/api/v1/auth/login",
+            new { username = "tom", password = "secret" }
+        );
         var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
 
         Client.DefaultRequestHeaders.Authorization = new("Bearer", token!.Token);
@@ -183,7 +183,11 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterApiEndpointInstance(new ServerSettingsAdminEndpoints(serverSettings, assetStore, config));
 
         // A low limit (2/window) so a test can prove the throttle without flooding: the 3rd call is denied.
-        var rateLimiter = new RegistrationRateLimiter(TimeProvider.System, permitPerWindow: 2, window: TimeSpan.FromMinutes(10));
+        var rateLimiter = new RegistrationRateLimiter(
+            TimeProvider.System,
+            permitPerWindow: 2,
+            window: TimeSpan.FromMinutes(10)
+        );
         container.RegisterApiEndpointInstance(new RegistrationEndpoints(accounts, serverSettings, rateLimiter));
 
         var stats = new StubServerStatsService();

--- a/tests/Moongate.Tests/Support/UltimaClientDataCollection.cs
+++ b/tests/Moongate.Tests/Support/UltimaClientDataCollection.cs
@@ -6,4 +6,6 @@ namespace Moongate.Tests.Support;
 /// these tests would race on the shared client-file paths.
 /// </summary>
 [CollectionDefinition("UltimaClientData", DisableParallelization = true)]
-public sealed class UltimaClientDataCollection { }
+public sealed class UltimaClientDataCollection
+{
+}

--- a/tests/Moongate.Tests/UO/Bodies/BodyTests.cs
+++ b/tests/Moongate.Tests/UO/Bodies/BodyTests.cs
@@ -8,7 +8,7 @@ public class BodyTests
 
     // no body
     // horse
-     // ogre
+    // ogre
     public void IsHumanoid_FalseForCreatureBodies(int value)
         => Assert.False(new Body(value).IsHumanoid);
 
@@ -18,7 +18,7 @@ public class BodyTests
     // human female
     // elf male
     // elf female
-     // male ghost — still a humanoid body
+    // male ghost — still a humanoid body
     public void IsHumanoid_TrueForPlayerBodies(int value)
         => Assert.True(new Body(value).IsHumanoid);
 }


### PR DESCRIPTION
Applies the JetBrains ReSharper **Reformat Code** profile across `Moongate.slnx` — layout and line-wrapping per `.editorconfig` only. No semantic changes, no member reordering, no `var`/modifier rewrites (the conservative reformat profile, not full cleanup).

## Scope
- 139 `.cs` files, +1071/-948 — almost entirely long argument lists wrapped onto multiple lines per the team's wrapping rules.

## Verification
- `dotnet build` clean; full .NET suite green (1410).
- Only `.cs` files touched (UI/TS untouched — jb is C#-only).