### PR TITLE
fix(loop-affinity): close follow-up gaps from the loop thread-affinity effort

### DIFF
--- a/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
@@ -96,6 +96,7 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// <remarks>
     /// Username and password are required, and the username must be free — a taken one answers 409. Level
     /// is optional and defaults to Player; when sent it must name an account level, case-insensitively.
+    /// A 503 means the game loop did not respond and the account was not created.
     /// </remarks>
     private async Task<IResult> Create(CreateAccountRequest request)
     {
@@ -210,7 +211,8 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// <summary>Updates an account, changing only the fields that are sent.</summary>
     /// <remarks>
     /// Every field is optional; an omitted one is left as it is. Answers 404 for an unknown account, and
-    /// 400 when the level does not name one. Returns the account as it stands after the update.
+    /// 400 when the level does not name one. Returns the account as it stands after the update. A 503
+    /// means the game loop did not respond and the account was not updated.
     /// </remarks>
     private async Task<IResult> Update(string username, UpdateAccountRequest request)
     {

--- a/src/Moongate.Server.Abstractions/Data/Events/CharacterReadyEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/CharacterReadyEvent.cs
@@ -1,6 +1,6 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
 
 namespace Moongate.Server.Abstractions.Data.Events;
 
@@ -14,4 +14,4 @@ public sealed record CharacterReadyEvent(
     MobileEntity Character,
     Serial BackpackId,
     Serial BankId
-) : IEvent;
+) : ILoopAffineEvent;

--- a/src/Moongate.Server/Handlers/SkillLockChangeHandler.cs
+++ b/src/Moongate.Server/Handlers/SkillLockChangeHandler.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Extensions;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Network.Packets.Incoming;
 using Moongate.Persistence.Entities;
@@ -19,17 +20,20 @@ public sealed class SkillLockChangeHandler : IPacketHandler<SkillLockChangePacke
 {
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
     private readonly ISkillService _skills;
+    private readonly ILoopAffinity? _loopAffinity;
 
-    public SkillLockChangeHandler(IPersistenceService persistence, ISkillService skills)
+    public SkillLockChangeHandler(IPersistenceService persistence, ISkillService skills, ILoopAffinity? loopAffinity = null)
     {
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
         _skills = skills;
+        _loopAffinity = loopAffinity;
     }
 
     public void Handle(SkillLockChangePacket packet, in PacketContext context)
     {
         if (context.Session.Character is { } mobile && TryApplyLock(mobile, packet.SkillId, packet.Lock, _skills))
         {
+            _loopAffinity?.AssertOnLoop("skill.lock_change");
             _mobiles.UpsertAsync(mobile).WaitSync();
         }
     }

--- a/src/Moongate.Server/Services/Accounts/CharacterService.cs
+++ b/src/Moongate.Server/Services/Accounts/CharacterService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Moongate.Core.Extensions;
 using Moongate.Core.Geometry;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Network.Packets.Incoming;
 using Moongate.Network.Types;
@@ -35,6 +36,7 @@ public class CharacterService : ICharacterService
     private readonly Random _random;
     private readonly IEventBus _eventBus;
     private readonly ISessionManager _sessions;
+    private readonly ILoopAffinity? _loopAffinity;
 
     private readonly ILogger _logger = Log.ForContext<CharacterService>();
 
@@ -48,7 +50,8 @@ public class CharacterService : ICharacterService
         ISkillService skills,
         Random random,
         IEventBus eventBus,
-        ISessionManager sessions
+        ISessionManager sessions,
+        ILoopAffinity? loopAffinity = null
     )
     {
         _mobileStore = persistenceService.GetStore<MobileEntity, Serial>();
@@ -62,10 +65,13 @@ public class CharacterService : ICharacterService
         _random = random;
         _eventBus = eventBus;
         _sessions = sessions;
+        _loopAffinity = loopAffinity;
     }
 
     public MobileEntity CreateCharacter(Serial accountId, CharacterCreationPacket packet)
     {
+        _loopAffinity?.AssertOnLoop("character.create");
+
         var mobile = _mobileFactory.CreatePlayerMobile(packet);
 
         // Upsert with a default serial: the store allocates the next mobile serial and writes it back
@@ -116,6 +122,8 @@ public class CharacterService : ICharacterService
 
     public DeleteResultType? DeleteCharacter(Serial accountId, int slot)
     {
+        _loopAffinity?.AssertOnLoop("character.delete");
+
         var characters = GetPlayerCharacters(accountId).ToList();
 
         if (slot < 0 || slot >= characters.Count)

--- a/src/Moongate.Server/Services/Events/LoopAffineEventBus.cs
+++ b/src/Moongate.Server/Services/Events/LoopAffineEventBus.cs
@@ -81,6 +81,8 @@ public sealed class LoopAffineEventBus : IEventBus
         );
     }
 
+    // Passed straight through, unguarded: there are no IEventListener<> subscribers today, so this path
+    // carries no loop-affine enforcement. Guard it here the same way Subscribe is if that changes.
     public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
         => _inner.RegisterListener(listener);
 }

--- a/src/Moongate.Server/Services/Game/EventLoopThread.cs
+++ b/src/Moongate.Server/Services/Game/EventLoopThread.cs
@@ -8,10 +8,10 @@ public sealed class EventLoopThread : ILoopThread
 {
     private readonly IEventLoopService _loop;
 
+    public bool IsOnLoopThread => _loop.IsOnLoopThread;
+
     public EventLoopThread(IEventLoopService loop)
     {
         _loop = loop;
     }
-
-    public bool IsOnLoopThread => _loop.IsOnLoopThread;
 }

--- a/tests/Moongate.Tests/Server/CharacterServiceTests.cs
+++ b/tests/Moongate.Tests/Server/CharacterServiceTests.cs
@@ -2,9 +2,11 @@ using Moongate.Core.Primitives;
 using Moongate.Network.Packets.Incoming;
 using Moongate.Network.Types;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Services.Accounts;
+using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Tests.Support;
 using Moongate.Ultima.Types;
@@ -72,6 +74,19 @@ public class CharacterServiceTests
         var shirt = Assert.Single(equipped.Where(item => item.ItemId == 5399)); // shirt from ByBody Elf/Female
         Assert.Equal(LayerType.Shirt, shirt.EquippedLayer);
         Assert.Equal((ushort)0x0765, shirt.Hue.Value); // Hue "shirt" resolved to packet.ShirtHue
+    }
+
+    [Fact]
+    public void CreateCharacter_OffLoopStrict_Throws()
+    {
+        var persistence = new FakePersistenceService();
+        var loopAffinity = new LoopAffinity(
+            new StubLoopThread(onLoop: false),
+            new MoongateConfig { StrictLoopAffinity = true }
+        );
+        var service = CharacterServiceFixture.Create(persistence, new EventBusService(), loopAffinity: loopAffinity);
+
+        Assert.Throws<InvalidOperationException>(() => service.CreateCharacter((Serial)5, Packet()));
     }
 
     [Fact]
@@ -175,6 +190,32 @@ public class CharacterServiceTests
         // The survivor kept its own gear.
         Assert.NotNull(persistence.Store<ItemEntity>().GetById(second.BackpackId));
         Assert.Null(persistence.Store<ItemEntity>().GetById(first.BackpackId));
+    }
+
+    [Fact]
+    public async Task DeleteCharacter_OffLoopStrict_Throws()
+    {
+        var persistence = new FakePersistenceService();
+        var accountId = (Serial)5;
+        await persistence.Store<AccountEntity>().UpsertAsync(new() { Id = accountId, Username = "bob" });
+
+        var service = CharacterServiceFixture.Create(persistence, new EventBusService());
+        var mobile = service.CreateCharacter(accountId, Packet());
+
+        var loopAffinity = new LoopAffinity(
+            new StubLoopThread(onLoop: false),
+            new MoongateConfig { StrictLoopAffinity = true }
+        );
+        var guardedService = CharacterServiceFixture.Create(
+            persistence,
+            new EventBusService(),
+            loopAffinity: loopAffinity
+        );
+
+        Assert.Throws<InvalidOperationException>(() => guardedService.DeleteCharacter(accountId, 0));
+
+        // Refused before anything was touched: the mobile created above is still there.
+        Assert.NotNull(persistence.Store<MobileEntity>().GetById(mobile.Id));
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Support/CharacterServiceFixture.cs
+++ b/tests/Moongate.Tests/Support/CharacterServiceFixture.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Interfaces;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Services.Accounts;
@@ -35,7 +36,8 @@ public static class CharacterServiceFixture
         FakePersistenceService persistence,
         IEventBus eventBus,
         ISessionManager? sessions = null,
-        IStartingCityService? cities = null
+        IStartingCityService? cities = null,
+        ILoopAffinity? loopAffinity = null
     )
     {
         var templates = Templates();
@@ -51,7 +53,8 @@ public static class CharacterServiceFixture
             Skills(),
             random,
             eventBus,
-            sessions ?? new StubSessionManager()
+            sessions ?? new StubSessionManager(),
+            loopAffinity
         );
     }
 

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -34,7 +34,7 @@
           "accounts"
         ],
         "summary": "Creates an account.",
-        "description": "Username and password are required, and the username must be free — a taken one answers 409. Level\nis optional and defaults to Player; when sent it must name an account level, case-insensitively.",
+        "description": "Username and password are required, and the username must be free — a taken one answers 409. Level\nis optional and defaults to Player; when sent it must name an account level, case-insensitively.\nA 503 means the game loop did not respond and the account was not created.",
         "operationId": "CreateAccount",
         "requestBody": {
           "content": {
@@ -96,7 +96,7 @@
           "accounts"
         ],
         "summary": "Updates an account, changing only the fields that are sent.",
-        "description": "Every field is optional; an omitted one is left as it is. Answers 404 for an unknown account, and\n400 when the level does not name one. Returns the account as it stands after the update.",
+        "description": "Every field is optional; an omitted one is left as it is. Answers 404 for an unknown account, and\n400 when the level does not name one. Returns the account as it stands after the update. A 503\nmeans the game loop did not respond and the account was not updated.",
         "operationId": "UpdateAccount",
         "parameters": [
           {

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -21,6 +21,7 @@ export interface paths {
          * Creates an account.
          * @description Username and password are required, and the username must be free — a taken one answers 409. Level
          *     is optional and defaults to Player; when sent it must name an account level, case-insensitively.
+         *     A 503 means the game loop did not respond and the account was not created.
          */
         post: operations["CreateAccount"];
         delete?: never;
@@ -55,7 +56,8 @@ export interface paths {
         /**
          * Updates an account, changing only the fields that are sent.
          * @description Every field is optional; an omitted one is left as it is. Answers 404 for an unknown account, and
-         *     400 when the level does not name one. Returns the account as it stands after the update.
+         *     400 when the level does not name one. Returns the account as it stands after the update. A 503
+         *     means the game loop did not respond and the account was not updated.
          */
         patch: operations["UpdateAccount"];
         trace?: never;


### PR DESCRIPTION
## Summary
Closes the latent gaps and Minors found in a whole-branch review of the 6-phase loop thread-affinity effort (already merged into `develop`):

- Mark `CharacterReadyEvent` as `ILoopAffineEvent` for parity with `CharacterCreatedEvent`, so a future C# subscriber gets the same publish-routing and subscribe-guard.
- Guard `CharacterService.CreateCharacter` / `DeleteCharacter` with the established optional `ILoopAffinity? loopAffinity = null` pattern.
- Guard `SkillLockChangeHandler`'s mobile upsert the same way.
- Bring the `Create`/`Update` account endpoint `<remarks>` in line with `Delete`'s existing 503 phrasing (docs-only).
- Comment `LoopAffineEventBus.RegisterListener` as an unguarded pass-through, since there are no `IEventListener<>` subscribers today.
- Reorder `EventLoopThread` so `IsOnLoopThread` precedes the constructor per `CODE_CONVENTION.md` class layout (no behavior change).

## Test plan
- [x] Added `CreateCharacter_OffLoopStrict_Throws` and `DeleteCharacter_OffLoopStrict_Throws` in `CharacterServiceTests.cs`, using `CharacterServiceFixture` extended with an optional `ILoopAffinity?` parameter.
- [x] Verified red/green: temporarily removed the two `AssertOnLoop` guard calls, confirmed both new tests fail, restored the guards, confirmed both pass.
- [x] `dotnet test Moongate.slnx` — full suite green (1424/1424).
- [x] `dotnet test Moongate.slnx --configuration Release` — full suite green (1424/1424).
- [x] `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings.