### PR TITLE
feat(http): expose online players for admin map

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -110,6 +110,7 @@ good token that is simply not staff.
 | `DELETE` | `/api/v1/admin/accounts/{username}`  | `admin`  | 204, or 404 / 409 / 503            |
 | `GET`    | `/api/v1/player/me/characters`       | `player` | the caller's own characters        |
 | `GET`    | `/api/v1/admin/characters`           | `admin`  | every character, paged             |
+| `GET`    | `/api/v1/admin/players/online`       | `admin`  | players currently in the world     |
 | `GET`    | `/api/v1/images/items/{id}.png`      | none     | item art as PNG, or 400 / 404 / 503 |
 | `POST`   | `/api/v1/admin/images/items`         | `admin`  | 202, or 409 / 503                  |
 | `GET`    | `/api/v1/admin/images/items`         | `admin`  | export progress                    |
@@ -212,6 +213,23 @@ One detail worth copying if you add a route that reads the caller's identity: th
 account id is read from `NameIdentifier` before `sub`. `JwtTokenService` writes it
 into `sub`, but JwtBearer's inbound claim mapping is on by default and renames it
 before the principal reaches the route — reading only `sub` 401s every request.
+
+## Online players on the admin map
+
+`GET /api/v1/admin/players/online` returns the players who have completed login
+and entered the world. It is staff-only and intentionally unpaged: the result is
+the current marker set, not a historical character catalogue.
+
+Each row carries stable account and character serials, their names, facet id and
+name, `x/y/z`, facing and running state, body and skin hue, hit points and war
+mode. Sessions still at login or character selection are excluded. Email, IP
+address and connection ids are not part of the map contract.
+
+This route reads the live session/mobile values directly from the HTTP thread.
+The game loop can move, transfer or disconnect a character during that read, so
+one response may be momentarily stale or combine values from adjacent frames.
+The next poll naturally replaces it. This trade-off is local to this read-only
+map snapshot; world mutations still belong on the game loop.
 
 ## Item templates
 

--- a/plugins/Moongate.Http.Plugin/Data/Api/Players/OnlinePlayerMapResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Players/OnlinePlayerMapResponse.cs
@@ -1,0 +1,83 @@
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Http.Plugin.Data.Api.Players;
+
+/// <summary>A map-ready snapshot of one player currently in the world.</summary>
+/// <param name="CharacterSerial">Stable character serial, formatted as hexadecimal.</param>
+/// <param name="CharacterName">Character display name.</param>
+/// <param name="AccountSerial">Owning account serial, formatted as hexadecimal.</param>
+/// <param name="AccountUsername">Owning account username.</param>
+/// <param name="MapId">Numeric UO facet id.</param>
+/// <param name="MapName">Known facet name, or Unknown for an unrecognised id.</param>
+/// <param name="X">World X coordinate.</param>
+/// <param name="Y">World Y coordinate.</param>
+/// <param name="Z">World altitude.</param>
+/// <param name="Direction">Facing direction without the running flag.</param>
+/// <param name="Running">Whether the latest direction carries the running flag.</param>
+/// <param name="Body">Body graphic id.</param>
+/// <param name="SkinHue">Skin hue id.</param>
+/// <param name="Hits">Current hit points.</param>
+/// <param name="HitsMax">Maximum hit points.</param>
+/// <param name="Warmode">Whether the character is in war mode.</param>
+public sealed record OnlinePlayerMapResponse(
+    string CharacterSerial,
+    string CharacterName,
+    string AccountSerial,
+    string AccountUsername,
+    int MapId,
+    string MapName,
+    int X,
+    int Y,
+    int Z,
+    string Direction,
+    bool Running,
+    int Body,
+    int SkinHue,
+    int Hits,
+    int HitsMax,
+    bool Warmode
+)
+{
+    private const byte DirectionMask = 0x07;
+
+    /// <summary>Copies session and character state into the public wire contract.</summary>
+    public static OnlinePlayerMapResponse From(PlayerSession session, MobileEntity mobile)
+    {
+        var facing = (DirectionType)((byte)mobile.Direction & DirectionMask);
+        var mapName = MapNameFor(mobile.MapId);
+
+        return new(
+            mobile.Id.ToString(),
+            mobile.Name,
+            session.AccountId.ToString(),
+            session.Username ?? string.Empty,
+            mobile.MapId,
+            mapName,
+            mobile.Position.X,
+            mobile.Position.Y,
+            mobile.Position.Z,
+            facing.ToString(),
+            (mobile.Direction & DirectionType.Running) != 0,
+            mobile.Body,
+            mobile.SkinHue.Value,
+            mobile.Hits,
+            mobile.HitsMax,
+            mobile.Warmode
+        );
+    }
+
+    private static string MapNameFor(int mapId)
+    {
+        if (mapId is < byte.MinValue or > byte.MaxValue)
+        {
+            return "Unknown";
+        }
+
+        var facet = (MapType)mapId;
+
+        return Enum.IsDefined(facet) ? facet.ToString() : "Unknown";
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Endpoints/Players/OnlinePlayerAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Players/OnlinePlayerAdminEndpoints.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data.Api.Players;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Http.Plugin.Endpoints.Players;
+
+/// <summary>Staff-only views over players currently present in the world.</summary>
+public sealed class OnlinePlayerAdminEndpoints : IApiEndpointRegistration
+{
+    private readonly ISessionManager _sessions;
+
+    public OnlinePlayerAdminEndpoints(ISessionManager sessions)
+    {
+        _sessions = sessions;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+        => routes.MapGet("/api/v1/admin/players/online", List)
+            .WithName("ListOnlinePlayers")
+            .WithTags("players")
+            .Produces<IReadOnlyList<OnlinePlayerMapResponse>>()
+            .RequireAuthorization(HttpServerService.AdminPolicy);
+
+    /// <summary>Lists players who have entered the world with map-ready positions.</summary>
+    /// <remarks>
+    /// Staff only. The response is an unpaged snapshot ordered by character name and serial. Login and
+    /// character-selection sessions are excluded. The snapshot is read directly while the game loop may
+    /// move or disconnect a player, so one response can be briefly stale or internally inconsistent.
+    /// </remarks>
+    private IResult List()
+    {
+        var players = new List<OnlinePlayerMapResponse>();
+
+        foreach (var session in _sessions.All)
+        {
+            if (session.State != SessionStateType.InWorld || session.Character is not { } character)
+            {
+                continue;
+            }
+
+            players.Add(OnlinePlayerMapResponse.From(session, character));
+        }
+
+        return Results.Ok(
+            players
+                .OrderBy(player => player.CharacterName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(player => player.CharacterSerial, StringComparer.Ordinal)
+                .ToArray()
+        );
+    }
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -110,6 +110,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<AuthEndpoints>();
         container.RegisterApiEndpoint<AdminEndpoints>();
         container.RegisterApiEndpoint<PlayerEndpoints>();
+        container.RegisterApiEndpoint<OnlinePlayerAdminEndpoints>();
         container.RegisterApiEndpoint<CharacterEndpoints>();
         container.RegisterApiEndpoint<CharacterAdminEndpoints>();
         container.RegisterApiEndpoint<ItemTemplateEndpoints>();

--- a/tests/Moongate.Tests/Http/Endpoints/Players/OnlinePlayerAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Players/OnlinePlayerAdminEndpointsTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Api.Players;
+using Moongate.Http.Plugin.Endpoints.Players;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Client;
+
+namespace Moongate.Tests.Http.Endpoints.Players;
+
+public class OnlinePlayerAdminEndpointsTests
+{
+    private const string Route = "/api/v1/admin/players/online";
+
+    [Fact]
+    public async Task List_WithoutToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Theory, InlineData(AccountLevelType.Administrator), InlineData(AccountLevelType.GrandMaster)]
+    public async Task List_AsStaff_WithNoPlayersInWorld_ReturnsAnEmptyArray(AccountLevelType level)
+    {
+        await using var server = await StartAsync(level);
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync(Route);
+        var players = await response.Content.ReadFromJsonAsync<OnlinePlayerMapResponse[]>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Empty(players!);
+    }
+
+    [Fact]
+    public async Task List_ReturnsOnlyInWorldPlayersWithMapFields()
+    {
+        await using var server = await StartAsync();
+        server.Sessions.Connections.Add(
+            Session(
+                "alice",
+                new(0x11),
+                new()
+                {
+                    Id = new(0x42),
+                    Name = "Freydis",
+                    MapId = (int)MapType.Trammel,
+                    Position = new(1420, 1698, 10),
+                    Direction = DirectionType.SouthEast | DirectionType.Running,
+                    Body = 401,
+                    SkinHue = new Hue(1002),
+                    Hits = 48,
+                    HitsMax = 70,
+                    Warmode = true
+                },
+                SessionStateType.InWorld
+            )
+        );
+        server.Sessions.Connections.Add(
+            Session(
+                "waiting",
+                new(0x12),
+                new() { Id = new(0x43), Name = "Not Yet In World" },
+                SessionStateType.Authenticated
+            )
+        );
+        server.Sessions.Connections.Add(Session("broken", new(0x13), null, SessionStateType.InWorld));
+        await server.AuthenticateAsync();
+
+        var players = await server.Client.GetFromJsonAsync<OnlinePlayerMapResponse[]>(Route);
+        var player = Assert.Single(players!);
+
+        Assert.Equal("0x00000042", player.CharacterSerial);
+        Assert.Equal("Freydis", player.CharacterName);
+        Assert.Equal("0x00000011", player.AccountSerial);
+        Assert.Equal("alice", player.AccountUsername);
+        Assert.Equal(1, player.MapId);
+        Assert.Equal("Trammel", player.MapName);
+        Assert.Equal(1420, player.X);
+        Assert.Equal(1698, player.Y);
+        Assert.Equal(10, player.Z);
+        Assert.Equal("SouthEast", player.Direction);
+        Assert.True(player.Running);
+        Assert.Equal(401, player.Body);
+        Assert.Equal(1002, player.SkinHue);
+        Assert.Equal(48, player.Hits);
+        Assert.Equal(70, player.HitsMax);
+        Assert.True(player.Warmode);
+    }
+
+    [Fact]
+    public async Task List_UnknownMapId_UsesUnknownMapName()
+    {
+        await using var server = await StartAsync();
+        server.Sessions.Connections.Add(
+            Session(
+                "alice",
+                new(0x11),
+                new() { Id = new(0x42), Name = "Freydis", MapId = 99 },
+                SessionStateType.InWorld
+            )
+        );
+        await server.AuthenticateAsync();
+
+        var players = await server.Client.GetFromJsonAsync<OnlinePlayerMapResponse[]>(Route);
+
+        Assert.Equal("Unknown", Assert.Single(players!).MapName);
+    }
+
+    [Fact]
+    public async Task List_OrdersByCharacterNameThenSerial()
+    {
+        await using var server = await StartAsync();
+        server.Sessions.Connections.Add(
+            Session("one", new(1), new() { Id = new(3), Name = "Cedric" }, SessionStateType.InWorld)
+        );
+        server.Sessions.Connections.Add(
+            Session("two", new(2), new() { Id = new(2), Name = "aramis" }, SessionStateType.InWorld)
+        );
+        server.Sessions.Connections.Add(
+            Session("three", new(3), new() { Id = new(1), Name = "Aramis" }, SessionStateType.InWorld)
+        );
+        await server.AuthenticateAsync();
+
+        var players = await server.Client.GetFromJsonAsync<OnlinePlayerMapResponse[]>(Route);
+
+        Assert.Equal(
+            ["0x00000001", "0x00000002", "0x00000003"],
+            players!.Select(player => player.CharacterSerial)
+        );
+    }
+
+    private static PlayerSession Session(
+        string username,
+        Serial accountId,
+        MobileEntity? character,
+        SessionStateType state
+    )
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        using var client = new SquidStdTcpClient(socket, Stream.Null);
+        var session = new PlayerSession(client);
+
+        session.SetAccountId(accountId);
+        session.MarkAuthenticated(username);
+
+        if (character is not null)
+        {
+            session.SetCharacter(character);
+        }
+
+        session.SetState(state);
+
+        return session;
+    }
+
+    private static Task<TestApiServer> StartAsync(
+        AccountLevelType level = AccountLevelType.Administrator
+    )
+        => TestApiServer.StartAsync(
+            level,
+            configure: container => container.RegisterApiEndpoint<OnlinePlayerAdminEndpoints>()
+        );
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -57,6 +57,7 @@ public class MoongateHttpPluginTests
                 typeof(MapImageEndpoints),
                 typeof(MobileImageAdminEndpoints),
                 typeof(MobileTemplateImageEndpoints),
+                typeof(OnlinePlayerAdminEndpoints),
                 typeof(PaperdollEndpoints),
                 typeof(PlayerEndpoints),
                 typeof(PluginAdminEndpoints),

--- a/tests/Moongate.Tests/Support/StubSessionManager.cs
+++ b/tests/Moongate.Tests/Support/StubSessionManager.cs
@@ -6,8 +6,8 @@ using SquidStd.Network.Client;
 namespace Moongate.Tests.Support;
 
 /// <summary>
-/// Test double for <see cref="ISessionManager" />: holds no real sessions — which need a live socket —
-/// and instead lets a test declare which characters count as played via <see cref="Played" />.
+/// Test double for <see cref="ISessionManager" />: lets tests expose explicit sessions and declare
+/// which character serials count as being played.
 /// </summary>
 public sealed class StubSessionManager : ISessionManager
 {
@@ -15,6 +15,9 @@ public sealed class StubSessionManager : ISessionManager
 
     /// <summary>Characters a session is pretending to play.</summary>
     public HashSet<Serial> Played { get; } = [];
+
+    /// <summary>Concrete sessions returned from <see cref="All" />.</summary>
+    public List<PlayerSession> Connections { get; } = [];
 
     /// <summary>When set, reading <see cref="Count" /> throws, so a caller's failure handling can be exercised.</summary>
     public bool ThrowOnCount { get; set; }
@@ -26,7 +29,7 @@ public sealed class StubSessionManager : ISessionManager
         set => _count = value;
     }
 
-    public IReadOnlyCollection<PlayerSession> All => [];
+    public IReadOnlyCollection<PlayerSession> All => [.. Connections];
 
     public PlayerSession GetOrCreate(SquidStdTcpClient client)
         => throw new NotSupportedException("The stub holds no sessions.");

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -147,6 +147,7 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterInstance(timeProvider);
         container.RegisterInstance(moongateConfig);
         container.RegisterInstance<IAccountService>(accounts);
+        container.RegisterInstance<ISessionManager>(sessions);
 
         // Mirrors production, where the persistence plugin registers it: a service resolved from this
         // container can ask for a store, exactly as it does on a real shard.

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -1240,6 +1240,31 @@
         }
       }
     },
+    "/api/v1/admin/players/online": {
+      "get": {
+        "tags": [
+          "players"
+        ],
+        "summary": "Lists players who have entered the world with map-ready positions.",
+        "description": "Staff only. The response is an unpaged snapshot ordered by character name and serial. Login and\ncharacter-selection sessions are excluded. The snapshot is read directly while the game loop may\nmove or disconnect a player, so one response can be briefly stale or internally inconsistent.",
+        "operationId": "ListOnlinePlayers",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OnlinePlayerMapResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/register": {
       "post": {
         "tags": [
@@ -2539,6 +2564,103 @@
         "additionalProperties": false,
         "description": "A news entry as returned by the API."
       },
+      "OnlinePlayerMapResponse": {
+        "required": [
+          "accountSerial",
+          "accountUsername",
+          "body",
+          "characterName",
+          "characterSerial",
+          "direction",
+          "hits",
+          "hitsMax",
+          "mapId",
+          "mapName",
+          "running",
+          "skinHue",
+          "warmode",
+          "x",
+          "y",
+          "z"
+        ],
+        "type": "object",
+        "properties": {
+          "characterSerial": {
+            "type": "string",
+            "description": "Stable character serial, formatted as hexadecimal."
+          },
+          "characterName": {
+            "type": "string",
+            "description": "Character display name."
+          },
+          "accountSerial": {
+            "type": "string",
+            "description": "Owning account serial, formatted as hexadecimal."
+          },
+          "accountUsername": {
+            "type": "string",
+            "description": "Owning account username."
+          },
+          "mapId": {
+            "type": "integer",
+            "description": "Numeric UO facet id.",
+            "format": "int32"
+          },
+          "mapName": {
+            "type": "string",
+            "description": "Known facet name, or Unknown for an unrecognised id."
+          },
+          "x": {
+            "type": "integer",
+            "description": "World X coordinate.",
+            "format": "int32"
+          },
+          "y": {
+            "type": "integer",
+            "description": "World Y coordinate.",
+            "format": "int32"
+          },
+          "z": {
+            "type": "integer",
+            "description": "World altitude.",
+            "format": "int32"
+          },
+          "direction": {
+            "type": "string",
+            "description": "Facing direction without the running flag."
+          },
+          "running": {
+            "type": "boolean",
+            "description": "Whether the latest direction carries the running flag."
+          },
+          "body": {
+            "type": "integer",
+            "description": "Body graphic id.",
+            "format": "int32"
+          },
+          "skinHue": {
+            "type": "integer",
+            "description": "Skin hue id.",
+            "format": "int32"
+          },
+          "hits": {
+            "type": "integer",
+            "description": "Current hit points.",
+            "format": "int32"
+          },
+          "hitsMax": {
+            "type": "integer",
+            "description": "Maximum hit points.",
+            "format": "int32"
+          },
+          "warmode": {
+            "type": "boolean",
+            "description": "Whether the character is in war mode."
+          }
+        },
+        "additionalProperties": false,
+        "description": "A map-ready snapshot of one player currently in the world."
+      },
       "PlayerMeResponse": {
         "required": [
           "level",
@@ -3026,6 +3148,9 @@
     },
     {
       "name": "player"
+    },
+    {
+      "name": "players"
     },
     {
       "name": "registration"

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -676,6 +676,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/players/online": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Lists players who have entered the world with map-ready positions.
+         * @description Staff only. The response is an unpaged snapshot ordered by character name and serial. Login and
+         *     character-selection sessions are excluded. The snapshot is read directly while the game loop may
+         *     move or disconnect a player, so one response can be briefly stale or internally inconsistent.
+         */
+        get: operations["ListOnlinePlayers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/register": {
         parameters: {
             query?: never;
@@ -1278,6 +1300,65 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
             isPublished: boolean;
+        };
+        /** @description A map-ready snapshot of one player currently in the world. */
+        OnlinePlayerMapResponse: {
+            /** @description Stable character serial, formatted as hexadecimal. */
+            characterSerial: string;
+            /** @description Character display name. */
+            characterName: string;
+            /** @description Owning account serial, formatted as hexadecimal. */
+            accountSerial: string;
+            /** @description Owning account username. */
+            accountUsername: string;
+            /**
+             * Format: int32
+             * @description Numeric UO facet id.
+             */
+            mapId: number;
+            /** @description Known facet name, or Unknown for an unrecognised id. */
+            mapName: string;
+            /**
+             * Format: int32
+             * @description World X coordinate.
+             */
+            x: number;
+            /**
+             * Format: int32
+             * @description World Y coordinate.
+             */
+            y: number;
+            /**
+             * Format: int32
+             * @description World altitude.
+             */
+            z: number;
+            /** @description Facing direction without the running flag. */
+            direction: string;
+            /** @description Whether the latest direction carries the running flag. */
+            running: boolean;
+            /**
+             * Format: int32
+             * @description Body graphic id.
+             */
+            body: number;
+            /**
+             * Format: int32
+             * @description Skin hue id.
+             */
+            skinHue: number;
+            /**
+             * Format: int32
+             * @description Current hit points.
+             */
+            hits: number;
+            /**
+             * Format: int32
+             * @description Maximum hit points.
+             */
+            hitsMax: number;
+            /** @description Whether the character is in war mode. */
+            warmode: boolean;
         };
         /** @description Who the caller's token says they are. Deliberately not their characters — see PlayerEndpoints. */
         PlayerMeResponse: {
@@ -2298,6 +2379,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CharacterResponse"][];
+                };
+            };
+        };
+    };
+    ListOnlinePlayers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OnlinePlayerMapResponse"][];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- add `GET /api/v1/admin/players/online`, protected by the admin policy
- return in-world player identity, map coordinates, orientation, appearance and current combat status
- keep REST docs, OpenAPI schema and generated TypeScript types in sync
- cover authorization, filtering, ordering and payload mapping with integration tests

## Verification

- `dotnet build Moongate.slnx --configuration Release --no-restore`
- `dotnet test Moongate.slnx --configuration Release --no-build` — 1431 passed
- `npm test -- --run` — 118 passed
- `npm run build`
- DocFX build — 0 warnings, 0 errors
- OpenAPI regeneration — clean diff

Refs #102