### PR TITLE
feat(events): loop-affine event bus decorator

### DIFF
--- a/src/Moongate.Server.Abstractions/Data/Events/CharacterCreatedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/CharacterCreatedEvent.cs
@@ -1,8 +1,8 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
 /// <summary>Raised after a new player character has been created, persisted and linked to its account.</summary>
-public sealed record CharacterCreatedEvent(Serial AccountId, Serial MobileId, MobileEntity Character) : IEvent;
+public sealed record CharacterCreatedEvent(Serial AccountId, Serial MobileId, MobileEntity Character) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/CharacterDeletedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/CharacterDeletedEvent.cs
@@ -1,6 +1,6 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -9,4 +9,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// its account. <see cref="Character" /> is the mobile as it was: by the time this is raised it is gone
 /// from the store, so subscribers that need its state must read it from here.
 /// </summary>
-public sealed record CharacterDeletedEvent(Serial AccountId, Serial MobileId, MobileEntity Character) : IEvent;
+public sealed record CharacterDeletedEvent(Serial AccountId, Serial MobileId, MobileEntity Character) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/ItemDoubleClickEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/ItemDoubleClickEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -7,4 +7,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// Raised when a player double-clicks an item. Carries only the clicking session and the target
 /// serial; resolving the item and deciding what to do is left to subscribers.
 /// </summary>
-public sealed record ItemDoubleClickEvent(long SessionId, Serial Serial) : IEvent;
+public sealed record ItemDoubleClickEvent(long SessionId, Serial Serial) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/ItemSingleClickEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/ItemSingleClickEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -7,4 +7,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// Raised when a player single-clicks an item. Carries only the clicking session and the target
 /// serial; resolving the item and deciding what to do is left to subscribers.
 /// </summary>
-public sealed record ItemSingleClickEvent(long SessionId, Serial Serial) : IEvent;
+public sealed record ItemSingleClickEvent(long SessionId, Serial Serial) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileChangedSectorEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileChangedSectorEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -19,4 +19,4 @@ public sealed record MobileChangedSectorEvent(
     int ToMapId,
     int ToSectorX,
     int ToSectorY
-) : IEvent;
+) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileDoubleClickEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileDoubleClickEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -7,4 +7,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// Raised when a player double-clicks a mobile. Carries only the clicking session and the target
 /// serial; resolving the mobile and deciding what to do is left to subscribers.
 /// </summary>
-public sealed record MobileDoubleClickEvent(long SessionId, Serial Serial) : IEvent;
+public sealed record MobileDoubleClickEvent(long SessionId, Serial Serial) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileEnteredSectorEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileEnteredSectorEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -9,4 +9,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// mobiles (not items). Auto-exposed to Lua as <c>events.on("mobile_entered_sector", ...)</c>, with a
 /// table carrying <c>mobile</c>, <c>map_id</c>, <c>sector_x</c> and <c>sector_y</c>.
 /// </summary>
-public sealed record MobileEnteredSectorEvent(Serial Mobile, int MapId, int SectorX, int SectorY) : IEvent;
+public sealed record MobileEnteredSectorEvent(Serial Mobile, int MapId, int SectorX, int SectorY) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileLeftSectorEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileLeftSectorEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -9,4 +9,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// mobiles (not items). Auto-exposed to Lua as <c>events.on("mobile_left_sector", ...)</c>, with a table
 /// carrying <c>mobile</c>, <c>map_id</c>, <c>sector_x</c> and <c>sector_y</c>.
 /// </summary>
-public sealed record MobileLeftSectorEvent(Serial Mobile, int MapId, int SectorX, int SectorY) : IEvent;
+public sealed record MobileLeftSectorEvent(Serial Mobile, int MapId, int SectorX, int SectorY) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileSingleClickEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileSingleClickEvent.cs
@@ -1,5 +1,5 @@
 using Moongate.Core.Primitives;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -7,4 +7,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// Raised when a player single-clicks a mobile. Carries only the clicking session and the target
 /// serial; resolving the mobile and deciding what to do is left to subscribers.
 /// </summary>
-public sealed record MobileSingleClickEvent(long SessionId, Serial Serial) : IEvent;
+public sealed record MobileSingleClickEvent(long SessionId, Serial Serial) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileSpeechEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileSpeechEvent.cs
@@ -1,6 +1,6 @@
 using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
 using Moongate.UO.Data.Types;
-using SquidStd.Core.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -9,4 +9,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// script systems react to nearby speech without touching the network layer — auto-exposed to Lua
 /// as <c>events.on("mobile_speech", ...)</c> by the existing event-bus-to-Lua bridge.
 /// </summary>
-public sealed record MobileSpeechEvent(Serial Speaker, ChatMessageType Type, string Text) : IEvent;
+public sealed record MobileSpeechEvent(Serial Speaker, ChatMessageType Type, string Text) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/PlayerEnteredWorldEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/PlayerEnteredWorldEvent.cs
@@ -1,6 +1,6 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -9,4 +9,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// systems react to a character coming online (spawns, greetings, presence) without touching the
 /// network layer.
 /// </summary>
-public sealed record PlayerEnteredWorldEvent(long SessionId, Serial AccountId, MobileEntity Mobile) : IEvent;
+public sealed record PlayerEnteredWorldEvent(long SessionId, Serial AccountId, MobileEntity Mobile) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/SessionCreatedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/SessionCreatedEvent.cs
@@ -1,7 +1,7 @@
 using Moongate.Server.Abstractions.Data.Session;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
 /// <summary>Raised when a client connects and its <see cref="PlayerSession" /> is created.</summary>
-public sealed record SessionCreatedEvent(PlayerSession Session) : IEvent;
+public sealed record SessionCreatedEvent(PlayerSession Session) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/SessionDestroyedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/SessionDestroyedEvent.cs
@@ -1,7 +1,7 @@
 using Moongate.Server.Abstractions.Data.Session;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
 /// <summary>Raised when a client disconnects and its <see cref="PlayerSession" /> is removed.</summary>
-public sealed record SessionDestroyedEvent(PlayerSession Session) : IEvent;
+public sealed record SessionDestroyedEvent(PlayerSession Session) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/WorldReadyEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/WorldReadyEvent.cs
@@ -1,4 +1,4 @@
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -6,4 +6,4 @@ namespace Moongate.Server.Abstractions.Data.Events;
 /// Published on the game-loop thread once the world is loaded and ready. Forwarded to Lua as
 /// <c>world_ready</c>; scripts use it for bootstrap spawns without <c>game.post</c>.
 /// </summary>
-public sealed record WorldReadyEvent : IEvent;
+public sealed record WorldReadyEvent : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Interfaces/Events/ILoopAffineEvent.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Events/ILoopAffineEvent.cs
@@ -1,0 +1,12 @@
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Interfaces.Events;
+
+/// <summary>
+/// Marks an event whose subscribers mutate or read world state and therefore must run on the
+/// game-loop thread. The event bus decorator routes such an event onto the loop when it is
+/// published off it, and guards its handlers against running — or going async — off the loop.
+/// </summary>
+public interface ILoopAffineEvent : IEvent
+{
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -23,6 +23,7 @@ using Moongate.Server.Extensions;
 using Moongate.Server.Plugins;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Chat;
+using Moongate.Server.Services.Events;
 using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
@@ -241,6 +242,10 @@ await ConsoleApp.RunAsync(
                 );
 
                 container.RegisterEventBusService();
+
+                // Decorate the bus so loop-affine events route onto the game loop structurally,
+                // instead of each publisher remembering to marshal by hand.
+                container.Register<IEventBus, LoopAffineEventBus>(setup: Setup.Decorator);
 
                 var eventBus = container.Resolve<IEventBus>();
 

--- a/src/Moongate.Server/Services/Events/LoopAffineEventBus.cs
+++ b/src/Moongate.Server/Services/Events/LoopAffineEventBus.cs
@@ -1,0 +1,86 @@
+using Moongate.Core.Interfaces;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Core.Interfaces.Threading;
+
+namespace Moongate.Server.Services.Events;
+
+/// <summary>
+/// Decorates the event bus to make the single-writer invariant structural. An
+/// <see cref="ILoopAffineEvent" /> published off the game loop is marshalled onto it; a handler
+/// subscribed to one is wrapped so it throws if it runs off the loop or does not complete
+/// synchronously (i.e. it went async and its continuation left the loop). In production the inner
+/// bus isolates that throw into a logged error, so a bad handler is loud but cannot take down the
+/// loop.
+/// </summary>
+public sealed class LoopAffineEventBus : IEventBus
+{
+    private readonly IEventBus _inner;
+    private readonly IMainThreadDispatcher _dispatcher;
+    private readonly ILoopThread _loopThread;
+
+    public LoopAffineEventBus(IEventBus inner, IMainThreadDispatcher dispatcher, ILoopThread loopThread)
+    {
+        _inner = inner;
+        _dispatcher = dispatcher;
+        _loopThread = loopThread;
+    }
+
+    public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
+    {
+        if (eventData is ILoopAffineEvent && !_loopThread.IsOnLoopThread)
+        {
+            _dispatcher.Post(() => _inner.Publish(eventData));
+
+            return;
+        }
+
+        _inner.Publish(eventData);
+    }
+
+    public Task PublishAsync<TEvent>(TEvent eventData, CancellationToken cancellationToken = default)
+        where TEvent : IEvent
+    {
+        if (eventData is ILoopAffineEvent && !_loopThread.IsOnLoopThread)
+        {
+            _dispatcher.Post(() => _inner.Publish(eventData));
+
+            return Task.CompletedTask;
+        }
+
+        return _inner.PublishAsync(eventData, cancellationToken);
+    }
+
+    public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
+    {
+        if (!typeof(ILoopAffineEvent).IsAssignableFrom(typeof(TEvent)))
+        {
+            return _inner.Subscribe(handler);
+        }
+
+        return _inner.Subscribe<TEvent>((evt, ct) =>
+            {
+                if (!_loopThread.IsOnLoopThread)
+                {
+                    throw new InvalidOperationException(
+                        $"Loop-affine event {typeof(TEvent).Name} was handled off the game-loop thread."
+                    );
+                }
+
+                var task = handler(evt, ct);
+
+                if (!task.IsCompleted)
+                {
+                    throw new InvalidOperationException(
+                        $"Loop-affine handler for {typeof(TEvent).Name} did not complete synchronously; it went async off the loop."
+                    );
+                }
+
+                return task;
+            }
+        );
+    }
+
+    public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
+        => _inner.RegisterListener(listener);
+}

--- a/src/Moongate.Server/Services/Network/NetworkService.cs
+++ b/src/Moongate.Server/Services/Network/NetworkService.cs
@@ -151,10 +151,8 @@ public sealed class NetworkService : INetworkService, ISquidStdService, IAsyncDi
         var session = _sessions.GetOrCreate(e.Client);
         _logger.Information("Client connected: {SessionId}", e.Client.SessionId);
 
-        // Session lifecycle subscribers mutate world state (the spatial index), so their event must be
-        // published on the game loop — like inbound packets (see OnDataReceived) — never on this
-        // transport thread.
-        _mainThreadDispatcher.Post(() => _eventBus.Publish(new SessionCreatedEvent(session)));
+        // SessionCreatedEvent is loop-affine; the event bus decorator marshals it onto the game loop.
+        _eventBus.Publish(new SessionCreatedEvent(session));
     }
 
     private void OnClientDisconnect(object? sender, SquidStdTcpClientEventArgs e)
@@ -163,10 +161,8 @@ public sealed class NetworkService : INetworkService, ISquidStdService, IAsyncDi
         {
             _sessions.Remove(e.Client.SessionId);
 
-            // Publish on the game loop, not this transport thread: SpatialSubscriber removes the character
-            // from the spatial index here, and that world mutation must be loop-affine to avoid racing the
-            // loop's own reads/writes (movement re-indexing, range queries).
-            _mainThreadDispatcher.Post(() => _eventBus.Publish(new SessionDestroyedEvent(session)));
+            // SessionDestroyedEvent is loop-affine; the decorator marshals it onto the game loop.
+            _eventBus.Publish(new SessionDestroyedEvent(session));
         }
 
         _logger.Information("Client disconnected: {SessionId}", e.Client.SessionId);

--- a/tests/Moongate.Tests/Server/Events/LoopAffineEventBusTests.cs
+++ b/tests/Moongate.Tests/Server/Events/LoopAffineEventBusTests.cs
@@ -1,0 +1,137 @@
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Services.Events;
+using Moongate.Tests.Support;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Events;
+
+public class LoopAffineEventBusTests
+{
+    private sealed record LoopEvent : ILoopAffineEvent;
+
+    private sealed record PlainEvent : IEvent;
+
+    // Records what inner.Publish received, and captures the last handler passed to Subscribe so a
+    // test can invoke it directly — bypassing the real bus, which would swallow a thrown guard.
+    private sealed class CapturingEventBus : IEventBus
+    {
+        public List<IEvent> Published { get; } = [];
+        public Delegate? LastHandler { get; private set; }
+
+        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
+            => Published.Add(eventData);
+
+        public Task PublishAsync<TEvent>(TEvent eventData, CancellationToken cancellationToken = default)
+            where TEvent : IEvent
+        {
+            Published.Add(eventData);
+            return Task.CompletedTask;
+        }
+
+        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
+        {
+            LastHandler = handler;
+            return new Noop();
+        }
+
+        public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
+            => new Noop();
+
+        private sealed class Noop : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    [Fact]
+    public void Publish_LoopAffineEventOffLoop_IsPostedNotRunInline()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: false));
+
+        bus.Publish(new LoopEvent());
+
+        Assert.Empty(inner.Published);
+        Assert.Equal(1, dispatcher.PendingCount);
+
+        dispatcher.DrainPending();
+
+        Assert.Single(inner.Published);
+    }
+
+    [Fact]
+    public void Publish_LoopAffineEventOnLoop_RunsInline()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
+
+        bus.Publish(new LoopEvent());
+
+        Assert.Single(inner.Published);
+        Assert.Equal(0, dispatcher.PendingCount);
+    }
+
+    [Fact]
+    public void Publish_PlainEventOffLoop_PassesThrough()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: false));
+
+        bus.Publish(new PlainEvent());
+
+        Assert.Single(inner.Published);
+        Assert.Equal(0, dispatcher.PendingCount);
+    }
+
+    [Fact]
+    public void Subscribe_LoopAffineHandlerOffLoop_Throws()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: false));
+
+        bus.Subscribe<LoopEvent>((_, _) => Task.CompletedTask);
+        var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
+
+        Assert.Throws<InvalidOperationException>(() => wrapped(new LoopEvent(), default).GetAwaiter().GetResult());
+    }
+
+    [Fact]
+    public void Subscribe_LoopAffineHandlerGoesAsync_Throws()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
+
+        bus.Subscribe<LoopEvent>(async (_, _) => await Task.Yield());
+        var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
+
+        Assert.Throws<InvalidOperationException>(() => wrapped(new LoopEvent(), default).GetAwaiter().GetResult());
+    }
+
+    [Fact]
+    public void Subscribe_LoopAffineHandlerOnLoopSynchronous_RunsAndPassesThrough()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
+        var ran = false;
+
+        bus.Subscribe<LoopEvent>((_, _) =>
+            {
+                ran = true;
+                return Task.CompletedTask;
+            }
+        );
+        var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
+        wrapped(new LoopEvent(), default).GetAwaiter().GetResult();
+
+        Assert.True(ran);
+    }
+}

--- a/tests/Moongate.Tests/Server/Events/LoopAffineEventBusTests.cs
+++ b/tests/Moongate.Tests/Server/Events/LoopAffineEventBusTests.cs
@@ -109,9 +109,17 @@ public class LoopAffineEventBusTests
         var dispatcher = new MainThreadDispatcherService();
         var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
 
-        bus.Subscribe<LoopEvent>(async (_, _) => await Task.Yield());
+        // A never-completed task models a handler that did not finish synchronously (it went async),
+        // deterministically — unlike Task.Yield(), whose thread-pool continuation can complete before
+        // the guard checks IsCompleted, racing the assertion.
+        var pending = new TaskCompletionSource();
+        bus.Subscribe<LoopEvent>((_, _) => pending.Task);
         var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
 
+        // .GetAwaiter().GetResult() makes the lambda void-returning (not Task-returning), so it binds
+        // to Assert.Throws<T>(Action) instead of the xUnit-analyzer-flagged Func<Task> overload. The
+        // guard throws synchronously before ever returning a task, so GetResult() is never reached —
+        // this is equivalent to a plain synchronous throw, just in a shape the analyzer accepts.
         Assert.Throws<InvalidOperationException>(() => wrapped(new LoopEvent(), default).GetAwaiter().GetResult());
     }
 

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using DryIoc;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Network.Packets.Outgoing;
@@ -23,6 +24,7 @@ using Moongate.Server.Handlers;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Chat;
 using Moongate.Server.Services.Commands;
+using Moongate.Server.Services.Events;
 using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Network;
@@ -103,6 +105,24 @@ public class LoginFlowIntegrationTests
         {
             _queue.CompleteAdding();
             _thread.Join(TimeSpan.FromSeconds(2));
+        }
+    }
+
+    // Tells LoopAffineEventBus whether the calling thread is a LoopThreadDispatcher's dedicated
+    // thread — the same on-loop check the decorator makes in production against LoopThreadMarker.
+    private sealed class LoopThreadDispatcherAdapter : ILoopThread
+    {
+        private readonly int _loopThreadId;
+
+        public LoopThreadDispatcherAdapter(int loopThreadId)
+        {
+            _loopThreadId = loopThreadId;
+        }
+
+        public bool IsOnLoopThread => Environment.CurrentManagedThreadId == _loopThreadId;
+
+        public void Capture()
+        {
         }
     }
 
@@ -925,14 +945,16 @@ public class LoginFlowIntegrationTests
 
     // A client disconnect is raised on the transport thread, but its SessionDestroyedEvent subscribers
     // mutate world state (SpatialSubscriber removes the character from the spatial index), so they must
-    // run on the game loop — never on the transport thread. This drives a real connect/disconnect through
-    // a dedicated-loop dispatcher and asserts the event surfaces on the loop thread.
+    // run on the game loop — never on the transport thread. NetworkService now publishes directly and
+    // relies on LoopAffineEventBus to marshal the event onto the loop, exactly as production wires it
+    // (Program.cs registers the decorator around the raw bus), so this test wraps the bus the same way.
     [Fact]
     public async Task SessionDestroyed_IsPublishedOnTheGameLoopThread_NotTheTransportThread()
     {
         var config = LoopbackConfig();
-        var eventBus = new EventBusService();
+        var inner = new EventBusService();
         using var loop = new LoopThreadDispatcher();
+        IEventBus eventBus = new LoopAffineEventBus(inner, loop, new LoopThreadDispatcherAdapter(loop.LoopThreadId));
 
         using var destroyed = new ManualResetEventSlim();
         var subscriberThreadId = 0;


### PR DESCRIPTION
Keystone of the thread-affinity work: ILoopAffineEvent marker + LoopAffineEventBus decorator that marshals loop-affine events onto the game loop and guards their handlers. Removes the manual Posts in NetworkService.