### PR TITLE
feat(accounts): account writes on the game loop

### DIFF
--- a/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
@@ -97,7 +97,7 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// Username and password are required, and the username must be free — a taken one answers 409. Level
     /// is optional and defaults to Player; when sent it must name an account level, case-insensitively.
     /// </remarks>
-    private IResult Create(CreateAccountRequest request)
+    private async Task<IResult> Create(CreateAccountRequest request)
     {
         // Before the write, so an unknown level cannot leave a half-made account behind.
         if (!TryParseLevel(request.Level, AccountLevelType.Player, out var level))
@@ -105,7 +105,26 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
             return InvalidLevel(request.Level);
         }
 
-        return _accounts.Create(request.Username, request.Password, request.Email, level) switch
+        // The write runs on the game loop: account creation mutates the store the loop's login flow
+        // reads, so check-and-write must not interleave with it.
+        AccountCreateResultType created;
+
+        try
+        {
+            created = await _loop.InvokeAsync(
+                () => _accounts.Create(request.Username, request.Password, request.Email, level),
+                DeleteTimeout
+            );
+        }
+        catch (TimeoutException)
+        {
+            return Results.Problem(
+                "The game loop did not respond; the account was not created.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        return created switch
         {
             AccountCreateResultType.Created => Results.Created(
                 $"/api/v1/admin/accounts/{request.Username}",
@@ -138,25 +157,14 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// </remarks>
     private async Task<IResult> Delete(string username)
     {
-        // Runs on the game loop rather than here. This checks IsCharacterPlayed and then deletes, and
-        // login runs on the loop — so off the loop a player can log in between the two and lose their
-        // character from under them. The stores lock internally, so the damage would not be corruption; it
-        // would be a silent, permanent loss. Handing the work to the loop puts check and act on login's
-        // own thread, where they cannot interleave.
-        //
-        // The timeout is why a stalled loop fails the request instead of hanging it forever, and 503 is
-        // the honest answer: the game loop is not responding.
-        var completion = new TaskCompletionSource<AccountDeleteResultType>(
-            TaskCreationOptions.RunContinuationsAsynchronously
-        );
-
-        _loop.Post(() => completion.SetResult(_accounts.Delete(username)));
-
+        // Runs on the game loop: this checks IsCharacterPlayed then deletes, and login runs on the
+        // loop — off it a player could log in between the two and lose their character. A stalled loop
+        // fails the request with 503 rather than hanging it.
         AccountDeleteResultType result;
 
         try
         {
-            result = await completion.Task.WaitAsync(DeleteTimeout);
+            result = await _loop.InvokeAsync(() => _accounts.Delete(username), DeleteTimeout);
         }
         catch (TimeoutException)
         {
@@ -204,13 +212,8 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// Every field is optional; an omitted one is left as it is. Answers 404 for an unknown account, and
     /// 400 when the level does not name one. Returns the account as it stands after the update.
     /// </remarks>
-    private IResult Update(string username, UpdateAccountRequest request)
+    private async Task<IResult> Update(string username, UpdateAccountRequest request)
     {
-        // Applying several fields is not atomic: nothing rolls the level back if a later setter fails.
-        // Accepted rather than solved — the setters fail only when the account is missing, which is ruled
-        // out a line below, so a delete would have to race this patch for the window to open at all, and
-        // closing it properly needs a transaction the store does not offer. The level, the one input a
-        // caller can get wrong, is validated before any setter runs.
         if (_accounts.GetByUsername(username) is null)
         {
             return NotFound(username);
@@ -221,19 +224,38 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
             return InvalidLevel(request.Level);
         }
 
-        if (request.Level is not null)
+        // The setters run together on the loop so a concurrent delete cannot land between them.
+        try
         {
-            _accounts.SetLevel(username, level);
-        }
+            await _loop.InvokeAsync<bool>(
+                () =>
+                {
+                    if (request.Level is not null)
+                    {
+                        _accounts.SetLevel(username, level);
+                    }
 
-        if (request.IsActive is { } isActive)
-        {
-            _accounts.SetActive(username, isActive);
-        }
+                    if (request.IsActive is { } isActive)
+                    {
+                        _accounts.SetActive(username, isActive);
+                    }
 
-        if (!string.IsNullOrEmpty(request.Password))
+                    if (!string.IsNullOrEmpty(request.Password))
+                    {
+                        _accounts.SetPassword(username, request.Password);
+                    }
+
+                    return true;
+                },
+                DeleteTimeout
+            );
+        }
+        catch (TimeoutException)
         {
-            _accounts.SetPassword(username, request.Password);
+            return Results.Problem(
+                "The game loop did not respond; the account was not updated.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
         }
 
         return Results.Ok(ToResponse(_accounts.GetByUsername(username)!));

--- a/src/Moongate.Core/Interfaces/IGameLoopContext.cs
+++ b/src/Moongate.Core/Interfaces/IGameLoopContext.cs
@@ -34,4 +34,11 @@ public interface IGameLoopContext
     /// </summary>
     /// <returns>The timer id, usable with <see cref="Cancel" />.</returns>
     string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null);
+
+    /// <summary>
+    /// Runs <paramref name="work" /> on the game-loop thread and returns its result. Throws
+    /// <see cref="TimeoutException" /> if the loop does not run it within <paramref name="timeout" />
+    /// (default 5 seconds).
+    /// </summary>
+    Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null);
 }

--- a/src/Moongate.Server/Services/Game/GameLoopContext.cs
+++ b/src/Moongate.Server/Services/Game/GameLoopContext.cs
@@ -31,4 +31,24 @@ public sealed class GameLoopContext : IGameLoopContext
 
     public string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null)
         => Timers.RegisterTimer(name, interval, callback, delay, true);
+
+    public async Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Dispatcher.Post(() =>
+            {
+                try
+                {
+                    completion.SetResult(work());
+                }
+                catch (Exception exception)
+                {
+                    completion.SetException(exception);
+                }
+            }
+        );
+
+        return await completion.Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(5));
+    }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Accounts/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Accounts/AccountEndpointsTests.cs
@@ -55,6 +55,38 @@ public class AccountEndpointsTests
     }
 
     [Fact]
+    public async Task Create_RunsOnTheGameLoop()
+    {
+        var loop = new StubGameLoopContext();
+        await using var server = await TestApiServer.StartAsync(loop: loop);
+        await server.AuthenticateAsync();
+
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret" }
+        );
+
+        Assert.True(loop.PostCount >= 1);
+    }
+
+    [Fact]
+    public async Task Create_LoopNeverAnswers_Is503()
+    {
+        await using var server = await TestApiServer.StartAsync(
+            loop: new StubGameLoopContext(false),
+            deleteTimeout: TimeSpan.FromMilliseconds(50)
+        );
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/admin/accounts",
+            new { username = "alice", password = "secret" }
+        );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Create_TakenUsername_Is409()
     {
         await using var server = await TestApiServer.StartAsync();
@@ -276,6 +308,21 @@ public class AccountEndpointsTests
         // authenticate and the old one must not.
         Assert.True(server.Accounts.Authenticate("tom", "nuova").Success);
         Assert.False(server.Accounts.Authenticate("tom", "secret").Success);
+    }
+
+    [Fact]
+    public async Task Update_RunsOnTheGameLoop()
+    {
+        var loop = new StubGameLoopContext();
+        await using var server = await TestApiServer.StartAsync(loop: loop);
+        await server.AuthenticateAsync();
+
+        await server.Client.PatchAsJsonAsync(
+            "/api/v1/admin/accounts/tom",
+            new { isActive = false }
+        );
+
+        Assert.True(loop.PostCount >= 1);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Game/GameLoopContextTests.cs
+++ b/tests/Moongate.Tests/Server/Game/GameLoopContextTests.cs
@@ -1,4 +1,5 @@
 using Moongate.Server.Services.Game;
+using Moongate.Tests.Support;
 using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Server.Game;
@@ -29,34 +30,4 @@ public class GameLoopContextTests
 
         await Assert.ThrowsAsync<TimeoutException>(async () => await task);
     }
-}
-
-/// <summary>
-/// Stands in for the real timer wheel: <see cref="GameLoopContext" /> only needs an
-/// <see cref="SquidStd.Core.Interfaces.Timing.ITimerService" /> to satisfy its constructor for these
-/// tests, which exercise <see cref="GameLoopContext.InvokeAsync{T}" /> and never touch timers.
-/// </summary>
-internal sealed class FakeTimerServiceForContext : SquidStd.Core.Interfaces.Timing.ITimerService
-{
-    public string RegisterTimer(
-        string name,
-        System.TimeSpan interval,
-        System.Action callback,
-        System.TimeSpan? delay = null,
-        bool repeat = false
-    )
-        => name;
-
-    public void UnregisterAllTimers()
-    {
-    }
-
-    public bool UnregisterTimer(string timerId)
-        => true;
-
-    public int UnregisterTimersByName(string name)
-        => 0;
-
-    public int UpdateTicksDelta(long timestampMilliseconds)
-        => 0;
 }

--- a/tests/Moongate.Tests/Server/Game/GameLoopContextTests.cs
+++ b/tests/Moongate.Tests/Server/Game/GameLoopContextTests.cs
@@ -1,0 +1,62 @@
+using Moongate.Server.Services.Game;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Game;
+
+public class GameLoopContextTests
+{
+    [Fact]
+    public async Task InvokeAsync_RunsWorkOnLoop_ReturnsResult()
+    {
+        var dispatcher = new MainThreadDispatcherService();
+        var timers = new FakeTimerServiceForContext();
+        var loop = new GameLoopContext(dispatcher, timers);
+
+        var task = loop.InvokeAsync(() => 21 * 2);
+        dispatcher.DrainPending();
+
+        Assert.Equal(42, await task);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_LoopNeverRuns_TimesOut()
+    {
+        var dispatcher = new MainThreadDispatcherService();
+        var timers = new FakeTimerServiceForContext();
+        var loop = new GameLoopContext(dispatcher, timers);
+
+        var task = loop.InvokeAsync(() => 1, TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAsync<TimeoutException>(async () => await task);
+    }
+}
+
+/// <summary>
+/// Stands in for the real timer wheel: <see cref="GameLoopContext" /> only needs an
+/// <see cref="SquidStd.Core.Interfaces.Timing.ITimerService" /> to satisfy its constructor for these
+/// tests, which exercise <see cref="GameLoopContext.InvokeAsync{T}" /> and never touch timers.
+/// </summary>
+internal sealed class FakeTimerServiceForContext : SquidStd.Core.Interfaces.Timing.ITimerService
+{
+    public string RegisterTimer(
+        string name,
+        System.TimeSpan interval,
+        System.Action callback,
+        System.TimeSpan? delay = null,
+        bool repeat = false
+    )
+        => name;
+
+    public void UnregisterAllTimers()
+    {
+    }
+
+    public bool UnregisterTimer(string timerId)
+        => true;
+
+    public int UnregisterTimersByName(string name)
+        => 0;
+
+    public int UpdateTicksDelta(long timestampMilliseconds)
+        => 0;
+}

--- a/tests/Moongate.Tests/Support/FakeTimerServiceForContext.cs
+++ b/tests/Moongate.Tests/Support/FakeTimerServiceForContext.cs
@@ -1,0 +1,33 @@
+using SquidStd.Core.Interfaces.Timing;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Stands in for the real timer wheel: <see cref="Moongate.Server.Services.Game.GameLoopContext" /> only
+/// needs an <see cref="ITimerService" /> to satisfy its constructor for
+/// <c>GameLoopContext.InvokeAsync{T}</c> tests, which never touch timers.
+/// </summary>
+public sealed class FakeTimerServiceForContext : ITimerService
+{
+    public string RegisterTimer(
+        string name,
+        TimeSpan interval,
+        Action callback,
+        TimeSpan? delay = null,
+        bool repeat = false
+    )
+        => name;
+
+    public void UnregisterAllTimers()
+    {
+    }
+
+    public bool UnregisterTimer(string timerId)
+        => true;
+
+    public int UnregisterTimersByName(string name)
+        => 0;
+
+    public int UpdateTicksDelta(long timestampMilliseconds)
+        => 0;
+}

--- a/tests/Moongate.Tests/Support/StubGameLoopContext.cs
+++ b/tests/Moongate.Tests/Support/StubGameLoopContext.cs
@@ -58,4 +58,16 @@ public sealed class StubGameLoopContext : IGameLoopContext
 
         return name;
     }
+
+    public Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null)
+    {
+        PostCount++;
+
+        if (_answers)
+        {
+            return Task.FromResult(work());
+        }
+
+        return Task.FromException<T>(new TimeoutException("Stub game loop is not answering."));
+    }
 }


### PR DESCRIPTION
Adds IGameLoopContext.InvokeAsync and routes account Create/Update/Delete through it, closing the check/act race against the loop's login flow. Reads stay eventually-consistent by design.