### PR TITLE
feat(scripting): warn on off-loop Lua result drop

### DIFF
--- a/src/Moongate.Scripting/LoopAffineInvokeMarshaller.cs
+++ b/src/Moongate.Scripting/LoopAffineInvokeMarshaller.cs
@@ -1,5 +1,6 @@
 using Moongate.Core.Interfaces;
 using MoonSharp.Interpreter;
+using Serilog;
 using SquidStd.Core.Interfaces.Threading;
 using SquidStd.Scripting.Lua.Interfaces.Events;
 
@@ -7,17 +8,21 @@ namespace Moongate.Scripting;
 
 /// <summary>
 /// Runs Lua event callbacks on the game-loop thread: inline when already on the loop, otherwise
-/// posted onto the main-thread dispatcher (returning nil, since off-loop handlers are fire-and-forget).
+/// posted onto the main-thread dispatcher (returning nil, since off-loop handlers are
+/// fire-and-forget). Warns when an off-loop call discards a non-nil result, so a silently dropped
+/// return value is visible.
 /// </summary>
 public sealed class LoopAffineInvokeMarshaller : ILuaInvokeMarshaller
 {
     private readonly ILoopThread _loopThread;
     private readonly IMainThreadDispatcher _dispatcher;
+    private readonly ILogger _logger;
 
-    public LoopAffineInvokeMarshaller(ILoopThread loopThread, IMainThreadDispatcher dispatcher)
+    public LoopAffineInvokeMarshaller(ILoopThread loopThread, IMainThreadDispatcher dispatcher, ILogger? logger = null)
     {
         _loopThread = loopThread;
         _dispatcher = dispatcher;
+        _logger = logger ?? Log.ForContext<LoopAffineInvokeMarshaller>();
     }
 
     public DynValue Invoke(Func<DynValue> call)
@@ -29,7 +34,19 @@ public sealed class LoopAffineInvokeMarshaller : ILuaInvokeMarshaller
             return call();
         }
 
-        _dispatcher.Post(() => call());
+        _dispatcher.Post(() =>
+            {
+                var result = call();
+
+                if (result is not null && !result.IsNil())
+                {
+                    _logger.Warning(
+                        "Lua event callback ran off the game loop and its result was discarded (returned {ResultType})",
+                        result.Type
+                    );
+                }
+            }
+        );
 
         return DynValue.Nil;
     }

--- a/tests/Moongate.Tests/Server/Scripting/LoopAffineInvokeMarshallerTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/LoopAffineInvokeMarshallerTests.cs
@@ -1,6 +1,9 @@
 using Moongate.Core.Interfaces;
 using Moongate.Scripting;
 using MoonSharp.Interpreter;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Server.Scripting;
@@ -39,6 +42,32 @@ public class LoopAffineInvokeMarshallerTests
         dispatcher.DrainPending();
 
         Assert.True(ran);
+    }
+
+    [Fact]
+    public void OffLoopThread_DroppingNonNilResult_Warns()
+    {
+        var sink = new ListSink();
+        var dispatcher = new MainThreadDispatcherService();
+        var marshaller = new LoopAffineInvokeMarshaller(
+            new StubLoopThread(false),
+            dispatcher,
+            new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Sink(sink).CreateLogger()
+        );
+
+        marshaller.Invoke(() => DynValue.NewNumber(42));
+
+        dispatcher.DrainPending();
+
+        Assert.Contains(sink.Events, e => e.Level == LogEventLevel.Warning);
+    }
+
+    private sealed class ListSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+
+        public void Emit(LogEvent logEvent)
+            => Events.Add(logEvent);
     }
 
     [Fact]


### PR DESCRIPTION
LoopAffineInvokeMarshaller now logs a warning when an off-loop callback's non-nil result is discarded, instead of swallowing it silently.