### PR TITLE
fix(ui): remove dark: variants for [data-theme] coherence

### DIFF
--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -15,12 +15,10 @@ const buttonVariants = cva(
         // out flat and in the body font.
         default:
           'bg-primary text-primary-foreground border border-gold-hi font-display font-bold tracking-[0.1em] shadow-[inset_0_1px_0_rgba(255,255,255,0.35)] hover:bg-gold-hi',
-        destructive:
-          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
-        outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        destructive: 'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20',
+        outline: 'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -13,7 +13,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
         // tints them in dark mode, which left them all but invisible against the panel.
         'h-9 w-full min-w-0 rounded-md border border-input bg-deep px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
-        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20',
         className,
       )}
       {...props}

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -65,9 +65,8 @@
      `text-muted-foreground` agree; `bg-muted` would come out the colour of secondary text and should
      not be used — reach for `bg-raised`.
 
-     `input` has to serve both `border-input` and `dark:bg-input/30`, which the design separates:
-     --mg-border for field borders, --mg-bg-deep for field fills. The border wins, since it is the
-     structural, always-visible half; the fill only ever appears as a 30% wash. */
+     `input` feeds only `border-input`: the registry's `dark:bg-input/30` fill is not used here (the
+     design gives fields an explicit recessed `bg-deep` in both themes), so it maps to --mg-border. */
   --color-background: var(--mg-bg-page);
   --color-foreground: var(--mg-text);
   --color-card: var(--mg-surface);


### PR DESCRIPTION
`globals.css` documents the theming contract: **no `dark:` variants** — the design flips every `--mg-*` token at once via `[data-theme]`, and `@custom-variant dark` is only redeclared so a stray `dark:` would follow the app's switch rather than the OS.

The shadcn `button` and `input` primitives still shipped registry `dark:` variants — a second, conflicting theming path:
- `dark:bg-input/30` (a dark-only field/outline fill the design deliberately replaced with `bg-deep`)
- `dark:bg-destructive/60`, `dark:aria-invalid:ring-destructive/40`, `dark:focus-visible:ring-destructive/40`, `dark:border-input`, `dark:hover:bg-input/50`, `dark:hover:bg-accent/50`

## What
- Remove all `dark:` variant classes from `button.tsx` and `input.tsx` so both themes render from the same token-driven base.
- Update the shadcn-bridge comment in `globals.css` that referenced the now-removed `dark:bg-input/30`.

## Verification
- `grep` confirms **zero** `dark:` variant classes remain in `ui/src`.
- `tsc` + `vite build` clean; 102 UI tests green; Prettier clean.
- Browser check in **dark theme**: outline/ghost "Upload"/"Remove" buttons, the destructive "Delete account" action, selects and inputs all render correctly and coherently.