### PR TITLE
feat(ui): show online players on the live map

### DIFF
--- a/ui/src/components/map/LiveMap.test.tsx
+++ b/ui/src/components/map/LiveMap.test.tsx
@@ -1,6 +1,8 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '../../lib/i18n'
 import { LiveMap } from './LiveMap'
 import type { MapFacetInfo } from '../../lib/maps'
+import type { OnlinePlayer } from '../../lib/online-players'
 
 const felucca: MapFacetInfo = {
   name: 'Felucca',
@@ -12,15 +14,129 @@ const felucca: MapFacetInfo = {
   tilesDown: 16,
 }
 
+const freydis: OnlinePlayer = {
+  characterSerial: '0x00000042',
+  characterName: 'Freydis',
+  accountSerial: '0x00000001',
+  accountUsername: 'alice',
+  mapId: 0,
+  mapName: 'Felucca',
+  x: 1420,
+  y: 1698,
+  z: 10,
+  direction: 'North',
+  running: false,
+  body: 401,
+  skinHue: 1002,
+  hits: 48,
+  hitsMax: 70,
+  warmode: false,
+}
+
+function map(players: readonly OnlinePlayer[]) {
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <LiveMap facet={felucca} style="flat" centerTarget={null} onHover={() => {}} players={players} />
+    </div>
+  )
+}
+
 describe('LiveMap', () => {
   it('mounts a Leaflet map and tears it down without throwing', () => {
-    const { container, unmount } = render(
-      <div style={{ width: 800, height: 600 }}>
-        <LiveMap facet={felucca} style="flat" centerTarget={null} onHover={() => {}} />
-      </div>,
-    )
+    const { container, unmount } = render(map([]))
 
     expect(container.querySelector('.leaflet-container')).not.toBeNull()
     expect(() => unmount()).not.toThrow()
+  })
+
+  it('adds, updates in place, and removes a keyed player marker', async () => {
+    const view = render(map([freydis]))
+    const marker = await waitFor(() => {
+      const element = view.container.querySelector<HTMLElement>('.mg-player-marker')
+      expect(element).not.toBeNull()
+      return element!
+    })
+
+    expect(marker).not.toHaveClass('mg-player-marker--warmode')
+    expect(marker.querySelector<HTMLElement>('.mg-player-marker__arrow')).toHaveStyle({
+      transform: 'rotate(0deg)',
+    })
+
+    view.rerender(
+      map([
+        {
+          ...freydis,
+          x: 1500,
+          y: 1700,
+          direction: 'East',
+          warmode: true,
+        },
+      ]),
+    )
+
+    await waitFor(() => {
+      const updated = view.container.querySelector<HTMLElement>('.mg-player-marker')
+      expect(updated).toBe(marker)
+      expect(updated).toHaveClass('mg-player-marker--warmode')
+      expect(updated?.querySelector<HTMLElement>('.mg-player-marker__arrow')).toHaveStyle({
+        transform: 'rotate(90deg)',
+      })
+    })
+
+    view.rerender(map([]))
+    await waitFor(() => expect(view.container.querySelector('.mg-player-marker')).toBeNull())
+  })
+
+  it('opens a complete popup without interpreting player data as HTML', async () => {
+    const unsafeName = '<img src=x data-pwned=true>'
+    const unsafeAccount = '<script data-pwned=true>'
+    const view = render(
+      map([
+        {
+          ...freydis,
+          characterName: unsafeName,
+          accountUsername: unsafeAccount,
+          running: true,
+          warmode: true,
+        },
+      ]),
+    )
+
+    const markerHost = await waitFor(() => {
+      const element = view.container.querySelector<HTMLElement>('.mg-player-marker-host')
+      expect(element).not.toBeNull()
+      return element!
+    })
+
+    fireEvent.click(markerHost)
+
+    expect(await screen.findByRole('heading', { name: unsafeName })).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        (content, element) =>
+          element?.classList.contains('mg-player-popup__account') === true && content.includes(unsafeAccount),
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText('48 / 70')).toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('War mode')).toBeInTheDocument()
+    expect(view.container.querySelector('[data-pwned="true"]')).toBeNull()
+  })
+
+  it('preserves an open popup while the same serial is updated', async () => {
+    const view = render(map([freydis]))
+    const markerHost = await waitFor(() => {
+      const element = view.container.querySelector<HTMLElement>('.mg-player-marker-host')
+      expect(element).not.toBeNull()
+      return element!
+    })
+
+    fireEvent.click(markerHost)
+    expect(await screen.findByText('1420, 1698, 10')).toBeInTheDocument()
+
+    view.rerender(map([{ ...freydis, x: 1421, y: 1699, z: 11 }]))
+
+    expect(await screen.findByText('1421, 1699, 11')).toBeInTheDocument()
+    expect(view.container.querySelector('.leaflet-popup')).not.toBeNull()
   })
 })

--- a/ui/src/components/map/LiveMap.tsx
+++ b/ui/src/components/map/LiveMap.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import {
@@ -10,6 +12,7 @@ import {
   type MapFacetInfo,
   type MapStyle,
 } from '../../lib/maps'
+import { directionDegrees, type OnlinePlayer } from '../../lib/online-players'
 
 export type WorldCoord = { x: number; y: number }
 
@@ -22,16 +25,125 @@ export type LiveMapProps = {
   centerTarget: WorldCoord | null
   /** The tile under the cursor, or null when the cursor leaves the map. */
   onHover: (coord: WorldCoord | null) => void
+  /** Staff players already filtered to this facet and to valid world bounds. */
+  players: readonly OnlinePlayer[]
+}
+
+function textElement<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className: string,
+  text: string,
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tag)
+  element.className = className
+  element.textContent = text
+  return element
+}
+
+function playerTooltip(player: OnlinePlayer): HTMLElement {
+  return textElement('span', 'mg-player-tooltip', player.characterName)
+}
+
+function addPopupRow(list: HTMLDListElement, label: string, value: string): void {
+  list.append(textElement('dt', 'mg-player-popup__label', label), textElement('dd', 'mg-player-popup__value', value))
+}
+
+function playerPopup(player: OnlinePlayer, t: TFunction): HTMLElement {
+  const root = document.createElement('section')
+  root.className = 'mg-player-popup'
+
+  root.append(
+    textElement('h3', 'mg-player-popup__title', player.characterName),
+    textElement('p', 'mg-player-popup__account', `${t('map.players.account')}: ${player.accountUsername}`),
+  )
+
+  const facts = document.createElement('dl')
+  facts.className = 'mg-player-popup__facts'
+  addPopupRow(facts, t('map.players.facet'), player.mapName)
+  addPopupRow(facts, t('map.players.coordinates'), `${player.x}, ${player.y}, ${player.z}`)
+  addPopupRow(facts, t('map.players.hits'), `${player.hits} / ${player.hitsMax}`)
+  addPopupRow(facts, t('map.players.direction'), player.direction)
+  root.append(facts)
+
+  const statuses = document.createElement('div')
+  statuses.className = 'mg-player-popup__statuses'
+  if (player.running) {
+    statuses.append(textElement('span', 'mg-player-popup__status', t('map.players.running')))
+  }
+  if (player.warmode) {
+    statuses.append(
+      textElement('span', 'mg-player-popup__status mg-player-popup__status--danger', t('map.players.warmode')),
+    )
+  }
+  if (statuses.childElementCount > 0) {
+    root.append(statuses)
+  }
+
+  const technical = document.createElement('details')
+  technical.className = 'mg-player-popup__technical'
+  technical.append(textElement('summary', 'mg-player-popup__summary', t('map.players.technical')))
+
+  const technicalFacts = document.createElement('dl')
+  technicalFacts.className = 'mg-player-popup__facts'
+  addPopupRow(technicalFacts, t('map.players.characterSerial'), player.characterSerial)
+  addPopupRow(technicalFacts, t('map.players.accountSerial'), player.accountSerial)
+  addPopupRow(technicalFacts, t('map.players.body'), String(player.body))
+  addPopupRow(technicalFacts, t('map.players.skinHue'), String(player.skinHue))
+  technical.append(technicalFacts)
+  root.append(technical)
+
+  return root
+}
+
+function playerIcon(player: OnlinePlayer): L.DivIcon {
+  const pin = document.createElement('span')
+  pin.className = 'mg-player-marker'
+  pin.classList.toggle('mg-player-marker--warmode', player.warmode)
+
+  const arrow = textElement('span', 'mg-player-marker__arrow', '▲')
+  arrow.style.transform = `rotate(${directionDegrees(player.direction)}deg)`
+  pin.append(arrow)
+
+  return L.divIcon({
+    className: 'mg-player-marker-host',
+    html: pin,
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+    tooltipAnchor: [0, -16],
+    popupAnchor: [0, -16],
+  })
+}
+
+function updatePlayerMarker(marker: L.Marker, player: OnlinePlayer, facet: MapFacetInfo, t: TFunction): void {
+  marker.setLatLng(worldToLatLng(facet, player.x, player.y))
+
+  const host = marker.getElement()
+  host?.setAttribute('title', player.characterName)
+  host?.setAttribute('aria-label', t('map.players.markerAlt', { name: player.characterName }))
+
+  const pin = host?.querySelector<HTMLElement>('.mg-player-marker')
+  pin?.classList.toggle('mg-player-marker--warmode', player.warmode)
+
+  const arrow = pin?.querySelector<HTMLElement>('.mg-player-marker__arrow')
+  if (arrow !== null && arrow !== undefined) {
+    arrow.style.transform = `rotate(${directionDegrees(player.direction)}deg)`
+  }
+
+  marker.getTooltip()?.setContent(playerTooltip(player))
+  marker.getPopup()?.setContent(playerPopup(player, t))
 }
 
 /**
- * The only imperative, Leaflet-touching piece. Every calculation lives in lib/maps.ts (and is unit-tested
- * there); this file is wiring: create the map, keep one tile layer, translate mouse events to world tiles.
+ * The only imperative, Leaflet-touching piece. Every calculation lives in lib/maps.ts and
+ * lib/online-players.ts; this file wires tiles, hover coordinates, and keyed staff markers.
  */
-export function LiveMap({ facet, style, centerTarget, onHover }: LiveMapProps) {
+export function LiveMap({ facet, style, centerTarget, onHover, players }: LiveMapProps) {
+  const { t } = useTranslation()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const mapRef = useRef<L.Map | null>(null)
   const layerRef = useRef<L.TileLayer | null>(null)
+  const playerLayerRef = useRef<L.LayerGroup | null>(null)
+  const playerMarkersRef = useRef(new Map<string, L.Marker>())
 
   // Read the latest onHover through a ref so changing the callback never re-subscribes the map events.
   const onHoverRef = useRef(onHover)
@@ -54,14 +166,20 @@ export function LiveMap({ facet, style, centerTarget, onHover }: LiveMapProps) {
     })
     map.fitBounds(bounds)
 
+    const playerLayer = L.layerGroup().addTo(map)
+    playerLayerRef.current = playerLayer
+
     map.on('mousemove', (e: L.LeafletMouseEvent) => onHoverRef.current(latLngToWorld(facet, e.latlng)))
     map.on('mouseout', () => onHoverRef.current(null))
 
     mapRef.current = map
     return () => {
+      playerLayer.clearLayers()
+      playerMarkersRef.current.clear()
       map.remove()
       mapRef.current = null
       layerRef.current = null
+      playerLayerRef.current = null
     }
   }, [facet])
 
@@ -81,6 +199,47 @@ export function LiveMap({ facet, style, centerTarget, onHover }: LiveMapProps) {
     layer.addTo(map)
     layerRef.current = layer
   }, [facet, style])
+
+  // Diff by serial so marker DOM and any open popup survive a five-second position update.
+  useEffect(() => {
+    const playerLayer = playerLayerRef.current
+    if (playerLayer === null) return
+
+    const present = new Set(players.map((player) => player.characterSerial))
+
+    for (const [serial, marker] of playerMarkersRef.current) {
+      if (present.has(serial)) continue
+      playerLayer.removeLayer(marker)
+      playerMarkersRef.current.delete(serial)
+    }
+
+    for (const player of players) {
+      let marker = playerMarkersRef.current.get(player.characterSerial)
+
+      if (marker === undefined) {
+        marker = L.marker(worldToLatLng(facet, player.x, player.y), {
+          icon: playerIcon(player),
+          keyboard: true,
+          title: player.characterName,
+          alt: t('map.players.markerAlt', { name: player.characterName }),
+          riseOnHover: true,
+        })
+          .bindTooltip(playerTooltip(player), {
+            direction: 'top',
+            opacity: 0.95,
+          })
+          .bindPopup(playerPopup(player, t), {
+            className: 'mg-player-popup-shell',
+            maxWidth: 320,
+          })
+          .addTo(playerLayer)
+
+        playerMarkersRef.current.set(player.characterSerial, marker)
+      }
+
+      updatePlayerMarker(marker, player, facet, t)
+    }
+  }, [facet, players, t])
 
   // Pan on demand. A fresh centerTarget object per request is what re-runs this (see MapScreen).
   useEffect(() => {

--- a/ui/src/lib/online-players.test.tsx
+++ b/ui/src/lib/online-players.test.tsx
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import type { MapFacetInfo } from './maps'
+import {
+  directionDegrees,
+  ONLINE_PLAYERS_QUERY_KEY,
+  ONLINE_PLAYERS_REFETCH_MS,
+  onlinePlayersQueryOptions,
+  playersForFacet,
+  type OnlinePlayer,
+  useOnlinePlayers,
+} from './online-players'
+
+const felucca: MapFacetInfo = {
+  name: 'Felucca',
+  width: 6144,
+  height: 4096,
+  maxZoom: 5,
+  tileSize: 256,
+  tilesAcross: 24,
+  tilesDown: 16,
+}
+
+const freydis: OnlinePlayer = {
+  characterSerial: '0x00000042',
+  characterName: 'Freydis',
+  accountSerial: '0x00000001',
+  accountUsername: 'alice',
+  mapId: 0,
+  mapName: 'Felucca',
+  x: 1420,
+  y: 1698,
+  z: 10,
+  direction: 'SouthEast',
+  running: false,
+  body: 401,
+  skinHue: 1002,
+  hits: 48,
+  hitsMax: 70,
+  warmode: false,
+}
+
+function queryWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('online players data module', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it.each([
+    ['North', 0],
+    ['NorthEast', 45],
+    ['East', 90],
+    ['SouthEast', 135],
+    ['South', 180],
+    ['SouthWest', 225],
+    ['West', 270],
+    ['NorthWest', 315],
+    ['Unexpected', 0],
+  ])('maps %s to %i degrees', (direction, expected) => {
+    expect(directionDegrees(direction)).toBe(expected)
+  })
+
+  it('keeps only valid players on the selected facet, case-insensitively', () => {
+    const players: OnlinePlayer[] = [
+      freydis,
+      { ...freydis, characterSerial: '0x43', mapName: 'felucca', x: 0, y: 0 },
+      { ...freydis, characterSerial: '0x44', mapName: 'Ilshenar' },
+      { ...freydis, characterSerial: '0x45', x: -1 },
+      { ...freydis, characterSerial: '0x46', x: felucca.width },
+      { ...freydis, characterSerial: '0x47', y: felucca.height },
+    ]
+
+    expect(playersForFacet(players, felucca).map((player) => player.characterSerial)).toEqual([
+      '0x00000042',
+      '0x43',
+    ])
+  })
+
+  it('describes five-second foreground polling only while enabled', () => {
+    expect(ONLINE_PLAYERS_QUERY_KEY).toEqual(['admin', 'players', 'online'])
+    expect(ONLINE_PLAYERS_REFETCH_MS).toBe(5000)
+    expect(onlinePlayersQueryOptions(true)).toMatchObject({
+      queryKey: ONLINE_PLAYERS_QUERY_KEY,
+      enabled: true,
+      refetchInterval: 5000,
+      refetchIntervalInBackground: false,
+      refetchOnWindowFocus: true,
+    })
+    expect(onlinePlayersQueryOptions(false)).toMatchObject({
+      enabled: false,
+      refetchInterval: false,
+    })
+  })
+
+  it('does not request the admin endpoint while disabled', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json([]))
+
+    const { result } = renderHook(() => useOnlinePlayers(false), {
+      wrapper: queryWrapper(),
+    })
+
+    await Promise.resolve()
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('reads the online-player snapshot while enabled', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json([freydis]))
+
+    const { result } = renderHook(() => useOnlinePlayers(true), {
+      wrapper: queryWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.data).toEqual([freydis]))
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/v1/admin/players/online',
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    )
+  })
+})

--- a/ui/src/lib/online-players.test.tsx
+++ b/ui/src/lib/online-players.test.tsx
@@ -82,10 +82,7 @@ describe('online players data module', () => {
       { ...freydis, characterSerial: '0x47', y: felucca.height },
     ]
 
-    expect(playersForFacet(players, felucca).map((player) => player.characterSerial)).toEqual([
-      '0x00000042',
-      '0x43',
-    ])
+    expect(playersForFacet(players, felucca).map((player) => player.characterSerial)).toEqual(['0x00000042', '0x43'])
   })
 
   it('describes five-second foreground polling only while enabled', () => {

--- a/ui/src/lib/online-players.ts
+++ b/ui/src/lib/online-players.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from './api'
+import type { components } from './api-types'
+import type { MapFacetInfo } from './maps'
+
+export type OnlinePlayer = components['schemas']['OnlinePlayerMapResponse']
+
+export const ONLINE_PLAYERS_QUERY_KEY = ['admin', 'players', 'online'] as const
+export const ONLINE_PLAYERS_REFETCH_MS = 5000
+
+export function directionDegrees(direction: string): number {
+  switch (direction) {
+    case 'NorthEast':
+      return 45
+    case 'East':
+      return 90
+    case 'SouthEast':
+      return 135
+    case 'South':
+      return 180
+    case 'SouthWest':
+      return 225
+    case 'West':
+      return 270
+    case 'NorthWest':
+      return 315
+    default:
+      return 0
+  }
+}
+
+export function playersForFacet(players: readonly OnlinePlayer[], facet: MapFacetInfo): OnlinePlayer[] {
+  const facetName = facet.name.toLowerCase()
+
+  return players.filter(
+    (player) =>
+      player.mapName.toLowerCase() === facetName &&
+      player.x >= 0 &&
+      player.x < facet.width &&
+      player.y >= 0 &&
+      player.y < facet.height,
+  )
+}
+
+export function onlinePlayersQueryOptions(enabled: boolean) {
+  return {
+    queryKey: ONLINE_PLAYERS_QUERY_KEY,
+    queryFn: () => apiFetch<OnlinePlayer[]>('/api/v1/admin/players/online'),
+    enabled,
+    refetchInterval: enabled ? ONLINE_PLAYERS_REFETCH_MS : false,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+  } as const
+}
+
+export const useOnlinePlayers = (enabled: boolean) => useQuery(onlinePlayersQueryOptions(enabled))

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -45,7 +45,25 @@
     "copyHint": "Click to copy the coordinate",
     "copied": "Copied {{x}}, {{y}}",
     "jumpError": "Enter a coordinate inside the facet (0–{{width}}, 0–{{height}}).",
-    "unavailable": "The map is unavailable — the shard has not loaded its client files."
+    "unavailable": "The map is unavailable — the shard has not loaded its client files.",
+    "players": {
+      "toggle": "Online players",
+      "count": "{{visible}} / {{total}}",
+      "unavailable": "Player positions are temporarily unavailable.",
+      "markerAlt": "{{name}} on the map",
+      "account": "Account",
+      "facet": "Facet",
+      "coordinates": "Coordinates",
+      "hits": "Hits",
+      "direction": "Direction",
+      "running": "Running",
+      "warmode": "War mode",
+      "technical": "Technical details",
+      "characterSerial": "Character serial",
+      "accountSerial": "Account serial",
+      "body": "Body",
+      "skinHue": "Skin hue"
+    }
   },
   "common": {
     "signOut": "Sign out",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -45,7 +45,25 @@
     "copyHint": "Clicca per copiare la coordinata",
     "copied": "Copiato {{x}}, {{y}}",
     "jumpError": "Inserisci una coordinata dentro la facet (0–{{width}}, 0–{{height}}).",
-    "unavailable": "Mappa non disponibile — lo shard non ha caricato i file client."
+    "unavailable": "Mappa non disponibile — lo shard non ha caricato i file client.",
+    "players": {
+      "toggle": "Giocatori online",
+      "count": "{{visible}} / {{total}}",
+      "unavailable": "Le posizioni dei giocatori non sono momentaneamente disponibili.",
+      "markerAlt": "{{name}} sulla mappa",
+      "account": "Account",
+      "facet": "Facet",
+      "coordinates": "Coordinate",
+      "hits": "Punti vita",
+      "direction": "Direzione",
+      "running": "In corsa",
+      "warmode": "Modalità guerra",
+      "technical": "Dettagli tecnici",
+      "characterSerial": "Seriale personaggio",
+      "accountSerial": "Seriale account",
+      "body": "Body",
+      "skinHue": "Skin hue"
+    }
   },
   "common": {
     "signOut": "Esci",

--- a/ui/src/routes/MapScreen.test.tsx
+++ b/ui/src/routes/MapScreen.test.tsx
@@ -5,6 +5,14 @@ import '../lib/i18n'
 import { MapScreen } from './MapScreen'
 import type { LiveMapProps } from '../components/map/LiveMap'
 
+const authState = vi.hoisted(() => ({
+  level: 'Administrator' as string | null,
+}))
+
+vi.mock('../lib/auth', () => ({
+  useSession: () => ({ level: authState.level }),
+}))
+
 // Leaflet can't lay out in jsdom, so the map is replaced by a stub that records the props it was given as
 // data-attributes and exposes a button to fire onHover — enough to drive every control.
 vi.mock('../components/map/LiveMap', () => ({
@@ -14,6 +22,7 @@ vi.mock('../components/map/LiveMap', () => ({
       data-facet={props.facet.name}
       data-style={props.style}
       data-center={props.centerTarget ? `${props.centerTarget.x},${props.centerTarget.y}` : ''}
+      data-players={props.players.map((player) => player.characterName).join(',')}
     >
       <button type="button" onClick={() => props.onHover({ x: 1234, y: 5678 })}>
         hover
@@ -27,24 +36,86 @@ const facets = [
   { name: 'Ilshenar', width: 2304, height: 1600, maxZoom: 4, tileSize: 256, tilesAcross: 9, tilesDown: 7 },
 ]
 
+const onlinePlayers = [
+  {
+    characterSerial: '0x42',
+    characterName: 'Freydis',
+    accountSerial: '0x01',
+    accountUsername: 'alice',
+    mapId: 0,
+    mapName: 'Felucca',
+    x: 1420,
+    y: 1698,
+    z: 10,
+    direction: 'SouthEast',
+    running: false,
+    body: 401,
+    skinHue: 1002,
+    hits: 48,
+    hitsMax: 70,
+    warmode: false,
+  },
+  {
+    characterSerial: '0x43',
+    characterName: 'Dupre',
+    accountSerial: '0x02',
+    accountUsername: 'bob',
+    mapId: 2,
+    mapName: 'Ilshenar',
+    x: 100,
+    y: 200,
+    z: 0,
+    direction: 'North',
+    running: true,
+    body: 400,
+    skinHue: 0,
+    hits: 60,
+    hitsMax: 60,
+    warmode: false,
+  },
+  {
+    characterSerial: '0x44',
+    characterName: 'Lost',
+    accountSerial: '0x03',
+    accountUsername: 'carol',
+    mapId: 99,
+    mapName: 'Unknown',
+    x: 10,
+    y: 10,
+    z: 0,
+    direction: 'West',
+    running: false,
+    body: 400,
+    skinHue: 0,
+    hits: 10,
+    hitsMax: 10,
+    warmode: false,
+  },
+]
+
 function json(body: unknown) {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
 }
 
 function renderScreen() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(
+  const view = render(
     <QueryClientProvider client={client}>
       <MapScreen />
     </QueryClientProvider>,
   )
+
+  return { ...view, client }
 }
 
 describe('MapScreen', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    authState.level = 'Administrator'
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-      if (String(input).includes('/api/v1/images/maps')) return json(facets)
+      const url = String(input)
+      if (url.includes('/api/v1/images/maps')) return json(facets)
+      if (url.includes('/api/v1/admin/players/online')) return json(onlinePlayers)
       return json({})
     })
   })
@@ -107,5 +178,100 @@ describe('MapScreen', () => {
 
     await userEvent.selectOptions(screen.getByLabelText('Facet'), 'Ilshenar')
     await waitFor(() => expect(screen.getByTestId('live-map')).toHaveAttribute('data-center', ''))
+  })
+
+  it.each(['Administrator', 'GrandMaster'])('shows the online-player overlay to %s', async (level) => {
+    authState.level = level
+    renderScreen()
+
+    expect(await screen.findByLabelText('Online players')).toBeChecked()
+    expect(await screen.findByText('1 / 3')).toBeInTheDocument()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', 'Freydis')
+  })
+
+  it('never exposes or requests the admin overlay for a player account', async () => {
+    authState.level = 'Player'
+    const fetchSpy = vi.mocked(globalThis.fetch)
+    renderScreen()
+
+    await screen.findByTestId('live-map')
+    expect(screen.queryByLabelText('Online players')).not.toBeInTheDocument()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', '')
+    expect(fetchSpy.mock.calls.some(([input]) => String(input).includes('/api/v1/admin/players/online'))).toBe(false)
+  })
+
+  it('switches the visible player subset with the facet', async () => {
+    renderScreen()
+    expect(await screen.findByText('1 / 3')).toBeInTheDocument()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', 'Freydis')
+
+    await userEvent.selectOptions(screen.getByLabelText('Facet'), 'Ilshenar')
+
+    await waitFor(() => expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', 'Dupre'))
+    expect(screen.getByText('1 / 3')).toBeInTheDocument()
+  })
+
+  it('hides players, disables polling, and refetches when re-enabled', async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch)
+    renderScreen()
+
+    const toggle = await screen.findByLabelText('Online players')
+    await screen.findByText('1 / 3')
+    const initialRequests = fetchSpy.mock.calls.filter(([input]) =>
+      String(input).includes('/api/v1/admin/players/online'),
+    ).length
+
+    await userEvent.click(toggle)
+    expect(toggle).not.toBeChecked()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', '')
+    expect(screen.getByText('0 / 3')).toBeInTheDocument()
+
+    await userEvent.click(toggle)
+    expect(toggle).toBeChecked()
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.filter(([input]) => String(input).includes('/api/v1/admin/players/online')).length,
+      ).toBeGreaterThan(initialRequests),
+    )
+  })
+
+  it('keeps the map usable when the player snapshot fails', async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/v1/images/maps')) return json(facets)
+      if (url.includes('/api/v1/admin/players/online')) {
+        return new Response(null, { status: 503 })
+      }
+      return json({})
+    })
+
+    renderScreen()
+
+    expect(await screen.findByTestId('live-map')).toBeInTheDocument()
+    expect(await screen.findByText('Player positions are temporarily unavailable.')).toBeInTheDocument()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', '')
+  })
+
+  it('retains the last marker snapshot when a background refetch fails', async () => {
+    let playerRequestFails = false
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/v1/images/maps')) return json(facets)
+      if (url.includes('/api/v1/admin/players/online')) {
+        return playerRequestFails ? new Response(null, { status: 503 }) : json(onlinePlayers)
+      }
+      return json({})
+    })
+
+    const { client } = renderScreen()
+    expect(await screen.findByText('1 / 3')).toBeInTheDocument()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', 'Freydis')
+
+    playerRequestFails = true
+    await client.invalidateQueries({ queryKey: ['admin', 'players', 'online'] })
+
+    expect(await screen.findByText('Player positions are temporarily unavailable.')).toBeInTheDocument()
+    expect(screen.getByTestId('live-map')).toHaveAttribute('data-players', 'Freydis')
+    expect(screen.getByText('1 / 3')).toBeInTheDocument()
   })
 })

--- a/ui/src/routes/MapScreen.tsx
+++ b/ui/src/routes/MapScreen.tsx
@@ -142,7 +142,14 @@ export function MapScreen() {
       )}
 
       <Card className="relative h-[70vh] overflow-hidden p-0">
-        <LiveMap key={facet.name} facet={facet} style={style} centerTarget={centerTarget} onHover={setHover} />
+        <LiveMap
+          key={facet.name}
+          facet={facet}
+          style={style}
+          centerTarget={centerTarget}
+          onHover={setHover}
+          players={[]}
+        />
 
         {/* Coordinate readout as a corner overlay, like a real map viewer; click to copy. */}
         <button

--- a/ui/src/routes/MapScreen.tsx
+++ b/ui/src/routes/MapScreen.tsx
@@ -8,28 +8,40 @@ import { Switch } from '../components/ui/switch'
 import { Button } from '../components/ui/button'
 import { LiveMap, type WorldCoord } from '../components/map/LiveMap'
 import { clampWorld, useMaps, type MapFacetInfo, type MapStyle } from '../lib/maps'
+import { useSession } from '../lib/auth'
+import { isAdmin } from '../lib/roles'
+import { playersForFacet, useOnlinePlayers } from '../lib/online-players'
 
 // The default facet when the shard serves it; otherwise the first one it does serve (see below).
 const PREFERRED_FACET = 'Felucca'
 
 export function MapScreen() {
   const { t } = useTranslation()
+  const { level } = useSession()
+  const staff = isAdmin(level)
   const maps = useMaps()
 
   const facets = maps.data ?? []
   const [facetName, setFacetName] = useState<string | null>(null)
   const [style, setStyle] = useState<MapStyle>('flat')
+  const [playersVisible, setPlayersVisible] = useState(true)
   const [hover, setHover] = useState<WorldCoord | null>(null)
   const [centerTarget, setCenterTarget] = useState<WorldCoord | null>(null)
   const [jumpX, setJumpX] = useState('')
   const [jumpY, setJumpY] = useState('')
   const [jumpError, setJumpError] = useState(false)
+  const onlinePlayers = useOnlinePlayers(staff && playersVisible)
 
   // The selected facet: the user's pick, else Felucca, else the first the shard serves.
   const facet: MapFacetInfo | undefined = useMemo(() => {
     if (facets.length === 0) return undefined
     return facets.find((f) => f.name === facetName) ?? facets.find((f) => f.name === PREFERRED_FACET) ?? facets[0]
   }, [facets, facetName])
+
+  const visiblePlayers = useMemo(
+    () => (facet !== undefined && playersVisible ? playersForFacet(onlinePlayers.data ?? [], facet) : []),
+    [facet, onlinePlayers.data, playersVisible],
+  )
 
   if (maps.isPending) {
     return <p className="text-sm text-muted">{t('common.loading')}</p>
@@ -110,6 +122,28 @@ export function MapScreen() {
           </Label>
         </div>
 
+        {staff && (
+          <div className="flex items-center gap-2">
+            <Switch id="map-online-players" checked={playersVisible} onCheckedChange={setPlayersVisible} />
+            <Label htmlFor="map-online-players" className="text-ink">
+              {t('map.players.toggle')}
+            </Label>
+            <span aria-live="polite" className="font-mono text-xs text-muted">
+              {onlinePlayers.isPending
+                ? '…'
+                : t('map.players.count', {
+                    visible: visiblePlayers.length,
+                    total: onlinePlayers.data?.length ?? 0,
+                  })}
+            </span>
+            {playersVisible && onlinePlayers.isError && (
+              <span role="status" className="text-xs text-danger-text">
+                {t('map.players.unavailable')}
+              </span>
+            )}
+          </div>
+        )}
+
         <form onSubmit={submitJump} className="flex items-center gap-2">
           <Label htmlFor="map-x" className="text-muted">
             {t('map.x')}
@@ -148,7 +182,7 @@ export function MapScreen() {
           style={style}
           centerTarget={centerTarget}
           onHover={setHover}
-          players={[]}
+          players={staff && playersVisible ? visiblePlayers : []}
         />
 
         {/* Coordinate readout as a corner overlay, like a real map viewer; click to copy. */}

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -108,3 +108,105 @@ body {
   color: var(--mg-text);
   font-family: var(--mg-font-body);
 }
+
+.mg-player-marker-host {
+  border: 0;
+  background: transparent;
+}
+
+.mg-player-marker {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 2px solid var(--mg-gold-hi);
+  border-radius: 50%;
+  background: var(--mg-gold);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 45%);
+}
+
+.mg-player-marker--warmode {
+  border-color: var(--mg-danger-text);
+  background: var(--mg-danger);
+}
+
+.mg-player-marker__arrow {
+  color: var(--mg-gold-ink);
+  font-size: 12px;
+  line-height: 1;
+  transform-origin: center;
+}
+
+.mg-player-popup-shell .leaflet-popup-content-wrapper,
+.mg-player-popup-shell .leaflet-popup-tip {
+  border: 1px solid var(--mg-border-strong);
+  border-radius: var(--mg-radius-card);
+  background: var(--mg-surface);
+  color: var(--mg-text);
+}
+
+.mg-player-popup-shell .leaflet-popup-content {
+  margin: 14px;
+}
+
+.mg-player-popup {
+  min-width: 220px;
+  font-family: var(--mg-font-body);
+}
+
+.mg-player-popup__title {
+  margin: 0;
+  color: var(--mg-gold);
+  font-family: var(--mg-font-display);
+  font-size: 17px;
+}
+
+.mg-player-popup__account {
+  margin: 2px 0 10px;
+  color: var(--mg-text-muted);
+}
+
+.mg-player-popup__facts {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 3px 10px;
+  margin: 0;
+}
+
+.mg-player-popup__label {
+  color: var(--mg-text-faint);
+}
+
+.mg-player-popup__value {
+  margin: 0;
+  color: var(--mg-text);
+  text-align: right;
+}
+
+.mg-player-popup__statuses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.mg-player-popup__status {
+  border: 1px solid var(--mg-border-strong);
+  padding: 1px 5px;
+  color: var(--mg-text-muted);
+  font-size: 13px;
+}
+
+.mg-player-popup__status--danger {
+  border-color: var(--mg-danger);
+  color: var(--mg-danger-text);
+}
+
+.mg-player-popup__technical {
+  margin-top: 10px;
+  color: var(--mg-text-faint);
+}
+
+.mg-player-popup__summary {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary

- add a staff-only online-player overlay to the existing live map
- poll the read-only admin snapshot every 5 seconds while the overlay is enabled and the tab is active
- render keyed Leaflet markers with facing direction, warmode styling, safe tooltips, and detailed popups
- filter markers to the selected facet and valid map bounds, with localized controls, counts, and non-blocking errors

## Validation

- `npm --prefix ui run test:run` — 39 files, 141 tests passed
- `npm --prefix ui run build`
- Prettier check passed for all 9 changed files
- OpenAPI and generated API types unchanged

Note: the repository-wide Prettier check still reports the pre-existing `ui/scripts/generate-api-types.mjs`, which is byte-identical to `develop` and outside this PR.

Refs #104