### PR TITLE
chore(format): add Prettier and format the UI

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,0 +1,7 @@
+dist
+coverage
+node_modules
+
+# Generated from the server's OpenAPI document; reformatting it would just diff against the generator.
+src/lib/api-types.ts
+openapi.json

--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.4",
         "jsdom": "^29.1.1",
+        "prettier": "^3.9.6",
         "shadcn": "^4.13.1",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
@@ -7103,6 +7104,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,9 @@
     "test": "vitest",
     "test:run": "vitest run",
     "openapi:sync": "node scripts/sync-openapi.mjs",
-    "openapi:types": "node scripts/generate-api-types.mjs"
+    "openapi:types": "node scripts/generate-api-types.mjs",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
@@ -36,6 +38,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.4",
     "jsdom": "^29.1.1",
+    "prettier": "^3.9.6",
     "shadcn": "^4.13.1",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",

--- a/ui/src/components/ui/alert.tsx
+++ b/ui/src/components/ui/alert.tsx
@@ -14,11 +14,7 @@ const alertVariants = cva('rounded-card border p-4 text-sm', {
   defaultVariants: { variant: 'info' },
 })
 
-function Alert({
-  className,
-  variant,
-  ...props
-}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+function Alert({ className, variant, ...props }: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
   return <div role="alert" data-slot="alert" className={cn(alertVariants({ variant }), className)} {...props} />
 }
 

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -20,11 +20,7 @@ const badgeVariants = cva(
   },
 )
 
-function Badge({
-  className,
-  variant,
-  ...props
-}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
+function Badge({ className, variant, ...props }: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
   return <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
 }
 

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -14,46 +14,44 @@ const buttonVariants = cva(
         // along the top edge that reads as struck metal. `bg-primary text-primary-foreground` alone came
         // out flat and in the body font.
         default:
-          "bg-primary text-primary-foreground border border-gold-hi font-display font-bold tracking-[0.1em] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)] hover:bg-gold-hi",
+          'bg-primary text-primary-foreground border border-gold-hi font-display font-bold tracking-[0.1em] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)] hover:bg-gold-hi',
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
+  },
 )
 
 function Button({
   className,
-  variant = "default",
-  size = "default",
+  variant = 'default',
+  size = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : 'button'
 
   return (
     <Comp

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -1,92 +1,54 @@
-import * as React from "react"
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card"
-      className={cn(
-        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
-        className
-      )}
+      className={cn('flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm', className)}
       {...props}
     />
   )
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
-        className
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
-      {...props}
-    />
-  )
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-description"
-      className={cn("text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-description" className={cn('text-sm text-muted-foreground', className)} {...props} />
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
       {...props}
     />
   )
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-content"
-      className={cn("px-6", className)}
-      {...props}
-    />
-  )
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
-      {...props}
-    />
-  )
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
 }
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-}
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,20 +1,17 @@
-import * as React from "react"
-import { CheckIcon } from "lucide-react"
-import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import * as React from 'react'
+import { CheckIcon } from 'lucide-react'
+import { Checkbox as CheckboxPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Checkbox({
-  className,
-  ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       // Faithful: off = border-strong; on = gold with the tick in gold-ink.
       className={cn(
-        "peer size-[15px] shrink-0 rounded-control border border-border-strong outline-none focus-visible:border-gold focus-visible:ring-[3px] focus-visible:ring-gold/20 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-gold-hi data-[state=checked]:bg-gold data-[state=checked]:text-gold-ink",
-        className
+        'peer size-[15px] shrink-0 rounded-control border border-border-strong outline-none focus-visible:border-gold focus-visible:ring-[3px] focus-visible:ring-gold/20 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-gold-hi data-[state=checked]:bg-gold data-[state=checked]:text-gold-ink',
+        className,
       )}
       {...props}
     >

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -1,44 +1,33 @@
-import * as React from "react"
-import { XIcon } from "lucide-react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/60 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
-        className
+        'fixed inset-0 z-50 bg-black/60 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
       )}
       {...props}
     />
@@ -59,8 +48,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-card border border-border-subtle bg-surface p-5 text-ink shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
-          className
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-card border border-border-subtle bg-surface p-5 text-ink shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className,
         )}
         {...props}
       >
@@ -79,11 +68,11 @@ function DialogContent({
   )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
   )
@@ -94,16 +83,13 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
+}: React.ComponentProps<'div'> & {
   showCloseButton?: boolean
 }) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
       {...props}
     >
       {children}
@@ -116,27 +102,21 @@ function DialogFooter({
   )
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("font-display text-lg leading-none font-bold text-gold", className)}
+      className={cn('font-display text-lg leading-none font-bold text-gold', className)}
       {...props}
     />
   )
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )

--- a/ui/src/components/ui/filter-pill.tsx
+++ b/ui/src/components/ui/filter-pill.tsx
@@ -13,9 +13,7 @@ export function FilterPill({
       aria-pressed={active}
       className={cn(
         'rounded-control border px-3 py-1 text-xs',
-        active
-          ? 'border-gold/35 bg-gold/10 font-bold text-gold'
-          : 'border-border-subtle text-muted hover:text-ink',
+        active ? 'border-gold/35 bg-gold/10 font-bold text-gold' : 'border-border-subtle text-muted hover:text-ink',
         className,
       )}
       {...props}

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
@@ -11,10 +11,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
         // bg-deep rather than the registry's transparent/dark:bg-input/30. The design gives fields their
         // own recessed surface, darker than the card they sit on, in both themes — the registry only
         // tints them in dark mode, which left them all but invisible against the panel.
-        "h-9 w-full min-w-0 rounded-md border border-input bg-deep px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
-        className
+        'h-9 w-full min-w-0 rounded-md border border-input bg-deep px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        className,
       )}
       {...props}
     />

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -1,18 +1,15 @@
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import * as React from 'react'
+import { Label as LabelPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className,
       )}
       {...props}
     />

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -1,34 +1,28 @@
-import * as React from "react"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
-import { Select as SelectPrimitive } from "radix-ui"
+import * as React from 'react'
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import { Select as SelectPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
-function SelectGroup({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
 function SelectTrigger({
   className,
-  size = "default",
+  size = 'default',
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: 'sm' | 'default'
 }) {
   return (
     <SelectPrimitive.Trigger
@@ -37,7 +31,7 @@ function SelectTrigger({
       // Faithful to mg-select: bg-deep, gold focus, caret in border-strong.
       className={cn(
         "flex w-full items-center justify-between gap-2 rounded-control border border-border-subtle bg-deep px-3.5 py-2.5 text-sm text-ink whitespace-nowrap outline-none focus-visible:border-gold focus-visible:ring-[3px] focus-visible:ring-gold/20 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-faint data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-border-strong",
-        className
+        className,
       )}
       {...props}
     >
@@ -52,8 +46,8 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
-  align = "center",
+  position = 'item-aligned',
+  align = 'center',
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -61,10 +55,10 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-control border border-border-subtle bg-surface text-ink shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-control border border-border-subtle bg-surface text-ink shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
         )}
         position={position}
         align={align}
@@ -73,9 +67,9 @@ function SelectContent({
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
-            "p-1",
-            position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
           )}
         >
           {children}
@@ -86,37 +80,27 @@ function SelectContent({
   )
 }
 
-function SelectLabel({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
       {...props}
     />
   )
 }
 
-function SelectItem({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
         "relative flex w-full cursor-default items-center gap-2 rounded-control py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-raised focus:text-ink data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
+        className,
       )}
       {...props}
     >
-      <span
-        data-slot="select-item-indicator"
-        className="absolute right-2 flex size-3.5 items-center justify-center"
-      >
+      <span data-slot="select-item-indicator" className="absolute right-2 flex size-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>
@@ -126,30 +110,21 @@ function SelectItem({
   )
 }
 
-function SelectSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+function SelectSeparator({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
       {...props}
     />
   )
 }
 
-function SelectScrollUpButton({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
   return (
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
-      className={cn(
-        "flex cursor-default items-center justify-center py-1",
-        className
-      )}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
@@ -164,10 +139,7 @@ function SelectScrollDownButton({
   return (
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
-      className={cn(
-        "flex cursor-default items-center justify-center py-1",
-        className
-      )}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
       {...props}
     >
       <ChevronDownIcon className="size-4" />

--- a/ui/src/components/ui/switch.tsx
+++ b/ui/src/components/ui/switch.tsx
@@ -1,31 +1,31 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import { Switch as SwitchPrimitive } from "radix-ui"
+import * as React from 'react'
+import { Switch as SwitchPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 function Switch({
   className,
-  size = "default",
+  size = 'default',
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
-  size?: "sm" | "default"
+  size?: 'sm' | 'default'
 }) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-gold data-[state=unchecked]:bg-border",
-        className
+        'peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-gold data-[state=unchecked]:bg-border',
+        className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 data-[state=checked]:bg-gold-ink"
+          'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 data-[state=checked]:bg-gold-ink',
         )}
       />
     </SwitchPrimitive.Root>

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -1,116 +1,81 @@
-import * as React from "react"
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
     <div
       data-slot="table-container"
       className="relative w-full overflow-hidden rounded-card border border-border-subtle"
     >
-      <table
-        data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
+      <table data-slot="table" className={cn('w-full caption-bottom text-sm', className)} {...props} />
     </div>
   )
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  )
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />
 }
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
-  return (
-    <tbody
-      data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
-      {...props}
-    />
-  )
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return <tbody data-slot="table-body" className={cn('[&_tr:last-child]:border-0', className)} {...props} />
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-        className
-      )}
+      className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
       {...props}
     />
   )
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   return (
     <tr
       data-slot="table-row"
       // Faithful to mg-row: bordered, hover strengthens the border; selection = a gold border, no
       // background change.
       className={cn(
-        "border-b border-border-subtle transition-colors hover:border-border-strong data-[state=selected]:border-gold",
-        className
+        'border-b border-border-subtle transition-colors hover:border-border-strong data-[state=selected]:border-gold',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   return (
     <th
       data-slot="table-head"
       className={cn(
-        "h-9 bg-deep px-3.5 text-left align-middle text-[14px] font-normal uppercase tracking-[0.12em] whitespace-nowrap text-faint [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'h-9 bg-deep px-3.5 text-left align-middle text-[14px] font-normal uppercase tracking-[0.12em] whitespace-nowrap text-faint [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   return (
     <td
       data-slot="table-cell"
       className={cn(
-        "px-3.5 py-2.5 align-middle whitespace-nowrap text-ink [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'px-3.5 py-2.5 align-middle whitespace-nowrap text-ink [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
   return (
-    <caption
-      data-slot="table-caption"
-      className={cn("mt-4 text-sm text-muted-foreground", className)}
-      {...props}
-    />
+    <caption data-slot="table-caption" className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
   )
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }

--- a/ui/src/lib/accounts.test.tsx
+++ b/ui/src/lib/accounts.test.tsx
@@ -26,9 +26,11 @@ describe('accounts data module', () => {
   })
 
   it('useCreateAccount POSTs the body', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      json({ username: 'new', email: null, level: 'Player', isActive: true, characterCount: 0 }, 201),
-    )
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        json({ username: 'new', email: null, level: 'Player', isActive: true, characterCount: 0 }, 201),
+      )
     const { result } = renderHook(() => useCreateAccount(), { wrapper: wrapper() })
     await result.current.mutateAsync({ username: 'new', password: 'pw' })
 
@@ -39,9 +41,11 @@ describe('accounts data module', () => {
   })
 
   it('useUpdateAccount PATCHes the named account', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      json({ username: 'tom', email: null, level: 'Administrator', isActive: false, characterCount: 2 }),
-    )
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        json({ username: 'tom', email: null, level: 'Administrator', isActive: false, characterCount: 2 }),
+      )
     const { result } = renderHook(() => useUpdateAccount(), { wrapper: wrapper() })
     await result.current.mutateAsync({ username: 'tom', patch: { isActive: false } })
 

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -8,9 +8,11 @@ describe('apiFetch', () => {
   })
 
   function respond(status: number, body: unknown = {}) {
-    return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } }),
-    )
+    return vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } }),
+      )
   }
 
   it('returns the parsed body on success', async () => {
@@ -45,9 +47,7 @@ describe('apiFetch', () => {
   it('encodes path parameters', () => {
     // Without encoding, an account named `bob#x` would address `bob` and the operation would silently hit
     // the wrong record.
-    expect(apiPath('/api/v1/admin/accounts/{username}', { username: 'bob#x' })).toBe(
-      '/api/v1/admin/accounts/bob%23x',
-    )
+    expect(apiPath('/api/v1/admin/accounts/{username}', { username: 'bob#x' })).toBe('/api/v1/admin/accounts/bob%23x')
   })
 
   it('lets the browser set the content-type for a FormData body', async () => {

--- a/ui/src/lib/auth.tsx
+++ b/ui/src/lib/auth.tsx
@@ -1,13 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ApiError, apiFetch, setAuthToken, setUnauthorizedHandler } from './api'
 
 const STORAGE_KEY = 'mg-token'
@@ -101,9 +92,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const delay = new Date(stored.expiresAt).getTime() - Date.now() - RENEW_MARGIN_MS
 
     clearTimeout(timer.current)
-    timer.current = setTimeout(() => {
-      void renew.current()
-    }, Math.max(delay, 0))
+    timer.current = setTimeout(
+      () => {
+        void renew.current()
+      },
+      Math.max(delay, 0),
+    )
   }, [])
 
   renew.current = async () => {

--- a/ui/src/lib/console.test.tsx
+++ b/ui/src/lib/console.test.tsx
@@ -34,7 +34,9 @@ describe('useConsole', () => {
 
     await waitFor(() => expect(result.current.status).toBe('connected'))
     await waitFor(() =>
-      expect(result.current.lines.some((line) => line.kind === 'output' && line.text === '2 players online')).toBe(true),
+      expect(result.current.lines.some((line) => line.kind === 'output' && line.text === '2 players online')).toBe(
+        true,
+      ),
     )
   })
 

--- a/ui/src/lib/queries.ts
+++ b/ui/src/lib/queries.ts
@@ -9,8 +9,7 @@ export type PlayerMe = components['schemas']['PlayerMeResponse']
 export type Character = components['schemas']['CharacterResponse']
 export type ServerStats = components['schemas']['ServerStatsResponse']
 
-export const useMe = () =>
-  useQuery({ queryKey: ['me'], queryFn: () => apiFetch<PlayerMe>('/api/v1/player/me') })
+export const useMe = () => useQuery({ queryKey: ['me'], queryFn: () => apiFetch<PlayerMe>('/api/v1/player/me') })
 
 export const useMyCharacters = () =>
   useQuery({
@@ -18,8 +17,7 @@ export const useMyCharacters = () =>
     queryFn: () => apiFetch<Character[]>('/api/v1/player/me/characters'),
   })
 
-export const useStats = () =>
-  useQuery({ queryKey: ['stats'], queryFn: () => apiFetch<ServerStats>('/api/v1/stats') })
+export const useStats = () => useQuery({ queryKey: ['stats'], queryFn: () => apiFetch<ServerStats>('/api/v1/stats') })
 
 export type ServerInfo = components['schemas']['ServerInfoResponse']
 

--- a/ui/src/lib/sse.ts
+++ b/ui/src/lib/sse.ts
@@ -24,10 +24,7 @@ export function parseSseFrame(frame: string): SseFrame {
 }
 
 /** Reads an SSE byte stream and yields one frame per blank-line-separated block until it ends or aborts. */
-export async function* readSseFrames(
-  body: ReadableStream<Uint8Array>,
-  signal: AbortSignal,
-): AsyncGenerator<SseFrame> {
+export async function* readSseFrames(body: ReadableStream<Uint8Array>, signal: AbortSignal): AsyncGenerator<SseFrame> {
   const reader = body.getReader()
   const decoder = new TextDecoder()
   let buffer = ''

--- a/ui/src/routes/DashboardScreen.tsx
+++ b/ui/src/routes/DashboardScreen.tsx
@@ -10,14 +10,10 @@ export function DashboardScreen() {
 
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="font-display text-xl text-ink">
-        {t('dashboard.welcome', { name: me.data?.username ?? '' })}
-      </h1>
+      <h1 className="font-display text-xl text-ink">{t('dashboard.welcome', { name: me.data?.username ?? '' })}</h1>
 
       <Card className="p-5">
-        <h2 className="mb-3 font-display text-[16px] tracking-widest text-gold">
-          {t('dashboard.characters')}
-        </h2>
+        <h2 className="mb-3 font-display text-[16px] tracking-widest text-gold">{t('dashboard.characters')}</h2>
 
         {characters.isPending && <p className="text-sm text-muted">{t('common.loading')}</p>}
         {characters.isError && (
@@ -25,9 +21,7 @@ export function DashboardScreen() {
             {t('error.generic')}
           </p>
         )}
-        {characters.data?.length === 0 && (
-          <p className="text-sm text-muted">{t('dashboard.noCharacters')}</p>
-        )}
+        {characters.data?.length === 0 && <p className="text-sm text-muted">{t('dashboard.noCharacters')}</p>}
 
         <ul className="flex flex-col gap-2">
           {characters.data?.map((character) => (

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -65,9 +65,7 @@ export function LoginScreen() {
             Rendered only once the reply lands — a zero here means an empty shard, which is worth saying,
             but saying it before asking would be a guess. */}
         {stats.data !== undefined && (
-          <p className="relative mt-1 text-sm text-muted">
-            {t('login.online', { count: stats.data.players.online })}
-          </p>
+          <p className="relative mt-1 text-sm text-muted">{t('login.online', { count: stats.data.players.online })}</p>
         )}
       </div>
 
@@ -125,9 +123,7 @@ export function LoginScreen() {
           {t('login.submit')}
         </Button>
 
-        <p className="border-t border-border-subtle pt-4 text-xs leading-relaxed text-faint">
-          {t('login.staffNote')}
-        </p>
+        <p className="border-t border-border-subtle pt-4 text-xs leading-relaxed text-faint">{t('login.staffNote')}</p>
 
         {/* Data from the anonymous /api/v1/version, not UI copy — no i18n key needed. Rendered only once
             it resolves, so an unreached shard shows nothing rather than "undefined". */}

--- a/ui/src/routes/accounts/NewAccountDialog.test.tsx
+++ b/ui/src/routes/accounts/NewAccountDialog.test.tsx
@@ -23,7 +23,9 @@ describe('NewAccountDialog', () => {
   it('posts the new account', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(json({ username: 'new', email: null, level: 'Player', isActive: true, characterCount: 0 }, 201))
+      .mockResolvedValue(
+        json({ username: 'new', email: null, level: 'Player', isActive: true, characterCount: 0 }, 201),
+      )
     renderDialog()
 
     await userEvent.type(screen.getByLabelText(/username/i), 'new')

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "./tokens.css";
+@import 'tailwindcss';
+@import './tokens.css';
 
 /* Tailwind's stock `dark:` follows the operating system. This codebase switches on a `data-theme`
    attribute instead, so the two would disagree the moment a viewer's OS preference differed from the

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -5,12 +5,11 @@
    The Google Fonts @import was dropped on purpose — the fonts are <link>ed from index.html,
    because a CSS @import blocks rendering until it resolves. */
 
-
 :root {
   /* Superfici */
-  --mg-bg-deep: #12151d;      /* console, log, input */
-  --mg-bg-page: #161a22;      /* sfondo pagina */
-  --mg-surface: #1a1f2a;      /* card, pannelli, top bar */
+  --mg-bg-deep: #12151d; /* console, log, input */
+  --mg-bg-page: #161a22; /* sfondo pagina */
+  --mg-surface: #1a1f2a; /* card, pannelli, top bar */
   --mg-surface-raised: #232936;
 
   /* Bordi */
@@ -28,15 +27,15 @@
   --mg-gold: #e2b856;
   --mg-gold-hi: #ecc76a;
   --mg-gold-lo: #c99a3c;
-  --mg-gold-ink: #1c1608;     /* testo su bottoni gold */
+  --mg-gold-ink: #1c1608; /* testo su bottoni gold */
   --mg-gradient-cta: linear-gradient(180deg, var(--mg-gold-hi), var(--mg-gold-lo));
 
   /* Semantici */
   --mg-success: #6fc98d;
   --mg-danger: #d05548;
   --mg-danger-text: #e88f83;
-  --mg-info: #7fa7d9;         /* anche: mana, freddo */
-  --mg-staff: #a86fd1;        /* badge STAFF, GM */
+  --mg-info: #7fa7d9; /* anche: mana, freddo */
+  --mg-staff: #a86fd1; /* badge STAFF, GM */
   --mg-staff-text: #cda3e8;
 
   /* Rarità item (nome item + bordo tile; sfondo = tinta 10%) */
@@ -47,7 +46,7 @@
   --mg-rarity-legendary: #f5923e;
 
   /* Tipografia */
-  --mg-font-display: 'Cinzel', serif;              /* titoli, brand, bottoni — 600/700 */
+  --mg-font-display: 'Cinzel', serif; /* titoli, brand, bottoni — 600/700 */
   --mg-font-body: 'Alegreya Sans', system-ui, sans-serif; /* UI e testo — 400/500/700 */
   --mg-font-mono: 'Victor Mono', ui-monospace, Menlo, monospace; /* numeri, gp, timestamp, log, ID, codice */
 
@@ -61,13 +60,13 @@
   --mg-tabrow-h: 46px;
 
   /* Focus */
-  --mg-focus-ring: 0 0 0 3px rgba(226, 184, 86, .12);
+  --mg-focus-ring: 0 0 0 3px rgba(226, 184, 86, 0.12);
 }
 
 /* ── Tema chiaro ─────────────────────────────────────────
    Applica data-theme="light" su <html> o su un contenitore.
    Forme, spazi, font e --mg-gold-ink restano invariati. */
-[data-theme="light"] {
+[data-theme='light'] {
   --mg-bg-deep: #eceef2;
   --mg-bg-page: #f4f5f8;
   --mg-surface: #ffffff;
@@ -100,5 +99,5 @@
   --mg-rarity-epic: #8b3fc4;
   --mg-rarity-legendary: #d97a1e;
 
-  --mg-focus-ring: 0 0 0 3px rgba(184, 137, 47, .18);
+  --mg-focus-ring: 0 0 0 3px rgba(184, 137, 47, 0.18);
 }


### PR DESCRIPTION
Sets up Prettier for the web UI and runs it, the TS/React parallel to the C# jb reformat (#90).

## What
- Adds `ui/.prettierrc.json` matching the existing hand-written style: **no semicolons, single quotes, 120 print width, trailing commas** (so Prettier normalizes toward the current code, not away from it).
- Adds `format` / `format:check` npm scripts and Prettier as a devDependency.
- `ui/.prettierignore` excludes the generated `src/lib/api-types.ts` and `openapi.json` (reformatting them would only diff against the generator).
- Running it reformats 23 files (+196/−349) — almost all of it normalizing the shadcn `components/ui/*` (which shipped double-quoted and semicolon'd) to match the rest.

## Verification
- `tsc --noEmit` + `vite build` clean; 102 UI tests green.
- No `node_modules` or generated files committed.