### PR TITLE
feat(ai): add deterministic Lua NPC brains

### DIFF
--- a/docs/scripting/data/mobile-templates.md
+++ b/docs/scripting/data/mobile-templates.md
@@ -65,7 +65,7 @@ path order) into one flat list, then `MobileTemplateBaseResolver` resolves
 | `Equipment` | `List<MobileEquipmentEntry>` | optional, default `[]` | **Wholesale replace**: if the derived template declares any equipment at all, the entire base list is discarded (not merged item-by-item). |
 | `Variants` | `List<MobileVariant>` | optional, default `[]` | **Wholesale replace**, same rule as `Equipment`. See [Variants](#variants). |
 | `LootTableId` | `string?` | optional, default `null` | Derived value wins if set, else the base's (`derived ?? base`). |
-| `BrainScript` | `string?` | optional, default `null` | Derived value wins if set, else the base's (`derived ?? base`). **Reserved** — copied onto the spawned mobile's `BrainScriptId` but no AI dispatcher in this codebase reads it yet. |
+| `BrainScript` | `string?` | optional, default `null` | Derived value wins if set, else the base's (`derived ?? base`). Binds the spawned NPC to `scripts/brains/<BrainScript>.lua`; the file's returned `id` must match. See [NPC brains](../guides/npc-brains.md). |
 
 ### Gender
 

--- a/docs/scripting/guides/how-scripting-works.md
+++ b/docs/scripting/guides/how-scripting-works.md
@@ -35,8 +35,10 @@ and pull them in with Lua's `require`; the loader searches the `scripts/`
 directory (including a `modules/` subfolder), so `require("modules/spawns")`
 loads `scripts/modules/spawns.lua`.
 
-The server also watches `scripts/` for changes while running, so edits to your
-`.lua` files are picked up without a restart.
+Bootstrap-script reload is handled by SquidStd. NPC brain files are different:
+`scripts/brains/*.lua` has its own dedicated watcher which validates a changed
+candidate before replacing the active brain definition. See
+[NPC brains](npc-brains.md#runtime-behavior).
 
 ## The game-loop thread
 

--- a/docs/scripting/guides/npc-brains.md
+++ b/docs/scripting/guides/npc-brains.md
@@ -65,7 +65,7 @@ end
 return guard
 ```
 
-The four required fields are:
+The five required fields are:
 
 | Field | Type | Rules |
 |---|---|---|
@@ -152,11 +152,15 @@ each same-id binding's private state and home.
 
 Brain files are loaded with an allowlisted authoring environment: the `brain`
 helpers, selected base functions (`assert`, `error`, `ipairs`, `next`, `pairs`,
-`pcall`, `select`, `tonumber`, `tostring`, `type`, `xpcall`), and the `math`,
-`string`, and `table` libraries. General world-mutating modules are not exposed
-to a brain file. This is the supported authoring contract; brains are loaded by
-the shared Lua engine through `Script.LoadFile`, so do not treat it as a
-stronger security sandbox than that implementation provides.
+`pcall`, `select`, `tonumber`, `tostring`, `type`, `xpcall`), and bounded
+subsets of the `math`, `string`, and `table` libraries. Native callbacks whose
+work scales with their input are capped at 4,096 characters or 1,024 values.
+Pattern matching, formatting, function dumping, and `table.sort` are
+unavailable because MoonSharp executes those operations in native callbacks
+outside the Lua instruction counter. General world-mutating modules are not
+exposed to a brain file. This is the supported authoring contract; brains are
+loaded by the shared Lua engine through `Script.LoadFile`, so do not treat it
+as a stronger security sandbox than that implementation provides.
 
 ## Intents and limits
 

--- a/docs/scripting/guides/npc-brains.md
+++ b/docs/scripting/guides/npc-brains.md
@@ -1,0 +1,191 @@
+# NPC brains
+
+NPC brains are small Lua strategies for non-player mobiles. A mobile template
+binds one with [`BrainScript`](../data/mobile-templates.md#top-level-keys); the
+value `guard`, for example, loads `scripts/brains/guard.lua` from the server
+root.
+
+Brains observe a snapshot of the world and return **intents**. They never
+receive a `MobileEntity` and cannot mutate the world directly. The server
+validates and executes accepted intents on the game loop. See the [`brain`
+reference](../reference/brain.md) for the helper signatures.
+
+## Write a brain
+
+Create exactly one file at `scripts/brains/<id>.lua`. Its filename and the
+returned table's `id` must match exactly. Brain ids use lowercase letters,
+digits, `_`, and `-`; they must begin with a letter or digit.
+
+The file returns one table. It does not register a global. The returned
+definition and its Lua environment are shared by every mobile using that brain
+id, so treat both as stateless strategy data. Put every per-mobile value in the
+`state` table passed to the hooks.
+
+This is the shipped `guard` brain shape:
+
+```lua
+-- scripts/brains/guard.lua
+local guard = {
+    id = "guard",
+    default_tick_ms = 1000,
+    perception_range = 12,
+    hearing_range = 15,
+}
+
+function guard.on_speech_heard(ctx, state, event)
+    if event == nil or event.speaker_is_player ~= true then
+        return nil
+    end
+
+    state.seen_players = state.seen_players or {}
+
+    local speaker_id = event.speaker_id
+    local known = state.seen_players[speaker_id]
+
+    if known == nil then
+        state.seen_players[speaker_id] = {
+            first_seen_at = ctx.now_ms,
+            last_seen_at = ctx.now_ms,
+            conversations = 1,
+        }
+
+        return brain.say("Non ti avevo mai visto prima.")
+    end
+
+    known.last_seen_at = ctx.now_ms
+    known.conversations = known.conversations + 1
+
+    return brain.say("Bentornato.")
+end
+
+function guard.think()
+    return brain.idle()
+end
+
+return guard
+```
+
+The four required fields are:
+
+| Field | Type | Rules |
+|---|---|---|
+| `id` | string | Must exactly equal the filename without `.lua`. |
+| `default_tick_ms` | integer | Default delay before the next `think`; must be within the configured minimum and maximum. |
+| `perception_range` | integer | `0` through `64`; controls `ctx.nearby` and range events. |
+| `hearing_range` | integer | `0` through `64`; controls speech events. |
+| `think` | function | Required periodic hook. |
+
+Each hook is called as `hook(ctx, state, event)`. `think` receives `nil` for
+`event`. A hook returns `nil`, one intent, or `brain.decision(next_tick_ms,
+intents)`. Hooks may not yield.
+
+## Context, state, and events
+
+`ctx` is a fresh snapshot-shaped Lua table for each invocation. Changing that
+table changes only the Lua value for the current call, never world state:
+
+| Key | Shape |
+|---|---|
+| `now_ms` | Unix time in milliseconds. |
+| `self` | Mobile snapshot: `id`, `name`, `is_player`, `map_id`, `position`, `hits`, `hits_max`, `hits_percent`, `warmode`, `combatant_id`, `criminal`, `kills`. |
+| `home` | `{ map_id, position }`, where `position` has `x`, `y`, `z`. |
+| `nearby` | Array of the same mobile snapshots, excluding `self`, within `perception_range`. |
+
+`combatant_id` is `nil` when no combatant is set. Every `position` table has
+`x`, `y`, and `z`.
+
+`state` is a private Lua table for one mobile, initially empty. It is retained
+when that mobile's brain sleeps and wakes, and it survives a successful reload
+of the same brain id. It is not persisted: a server restart starts with a new
+state table. Changing a mobile to a different brain id replaces its state table
+with a new one. The scheduler also clears state after four consecutive brain
+failures before retrying.
+
+`ctx.home` is the mobile's map and position when its current brain binding is
+created. It remains that bind-time origin through sleep/wake and a successful
+same-id reload. A brain-id change captures a new home, as does a server
+restart.
+
+## Hooks and event payloads
+
+`think(ctx, state, nil)` is required. All other hooks are optional; omit them
+or set them to `nil` when unused. Every delivered event table has a lowercase
+`type` key.
+
+| Hook | `event` keys |
+|---|---|
+| `on_activate` | `type = "activate"` |
+| `on_deactivate` | `type = "deactivate"` |
+| `on_speech_heard` | `type = "speechheard"`, `speaker_id`, `speaker_name`, `speaker_is_player`, `speech_type`, `text` |
+| `on_mobile_entered_range` | `type = "mobileenteredrange"`, `mobile_id`, `mobile_name`, `mobile_is_player`, `from_position`, `to_position` |
+| `on_mobile_left_range` | `type = "mobileleftrange"`, `mobile_id`, `mobile_name`, `mobile_is_player`, `from_position`, `to_position` |
+| `on_mobile_moved` | `type = "mobilemoved"`, `mobile_id`, `mobile_name`, `mobile_is_player`, `from_position`, `to_position` |
+| `on_attacked` | `type = "attacked"`, `attacker_id` |
+| `on_damage` | `type = "damage"`, `attacker_id`, `amount` |
+| `on_death` | `type = "death"`, `killer_id` |
+
+Subject ids and associated fields are `nil` when the source mobile cannot be
+resolved. `speech_type` and `text` are also `nil` when unavailable. Position
+keys are `nil` when the source event has no position; otherwise they are
+`{ x, y, z }`. `amount` is the reported damage amount.
+
+## Runtime behavior
+
+Brain execution is activated by **players only**. Each online player keeps the
+3×3 sector square centered on that player active. When the last player leaves a
+sector, it stays active for the configured grace period, 60 seconds by default,
+then brain execution there deactivates. This affects Lua AI only: it does not
+sleep the mobile entity or unrelated server systems.
+
+Activation queues `on_activate`; deactivation queues `on_deactivate`, runs that
+hook once, then sleeps the brain and clears its queued events. While active, the
+scheduler processes events before due `think` work. It gives one brain at most
+one wake per scheduler loop.
+
+The brain directory is seeded with missing built-in files (`guard.lua`,
+`orion.lua`, and `vega.lua`) without replacing an existing local file. A
+dedicated watcher observes direct `*.lua` changes in `scripts/brains/`,
+debounces them, and validates the candidate before installing it. Invalid Lua,
+metadata, or load results leave the last known-good definition in use. A
+successful reload updates the shared strategy and metadata while preserving
+each same-id binding's private state and home.
+
+Brain files are loaded with an allowlisted authoring environment: the `brain`
+helpers, selected base functions (`assert`, `error`, `ipairs`, `next`, `pairs`,
+`pcall`, `select`, `tonumber`, `tostring`, `type`, `xpcall`), and the `math`,
+`string`, and `table` libraries. General world-mutating modules are not exposed
+to a brain file. This is the supported authoring contract; brains are loaded by
+the shared Lua engine through `Script.LoadFile`, so do not treat it as a
+stronger security sandbox than that implementation provides.
+
+## Intents and limits
+
+Use [`brain`](../reference/brain.md) helpers to return intent tables. Intent
+execution is the only mutation boundary. The executor resolves the mobile
+again, validates target ids against the current perception snapshot and map,
+and may reject an intent; a returned intent is not a direct command.
+
+In particular, `brain.engage(target_id)` validates a visible target and, in v1,
+sets the owner's combat target and warmode. It does **not** attack or deal
+damage. `brain.say("...")` speaks only as the brain's owner (regular speech,
+range 15); it takes no serial, so a brain cannot choose an arbitrary speaker.
+
+The complete default `moongate.npcAi.advanced` limits are:
+
+| Setting | Default | Effect |
+|---|---:|---|
+| `sectorIdleGraceSeconds` | 60 | Grace before an uncovered player sector deactivates. |
+| `minTickMilliseconds` | 100 | Minimum hook-selected or default `think` delay. |
+| `maxTickMilliseconds` | 60,000 | Maximum hook-selected or default `think` delay. |
+| `maxBrainsPerLoop` | 100 | Brains the scheduler may wake in one loop. |
+| `maxEventsPerBrainWake` | 16 | Mailbox events delivered before `think` in one wake. |
+| `maxMailboxEvents` | 64 | Maximum queued mailbox events per brain. |
+| `maxIntentsPerDecision` | 8 | Intent tables read from one `brain.decision`. |
+| `instructionBudget` | 50,000 | Lua instruction budget for definition load and each hook. |
+
+All values must be positive; the minimum tick cannot exceed the maximum, and
+`maxMailboxEvents` cannot be smaller than `maxEventsPerBrainWake`. Brain files
+are limited to 256 KiB and cannot be symbolic links or reparse points. When a
+mailbox is full, lower-priority events can be dropped; movement events are
+coalesced. Invalid, unknown, malformed, or excess intents are ignored or
+rejected rather than granting extra capabilities.

--- a/docs/scripting/index.md
+++ b/docs/scripting/index.md
@@ -6,6 +6,10 @@ subscribe to server events, and create or manipulate items and mobiles by
 serial. Each module is a C# class bridged into the Lua runtime (the SquidStd
 scripting engine, built on MoonSharp).
 
+NPC behavior is authored separately as [NPC brains](guides/npc-brains.md).
+Brain files use their own `brain` helper environment and return validated
+intents; they do not receive the ordinary scripting modules below.
+
 ## Modules
 
 | Module | Purpose | Reference |

--- a/docs/scripting/reference/brain.md
+++ b/docs/scripting/reference/brain.md
@@ -1,0 +1,99 @@
+# brain
+
+`brain` creates NPC-brain intent tables. It exists only in a brain file's
+isolated environment; it is not available to ordinary `bootstrap.lua`,
+`init.lua`, or `main.lua` scripts.
+
+An intent is declarative. Return it from a hook and the server validates and
+applies it on the game loop. See the [NPC brains guide](../guides/npc-brains.md)
+for the file format, hooks, context, and lifecycle.
+
+## brain.idle
+
+```lua
+brain.idle() -> intent
+```
+
+Returns a no-op intent.
+
+## brain.say
+
+```lua
+brain.say(text) -> intent
+```
+
+Returns a regular-speech intent. `text` must be a non-blank string of at most
+128 characters to be accepted. The server always speaks as the brain owner;
+this helper accepts no arbitrary mobile serial.
+
+## brain.patrol
+
+```lua
+brain.patrol() -> intent
+```
+
+Returns a patrol intent. On its home map, the owner moves in a random direction
+while within eight tiles of `ctx.home.position`; outside that leash it moves one
+step toward home instead.
+
+## brain.move_toward
+
+```lua
+brain.move_toward(target_id) -> intent
+```
+
+Returns an intent to move one eight-way step toward `target_id`. The target must
+be a positive serial in `ctx.nearby`, must still exist, and must be on the
+owner's current map.
+
+## brain.move_away
+
+```lua
+brain.move_away(target_id) -> intent
+```
+
+Returns an intent to move one eight-way step away from `target_id`, with the
+same target checks as `brain.move_toward`.
+
+## brain.engage
+
+```lua
+brain.engage(target_id) -> intent
+```
+
+Returns an intent to engage a visible target. In v1 the accepted result only
+sets the owner's combat target and enables warmode. It does not move, attack,
+or deal damage.
+
+## brain.clear_target
+
+```lua
+brain.clear_target() -> intent
+```
+
+Returns an intent that clears the owner's combat target and disables warmode.
+
+## brain.return_home
+
+```lua
+brain.return_home() -> intent
+```
+
+Returns an intent to take one step toward `ctx.home.position`. It is accepted
+only while the owner remains on `ctx.home.map_id`.
+
+## brain.decision
+
+```lua
+brain.decision(next_tick_ms, intents) -> decision
+```
+
+Returns a decision table with these fields:
+
+| Key | Meaning |
+|---|---|
+| `next_tick_ms` | Requested delay before the next `think`; finite numbers are truncated and clamped to the configured minimum/maximum. Non-numbers leave the schedule unchanged. |
+| `intents` | Lua array of intent tables. Only the first configured maximum is read (8 by default). |
+
+A hook may return one intent directly instead of a decision. Returning `nil`
+produces no intents. Any other return type is a hook failure.

--- a/docs/scripting/reference/brain.md
+++ b/docs/scripting/reference/brain.md
@@ -11,89 +11,100 @@ for the file format, hooks, context, and lifecycle.
 ## brain.idle
 
 ```lua
-brain.idle() -> intent
+brain.idle() -> { type = "idle" }
 ```
 
-Returns a no-op intent.
+Returns the no-op intent table `{ type = "idle" }`.
 
 ## brain.say
 
 ```lua
-brain.say(text) -> intent
+brain.say(text) -> { type = "say", text = text }
 ```
 
-Returns a regular-speech intent. `text` must be a non-blank string of at most
-128 characters to be accepted. The server always speaks as the brain owner;
-this helper accepts no arbitrary mobile serial.
+Returns `{ type = "say", text = text }`, passing its argument through without
+validation. `text` must be a non-blank string of at most 128 characters for
+the intent to be accepted. The server always speaks as the brain owner; this
+helper accepts no arbitrary mobile serial.
 
 ## brain.patrol
 
 ```lua
-brain.patrol() -> intent
+brain.patrol() -> { type = "patrol" }
 ```
 
-Returns a patrol intent. On its home map, the owner moves in a random direction
-while within eight tiles of `ctx.home.position`; outside that leash it moves one
-step toward home instead.
+Returns `{ type = "patrol" }`. On its home map, the owner moves in a random
+direction while within eight tiles of `ctx.home.position`; outside that leash
+it moves one step toward home instead.
 
 ## brain.move_toward
 
 ```lua
-brain.move_toward(target_id) -> intent
+brain.move_toward(target_id) -> { type = "move_toward", target_id = target_id }
 ```
 
-Returns an intent to move one eight-way step toward `target_id`. The target must
-be a positive serial in `ctx.nearby`, must still exist, and must be on the
-owner's current map.
+Returns `{ type = "move_toward", target_id = target_id }`, passing its
+argument through without validation. The target must be a positive integer
+serial in `ctx.nearby`, must still exist, and must be on the owner's current
+map.
 
 ## brain.move_away
 
 ```lua
-brain.move_away(target_id) -> intent
+brain.move_away(target_id) -> { type = "move_away", target_id = target_id }
 ```
 
-Returns an intent to move one eight-way step away from `target_id`, with the
-same target checks as `brain.move_toward`.
+Returns `{ type = "move_away", target_id = target_id }`, with the same target
+checks as `brain.move_toward`.
 
 ## brain.engage
 
 ```lua
-brain.engage(target_id) -> intent
+brain.engage(target_id) -> { type = "engage", target_id = target_id }
 ```
 
-Returns an intent to engage a visible target. In v1 the accepted result only
-sets the owner's combat target and enables warmode. It does not move, attack,
-or deal damage.
+Returns `{ type = "engage", target_id = target_id }`. In v1 the accepted
+result only sets the owner's combat target and enables warmode. It does not
+move, attack, or deal damage.
 
 ## brain.clear_target
 
 ```lua
-brain.clear_target() -> intent
+brain.clear_target() -> { type = "clear_target" }
 ```
 
-Returns an intent that clears the owner's combat target and disables warmode.
+Returns `{ type = "clear_target" }`, an intent that clears the owner's combat
+target and disables warmode.
 
 ## brain.return_home
 
 ```lua
-brain.return_home() -> intent
+brain.return_home() -> { type = "return_home" }
 ```
 
-Returns an intent to take one step toward `ctx.home.position`. It is accepted
-only while the owner remains on `ctx.home.map_id`.
+Returns `{ type = "return_home" }`, an intent to take one step toward
+`ctx.home.position`. It is accepted only while the owner remains on
+`ctx.home.map_id`.
 
 ## brain.decision
 
 ```lua
-brain.decision(next_tick_ms, intents) -> decision
+brain.decision(next_tick_ms, intents) -> {
+  next_tick_ms = next_tick_ms,
+  intents = intents,
+}
 ```
 
-Returns a decision table with these fields:
+Returns this table without validating or reshaping either argument. Its fields
+are interpreted as follows:
 
 | Key | Meaning |
 |---|---|
-| `next_tick_ms` | Requested delay before the next `think`; finite numbers are truncated and clamped to the configured minimum/maximum. Non-numbers leave the schedule unchanged. |
-| `intents` | Lua array of intent tables. Only the first configured maximum is read (8 by default). |
+| `next_tick_ms` | Requested delay before the next `think`; finite numbers are truncated and clamped to the configured minimum/maximum. `nil`, non-numbers, and non-finite numbers leave the schedule unchanged. |
+| `intents` | A Lua array of intent tables. The runtime reads only the consecutive numeric entries from `1` through the array length, up to the configured maximum (8 by default); `nil` or a non-table produces no intents. |
 
 A hook may return one intent directly instead of a decision. Returning `nil`
-produces no intents. Any other return type is a hook failure.
+produces no intents. Any other return type is a hook failure. To represent an
+empty decision, pass an empty array: `brain.decision(nil, {})`. Calling
+`brain.decision()` leaves both fields `nil`, so it is not recognized as a
+decision and is treated as one malformed/unknown intent instead.

--- a/docs/scripting/toc.yml
+++ b/docs/scripting/toc.yml
@@ -4,6 +4,8 @@
   items:
     - name: How scripting works
       href: guides/how-scripting-works.md
+    - name: NPC brains
+      href: guides/npc-brains.md
     - name: Items
       href: guides/items.md
     - name: Mobiles
@@ -14,6 +16,8 @@
   items:
     - name: log
       href: reference/log.md
+    - name: brain
+      href: reference/brain.md
     - name: game
       href: reference/game.md
     - name: events

--- a/src/Moongate.Persistence/Entities/MobileEntity.cs
+++ b/src/Moongate.Persistence/Entities/MobileEntity.cs
@@ -74,6 +74,8 @@ public class MobileEntity : ISerialIdEntity, IPositionEntity
     /// <summary>True while the mobile is in war mode.</summary>
     public bool Warmode { get; set; }
 
+    public Serial CombatantId { get; set; }
+
     /// <summary>Murder count. From five kills the mobile reads as a murderer; see Notoriety.</summary>
     public int Kills { get; set; }
 

--- a/src/Moongate.Scripting/AI/BrainAssetSeeder.cs
+++ b/src/Moongate.Scripting/AI/BrainAssetSeeder.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+
+namespace Moongate.Scripting.AI;
+
+public static class BrainAssetSeeder
+{
+    private const string ResourcePrefix = "Moongate.Scripting.Assets.Brains.";
+
+    public static void SeedMissing(string brainsDirectory)
+    {
+        Directory.CreateDirectory(brainsDirectory);
+
+        var assembly = typeof(BrainAssetSeeder).Assembly;
+        var resources = assembly
+            .GetManifestResourceNames()
+            .Where(name => name.StartsWith(ResourcePrefix, StringComparison.Ordinal))
+            .Where(name => name.EndsWith(".lua", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal);
+
+        foreach (var resourceName in resources)
+        {
+            SeedMissing(assembly, resourceName, brainsDirectory);
+        }
+    }
+
+    private static void SeedMissing(Assembly assembly, string resourceName, string brainsDirectory)
+    {
+        var fileName = resourceName[ResourcePrefix.Length..];
+        var destination = Path.Combine(brainsDirectory, fileName);
+
+        if (File.Exists(destination))
+        {
+            return;
+        }
+
+        var temporaryPath = destination + "." + Guid.NewGuid().ToString("N") + ".tmp";
+
+        try
+        {
+            using (var source = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded brain resource was not found: {resourceName}"))
+            using (var temporary = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                source.CopyTo(temporary);
+            }
+
+            try
+            {
+                File.Move(temporaryPath, destination);
+            }
+            catch (IOException) when (File.Exists(destination))
+            {
+            }
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+    }
+}

--- a/src/Moongate.Scripting/AI/LuaBrainApi.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainApi.cs
@@ -1,0 +1,53 @@
+using MoonSharp.Interpreter;
+
+namespace Moongate.Scripting.AI;
+
+internal static class LuaBrainApi
+{
+    public static Table Create(Script script)
+    {
+        var brain = new Table(script);
+        brain.Set("idle", CreateIntentCallback(script, "idle"));
+        brain.Set("say", CreateIntentCallback(script, "say", "text"));
+        brain.Set("patrol", CreateIntentCallback(script, "patrol"));
+        brain.Set("move_toward", CreateIntentCallback(script, "move_toward", "target_id"));
+        brain.Set("move_away", CreateIntentCallback(script, "move_away", "target_id"));
+        brain.Set("engage", CreateIntentCallback(script, "engage", "target_id"));
+        brain.Set("clear_target", CreateIntentCallback(script, "clear_target"));
+        brain.Set("return_home", CreateIntentCallback(script, "return_home"));
+        brain.Set(
+            "decision",
+            DynValue.NewCallback(
+                (_, arguments) =>
+                {
+                    var decision = new Table(script);
+                    decision.Set("next_tick_ms", GetArgument(arguments, 0));
+                    decision.Set("intents", GetArgument(arguments, 1));
+
+                    return DynValue.NewTable(decision);
+                }
+            )
+        );
+
+        return brain;
+    }
+
+    private static DynValue CreateIntentCallback(Script script, string intentType, string? payloadName = null)
+        => DynValue.NewCallback(
+            (_, arguments) =>
+            {
+                var intent = new Table(script);
+                intent.Set("type", DynValue.NewString(intentType));
+
+                if (payloadName is not null)
+                {
+                    intent.Set(payloadName, GetArgument(arguments, 0));
+                }
+
+                return DynValue.NewTable(intent);
+            }
+        );
+
+    private static DynValue GetArgument(CallbackArguments arguments, int index)
+        => index < arguments.Count ? arguments[index] : DynValue.Nil;
+}

--- a/src/Moongate.Scripting/AI/LuaBrainDefinition.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainDefinition.cs
@@ -1,0 +1,6 @@
+using Moongate.Server.Abstractions.Data.AI;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Scripting.AI;
+
+internal sealed record LuaBrainDefinition(BrainDescriptor Descriptor, Table Strategy);

--- a/src/Moongate.Scripting/AI/LuaBrainDefinition.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainDefinition.cs
@@ -3,4 +3,8 @@ using MoonSharp.Interpreter;
 
 namespace Moongate.Scripting.AI;
 
-internal sealed record LuaBrainDefinition(BrainDescriptor Descriptor, Table Strategy);
+internal sealed record LuaBrainDefinition(
+    BrainDescriptor Descriptor,
+    Table Strategy,
+    Table StringMetatable
+);

--- a/src/Moongate.Scripting/AI/LuaBrainStandardLibrary.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainStandardLibrary.cs
@@ -1,0 +1,550 @@
+using MoonSharp.Interpreter;
+
+namespace Moongate.Scripting.AI;
+
+internal sealed class LuaBrainStandardLibrary
+{
+    private const int MaximumCallbackArguments = 1024;
+    private const int MaximumStringCharacters = 4096;
+    private const int MaximumTableElements = 1024;
+    private static readonly string[] GlobalCallbackNames =
+    [
+        "ipairs",
+        "next",
+        "pairs",
+        "tostring",
+        "type"
+    ];
+    private static readonly string[] MathCallbackNames =
+    [
+        "abs",
+        "acos",
+        "asin",
+        "atan",
+        "atan2",
+        "ceil",
+        "cos",
+        "cosh",
+        "deg",
+        "exp",
+        "floor",
+        "fmod",
+        "frexp",
+        "ldexp",
+        "log",
+        "max",
+        "min",
+        "modf",
+        "pow",
+        "rad",
+        "random",
+        "randomseed",
+        "sin",
+        "sinh",
+        "sqrt",
+        "tan",
+        "tanh"
+    ];
+    private static readonly string[] MathConstantNames = ["huge", "pi"];
+    private readonly Script _script;
+
+    public LuaBrainStandardLibrary(Script script)
+    {
+        _script = script;
+    }
+
+    public Table CreateEnvironment(Table brainApi, out Table stringMetatable)
+    {
+        var environment = new Table(_script);
+        environment.Set("brain", DynValue.NewTable(brainApi));
+
+        foreach (var name in GlobalCallbackNames)
+        {
+            CopyBoundedCallback(
+                _script.Globals,
+                environment,
+                name,
+                arguments => EnsureArgumentCount(name, arguments)
+            );
+        }
+
+        CopyBoundedCallback(
+            _script.Globals,
+            environment,
+            "assert",
+            arguments =>
+            {
+                EnsureArgumentCount("assert", arguments);
+                EnsureStringValueLength("assert", arguments, 1);
+            }
+        );
+        CopyBoundedCallback(
+            _script.Globals,
+            environment,
+            "error",
+            arguments =>
+            {
+                EnsureArgumentCount("error", arguments);
+                EnsureStringValueLength("error", arguments, 0);
+            }
+        );
+        CopyBoundedCallback(
+            _script.Globals,
+            environment,
+            "pcall",
+            arguments => EnsureArgumentCount("pcall", arguments)
+        );
+        CopyBoundedCallback(
+            _script.Globals,
+            environment,
+            "select",
+            arguments => EnsureArgumentCount("select", arguments)
+        );
+        CopyBoundedCallback(
+            _script.Globals,
+            environment,
+            "tonumber",
+            arguments =>
+            {
+                EnsureArgumentCount("tonumber", arguments);
+                EnsureStringValueLength("tonumber", arguments, 0);
+            }
+        );
+        CopyBoundedCallback(
+            _script.Globals,
+            environment,
+            "xpcall",
+            arguments => EnsureArgumentCount("xpcall", arguments)
+        );
+
+        var math = CreateMathLibrary();
+        var strings = CreateStringLibrary();
+        var tables = CreateTableLibrary();
+        environment.Set("math", DynValue.NewTable(math));
+        environment.Set("string", DynValue.NewTable(strings));
+        environment.Set("table", DynValue.NewTable(tables));
+        stringMetatable = new(_script);
+        stringMetatable.Set("__index", DynValue.NewTable(strings));
+
+        return environment;
+    }
+
+    public T RunWithStringMetatable<T>(Table stringMetatable, Func<T> action)
+    {
+        var previous = _script.GetTypeMetatable(DataType.String);
+        _script.SetTypeMetatable(DataType.String, stringMetatable);
+
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            _script.SetTypeMetatable(DataType.String, previous);
+        }
+    }
+
+    private Table CreateMathLibrary()
+    {
+        var source = GetLibrary("math");
+        var copy = new Table(_script);
+
+        foreach (var name in MathCallbackNames)
+        {
+            CopyBoundedCallback(
+                source,
+                copy,
+                name,
+                arguments => EnsureArgumentCount($"math.{name}", arguments)
+            );
+        }
+
+        foreach (var name in MathConstantNames)
+        {
+            CopyValue(source, copy, name);
+        }
+
+        return copy;
+    }
+
+    private Table CreateStringLibrary()
+    {
+        var source = GetLibrary("string");
+        var copy = new Table(_script);
+        CopyBoundedCallback(
+            source,
+            copy,
+            "byte",
+            arguments => EnsureStringLength("string.byte", arguments, 0, false)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "char",
+            arguments => EnsureArgumentCount("string.char", arguments)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "len",
+            arguments => EnsureArgumentCount("string.len", arguments)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "lower",
+            arguments => EnsureStringLength("string.lower", arguments, 0, false)
+        );
+        CopyBoundedCallback(source, copy, "rep", EnsureStringRep);
+        CopyBoundedCallback(
+            source,
+            copy,
+            "reverse",
+            arguments => EnsureStringLength("string.reverse", arguments, 0, false)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "sub",
+            arguments => EnsureStringLength("string.sub", arguments, 0, false)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "unicode",
+            arguments => EnsureStringLength("string.unicode", arguments, 0, false)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "upper",
+            arguments => EnsureStringLength("string.upper", arguments, 0, false)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "startsWith",
+            arguments => EnsureStringPair("string.startsWith", arguments)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "endsWith",
+            arguments => EnsureStringPair("string.endsWith", arguments)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "contains",
+            arguments => EnsureStringPair("string.contains", arguments)
+        );
+
+        return copy;
+    }
+
+    private Table CreateTableLibrary()
+    {
+        var source = GetLibrary("table");
+        var copy = new Table(_script);
+        CopyBoundedCallback(source, copy, "concat", EnsureTableConcat);
+        CopyBoundedCallback(
+            source,
+            copy,
+            "insert",
+            arguments =>
+            {
+                var table = EnsureTableLength("table.insert", arguments);
+
+                if (table.Length >= MaximumTableElements)
+                {
+                    ThrowLimit("table.insert");
+                }
+            }
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "pack",
+            arguments => EnsureArgumentCount("table.pack", arguments)
+        );
+        CopyBoundedCallback(
+            source,
+            copy,
+            "remove",
+            arguments => EnsureTableLength("table.remove", arguments)
+        );
+        CopyBoundedCallback(source, copy, "unpack", EnsureTableUnpack);
+
+        return copy;
+    }
+
+    private Table GetLibrary(string name)
+    {
+        var value = _script.Globals.Get(name);
+
+        if (value.Type != DataType.Table)
+        {
+            throw new InvalidOperationException($"Lua library '{name}' is unavailable.");
+        }
+
+        return value.Table;
+    }
+
+    private static void CopyValue(Table source, Table destination, string name)
+    {
+        var value = source.Get(name);
+
+        if (value.Type is not DataType.Nil and not DataType.Void)
+        {
+            destination.Set(name, value);
+        }
+    }
+
+    private static void CopyBoundedCallback(
+        Table source,
+        Table destination,
+        string name,
+        Action<CallbackArguments> validate
+    )
+    {
+        var value = source.Get(name);
+
+        if (value.Type != DataType.ClrFunction)
+        {
+            throw new InvalidOperationException($"Lua callback '{name}' is unavailable.");
+        }
+
+        destination.Set(
+            name,
+            DynValue.NewCallback(
+                (executionContext, arguments) =>
+                {
+                    validate(arguments);
+                    return value.Callback.Invoke(executionContext, arguments.GetArray());
+                }
+            )
+        );
+    }
+
+    private static void EnsureArgumentCount(
+        string functionName,
+        CallbackArguments arguments
+    )
+    {
+        if (arguments.Count > MaximumCallbackArguments)
+        {
+            ThrowLimit(functionName);
+        }
+    }
+
+    private static void EnsureStringLength(
+        string functionName,
+        CallbackArguments arguments,
+        int index,
+        bool allowNil
+    )
+    {
+        EnsureArgumentCount(functionName, arguments);
+        var value = arguments.AsType(
+            index,
+            functionName,
+            DataType.String,
+            allowNil
+        );
+
+        if (value.IsNotNil() && value.String.Length > MaximumStringCharacters)
+        {
+            ThrowLimit(functionName);
+        }
+    }
+
+    private static void EnsureStringPair(
+        string functionName,
+        CallbackArguments arguments
+    )
+    {
+        EnsureStringLength(functionName, arguments, 0, true);
+        EnsureStringLength(functionName, arguments, 1, true);
+    }
+
+    private static void EnsureStringValueLength(
+        string functionName,
+        CallbackArguments arguments,
+        int index
+    )
+    {
+        var value = arguments[index];
+
+        if (value.Type == DataType.String &&
+            value.String.Length > MaximumStringCharacters)
+        {
+            ThrowLimit(functionName);
+        }
+    }
+
+    private static void EnsureStringRep(CallbackArguments arguments)
+    {
+        const string functionName = "string.rep";
+        EnsureArgumentCount(functionName, arguments);
+        var value = arguments.AsType(0, functionName, DataType.String);
+        var repetitions = arguments.AsType(1, functionName, DataType.Number);
+        var separator = arguments.AsType(
+            2,
+            functionName,
+            DataType.String,
+            true
+        );
+        EnsureStringLength(functionName, arguments, 0, false);
+        EnsureStringLength(functionName, arguments, 2, true);
+
+        if (!double.IsFinite(repetitions.Number) ||
+            repetitions.Number != Math.Truncate(repetitions.Number))
+        {
+            throw new ScriptRuntimeException(
+                "bad argument #2 to 'rep' (finite integer expected)"
+            );
+        }
+
+        if (value.String.Length == 0 || repetitions.Number < 1)
+        {
+            return;
+        }
+
+        if (repetitions.Number > int.MaxValue)
+        {
+            ThrowLimit(functionName);
+        }
+
+        var count = (long)repetitions.Number;
+        var separatorLength = separator.IsNil() ? 0 : separator.String.Length;
+        var outputLength = (value.String.Length * count) +
+                           (separatorLength * (count - 1));
+
+        if (outputLength > MaximumStringCharacters)
+        {
+            ThrowLimit(functionName);
+        }
+    }
+
+    private static Table EnsureTableLength(
+        string functionName,
+        CallbackArguments arguments
+    )
+    {
+        EnsureArgumentCount(functionName, arguments);
+        var table = arguments.AsType(
+            0,
+            functionName,
+            DataType.Table
+        ).Table;
+
+        if (table.Length > MaximumTableElements)
+        {
+            ThrowLimit(functionName);
+        }
+
+        return table;
+    }
+
+    private static void EnsureTableUnpack(CallbackArguments arguments)
+    {
+        const string functionName = "table.unpack";
+        var table = EnsureTableLength(functionName, arguments);
+        var start = ReadOptionalInteger(functionName, arguments, 1, 1);
+        var end = ReadOptionalInteger(functionName, arguments, 2, table.Length);
+        EnsureRangeLength(functionName, start, end);
+    }
+
+    private static void EnsureTableConcat(CallbackArguments arguments)
+    {
+        const string functionName = "table.concat";
+        var table = EnsureTableLength(functionName, arguments);
+        var separatorValue = arguments.AsType(
+            1,
+            functionName,
+            DataType.String,
+            true
+        );
+        var separator = separatorValue.IsNil() ? "" : separatorValue.String;
+
+        if (separator.Length > MaximumStringCharacters)
+        {
+            ThrowLimit(functionName);
+        }
+
+        var start = ReadOptionalInteger(functionName, arguments, 2, 1);
+        var end = ReadOptionalInteger(functionName, arguments, 3, table.Length);
+        var count = EnsureRangeLength(functionName, start, end);
+        long outputLength = count > 0 ? separator.Length * (count - 1) : 0;
+
+        for (long offset = 0; offset < count; offset++)
+        {
+            var index = (int)((long)start + offset);
+            var value = table.Get(index);
+
+            if (value.Type is not DataType.Number and not DataType.String)
+            {
+                return;
+            }
+
+            outputLength += value.ToPrintString().Length;
+
+            if (outputLength > MaximumStringCharacters)
+            {
+                ThrowLimit(functionName);
+            }
+        }
+    }
+
+    private static int ReadOptionalInteger(
+        string functionName,
+        CallbackArguments arguments,
+        int index,
+        int defaultValue
+    )
+    {
+        var value = arguments.AsType(
+            index,
+            functionName,
+            DataType.Number,
+            true
+        );
+
+        if (value.IsNil())
+        {
+            return defaultValue;
+        }
+
+        if (!double.IsFinite(value.Number) ||
+            value.Number is < int.MinValue or > int.MaxValue)
+        {
+            ThrowLimit(functionName);
+        }
+
+        return (int)value.Number;
+    }
+
+    private static long EnsureRangeLength(
+        string functionName,
+        int start,
+        int end
+    )
+    {
+        var count = end >= start ? ((long)end - start) + 1 : 0;
+
+        if (count > MaximumTableElements ||
+            (count > 0 && end == int.MaxValue))
+        {
+            ThrowLimit(functionName);
+        }
+
+        return count;
+    }
+
+    private static void ThrowLimit(string functionName)
+    {
+        throw new ScriptRuntimeException(
+            $"NPC brain native callback limit exceeded for {functionName}."
+        );
+    }
+}

--- a/src/Moongate.Scripting/AI/LuaBrainStandardLibrary.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainStandardLibrary.cs
@@ -5,6 +5,7 @@ namespace Moongate.Scripting.AI;
 internal sealed class LuaBrainStandardLibrary
 {
     private const int MaximumCallbackArguments = 1024;
+    private const int MaximumStringRepetitions = 4096;
     private const int MaximumStringCharacters = 4096;
     private const int MaximumTableElements = 1024;
     private static readonly string[] GlobalCallbackNames =
@@ -405,24 +406,36 @@ internal sealed class LuaBrainStandardLibrary
             );
         }
 
-        if (value.String.Length == 0 || repetitions.Number < 1)
-        {
-            return;
-        }
-
-        if (repetitions.Number > int.MaxValue)
+        if (repetitions.Number > MaximumStringRepetitions)
         {
             ThrowLimit(functionName);
         }
 
-        var count = (long)repetitions.Number;
+        var count = repetitions.Number < 1 ? 0L : (long)repetitions.Number;
         var separatorLength = separator.IsNil() ? 0 : separator.String.Length;
-        var outputLength = (value.String.Length * count) +
-                           (separatorLength * (count - 1));
+        long outputLength;
+
+        try
+        {
+            outputLength = checked(
+                checked((long)value.String.Length * count) +
+                checked((long)separatorLength * Math.Max(count - 1, 0))
+            );
+        }
+        catch (OverflowException)
+        {
+            ThrowLimit(functionName);
+            return;
+        }
 
         if (outputLength > MaximumStringCharacters)
         {
             ThrowLimit(functionName);
+        }
+
+        if (value.String.Length == 0 || count == 0)
+        {
+            return;
         }
     }
 

--- a/src/Moongate.Scripting/AI/LuaBrainValueConverter.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainValueConverter.cs
@@ -1,0 +1,293 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Types;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Scripting.AI;
+
+internal sealed class LuaBrainValueConverter
+{
+    private readonly NpcAiAdvancedConfig _advanced;
+    private readonly Script _script;
+
+    public LuaBrainValueConverter(Script script, NpcAiAdvancedConfig advanced)
+    {
+        _script = script;
+        _advanced = advanced;
+    }
+
+    public Table ToContext(BrainContext context)
+    {
+        var table = new Table(_script);
+        table.Set("now_ms", DynValue.NewNumber(context.Now.ToUnixTimeMilliseconds()));
+        table.Set("self", DynValue.NewTable(ToMobileSnapshot(context.Self)));
+
+        var home = new Table(_script);
+        home.Set("map_id", DynValue.NewNumber(context.HomeMapId));
+        home.Set("position", DynValue.NewTable(ToPosition(context.HomePosition)));
+        table.Set("home", DynValue.NewTable(home));
+
+        var nearby = new Table(_script);
+
+        foreach (var mobile in context.Nearby)
+        {
+            nearby.Append(DynValue.NewTable(ToMobileSnapshot(mobile)));
+        }
+
+        table.Set("nearby", DynValue.NewTable(nearby));
+
+        return table;
+    }
+
+    public BrainDecision ToDecision(DynValue value)
+    {
+        if (value.Type is DataType.Nil or DataType.Void)
+        {
+            return BrainDecision.Empty;
+        }
+
+        if (value.Type != DataType.Table)
+        {
+            return BrainDecision.Empty;
+        }
+
+        var table = value.Table;
+        var typeValue = table.Get("type");
+        var intentsValue = table.Get("intents");
+        var nextTickValue = table.Get("next_tick_ms");
+        var isDecision =
+            typeValue.Type is DataType.Nil or DataType.Void &&
+            (intentsValue.Type is not DataType.Nil and not DataType.Void ||
+             nextTickValue.Type is not DataType.Nil and not DataType.Void);
+
+        if (!isDecision)
+        {
+            if (_advanced.MaxIntentsPerDecision <= 0)
+            {
+                return BrainDecision.Empty;
+            }
+
+            return new(null, [ToIntent(table)]);
+        }
+
+        var intents = new List<BrainIntent>();
+
+        if (intentsValue.Type == DataType.Table)
+        {
+            var maximum = Math.Max(0, _advanced.MaxIntentsPerDecision);
+            var source = intentsValue.Table;
+            var count = Math.Min(source.Length, maximum);
+
+            for (var index = 1; index <= count; index++)
+            {
+                var intentValue = source.Get(index);
+
+                if (intentValue.Type == DataType.Table)
+                {
+                    intents.Add(ToIntent(intentValue.Table));
+                }
+                else
+                {
+                    intents.Add(CreateUnknownIntent(""));
+                }
+            }
+        }
+
+        return new(ToNextTick(nextTickValue), intents);
+    }
+
+    public Table? ToEvent(NpcBrainEvent? brainEvent)
+    {
+        if (brainEvent is null)
+        {
+            return null;
+        }
+
+        var table = new Table(_script);
+        table.Set("type", DynValue.NewString(brainEvent.Type.ToString().ToLowerInvariant()));
+
+        switch (brainEvent.Type)
+        {
+            case NpcBrainEventType.Activate:
+            case NpcBrainEventType.Deactivate:
+                break;
+            case NpcBrainEventType.SpeechHeard:
+                SetSpeechFields(table, brainEvent);
+                break;
+            case NpcBrainEventType.MobileEnteredRange:
+            case NpcBrainEventType.MobileLeftRange:
+                SetMobileFields(table, brainEvent);
+                SetPosition(table, "from_position", brainEvent.FromPosition);
+                SetPosition(table, "to_position", brainEvent.ToPosition);
+                break;
+            case NpcBrainEventType.MobileMoved:
+                SetMobileFields(table, brainEvent);
+                SetPosition(table, "from_position", brainEvent.FromPosition);
+                SetPosition(table, "to_position", brainEvent.ToPosition);
+                break;
+            case NpcBrainEventType.Attacked:
+                SetSubjectSerial(table, "attacker_id", brainEvent.Mobile);
+                break;
+            case NpcBrainEventType.Damage:
+                SetSubjectSerial(table, "attacker_id", brainEvent.Mobile);
+                table.Set("amount", DynValue.NewNumber(brainEvent.Amount));
+                break;
+            case NpcBrainEventType.Death:
+                SetSubjectSerial(table, "killer_id", brainEvent.Mobile);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(brainEvent), brainEvent.Type, null);
+        }
+
+        return table;
+    }
+
+    private static BrainIntent CreateUnknownIntent(string rawType)
+        => new(BrainIntentType.Unknown, rawType, Serial.Zero, null);
+
+    private static bool IsValidTarget(DynValue value, out Serial targetId)
+    {
+        targetId = Serial.Zero;
+
+        if (value.Type != DataType.Number ||
+            !double.IsFinite(value.Number) ||
+            value.Number != Math.Truncate(value.Number) ||
+            value.Number is <= 0 or > uint.MaxValue)
+        {
+            return false;
+        }
+
+        targetId = new((uint)value.Number);
+
+        return true;
+    }
+
+    private static string ReadRawType(Table table)
+    {
+        var value = table.Get("type");
+
+        return value.Type == DataType.String ? value.String : "";
+    }
+
+    private BrainIntent ToIntent(Table table)
+    {
+        var rawType = ReadRawType(table);
+
+        return rawType switch
+        {
+            "idle" => new(BrainIntentType.Idle, rawType, Serial.Zero, null),
+            "say" when table.Get("text").Type == DataType.String
+                => new(BrainIntentType.Say, rawType, Serial.Zero, table.Get("text").String),
+            "patrol" => new(BrainIntentType.Patrol, rawType, Serial.Zero, null),
+            "move_toward" when IsValidTarget(table.Get("target_id"), out var targetId)
+                => new(BrainIntentType.MoveToward, rawType, targetId, null),
+            "move_away" when IsValidTarget(table.Get("target_id"), out var targetId)
+                => new(BrainIntentType.MoveAway, rawType, targetId, null),
+            "engage" when IsValidTarget(table.Get("target_id"), out var targetId)
+                => new(BrainIntentType.Engage, rawType, targetId, null),
+            "clear_target" => new(BrainIntentType.ClearTarget, rawType, Serial.Zero, null),
+            "return_home" => new(BrainIntentType.ReturnHome, rawType, Serial.Zero, null),
+            _ => CreateUnknownIntent(rawType)
+        };
+    }
+
+    private Table ToMobileSnapshot(BrainMobileSnapshot mobile)
+    {
+        var table = new Table(_script);
+        table.Set("id", DynValue.NewNumber(mobile.Id.Value));
+        table.Set("name", DynValue.NewString(mobile.Name));
+        table.Set("is_player", DynValue.NewBoolean(mobile.IsPlayer));
+        table.Set("map_id", DynValue.NewNumber(mobile.MapId));
+        table.Set("position", DynValue.NewTable(ToPosition(mobile.Position)));
+        table.Set("hits", DynValue.NewNumber(mobile.Hits));
+        table.Set("hits_max", DynValue.NewNumber(mobile.HitsMax));
+        table.Set(
+            "hits_percent",
+            DynValue.NewNumber(mobile.HitsMax <= 0 ? 0 : mobile.Hits * 100.0 / mobile.HitsMax)
+        );
+        table.Set("warmode", DynValue.NewBoolean(mobile.Warmode));
+        SetOptionalSerial(table, "combatant_id", mobile.CombatantId);
+        table.Set("criminal", DynValue.NewBoolean(mobile.Criminal));
+        table.Set("kills", DynValue.NewNumber(mobile.Kills));
+
+        return table;
+    }
+
+    private int? ToNextTick(DynValue value)
+    {
+        if (value.Type != DataType.Number || !double.IsFinite(value.Number))
+        {
+            return null;
+        }
+
+        var clamped = Math.Clamp(
+            Math.Truncate(value.Number),
+            _advanced.MinTickMilliseconds,
+            _advanced.MaxTickMilliseconds
+        );
+
+        return (int)clamped;
+    }
+
+    private Table ToPosition(Point3D position)
+    {
+        var table = new Table(_script);
+        table.Set("x", DynValue.NewNumber(position.X));
+        table.Set("y", DynValue.NewNumber(position.Y));
+        table.Set("z", DynValue.NewNumber(position.Z));
+
+        return table;
+    }
+
+    private void SetMobileFields(Table table, NpcBrainEvent brainEvent)
+    {
+        var mobile = brainEvent.Mobile;
+        SetSubjectSerial(table, "mobile_id", mobile);
+
+        if (mobile is null)
+        {
+            table.Set("mobile_name", DynValue.Nil);
+            table.Set("mobile_is_player", DynValue.Nil);
+            return;
+        }
+
+        table.Set("mobile_name", DynValue.NewString(mobile.Name));
+        table.Set("mobile_is_player", DynValue.NewBoolean(mobile.IsPlayer));
+    }
+
+    private void SetPosition(Table table, string name, Point3D? position)
+        => table.Set(name, position.HasValue ? DynValue.NewTable(ToPosition(position.Value)) : DynValue.Nil);
+
+    private void SetOptionalSerial(Table table, string name, Serial serial)
+        => table.Set(name, serial == Serial.Zero ? DynValue.Nil : DynValue.NewNumber(serial.Value));
+
+    private void SetSpeechFields(Table table, NpcBrainEvent brainEvent)
+    {
+        var speaker = brainEvent.Mobile;
+        SetSubjectSerial(table, "speaker_id", speaker);
+
+        if (speaker is null)
+        {
+            table.Set("speaker_name", DynValue.Nil);
+            table.Set("speaker_is_player", DynValue.Nil);
+        }
+        else
+        {
+            table.Set("speaker_name", DynValue.NewString(speaker.Name));
+            table.Set("speaker_is_player", DynValue.NewBoolean(speaker.IsPlayer));
+        }
+
+        table.Set(
+            "speech_type",
+            brainEvent.SpeechType.HasValue
+                ? DynValue.NewString(brainEvent.SpeechType.Value.ToString().ToLowerInvariant())
+                : DynValue.Nil
+        );
+        table.Set("text", brainEvent.Text is null ? DynValue.Nil : DynValue.NewString(brainEvent.Text));
+    }
+
+    private static void SetSubjectSerial(Table table, string name, BrainMobileSnapshot? mobile)
+        => table.Set(name, mobile is null ? DynValue.Nil : DynValue.NewNumber(mobile.Id.Value));
+}

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -37,21 +37,6 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         "^[a-z0-9][a-z0-9_-]*$",
         RegexOptions.CultureInvariant
     );
-    private static readonly string[] AllowedGlobalNames =
-    [
-        "assert",
-        "error",
-        "ipairs",
-        "next",
-        "pairs",
-        "pcall",
-        "select",
-        "tonumber",
-        "tostring",
-        "type",
-        "xpcall"
-    ];
-    private static readonly string[] AllowedLibraryNames = ["math", "string", "table"];
     private readonly NpcAiAdvancedConfig _advanced;
     private readonly Dictionary<Serial, BrainBinding> _bindings = [];
     private readonly string _brainsDirectory;
@@ -63,6 +48,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private readonly IGameLoopContext _gameLoop;
     private readonly INpcAiMetrics _metrics;
     private readonly Script _script;
+    private readonly LuaBrainStandardLibrary _standardLibrary;
     private readonly TimeProvider _timeProvider;
     private readonly LuaBrainValueConverter _valueConverter;
     private readonly Func<string, FileSystemWatcher> _watcherFactory;
@@ -95,6 +81,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         _gameLoop = gameLoop;
         _metrics = metrics;
         _script = luaScriptEngineService.LuaScript;
+        _standardLibrary = new(_script);
         _timeProvider = timeProvider;
         _valueConverter = new(_script, _advanced);
         _watcherFactory = watcherFactory ?? CreateFileSystemWatcher;
@@ -137,10 +124,13 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             var coroutine = coroutineValue.Coroutine;
             coroutine.AutoYieldCounter = _advanced.InstructionBudget;
 
-            var result = coroutine.Resume(
-                DynValue.NewTable(contextTable),
-                DynValue.NewTable(binding.State),
-                eventTable is null ? DynValue.Nil : DynValue.NewTable(eventTable)
+            var result = _standardLibrary.RunWithStringMetatable(
+                definition.StringMetatable,
+                () => coroutine.Resume(
+                    DynValue.NewTable(contextTable),
+                    DynValue.NewTable(binding.State),
+                    eventTable is null ? DynValue.Nil : DynValue.NewTable(eventTable)
+                )
             );
 
             if (coroutine.State == CoroutineState.ForceSuspended)
@@ -358,43 +348,6 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         return true;
     }
 
-    private Table CreateEnvironment()
-    {
-        var environment = new Table(_script);
-        environment.Set("brain", DynValue.NewTable(LuaBrainApi.Create(_script)));
-
-        foreach (var name in AllowedGlobalNames)
-        {
-            var value = _script.Globals.Get(name);
-
-            if (value.Type is not DataType.Nil and not DataType.Void)
-            {
-                environment.Set(name, value);
-            }
-        }
-
-        foreach (var name in AllowedLibraryNames)
-        {
-            var sourceValue = _script.Globals.Get(name);
-
-            if (sourceValue.Type != DataType.Table)
-            {
-                continue;
-            }
-
-            var copy = new Table(_script);
-
-            foreach (var pair in sourceValue.Table.Pairs)
-            {
-                copy.Set(pair.Key, pair.Value);
-            }
-
-            environment.Set(name, DynValue.NewTable(copy));
-        }
-
-        return environment;
-    }
-
     private NpcBrainInvocationResult FailInvocation(string error, bool budgetExceeded = false)
     {
         _metrics.RecordHookFailure(budgetExceeded);
@@ -539,12 +492,18 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
                 return false;
             }
 
-            var environment = CreateEnvironment();
+            var environment = _standardLibrary.CreateEnvironment(
+                LuaBrainApi.Create(_script),
+                out var stringMetatable
+            );
             var chunk = _script.LoadFile(path, environment, path);
             var coroutineValue = _script.CreateCoroutine(chunk);
             var coroutine = coroutineValue.Coroutine;
             coroutine.AutoYieldCounter = _advanced.InstructionBudget;
-            var result = coroutine.Resume();
+            var result = _standardLibrary.RunWithStringMetatable(
+                stringMetatable,
+                coroutine.Resume
+            );
 
             if (coroutine.State == CoroutineState.ForceSuspended)
             {
@@ -558,7 +517,13 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
                 return false;
             }
 
-            return TryValidateDefinition(brainId, result, out definition, out error);
+            return TryValidateDefinition(
+                brainId,
+                result,
+                stringMetatable,
+                out definition,
+                out error
+            );
         }
         catch (InterpreterException exception)
         {
@@ -575,6 +540,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private bool TryValidateDefinition(
         string brainId,
         DynValue value,
+        Table stringMetatable,
         out LuaBrainDefinition definition,
         out string? error
     )
@@ -639,7 +605,8 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
 
         definition = new(
             new(brainId, defaultTickMilliseconds, perceptionRange, hearingRange),
-            strategy
+            strategy,
+            stringMetatable
         );
         error = null;
 

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -65,9 +65,11 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private readonly ILogger _logger = Log.ForContext<LuaNpcBrainRuntime>();
     private readonly INpcAiMetrics _metrics;
     private readonly Script _script;
+    private readonly TimeProvider _timeProvider;
     private readonly LuaBrainValueConverter _valueConverter;
+    private readonly Func<string, FileSystemWatcher> _watcherFactory;
 
-    private FileSystemWatcher? _watcher;
+    private WatcherRegistration? _watcherRegistration;
     private int _watcherGeneration;
     private int _watching;
 
@@ -77,7 +79,9 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         MoongateConfig config,
         INpcAiMetrics metrics,
         IGameLoopContext gameLoop,
-        IEventBus eventBus
+        IEventBus eventBus,
+        TimeProvider timeProvider,
+        Func<string, FileSystemWatcher>? watcherFactory = null
     )
     {
         if (scriptEngineService is not LuaScriptEngineService luaScriptEngineService)
@@ -93,7 +97,9 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         _gameLoop = gameLoop;
         _metrics = metrics;
         _script = luaScriptEngineService.LuaScript;
+        _timeProvider = timeProvider;
         _valueConverter = new(_script, _advanced);
+        _watcherFactory = watcherFactory ?? CreateFileSystemWatcher;
     }
 
     public NpcBrainInvocationResult Invoke(
@@ -260,24 +266,20 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     {
         BrainAssetSeeder.SeedMissing(_brainsDirectory);
 
-        if (_watcher is not null)
+        if (_watcherRegistration is not null)
         {
             return ValueTask.CompletedTask;
         }
 
-        var watcher = new FileSystemWatcher(_brainsDirectory)
-        {
-            Filter = "*.lua",
-            IncludeSubdirectories = false,
-            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size
-        };
-        watcher.Changed += OnBrainFileChanged;
-        watcher.Created += OnBrainFileChanged;
-        watcher.Renamed += OnBrainFileRenamed;
-        _watcher = watcher;
-        Interlocked.Increment(ref _watcherGeneration);
+        var watcher = _watcherFactory(_brainsDirectory);
+        watcher.Filter = "*.lua";
+        watcher.IncludeSubdirectories = false;
+        watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size;
+        var watcherGeneration = Interlocked.Increment(ref _watcherGeneration);
+        var registration = new WatcherRegistration(watcher, watcherGeneration, QueueReload);
+        _watcherRegistration = registration;
         Volatile.Write(ref _watching, 1);
-        watcher.EnableRaisingEvents = true;
+        registration.Start();
 
         return ValueTask.CompletedTask;
     }
@@ -297,17 +299,9 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         Volatile.Write(ref _watching, 0);
         Interlocked.Increment(ref _watcherGeneration);
 
-        var watcher = _watcher;
-        _watcher = null;
-
-        if (watcher is not null)
-        {
-            watcher.EnableRaisingEvents = false;
-            watcher.Changed -= OnBrainFileChanged;
-            watcher.Created -= OnBrainFileChanged;
-            watcher.Renamed -= OnBrainFileRenamed;
-            watcher.Dispose();
-        }
+        var registration = _watcherRegistration;
+        _watcherRegistration = null;
+        registration?.Dispose();
 
         foreach (var debounce in _debounces)
         {
@@ -331,6 +325,9 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             // A completed debounce may dispose its token while StopAsync is enumerating a stale entry.
         }
     }
+
+    private static FileSystemWatcher CreateFileSystemWatcher(string path)
+        => new(path);
 
     private static string GetHookName(NpcBrainHookType hook)
         => hook switch
@@ -442,16 +439,22 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private async Task DebounceReloadAsync(
         string path,
         CancellationTokenSource cancellation,
+        FileSystemWatcher watcher,
         int watcherGeneration
     )
     {
         try
         {
-            await Task.Delay(ReloadDebounceMilliseconds, cancellation.Token).ConfigureAwait(false);
+            await Task
+                .Delay(
+                    TimeSpan.FromMilliseconds(ReloadDebounceMilliseconds),
+                    _timeProvider,
+                    cancellation.Token
+                )
+                .ConfigureAwait(false);
 
             if (!RemoveDebounce(path, cancellation) ||
-                Volatile.Read(ref _watching) == 0 ||
-                Volatile.Read(ref _watcherGeneration) != watcherGeneration)
+                !IsCurrentWatcher(watcher, watcherGeneration))
             {
                 return;
             }
@@ -461,8 +464,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             _gameLoop.Post(
                 () =>
                 {
-                    if (Volatile.Read(ref _watching) != 0 &&
-                        Volatile.Read(ref _watcherGeneration) == watcherGeneration)
+                    if (IsCurrentWatcher(watcher, watcherGeneration))
                     {
                         TryReload(brainId, out _, out _);
                     }
@@ -479,21 +481,30 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         }
     }
 
-    private void OnBrainFileChanged(object sender, FileSystemEventArgs eventArgs)
-        => QueueReload(eventArgs.FullPath);
-
-    private void OnBrainFileRenamed(object sender, RenamedEventArgs eventArgs)
-        => QueueReload(eventArgs.FullPath);
-
-    private void QueueReload(string path)
+    private bool IsCurrentWatcher(FileSystemWatcher watcher, int watcherGeneration)
     {
-        if (Volatile.Read(ref _watching) == 0)
+        var current = Volatile.Read(ref _watcherRegistration);
+
+        return Volatile.Read(ref _watching) != 0 &&
+               Volatile.Read(ref _watcherGeneration) == watcherGeneration &&
+               current is not null &&
+               current.Generation == watcherGeneration &&
+               ReferenceEquals(current.Watcher, watcher);
+    }
+
+    private void QueueReload(
+        FileSystemWatcher watcher,
+        int watcherGeneration,
+        object sender,
+        string path
+    )
+    {
+        if (!ReferenceEquals(sender, watcher) || !IsCurrentWatcher(watcher, watcherGeneration))
         {
             return;
         }
 
         var normalizedPath = Path.GetFullPath(path);
-        var watcherGeneration = Volatile.Read(ref _watcherGeneration);
         var cancellation = new CancellationTokenSource();
 
         _debounces.AddOrUpdate(
@@ -506,8 +517,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             }
         );
 
-        if (Volatile.Read(ref _watching) == 0 ||
-            Volatile.Read(ref _watcherGeneration) != watcherGeneration)
+        if (!IsCurrentWatcher(watcher, watcherGeneration))
         {
             CancelDebounce(cancellation);
             RemoveDebounce(normalizedPath, cancellation);
@@ -515,7 +525,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             return;
         }
 
-        _ = DebounceReloadAsync(normalizedPath, cancellation, watcherGeneration);
+        _ = DebounceReloadAsync(normalizedPath, cancellation, watcher, watcherGeneration);
     }
 
     private bool RemoveDebounce(string path, CancellationTokenSource cancellation)
@@ -680,6 +690,47 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         {
             BrainId = brainId;
             State = state;
+        }
+    }
+
+    private sealed class WatcherRegistration : IDisposable
+    {
+        private readonly FileSystemEventHandler _fileChanged;
+        private readonly RenamedEventHandler _fileRenamed;
+
+        public int Generation { get; }
+
+        public FileSystemWatcher Watcher { get; }
+
+        public WatcherRegistration(
+            FileSystemWatcher watcher,
+            int generation,
+            Action<FileSystemWatcher, int, object, string> queueReload
+        )
+        {
+            _fileChanged = (sender, eventArgs) =>
+                queueReload(watcher, generation, sender, eventArgs.FullPath);
+            _fileRenamed = (sender, eventArgs) =>
+                queueReload(watcher, generation, sender, eventArgs.FullPath);
+            Generation = generation;
+            Watcher = watcher;
+        }
+
+        public void Start()
+        {
+            Watcher.Changed += _fileChanged;
+            Watcher.Created += _fileChanged;
+            Watcher.Renamed += _fileRenamed;
+            Watcher.EnableRaisingEvents = true;
+        }
+
+        public void Dispose()
+        {
+            Watcher.EnableRaisingEvents = false;
+            Watcher.Changed -= _fileChanged;
+            Watcher.Created -= _fileChanged;
+            Watcher.Renamed -= _fileRenamed;
+            Watcher.Dispose();
         }
     }
 

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -8,7 +8,6 @@ using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Abstractions.Types;
 using MoonSharp.Interpreter;
-using Serilog;
 using SquidStd.Abstractions.Interfaces.Services;
 using SquidStd.Core.Directories;
 using SquidStd.Core.Interfaces.Events;
@@ -62,7 +61,6 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private readonly Dictionary<string, LuaBrainDefinition> _definitions = new(StringComparer.Ordinal);
     private readonly IEventBus _eventBus;
     private readonly IGameLoopContext _gameLoop;
-    private readonly ILogger _logger = Log.ForContext<LuaNpcBrainRuntime>();
     private readonly INpcAiMetrics _metrics;
     private readonly Script _script;
     private readonly TimeProvider _timeProvider;
@@ -114,15 +112,12 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         if (!_bindings.TryGetValue(mobileId, out var binding) ||
             !_definitions.TryGetValue(binding.BrainId, out var definition))
         {
-            return FailInvocation("<unbound>", mobileId, hookName, "No brain is bound to the mobile.");
+            return FailInvocation("No brain is bound to the mobile.");
         }
 
         if (!IsSupportedHook(hook))
         {
             return FailInvocation(
-                definition.Descriptor.BrainId,
-                mobileId,
-                hookName,
                 $"Unsupported brain hook value: {(int)hook}."
             );
         }
@@ -151,9 +146,6 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             if (coroutine.State == CoroutineState.ForceSuspended)
             {
                 return FailInvocation(
-                    definition.Descriptor.BrainId,
-                    mobileId,
-                    hookName,
                     "Instruction budget exceeded.",
                     true
                 );
@@ -161,20 +153,12 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
 
             if (coroutine.State != CoroutineState.Dead)
             {
-                return FailInvocation(
-                    definition.Descriptor.BrainId,
-                    mobileId,
-                    hookName,
-                    "Brain hooks may not yield."
-                );
+                return FailInvocation("Brain hooks may not yield.");
             }
 
             if (result.Type is not DataType.Nil and not DataType.Void and not DataType.Table)
             {
                 return FailInvocation(
-                    definition.Descriptor.BrainId,
-                    mobileId,
-                    hookName,
                     $"Unsupported brain hook return type '{result.Type}'. Expected nil or table."
                 );
             }
@@ -183,16 +167,11 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         }
         catch (InterpreterException exception)
         {
-            return FailInvocation(
-                definition.Descriptor.BrainId,
-                mobileId,
-                hookName,
-                GetInterpreterError(exception)
-            );
+            return FailInvocation(GetInterpreterError(exception));
         }
         catch (Exception exception)
         {
-            return FailInvocation(definition.Descriptor.BrainId, mobileId, hookName, exception.Message);
+            return FailInvocation(exception.Message);
         }
     }
 
@@ -416,21 +395,8 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         return environment;
     }
 
-    private NpcBrainInvocationResult FailInvocation(
-        string brainId,
-        Serial mobileId,
-        string hookName,
-        string error,
-        bool budgetExceeded = false
-    )
+    private NpcBrainInvocationResult FailInvocation(string error, bool budgetExceeded = false)
     {
-        _logger.Error(
-            "NPC brain hook failed for brain {BrainId}, mobile {MobileId}, hook {HookName}: {LuaError}",
-            brainId,
-            mobileId.Value,
-            hookName,
-            error
-        );
         _metrics.RecordHookFailure(budgetExceeded);
 
         return NpcBrainInvocationResult.Failed(error, budgetExceeded);

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -1,0 +1,501 @@
+using System.Text.RegularExpressions;
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Types;
+using MoonSharp.Interpreter;
+using Serilog;
+using SquidStd.Core.Directories;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+using SquidStd.Scripting.Lua.Services;
+
+namespace Moongate.Scripting.AI;
+
+public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
+{
+    private const int MaximumBrainFileBytes = 256 * 1024;
+    private const int MaximumPerceptionRange = 64;
+    private static readonly string[] OptionalHookNames =
+    [
+        "on_activate",
+        "on_deactivate",
+        "on_speech_heard",
+        "on_mobile_entered_range",
+        "on_mobile_left_range",
+        "on_mobile_moved",
+        "on_attacked",
+        "on_damage",
+        "on_death"
+    ];
+    private static readonly Regex ValidBrainIdPattern = new(
+        "^[a-z0-9][a-z0-9_-]*$",
+        RegexOptions.CultureInvariant
+    );
+    private static readonly string[] AllowedGlobalNames =
+    [
+        "assert",
+        "error",
+        "ipairs",
+        "next",
+        "pairs",
+        "pcall",
+        "select",
+        "tonumber",
+        "tostring",
+        "type",
+        "xpcall"
+    ];
+    private static readonly string[] AllowedLibraryNames = ["math", "string", "table"];
+    private readonly NpcAiAdvancedConfig _advanced;
+    private readonly Dictionary<Serial, BrainBinding> _bindings = [];
+    private readonly string _brainsDirectory;
+    private readonly Dictionary<string, LuaBrainDefinition> _definitions = new(StringComparer.Ordinal);
+    private readonly ILogger _logger = Log.ForContext<LuaNpcBrainRuntime>();
+    private readonly INpcAiMetrics _metrics;
+    private readonly Script _script;
+    private readonly LuaBrainValueConverter _valueConverter;
+
+    public LuaNpcBrainRuntime(
+        IScriptEngineService scriptEngineService,
+        DirectoriesConfig directoriesConfig,
+        MoongateConfig config,
+        INpcAiMetrics metrics
+    )
+    {
+        if (scriptEngineService is not LuaScriptEngineService luaScriptEngineService)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(LuaNpcBrainRuntime)} requires the SquidStd Lua engine implementation."
+            );
+        }
+
+        _advanced = config.NpcAi.Advanced;
+        _brainsDirectory = Path.Combine(directoriesConfig.GetPath("scripts"), "brains");
+        _metrics = metrics;
+        _script = luaScriptEngineService.LuaScript;
+        _valueConverter = new(_script, _advanced);
+    }
+
+    public NpcBrainInvocationResult Invoke(
+        Serial mobileId,
+        NpcBrainHookType hook,
+        BrainContext context,
+        NpcBrainEvent? brainEvent = null
+    )
+    {
+        var hookName = GetHookName(hook);
+
+        if (!_bindings.TryGetValue(mobileId, out var binding) ||
+            !_definitions.TryGetValue(binding.BrainId, out var definition))
+        {
+            return FailInvocation("<unbound>", mobileId, hookName, "No brain is bound to the mobile.");
+        }
+
+        if (!IsSupportedHook(hook))
+        {
+            return FailInvocation(
+                definition.Descriptor.BrainId,
+                mobileId,
+                hookName,
+                $"Unsupported brain hook value: {(int)hook}."
+            );
+        }
+
+        var hookValue = definition.Strategy.Get(hookName);
+
+        if (hookValue.Type is DataType.Nil or DataType.Void)
+        {
+            return NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        }
+
+        try
+        {
+            var contextTable = _valueConverter.ToContext(context);
+            var eventTable = _valueConverter.ToEvent(brainEvent);
+            var coroutineValue = _script.CreateCoroutine(hookValue);
+            var coroutine = coroutineValue.Coroutine;
+            coroutine.AutoYieldCounter = _advanced.InstructionBudget;
+
+            var result = coroutine.Resume(
+                DynValue.NewTable(contextTable),
+                DynValue.NewTable(binding.State),
+                eventTable is null ? DynValue.Nil : DynValue.NewTable(eventTable)
+            );
+
+            if (coroutine.State == CoroutineState.ForceSuspended)
+            {
+                return FailInvocation(
+                    definition.Descriptor.BrainId,
+                    mobileId,
+                    hookName,
+                    "Instruction budget exceeded.",
+                    true
+                );
+            }
+
+            if (coroutine.State != CoroutineState.Dead)
+            {
+                return FailInvocation(
+                    definition.Descriptor.BrainId,
+                    mobileId,
+                    hookName,
+                    "Brain hooks may not yield."
+                );
+            }
+
+            return NpcBrainInvocationResult.Succeeded(_valueConverter.ToDecision(result));
+        }
+        catch (InterpreterException exception)
+        {
+            return FailInvocation(
+                definition.Descriptor.BrainId,
+                mobileId,
+                hookName,
+                GetInterpreterError(exception)
+            );
+        }
+        catch (Exception exception)
+        {
+            return FailInvocation(definition.Descriptor.BrainId, mobileId, hookName, exception.Message);
+        }
+    }
+
+    public void Reset(Serial mobileId)
+    {
+        if (_bindings.TryGetValue(mobileId, out var binding))
+        {
+            binding.State = new(_script);
+        }
+    }
+
+    public bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error)
+    {
+        if (!_definitions.TryGetValue(brainId, out var definition))
+        {
+            if (!TryLoadDefinition(brainId, out definition, out error))
+            {
+                descriptor = null;
+                return false;
+            }
+
+            _definitions[brainId] = definition;
+        }
+
+        descriptor = definition.Descriptor;
+        error = null;
+
+        if (!_bindings.TryGetValue(mobileId, out var binding) ||
+            !string.Equals(binding.BrainId, definition.Descriptor.BrainId, StringComparison.Ordinal))
+        {
+            _bindings[mobileId] = new(definition.Descriptor.BrainId, new(_script));
+        }
+
+        return true;
+    }
+
+    public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+    {
+        descriptor = null;
+
+        if (!_bindings.TryGetValue(mobileId, out var binding) ||
+            !_definitions.TryGetValue(binding.BrainId, out var definition))
+        {
+            return false;
+        }
+
+        descriptor = definition.Descriptor;
+
+        return true;
+    }
+
+    public bool TryReload(string brainId, out BrainDescriptor? descriptor, out string? error)
+    {
+        if (!TryLoadDefinition(brainId, out var definition, out error))
+        {
+            descriptor = null;
+            _metrics.RecordReload(false);
+            return false;
+        }
+
+        _definitions[brainId] = definition;
+        descriptor = definition.Descriptor;
+        error = null;
+        _metrics.RecordReload(true);
+
+        return true;
+    }
+
+    public void Unbind(Serial mobileId)
+        => _bindings.Remove(mobileId);
+
+    private static bool IsCallable(DynValue value)
+        => value.Type is DataType.Function or DataType.ClrFunction;
+
+    private static string GetHookName(NpcBrainHookType hook)
+        => hook switch
+        {
+            NpcBrainHookType.Activate => "on_activate",
+            NpcBrainHookType.Deactivate => "on_deactivate",
+            NpcBrainHookType.SpeechHeard => "on_speech_heard",
+            NpcBrainHookType.MobileEnteredRange => "on_mobile_entered_range",
+            NpcBrainHookType.MobileLeftRange => "on_mobile_left_range",
+            NpcBrainHookType.MobileMoved => "on_mobile_moved",
+            NpcBrainHookType.Attacked => "on_attacked",
+            NpcBrainHookType.Damage => "on_damage",
+            NpcBrainHookType.Death => "on_death",
+            NpcBrainHookType.Think => "think",
+            _ => $"unknown({(int)hook})"
+        };
+
+    private static string GetInterpreterError(InterpreterException exception)
+        => string.IsNullOrWhiteSpace(exception.DecoratedMessage) ? exception.Message : exception.DecoratedMessage;
+
+    private static bool IsSupportedHook(NpcBrainHookType hook)
+        => hook is
+            NpcBrainHookType.Activate or
+            NpcBrainHookType.Deactivate or
+            NpcBrainHookType.SpeechHeard or
+            NpcBrainHookType.MobileEnteredRange or
+            NpcBrainHookType.MobileLeftRange or
+            NpcBrainHookType.MobileMoved or
+            NpcBrainHookType.Attacked or
+            NpcBrainHookType.Damage or
+            NpcBrainHookType.Death or
+            NpcBrainHookType.Think;
+
+    private static bool TryReadInteger(Table table, string name, out int value)
+    {
+        value = 0;
+        var field = table.Get(name);
+
+        if (field.Type != DataType.Number ||
+            !double.IsFinite(field.Number) ||
+            field.Number != Math.Truncate(field.Number) ||
+            field.Number is < int.MinValue or > int.MaxValue)
+        {
+            return false;
+        }
+
+        value = (int)field.Number;
+
+        return true;
+    }
+
+    private Table CreateEnvironment()
+    {
+        var environment = new Table(_script);
+        environment.Set("brain", DynValue.NewTable(LuaBrainApi.Create(_script)));
+
+        foreach (var name in AllowedGlobalNames)
+        {
+            var value = _script.Globals.Get(name);
+
+            if (value.Type is not DataType.Nil and not DataType.Void)
+            {
+                environment.Set(name, value);
+            }
+        }
+
+        foreach (var name in AllowedLibraryNames)
+        {
+            var sourceValue = _script.Globals.Get(name);
+
+            if (sourceValue.Type != DataType.Table)
+            {
+                continue;
+            }
+
+            var copy = new Table(_script);
+
+            foreach (var pair in sourceValue.Table.Pairs)
+            {
+                copy.Set(pair.Key, pair.Value);
+            }
+
+            environment.Set(name, DynValue.NewTable(copy));
+        }
+
+        return environment;
+    }
+
+    private NpcBrainInvocationResult FailInvocation(
+        string brainId,
+        Serial mobileId,
+        string hookName,
+        string error,
+        bool budgetExceeded = false
+    )
+    {
+        _logger.Error(
+            "NPC brain hook failed for brain {BrainId}, mobile {MobileId}, hook {HookName}: {LuaError}",
+            brainId,
+            mobileId.Value,
+            hookName,
+            error
+        );
+        _metrics.RecordHookFailure(budgetExceeded);
+
+        return NpcBrainInvocationResult.Failed(error, budgetExceeded);
+    }
+
+    private bool TryLoadDefinition(
+        string brainId,
+        out LuaBrainDefinition definition,
+        out string? error
+    )
+    {
+        definition = null!;
+
+        if (string.IsNullOrWhiteSpace(brainId) || !ValidBrainIdPattern.IsMatch(brainId))
+        {
+            error = $"Brain ID '{brainId}' is invalid.";
+            return false;
+        }
+
+        var path = Path.Combine(_brainsDirectory, brainId + ".lua");
+
+        if (!File.Exists(path))
+        {
+            error = $"Brain file was not found: {path}";
+            return false;
+        }
+
+        try
+        {
+            var directoryInfo = new DirectoryInfo(_brainsDirectory);
+            var fileInfo = new FileInfo(path);
+
+            if ((directoryInfo.Attributes & FileAttributes.ReparsePoint) != 0 ||
+                (fileInfo.Attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                error = "Brain directories and files may not be symbolic links or reparse points.";
+                return false;
+            }
+
+            if (fileInfo.Length > MaximumBrainFileBytes)
+            {
+                error = "Brain files may not exceed 256 KiB.";
+                return false;
+            }
+
+            var environment = CreateEnvironment();
+            var chunk = _script.LoadFile(path, environment, path);
+            var coroutineValue = _script.CreateCoroutine(chunk);
+            var coroutine = coroutineValue.Coroutine;
+            coroutine.AutoYieldCounter = _advanced.InstructionBudget;
+            var result = coroutine.Resume();
+
+            if (coroutine.State == CoroutineState.ForceSuspended)
+            {
+                error = "Instruction budget exceeded while loading brain definition.";
+                return false;
+            }
+
+            if (coroutine.State != CoroutineState.Dead)
+            {
+                error = "Brain definition chunks may not yield.";
+                return false;
+            }
+
+            return TryValidateDefinition(brainId, result, out definition, out error);
+        }
+        catch (InterpreterException exception)
+        {
+            error = GetInterpreterError(exception);
+            return false;
+        }
+        catch (Exception exception)
+        {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    private bool TryValidateDefinition(
+        string brainId,
+        DynValue value,
+        out LuaBrainDefinition definition,
+        out string? error
+    )
+    {
+        definition = null!;
+
+        if (value.Type != DataType.Table)
+        {
+            error = "Brain definition must return a table.";
+            return false;
+        }
+
+        var strategy = value.Table;
+        var id = strategy.Get("id");
+
+        if (id.Type != DataType.String || !string.Equals(id.String, brainId, StringComparison.Ordinal))
+        {
+            error = $"Brain definition id must exactly match '{brainId}'.";
+            return false;
+        }
+
+        if (!TryReadInteger(strategy, "default_tick_ms", out var defaultTickMilliseconds) ||
+            defaultTickMilliseconds < _advanced.MinTickMilliseconds ||
+            defaultTickMilliseconds > _advanced.MaxTickMilliseconds)
+        {
+            error =
+                $"Brain default_tick_ms must be between {_advanced.MinTickMilliseconds} and "
+                + $"{_advanced.MaxTickMilliseconds}.";
+            return false;
+        }
+
+        if (!TryReadInteger(strategy, "perception_range", out var perceptionRange) ||
+            perceptionRange is < 0 or > MaximumPerceptionRange)
+        {
+            error = $"Brain perception_range must be between 0 and {MaximumPerceptionRange}.";
+            return false;
+        }
+
+        if (!TryReadInteger(strategy, "hearing_range", out var hearingRange) ||
+            hearingRange is < 0 or > MaximumPerceptionRange)
+        {
+            error = $"Brain hearing_range must be between 0 and {MaximumPerceptionRange}.";
+            return false;
+        }
+
+        if (!IsCallable(strategy.Get("think")))
+        {
+            error = "Brain think must be callable.";
+            return false;
+        }
+
+        foreach (var hookName in OptionalHookNames)
+        {
+            var hook = strategy.Get(hookName);
+
+            if (hook.Type is not DataType.Nil and not DataType.Void && !IsCallable(hook))
+            {
+                error = $"Brain {hookName} must be callable or nil.";
+                return false;
+            }
+        }
+
+        definition = new(
+            new(brainId, defaultTickMilliseconds, perceptionRange, hearingRange),
+            strategy
+        );
+        error = null;
+
+        return true;
+    }
+
+    private sealed class BrainBinding
+    {
+        public string BrainId { get; }
+
+        public Table State { get; set; }
+
+        public BrainBinding(string brainId, Table state)
+        {
+            BrainId = brainId;
+            State = state;
+        }
+    }
+}

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -1,21 +1,27 @@
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Abstractions.Types;
 using MoonSharp.Interpreter;
 using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
 using SquidStd.Core.Directories;
+using SquidStd.Core.Interfaces.Events;
 using SquidStd.Scripting.Lua.Interfaces.Scripts;
 using SquidStd.Scripting.Lua.Services;
 
 namespace Moongate.Scripting.AI;
 
-public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
+public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDisposable
 {
     private const int MaximumBrainFileBytes = 256 * 1024;
     private const int MaximumPerceptionRange = 64;
+    private const int ReloadDebounceMilliseconds = 250;
     private static readonly string[] OptionalHookNames =
     [
         "on_activate",
@@ -50,17 +56,28 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
     private readonly NpcAiAdvancedConfig _advanced;
     private readonly Dictionary<Serial, BrainBinding> _bindings = [];
     private readonly string _brainsDirectory;
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _debounces = new(
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal
+    );
     private readonly Dictionary<string, LuaBrainDefinition> _definitions = new(StringComparer.Ordinal);
+    private readonly IEventBus _eventBus;
+    private readonly IGameLoopContext _gameLoop;
     private readonly ILogger _logger = Log.ForContext<LuaNpcBrainRuntime>();
     private readonly INpcAiMetrics _metrics;
     private readonly Script _script;
     private readonly LuaBrainValueConverter _valueConverter;
 
+    private FileSystemWatcher? _watcher;
+    private int _watcherGeneration;
+    private int _watching;
+
     public LuaNpcBrainRuntime(
         IScriptEngineService scriptEngineService,
         DirectoriesConfig directoriesConfig,
         MoongateConfig config,
-        INpcAiMetrics metrics
+        INpcAiMetrics metrics,
+        IGameLoopContext gameLoop,
+        IEventBus eventBus
     )
     {
         if (scriptEngineService is not LuaScriptEngineService luaScriptEngineService)
@@ -72,6 +89,8 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
 
         _advanced = config.NpcAi.Advanced;
         _brainsDirectory = Path.Combine(directoriesConfig.GetPath("scripts"), "brains");
+        _eventBus = eventBus;
+        _gameLoop = gameLoop;
         _metrics = metrics;
         _script = luaScriptEngineService.LuaScript;
         _valueConverter = new(_script, _advanced);
@@ -229,6 +248,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
         }
 
         _definitions[brainId] = definition;
+        _eventBus.Publish(new BrainDefinitionReloadedEvent(brainId, definition.Descriptor));
         descriptor = definition.Descriptor;
         error = null;
         _metrics.RecordReload(true);
@@ -236,11 +256,81 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
         return true;
     }
 
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        BrainAssetSeeder.SeedMissing(_brainsDirectory);
+
+        if (_watcher is not null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var watcher = new FileSystemWatcher(_brainsDirectory)
+        {
+            Filter = "*.lua",
+            IncludeSubdirectories = false,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size
+        };
+        watcher.Changed += OnBrainFileChanged;
+        watcher.Created += OnBrainFileChanged;
+        watcher.Renamed += OnBrainFileRenamed;
+        _watcher = watcher;
+        Interlocked.Increment(ref _watcherGeneration);
+        Volatile.Write(ref _watching, 1);
+        watcher.EnableRaisingEvents = true;
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        StopWatching();
+
+        return ValueTask.CompletedTask;
+    }
+
     public void Unbind(Serial mobileId)
         => _bindings.Remove(mobileId);
 
+    private void StopWatching()
+    {
+        Volatile.Write(ref _watching, 0);
+        Interlocked.Increment(ref _watcherGeneration);
+
+        var watcher = _watcher;
+        _watcher = null;
+
+        if (watcher is not null)
+        {
+            watcher.EnableRaisingEvents = false;
+            watcher.Changed -= OnBrainFileChanged;
+            watcher.Created -= OnBrainFileChanged;
+            watcher.Renamed -= OnBrainFileRenamed;
+            watcher.Dispose();
+        }
+
+        foreach (var debounce in _debounces)
+        {
+            CancelDebounce(debounce.Value);
+        }
+
+        _debounces.Clear();
+    }
+
     private static bool IsCallable(DynValue value)
         => value.Type is DataType.Function or DataType.ClrFunction;
+
+    private static void CancelDebounce(CancellationTokenSource cancellation)
+    {
+        try
+        {
+            cancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // A completed debounce may dispose its token while StopAsync is enumerating a stale entry.
+        }
+    }
 
     private static string GetHookName(NpcBrainHookType hook)
         => hook switch
@@ -348,6 +438,90 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
 
         return NpcBrainInvocationResult.Failed(error, budgetExceeded);
     }
+
+    private async Task DebounceReloadAsync(
+        string path,
+        CancellationTokenSource cancellation,
+        int watcherGeneration
+    )
+    {
+        try
+        {
+            await Task.Delay(ReloadDebounceMilliseconds, cancellation.Token).ConfigureAwait(false);
+
+            if (!RemoveDebounce(path, cancellation) ||
+                Volatile.Read(ref _watching) == 0 ||
+                Volatile.Read(ref _watcherGeneration) != watcherGeneration)
+            {
+                return;
+            }
+
+            var brainId = Path.GetFileNameWithoutExtension(path);
+
+            _gameLoop.Post(
+                () =>
+                {
+                    if (Volatile.Read(ref _watching) != 0 &&
+                        Volatile.Read(ref _watcherGeneration) == watcherGeneration)
+                    {
+                        TryReload(brainId, out _, out _);
+                    }
+                }
+            );
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            RemoveDebounce(path, cancellation);
+            cancellation.Dispose();
+        }
+    }
+
+    private void OnBrainFileChanged(object sender, FileSystemEventArgs eventArgs)
+        => QueueReload(eventArgs.FullPath);
+
+    private void OnBrainFileRenamed(object sender, RenamedEventArgs eventArgs)
+        => QueueReload(eventArgs.FullPath);
+
+    private void QueueReload(string path)
+    {
+        if (Volatile.Read(ref _watching) == 0)
+        {
+            return;
+        }
+
+        var normalizedPath = Path.GetFullPath(path);
+        var watcherGeneration = Volatile.Read(ref _watcherGeneration);
+        var cancellation = new CancellationTokenSource();
+
+        _debounces.AddOrUpdate(
+            normalizedPath,
+            cancellation,
+            (_, previous) =>
+            {
+                CancelDebounce(previous);
+                return cancellation;
+            }
+        );
+
+        if (Volatile.Read(ref _watching) == 0 ||
+            Volatile.Read(ref _watcherGeneration) != watcherGeneration)
+        {
+            CancelDebounce(cancellation);
+            RemoveDebounce(normalizedPath, cancellation);
+            cancellation.Dispose();
+            return;
+        }
+
+        _ = DebounceReloadAsync(normalizedPath, cancellation, watcherGeneration);
+    }
+
+    private bool RemoveDebounce(string path, CancellationTokenSource cancellation)
+        => ((ICollection<KeyValuePair<string, CancellationTokenSource>>)_debounces).Remove(
+            new(path, cancellation)
+        );
 
     private bool TryLoadDefinition(
         string brainId,
@@ -507,5 +681,10 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
             BrainId = brainId;
             State = state;
         }
+    }
+
+    public void Dispose()
+    {
+        StopWatching();
     }
 }

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -144,6 +144,16 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime
                 );
             }
 
+            if (result.Type is not DataType.Nil and not DataType.Void and not DataType.Table)
+            {
+                return FailInvocation(
+                    definition.Descriptor.BrainId,
+                    mobileId,
+                    hookName,
+                    $"Unsupported brain hook return type '{result.Type}'. Expected nil or table."
+                );
+            }
+
             return NpcBrainInvocationResult.Succeeded(_valueConverter.ToDecision(result));
         }
         catch (InterpreterException exception)

--- a/src/Moongate.Scripting/Assets/Brains/guard.lua
+++ b/src/Moongate.Scripting/Assets/Brains/guard.lua
@@ -1,0 +1,38 @@
+local guard = {
+    id = "guard",
+    default_tick_ms = 1000,
+    perception_range = 12,
+    hearing_range = 15,
+}
+
+function guard.on_speech_heard(ctx, state, event)
+    if event == nil or event.speaker_is_player ~= true then
+        return nil
+    end
+
+    state.seen_players = state.seen_players or {}
+
+    local speaker_id = event.speaker_id
+    local known = state.seen_players[speaker_id]
+
+    if known == nil then
+        state.seen_players[speaker_id] = {
+            first_seen_at = ctx.now_ms,
+            last_seen_at = ctx.now_ms,
+            conversations = 1,
+        }
+
+        return brain.say("Non ti avevo mai visto prima.")
+    end
+
+    known.last_seen_at = ctx.now_ms
+    known.conversations = known.conversations + 1
+
+    return brain.say("Bentornato.")
+end
+
+function guard.think()
+    return brain.idle()
+end
+
+return guard

--- a/src/Moongate.Scripting/Assets/Brains/orion.lua
+++ b/src/Moongate.Scripting/Assets/Brains/orion.lua
@@ -1,0 +1,9 @@
+return {
+    id = "orion",
+    default_tick_ms = 1500,
+    perception_range = 10,
+    hearing_range = 12,
+    think = function()
+        return brain.patrol()
+    end,
+}

--- a/src/Moongate.Scripting/Assets/Brains/vega.lua
+++ b/src/Moongate.Scripting/Assets/Brains/vega.lua
@@ -1,0 +1,9 @@
+return {
+    id = "vega",
+    default_tick_ms = 1500,
+    perception_range = 10,
+    hearing_range = 12,
+    think = function()
+        return brain.patrol()
+    end,
+}

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -20,4 +20,8 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup>
+        <EmbeddedResource Include="Assets\Brains\**\*.lua"/>
+    </ItemGroup>
+
 </Project>

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Moongate.Core\Moongate.Core.csproj"/>
+        <ProjectReference Include="..\Moongate.Server.Abstractions\Moongate.Server.Abstractions.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Moongate.Scripting/MoongateScriptingPlugin.cs
+++ b/src/Moongate.Scripting/MoongateScriptingPlugin.cs
@@ -1,5 +1,8 @@
 using DryIoc;
+using Moongate.Scripting.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Scripting.Modules;
+using SquidStd.Abstractions.Extensions.Services;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Directories;
 using SquidStd.Core.Utils;
@@ -35,6 +38,8 @@ public class MoongateScriptingPlugin : ISquidStdPlugin
                 appConfig.AppVersion
             )
         );
+
+        container.RegisterStdService<INpcBrainRuntime, LuaNpcBrainRuntime>();
 
         container.Register<ILuaInvokeMarshaller, LoopAffineInvokeMarshaller>(Reuse.Singleton);
 

--- a/src/Moongate.Server.Abstractions/Data/AI/BrainContext.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/BrainContext.cs
@@ -1,0 +1,11 @@
+using Moongate.Core.Geometry;
+
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record BrainContext(
+    DateTimeOffset Now,
+    BrainMobileSnapshot Self,
+    int HomeMapId,
+    Point3D HomePosition,
+    IReadOnlyList<BrainMobileSnapshot> Nearby
+);

--- a/src/Moongate.Server.Abstractions/Data/AI/BrainDecision.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/BrainDecision.cs
@@ -1,0 +1,6 @@
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record BrainDecision(int? NextTickMilliseconds, IReadOnlyList<BrainIntent> Intents)
+{
+    public static BrainDecision Empty { get; } = new(null, []);
+}

--- a/src/Moongate.Server.Abstractions/Data/AI/BrainDescriptor.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/BrainDescriptor.cs
@@ -1,0 +1,8 @@
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record BrainDescriptor(
+    string BrainId,
+    int DefaultTickMilliseconds,
+    int PerceptionRange,
+    int HearingRange
+);

--- a/src/Moongate.Server.Abstractions/Data/AI/BrainIntent.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/BrainIntent.cs
@@ -1,0 +1,11 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record BrainIntent(
+    BrainIntentType Type,
+    string RawType,
+    Serial TargetId,
+    string? Text
+);

--- a/src/Moongate.Server.Abstractions/Data/AI/BrainMobileSnapshot.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/BrainMobileSnapshot.cs
@@ -1,0 +1,18 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record BrainMobileSnapshot(
+    Serial Id,
+    string Name,
+    bool IsPlayer,
+    int MapId,
+    Point3D Position,
+    int Hits,
+    int HitsMax,
+    bool Warmode,
+    Serial CombatantId,
+    bool Criminal,
+    int Kills
+);

--- a/src/Moongate.Server.Abstractions/Data/AI/NpcAiMetricsSnapshot.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/NpcAiMetricsSnapshot.cs
@@ -1,0 +1,28 @@
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record NpcAiMetricsSnapshot(
+    long ActiveSectors,
+    long GraceSectors,
+    long SleepingSectors,
+    long ActiveBrains,
+    long SleepingBrains,
+    long FaultBackoffBrains,
+    long BrainsExecuted,
+    long BrainsDeferred,
+    long HookInvocations,
+    long TotalHookDurationTicks,
+    long MaxHookDurationTicks,
+    long HookFailures,
+    long InstructionBudgetBreaches,
+    long EventsDelivered,
+    long EventsCoalesced,
+    long EventsDropped,
+    long IntentsAccepted,
+    long IntentsRejected,
+    long ReloadSuccesses,
+    long ReloadFallbacks
+)
+{
+    public TimeSpan AverageHookDuration =>
+        HookInvocations == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(TotalHookDurationTicks / HookInvocations);
+}

--- a/src/Moongate.Server.Abstractions/Data/AI/NpcBrainEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/NpcBrainEvent.cs
@@ -1,0 +1,15 @@
+using Moongate.Core.Geometry;
+using Moongate.Server.Abstractions.Types;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record NpcBrainEvent(
+    NpcBrainEventType Type,
+    BrainMobileSnapshot? Mobile = null,
+    string? Text = null,
+    ChatMessageType? SpeechType = null,
+    Point3D? FromPosition = null,
+    Point3D? ToPosition = null,
+    int Amount = 0
+);

--- a/src/Moongate.Server.Abstractions/Data/AI/NpcBrainInvocationResult.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/NpcBrainInvocationResult.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Server.Abstractions.Data.AI;
+
+public sealed record NpcBrainInvocationResult(
+    bool Success,
+    BrainDecision Decision,
+    string? Error,
+    bool InstructionBudgetExceeded
+)
+{
+    public static NpcBrainInvocationResult Succeeded(BrainDecision decision) => new(true, decision, null, false);
+
+    public static NpcBrainInvocationResult Failed(string error, bool budgetExceeded = false)
+        => new(false, BrainDecision.Empty, error, budgetExceeded);
+}

--- a/src/Moongate.Server.Abstractions/Data/Config/MoongateConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/MoongateConfig.cs
@@ -11,6 +11,8 @@ public sealed class MoongateConfig
 
     public MoongateNetworkConfig Network { get; set; } = new();
 
+    public NpcAiConfig NpcAi { get; set; } = new();
+
     /// <summary>
     /// When true, a world mutation attempted off the game-loop thread throws instead of warning.
     /// Off by default (a live shard warns rather than crashes); dev and CI turn it on so regressions

--- a/src/Moongate.Server.Abstractions/Data/Config/NpcAiAdvancedConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/NpcAiAdvancedConfig.cs
@@ -1,0 +1,20 @@
+namespace Moongate.Server.Abstractions.Data.Config;
+
+public sealed class NpcAiAdvancedConfig
+{
+    public int SectorIdleGraceSeconds { get; set; } = 60;
+
+    public int MinTickMilliseconds { get; set; } = 100;
+
+    public int MaxTickMilliseconds { get; set; } = 60_000;
+
+    public int MaxBrainsPerLoop { get; set; } = 100;
+
+    public int MaxEventsPerBrainWake { get; set; } = 16;
+
+    public int MaxMailboxEvents { get; set; } = 64;
+
+    public int MaxIntentsPerDecision { get; set; } = 8;
+
+    public long InstructionBudget { get; set; } = 50_000;
+}

--- a/src/Moongate.Server.Abstractions/Data/Config/NpcAiConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/NpcAiConfig.cs
@@ -1,0 +1,6 @@
+namespace Moongate.Server.Abstractions.Data.Config;
+
+public sealed class NpcAiConfig
+{
+    public NpcAiAdvancedConfig Advanced { get; set; } = new();
+}

--- a/src/Moongate.Server.Abstractions/Data/Events/BrainDefinitionReloadedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/BrainDefinitionReloadedEvent.cs
@@ -1,0 +1,6 @@
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record BrainDefinitionReloadedEvent(string BrainId, BrainDescriptor Descriptor) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileAttackedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileAttackedEvent.cs
@@ -1,0 +1,6 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record MobileAttackedEvent(Serial Defender, Serial Attacker) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileCreatedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileCreatedEvent.cs
@@ -1,0 +1,6 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record MobileCreatedEvent(MobileEntity Mobile) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileDamagedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileDamagedEvent.cs
@@ -1,0 +1,6 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record MobileDamagedEvent(Serial Mobile, Serial Attacker, int Amount) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileDeletedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileDeletedEvent.cs
@@ -1,0 +1,6 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record MobileDeletedEvent(MobileEntity Mobile) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileDiedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileDiedEvent.cs
@@ -1,0 +1,6 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record MobileDiedEvent(Serial Mobile, Serial Killer) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/MobileMovedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/MobileMovedEvent.cs
@@ -1,0 +1,13 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record MobileMovedEvent(
+    Serial Mobile,
+    int FromMapId,
+    Point3D FromPosition,
+    int ToMapId,
+    Point3D ToPosition
+) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/SectorActivatedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/SectorActivatedEvent.cs
@@ -1,0 +1,5 @@
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record SectorActivatedEvent(int MapId, int SectorX, int SectorY) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/SectorDeactivatedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/SectorDeactivatedEvent.cs
@@ -1,0 +1,5 @@
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+public sealed record SectorDeactivatedEvent(int MapId, int SectorX, int SectorY) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/World/SectorActivitySnapshot.cs
+++ b/src/Moongate.Server.Abstractions/Data/World/SectorActivitySnapshot.cs
@@ -1,0 +1,3 @@
+namespace Moongate.Server.Abstractions.Data.World;
+
+public sealed record SectorActivitySnapshot(int ActiveSectors, int GraceSectors);

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/IBrainIntentExecutor.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/IBrainIntentExecutor.cs
@@ -1,0 +1,11 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+
+namespace Moongate.Server.Abstractions.Interfaces.AI;
+
+/// <summary>Applies validated brain intents to world state.</summary>
+public interface IBrainIntentExecutor
+{
+    /// <summary>Executes the supplied intents for a mobile in the given brain context.</summary>
+    void Execute(Serial mobileId, BrainContext context, IReadOnlyList<BrainIntent> intents);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcAiMetrics.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcAiMetrics.cs
@@ -1,0 +1,41 @@
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Interfaces.AI;
+
+/// <summary>Records thread-safe, process-local measurements for NPC brain processing.</summary>
+public interface INpcAiMetrics
+{
+    /// <summary>Gets an immutable snapshot of the current measurements.</summary>
+    NpcAiMetricsSnapshot Current { get; }
+
+    /// <summary>Sets the current counts of active and grace-period sectors.</summary>
+    void SetActiveSectorCounts(int active, int grace);
+
+    /// <summary>Sets the current count of sleeping sectors.</summary>
+    void SetSleepingSectorCount(int sleeping);
+
+    /// <summary>Sets the current counts of active, sleeping and fault-backoff brains.</summary>
+    void SetBrainCounts(int active, int sleeping, int faultBackoff);
+
+    /// <summary>Records execution of a brain during a scheduler iteration.</summary>
+    void RecordBrainExecuted();
+
+    /// <summary>Records a brain deferred by scheduler limits.</summary>
+    void RecordBrainDeferred();
+
+    /// <summary>Records the duration of one brain hook invocation.</summary>
+    void RecordHookInvocation(TimeSpan duration);
+
+    /// <summary>Records a failed brain hook invocation.</summary>
+    void RecordHookFailure(bool instructionBudgetExceeded);
+
+    /// <summary>Records how a queued brain event was handled.</summary>
+    void RecordEvent(NpcBrainEventDispositionType disposition);
+
+    /// <summary>Records whether a brain intent was accepted for execution.</summary>
+    void RecordIntent(bool accepted);
+
+    /// <summary>Records whether a brain reload succeeded or used its fallback.</summary>
+    void RecordReload(bool succeeded);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainRuntime.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainRuntime.cs
@@ -1,0 +1,32 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Interfaces.AI;
+
+/// <summary>Provides runtime binding and hook invocation for NPC brain implementations.</summary>
+public interface INpcBrainRuntime
+{
+    /// <summary>Attempts to bind a mobile to a brain and returns its descriptor on success.</summary>
+    bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error);
+
+    /// <summary>Attempts to obtain the descriptor bound to a mobile.</summary>
+    bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor);
+
+    /// <summary>Invokes a brain hook with the supplied world context and optional event.</summary>
+    NpcBrainInvocationResult Invoke(
+        Serial mobileId,
+        NpcBrainHookType hook,
+        BrainContext context,
+        NpcBrainEvent? brainEvent = null
+    );
+
+    /// <summary>Attempts to reload a brain definition and returns its descriptor on success.</summary>
+    bool TryReload(string brainId, out BrainDescriptor? descriptor, out string? error);
+
+    /// <summary>Resets the runtime state held for a mobile.</summary>
+    void Reset(Serial mobileId);
+
+    /// <summary>Removes a mobile's brain binding and runtime state.</summary>
+    void Unbind(Serial mobileId);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainScheduler.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainScheduler.cs
@@ -1,0 +1,43 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Interfaces.AI;
+
+/// <summary>Coordinates NPC brain lifecycles, queued events and scheduled execution.</summary>
+public interface INpcBrainScheduler
+{
+    /// <summary>Gets the greatest hearing range of all scheduled brains.</summary>
+    int MaxHearingRange { get; }
+
+    /// <summary>Gets the greatest perception range of all scheduled brains.</summary>
+    int MaxPerceptionRange { get; }
+
+    /// <summary>Binds a mobile to its configured brain.</summary>
+    void Bind(MobileEntity mobile);
+
+    /// <summary>Removes a mobile and its brain from scheduling.</summary>
+    void Unbind(Serial mobileId);
+
+    /// <summary>Activates a mobile's scheduled brain.</summary>
+    void Activate(Serial mobileId);
+
+    /// <summary>Begins deactivating a mobile's scheduled brain.</summary>
+    void Deactivate(Serial mobileId);
+
+    /// <summary>Refreshes every scheduled brain using the supplied descriptor.</summary>
+    void RefreshDescriptor(string brainId, BrainDescriptor descriptor);
+
+    /// <summary>Returns whether a mobile's brain is active.</summary>
+    bool IsActive(Serial mobileId);
+
+    /// <summary>Attempts to obtain the descriptor scheduled for a mobile.</summary>
+    bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor);
+
+    /// <summary>Queues a brain event for delivery on the mobile's next wake.</summary>
+    void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent);
+
+    /// <summary>Executes due brain work for the current scheduler iteration.</summary>
+    void Tick();
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IMovementService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IMovementService.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Data.Session;
 
@@ -16,4 +17,10 @@ public interface IMovementService
     /// no character attached yet.
     /// </summary>
     void TryMove(PlayerSession session, DirectionType direction, byte sequence);
+
+    /// <summary>
+    /// Attempts to turn or step an NPC with a configured brain. Uses the authoritative movement rules without
+    /// client sequence or timing state, returning <see langword="true" /> only when the move is accepted.
+    /// </summary>
+    bool TryMoveNpc(Serial mobileId, DirectionType direction);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/World/ISectorActivityService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/ISectorActivityService.cs
@@ -1,0 +1,27 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.World;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>Tracks player-driven sector activity and its grace-period expiry on the game loop.</summary>
+public interface ISectorActivityService
+{
+    /// <summary>Gets the current counts of reference-positive and grace-period sectors.</summary>
+    SectorActivitySnapshot Current { get; }
+
+    /// <summary>Returns whether a sector is reference-positive or still within its idle grace period.</summary>
+    bool IsActive(int mapId, int sectorX, int sectorY);
+
+    /// <summary>Tracks a player at its current map and spatial-index sector.</summary>
+    void TrackPlayer(MobileEntity player);
+
+    /// <summary>Moves an already tracked player to a spatial-index sector; unknown serials are ignored.</summary>
+    void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY);
+
+    /// <summary>Stops tracking a player; unknown serials are ignored.</summary>
+    void UntrackPlayer(Serial playerId);
+
+    /// <summary>Expires zero-reference sectors whose idle grace period has elapsed.</summary>
+    void Tick();
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/ISpatialIndexService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/ISpatialIndexService.cs
@@ -30,6 +30,12 @@ public interface ISpatialIndexService
     /// <summary>Mobiles on <paramref name="mapId" /> within <paramref name="range" /> tiles of <paramref name="center" />.</summary>
     IReadOnlyList<MobileEntity> GetMobilesInRange(int mapId, Point3D center, int range);
 
+    /// <summary>
+    /// Mobiles indexed in the exact sector identified by <paramref name="mapId" />, <paramref name="sectorX" />
+    /// and <paramref name="sectorY" />.
+    /// </summary>
+    IReadOnlyList<MobileEntity> GetMobilesInSector(int mapId, int sectorX, int sectorY);
+
     /// <summary>Removes an entity from the index; unknown serials are a no-op.</summary>
     void Remove(Serial serial);
 }

--- a/src/Moongate.Server.Abstractions/Types/BrainIntentType.cs
+++ b/src/Moongate.Server.Abstractions/Types/BrainIntentType.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Server.Abstractions.Types;
+
+public enum BrainIntentType
+{
+    Unknown,
+    Idle,
+    Say,
+    Patrol,
+    MoveToward,
+    MoveAway,
+    Engage,
+    ClearTarget,
+    ReturnHome
+}

--- a/src/Moongate.Server.Abstractions/Types/NpcBrainEventDispositionType.cs
+++ b/src/Moongate.Server.Abstractions/Types/NpcBrainEventDispositionType.cs
@@ -1,0 +1,8 @@
+namespace Moongate.Server.Abstractions.Types;
+
+public enum NpcBrainEventDispositionType
+{
+    Delivered,
+    Coalesced,
+    Dropped
+}

--- a/src/Moongate.Server.Abstractions/Types/NpcBrainEventType.cs
+++ b/src/Moongate.Server.Abstractions/Types/NpcBrainEventType.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Server.Abstractions.Types;
+
+public enum NpcBrainEventType
+{
+    Activate,
+    Deactivate,
+    SpeechHeard,
+    MobileEnteredRange,
+    MobileLeftRange,
+    MobileMoved,
+    Attacked,
+    Damage,
+    Death
+}

--- a/src/Moongate.Server.Abstractions/Types/NpcBrainHookType.cs
+++ b/src/Moongate.Server.Abstractions/Types/NpcBrainHookType.cs
@@ -1,0 +1,15 @@
+namespace Moongate.Server.Abstractions.Types;
+
+public enum NpcBrainHookType
+{
+    Activate,
+    Deactivate,
+    SpeechHeard,
+    MobileEnteredRange,
+    MobileLeftRange,
+    MobileMoved,
+    Attacked,
+    Damage,
+    Death,
+    Think
+}

--- a/src/Moongate.Server.Abstractions/Types/NpcBrainStateType.cs
+++ b/src/Moongate.Server.Abstractions/Types/NpcBrainStateType.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Server.Abstractions.Types;
+
+public enum NpcBrainStateType
+{
+    Sleeping,
+    Active,
+    Deactivating,
+    FaultBackoff
+}

--- a/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
+++ b/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
@@ -21,21 +21,24 @@ public sealed class NpcBrainMailbox
         _metrics = metrics;
     }
 
-    public void Enqueue(NpcBrainHookType hook, NpcBrainEvent brainEvent)
+    public bool Enqueue(NpcBrainHookType hook, NpcBrainEvent brainEvent)
     {
         if (TryCoalesce(hook, brainEvent))
         {
             _metrics.RecordEvent(NpcBrainEventDispositionType.Coalesced);
-            return;
+            return false;
         }
 
         if (_entries.Count == _capacity && !MakeRoom(hook))
         {
             _metrics.RecordEvent(NpcBrainEventDispositionType.Dropped);
-            return;
+            return false;
         }
 
+        var schedulingChanged = _entries.Count == 0;
         _entries.Add((hook, brainEvent, _nextSequence++));
+
+        return schedulingChanged;
     }
 
     public IReadOnlyList<(NpcBrainHookType Hook, NpcBrainEvent Event)> Dequeue(int maximumCount)

--- a/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
+++ b/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
@@ -1,0 +1,124 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Data.Internal.AI;
+
+public sealed class NpcBrainMailbox
+{
+    private readonly int _capacity;
+    private readonly INpcAiMetrics _metrics;
+    private readonly List<(NpcBrainHookType Hook, NpcBrainEvent Event, long Sequence)> _entries = [];
+
+    private long _nextSequence;
+
+    public bool HasEvents => _entries.Count > 0;
+
+    public NpcBrainMailbox(int capacity, INpcAiMetrics metrics)
+    {
+        _capacity = capacity;
+        _metrics = metrics;
+    }
+
+    public void Enqueue(NpcBrainHookType hook, NpcBrainEvent brainEvent)
+    {
+        if (TryCoalesce(hook, brainEvent))
+        {
+            _metrics.RecordEvent(NpcBrainEventDispositionType.Coalesced);
+            return;
+        }
+
+        if (_entries.Count == _capacity && !MakeRoom(hook))
+        {
+            _metrics.RecordEvent(NpcBrainEventDispositionType.Dropped);
+            return;
+        }
+
+        _entries.Add((hook, brainEvent, _nextSequence++));
+    }
+
+    public IReadOnlyList<(NpcBrainHookType Hook, NpcBrainEvent Event)> Dequeue(int maximumCount)
+    {
+        if (maximumCount <= 0 || _entries.Count == 0)
+        {
+            return [];
+        }
+
+        var count = Math.Min(maximumCount, _entries.Count);
+        var delivered = new List<(NpcBrainHookType Hook, NpcBrainEvent Event)>(count);
+
+        for (var index = 0; index < count; index++)
+        {
+            var entry = _entries[index];
+            delivered.Add((entry.Hook, entry.Event));
+            _metrics.RecordEvent(NpcBrainEventDispositionType.Delivered);
+        }
+
+        _entries.RemoveRange(0, count);
+
+        return delivered;
+    }
+
+    public void Clear()
+    {
+        _entries.Clear();
+    }
+
+    private bool TryCoalesce(NpcBrainHookType hook, NpcBrainEvent brainEvent)
+    {
+        if (brainEvent.Mobile is not { Id: var mobileId } || mobileId == Serial.Zero)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < _entries.Count; index++)
+        {
+            var entry = _entries[index];
+
+            if (entry.Hook != hook || entry.Event.Mobile?.Id != mobileId)
+            {
+                continue;
+            }
+
+            if (hook == NpcBrainHookType.MobileMoved)
+            {
+                _entries[index] = (hook, brainEvent, entry.Sequence);
+                return true;
+            }
+
+            if (hook is NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool MakeRoom(NpcBrainHookType incomingHook)
+    {
+        var lowestPriority = _entries.Min(entry => Priority(entry.Hook));
+
+        if (Priority(incomingHook) < lowestPriority)
+        {
+            return false;
+        }
+
+        var evictionIndex = _entries.FindIndex(entry => Priority(entry.Hook) == lowestPriority);
+        _entries.RemoveAt(evictionIndex);
+        _metrics.RecordEvent(NpcBrainEventDispositionType.Dropped);
+
+        return true;
+    }
+
+    private static int Priority(NpcBrainHookType hook)
+        => hook switch
+        {
+            NpcBrainHookType.Activate or NpcBrainHookType.Deactivate or NpcBrainHookType.Death => 4,
+            NpcBrainHookType.Attacked or NpcBrainHookType.Damage => 3,
+            NpcBrainHookType.SpeechHeard => 2,
+            NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange => 1,
+            _ => 0
+        };
+}

--- a/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
+++ b/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
@@ -72,24 +72,39 @@ public sealed class NpcBrainMailbox
             return false;
         }
 
-        for (var index = 0; index < _entries.Count; index++)
+        if (hook == NpcBrainHookType.MobileMoved)
         {
-            var entry = _entries[index];
-
-            if (entry.Hook != hook || entry.Event.Mobile?.Id != mobileId)
+            for (var index = 0; index < _entries.Count; index++)
             {
-                continue;
-            }
+                var entry = _entries[index];
 
-            if (hook == NpcBrainHookType.MobileMoved)
-            {
+                if (entry.Hook != hook || entry.Event.Mobile?.Id != mobileId)
+                {
+                    continue;
+                }
+
                 _entries[index] = (hook, brainEvent, entry.Sequence);
                 return true;
             }
+        }
 
-            if (hook is NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange)
+        if (hook is NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange)
+        {
+            for (var index = _entries.Count - 1; index >= 0; index--)
             {
-                return true;
+                var entry = _entries[index];
+
+                if (
+                    entry.Event.Mobile?.Id != mobileId ||
+                    entry.Hook is not (
+                        NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange
+                    )
+                )
+                {
+                    continue;
+                }
+
+                return entry.Hook == hook;
             }
         }
 

--- a/src/Moongate.Server/Plugins/MoongateNpcAiPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateNpcAiPlugin.cs
@@ -1,0 +1,39 @@
+using DryIoc;
+using Moongate.Server.Abstractions.Extensions;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Services.AI;
+using Moongate.Server.Subscribers;
+using SquidStd.Abstractions.Extensions.Services;
+using SquidStd.Core.Utils;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
+
+namespace Moongate.Server.Plugins;
+
+/// <summary>Registers the NPC brain scheduler, player-driven sector activity and lifecycle subscribers.</summary>
+public sealed class MoongateNpcAiPlugin : ISquidStdPlugin
+{
+    public PluginMetadata Metadata
+        => new()
+        {
+            Id = "moongate.npcai.plugin",
+            Version = new(VersionUtils.GetVersion(typeof(MoongateNpcAiPlugin).Assembly)),
+            Author = "squid",
+            Name = "Moongate NPC AI",
+            Description = "NPC brain scheduling and lifecycle services"
+        };
+
+    public void Configure(IContainer container, PluginContext context)
+    {
+        container.Register<INpcAiMetrics, NpcAiMetrics>(Reuse.Singleton);
+        container.RegisterStdService<ISectorActivityService, SectorActivityService>();
+        container.Register<IBrainIntentExecutor, BrainIntentExecutor>(Reuse.Singleton);
+        container.Register<NpcBrainContextFactory>(Reuse.Singleton);
+        container.RegisterStdService<INpcBrainScheduler, NpcBrainScheduler>();
+
+        container.RegisterEventSubscriber<SectorActivitySubscriber>();
+        container.RegisterEventSubscriber<NpcBrainLifecycleSubscriber>();
+        container.RegisterEventSubscriber<NpcBrainEventRouter>();
+    }
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -22,6 +22,7 @@ using Moongate.Server.Data.Exceptions;
 using Moongate.Server.Extensions;
 using Moongate.Server.Plugins;
 using Moongate.Server.Services.Accounts;
+using Moongate.Server.Services.AI;
 using Moongate.Server.Services.Chat;
 using Moongate.Server.Services.Events;
 using Moongate.Server.Services.Game;
@@ -93,6 +94,8 @@ await ConsoleApp.RunAsync(
             moongateConfig.UltimaDirectory = uoDirectory;
         }
 
+        NpcAiConfigValidator.Validate(moongateConfig.NpcAi);
+
         if (string.IsNullOrEmpty(moongateConfig.UltimaDirectory))
         {
             throw new UODirectoryNotValidException(
@@ -136,6 +139,7 @@ await ConsoleApp.RunAsync(
                 AddTracked<MoongatePersistencePlugin>();
                 AddTracked<MoongateScriptingPlugin>();
                 AddTracked<MoongateScriptModulesPlugin>();
+                AddTracked<MoongateNpcAiPlugin>();
                 AddTracked<MoongateDataLoaderPlugin>();
                 AddTracked<MoongateCommandsPlugin>();
                 AddTracked<MoongatePacketHandlersPlugin>();

--- a/src/Moongate.Server/Scripting/MobileModule.cs
+++ b/src/Moongate.Server/Scripting/MobileModule.cs
@@ -3,12 +3,15 @@ using Moongate.Core.Extensions;
 using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Scripting.Views;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
+using SquidStd.Core.Interfaces.Events;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 using SquidStd.Scripting.Lua.Attributes.Scripts;
 
@@ -29,18 +32,24 @@ public sealed class MobileModule
     private readonly IMobileFactoryService _factory;
     private readonly IItemFactoryService _itemFactory;
     private readonly IItemService _items;
+    private readonly ISpatialIndexService _spatial;
+    private readonly IEventBus _eventBus;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
 
     public MobileModule(
         IMobileFactoryService factory,
         IItemFactoryService itemFactory,
         IItemService items,
-        IPersistenceService persistence
+        IPersistenceService persistence,
+        ISpatialIndexService spatial,
+        IEventBus eventBus
     )
     {
         _factory = factory;
         _itemFactory = itemFactory;
         _items = items;
+        _spatial = spatial;
+        _eventBus = eventBus;
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
     }
 
@@ -49,6 +58,8 @@ public sealed class MobileModule
     {
         var mobile = _factory.Create(name, map, new(x, y, z));
         _mobiles.UpsertAsync(mobile).WaitSync();
+        _spatial.AddOrUpdate(mobile);
+        _eventBus.Publish(new MobileCreatedEvent(mobile));
 
         return mobile.Id.Value;
     }
@@ -64,6 +75,7 @@ public sealed class MobileModule
         }
 
         _mobiles.UpsertAsync(spawn.Mobile).WaitSync();
+        _spatial.AddOrUpdate(spawn.Mobile);
 
         foreach (var entry in spawn.Equipment)
         {
@@ -79,13 +91,33 @@ public sealed class MobileModule
             _items.Equip(spawn.Mobile, item, entry.Layer);
         }
 
+        if (_mobiles.GetById(spawn.Mobile.Id) is { } completeMobile)
+        {
+            _eventBus.Publish(new MobileCreatedEvent(completeMobile));
+        }
+
         return spawn.Mobile.Id.Value;
     }
 
     [ScriptFunction("delete", "Deletes the mobile; true when it existed.")]
     public bool Delete(uint serial)
     {
-        return _mobiles.RemoveAsync((Serial)serial).WaitSync();
+        var mobile = _mobiles.GetById((Serial)serial);
+
+        if (mobile is null)
+        {
+            return false;
+        }
+
+        _spatial.Remove(mobile.Id);
+        var deleted = _mobiles.RemoveAsync(mobile.Id).WaitSync();
+
+        if (deleted)
+        {
+            _eventBus.Publish(new MobileDeletedEvent(mobile));
+        }
+
+        return deleted;
     }
 
     [ScriptFunction("get", "Returns a field table for the mobile, or nil.")]
@@ -115,8 +147,16 @@ public sealed class MobileModule
             return false;
         }
 
+        var fromMapId = mobile.MapId;
+        var fromPosition = mobile.Position;
         mobile.Position = new(x, y, z);
         _mobiles.UpsertAsync(mobile).WaitSync();
+        _spatial.AddOrUpdate(mobile);
+
+        if (mobile.MapId != fromMapId || mobile.Position != fromPosition)
+        {
+            _eventBus.Publish(new MobileMovedEvent(mobile.Id, fromMapId, fromPosition, mobile.MapId, mobile.Position));
+        }
 
         return true;
     }
@@ -131,6 +171,8 @@ public sealed class MobileModule
             return false;
         }
 
+        var fromMapId = mobile.MapId;
+        var fromPosition = mobile.Position;
         var name = fields.Get("name");
 
         if (name.Type == DataType.String)
@@ -165,6 +207,12 @@ public sealed class MobileModule
         }
 
         _mobiles.UpsertAsync(mobile).WaitSync();
+
+        if (mobile.MapId != fromMapId)
+        {
+            _spatial.AddOrUpdate(mobile);
+            _eventBus.Publish(new MobileMovedEvent(mobile.Id, fromMapId, fromPosition, mobile.MapId, mobile.Position));
+        }
 
         return true;
     }

--- a/src/Moongate.Server/Services/AI/BrainIntentExecutor.cs
+++ b/src/Moongate.Server/Services/AI/BrainIntentExecutor.cs
@@ -1,0 +1,325 @@
+using System.Diagnostics.CodeAnalysis;
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using Serilog;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+using ILogger = Serilog.ILogger;
+
+namespace Moongate.Server.Services.AI;
+
+/// <summary>Validates and applies the bounded world effects represented by NPC brain intents.</summary>
+public sealed class BrainIntentExecutor : IBrainIntentExecutor
+{
+    private const int SpeechRange = 15;
+    private const int SpeechMaximumLength = 128;
+    private const int HomeLeashRange = 8;
+
+    private readonly ILogger _logger = Log.ForContext<BrainIntentExecutor>();
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IMovementService _movement;
+    private readonly IChatService _chat;
+    private readonly Random _random;
+    private readonly ILoopAffinity _loopAffinity;
+    private readonly INpcAiMetrics _metrics;
+
+    public BrainIntentExecutor(
+        IPersistenceService persistenceService,
+        IMovementService movement,
+        IChatService chat,
+        Random random,
+        ILoopAffinity loopAffinity,
+        INpcAiMetrics metrics
+    )
+    {
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _movement = movement;
+        _chat = chat;
+        _random = random;
+        _loopAffinity = loopAffinity;
+        _metrics = metrics;
+    }
+
+    public void Execute(Serial mobileId, BrainContext context, IReadOnlyList<BrainIntent> intents)
+    {
+        _loopAffinity.AssertOnLoop("ai.brain_intent_execute");
+
+        foreach (var intent in intents ?? [])
+        {
+            var owner = _mobiles.GetById(mobileId);
+
+            if (owner is null)
+            {
+                Reject(mobileId, intent, "owner is missing");
+                continue;
+            }
+
+            if (context is null)
+            {
+                Reject(mobileId, intent, "brain context is missing");
+                continue;
+            }
+
+            if (TryExecute(owner, context, intent, out var reason))
+            {
+                _metrics.RecordIntent(true);
+                continue;
+            }
+
+            Reject(mobileId, intent, reason);
+        }
+    }
+
+    private bool TryExecute(MobileEntity owner, BrainContext context, BrainIntent? intent, out string reason)
+    {
+        if (intent is null)
+        {
+            reason = "intent is missing";
+            return false;
+        }
+
+        switch (intent.Type)
+        {
+            case BrainIntentType.Idle:
+                reason = "";
+                return true;
+            case BrainIntentType.Say:
+                return TrySay(owner, intent.Text, out reason);
+            case BrainIntentType.Patrol:
+                return TryPatrol(owner, context, out reason);
+            case BrainIntentType.MoveToward:
+                return TryMove(owner, context, intent.TargetId, false, out reason);
+            case BrainIntentType.MoveAway:
+                return TryMove(owner, context, intent.TargetId, true, out reason);
+            case BrainIntentType.Engage:
+                return TryEngage(owner, context, intent.TargetId, out reason);
+            case BrainIntentType.ClearTarget:
+                return TryClearTarget(owner, out reason);
+            case BrainIntentType.ReturnHome:
+                return TryReturnHome(owner, context, out reason);
+            default:
+                reason = "intent type is unknown or unsupported";
+                return false;
+        }
+    }
+
+    private bool TrySay(MobileEntity owner, string? text, out string reason)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            reason = "speech text is blank";
+            return false;
+        }
+
+        if (text.Length > SpeechMaximumLength)
+        {
+            reason = "speech text exceeds the maximum length";
+            return false;
+        }
+
+        _chat.Say(owner, ChatMessageType.Regular, text, Hue.Default, SpeechRange);
+        reason = "";
+        return true;
+    }
+
+    private bool TryEngage(MobileEntity owner, BrainContext context, Serial targetId, out string reason)
+    {
+        if (!TryGetPerceivedTarget(owner, context, targetId, out var target, out reason))
+        {
+            return false;
+        }
+
+        if (owner.CombatantId != target.Id || !owner.Warmode)
+        {
+            owner.CombatantId = target.Id;
+            owner.Warmode = true;
+            _mobiles.UpsertAsync(owner).WaitSync();
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private bool TryClearTarget(MobileEntity owner, out string reason)
+    {
+        if (owner.CombatantId != Serial.Zero || owner.Warmode)
+        {
+            owner.CombatantId = Serial.Zero;
+            owner.Warmode = false;
+            _mobiles.UpsertAsync(owner).WaitSync();
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private bool TryMove(
+        MobileEntity owner,
+        BrainContext context,
+        Serial targetId,
+        bool moveAway,
+        out string reason
+    )
+    {
+        if (!TryGetPerceivedTarget(owner, context, targetId, out var target, out reason))
+        {
+            return false;
+        }
+
+        var direction = DirectionToward(owner.Position, target.Position);
+
+        if (owner.Position == target.Position)
+        {
+            reason = "";
+            return true;
+        }
+
+        if (moveAway)
+        {
+            direction = direction.Opposite();
+        }
+
+        if (!_movement.TryMoveNpc(owner.Id, direction))
+        {
+            reason = "movement service rejected the move";
+            return false;
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private bool TryReturnHome(MobileEntity owner, BrainContext context, out string reason)
+    {
+        if (owner.MapId != context.HomeMapId)
+        {
+            reason = "owner is not on the home map";
+            return false;
+        }
+
+        return TryMoveToPosition(owner, context.HomePosition, out reason);
+    }
+
+    private bool TryPatrol(MobileEntity owner, BrainContext context, out string reason)
+    {
+        if (owner.MapId != context.HomeMapId)
+        {
+            reason = "owner is not on the home map";
+            return false;
+        }
+
+        if (!owner.Position.InRange(context.HomePosition, HomeLeashRange))
+        {
+            return TryMoveToPosition(owner, context.HomePosition, out reason);
+        }
+
+        if (!_movement.TryMoveNpc(owner.Id, (DirectionType)_random.Next(0, 8)))
+        {
+            reason = "movement service rejected the patrol move";
+            return false;
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private bool TryMoveToPosition(MobileEntity owner, Point3D target, out string reason)
+    {
+        if (owner.Position == target)
+        {
+            reason = "";
+            return true;
+        }
+
+        if (!_movement.TryMoveNpc(owner.Id, DirectionToward(owner.Position, target)))
+        {
+            reason = "movement service rejected the move";
+            return false;
+        }
+
+        reason = "";
+        return true;
+    }
+
+    private bool TryGetPerceivedTarget(
+        MobileEntity owner,
+        BrainContext context,
+        Serial targetId,
+        [NotNullWhen(true)] out MobileEntity? target,
+        out string reason
+    )
+    {
+        target = null;
+
+        if (targetId == Serial.Zero)
+        {
+            reason = "target is missing";
+            return false;
+        }
+
+        if (targetId == owner.Id)
+        {
+            reason = "owner cannot target itself";
+            return false;
+        }
+
+        if (context.Nearby is null || !context.Nearby.Any(snapshot => snapshot.Id == targetId))
+        {
+            reason = "target is outside current perception";
+            return false;
+        }
+
+        var resolvedTarget = _mobiles.GetById(targetId);
+
+        if (resolvedTarget is null)
+        {
+            reason = "target is missing";
+            return false;
+        }
+
+        if (resolvedTarget.MapId != owner.MapId)
+        {
+            reason = "target is on another map";
+            return false;
+        }
+
+        target = resolvedTarget;
+        reason = "";
+        return true;
+    }
+
+    private void Reject(Serial mobileId, BrainIntent? intent, string reason)
+    {
+        _logger.Debug(
+            "Rejected NPC brain intent {MobileId} {RawType}: {Reason}",
+            mobileId,
+            intent?.RawType,
+            reason
+        );
+        _metrics.RecordIntent(false);
+    }
+
+    private static DirectionType DirectionToward(Point3D from, Point3D to)
+        => (Math.Sign(to.X - from.X), Math.Sign(to.Y - from.Y)) switch
+        {
+            (0, -1) => DirectionType.North,
+            (1, -1) => DirectionType.NorthEast,
+            (1, 0) => DirectionType.East,
+            (1, 1) => DirectionType.SouthEast,
+            (0, 1) => DirectionType.South,
+            (-1, 1) => DirectionType.SouthWest,
+            (-1, 0) => DirectionType.West,
+            (-1, -1) => DirectionType.NorthWest,
+            _ => DirectionType.North
+        };
+}

--- a/src/Moongate.Server/Services/AI/NpcAiConfigValidator.cs
+++ b/src/Moongate.Server/Services/AI/NpcAiConfigValidator.cs
@@ -1,0 +1,42 @@
+using Moongate.Server.Abstractions.Data.Config;
+
+namespace Moongate.Server.Services.AI;
+
+public static class NpcAiConfigValidator
+{
+    public static void Validate(NpcAiConfig config)
+    {
+        var advanced = config.Advanced;
+
+        ValidatePositive(advanced.SectorIdleGraceSeconds, nameof(NpcAiAdvancedConfig.SectorIdleGraceSeconds));
+        ValidatePositive(advanced.MinTickMilliseconds, nameof(NpcAiAdvancedConfig.MinTickMilliseconds));
+        ValidatePositive(advanced.MaxTickMilliseconds, nameof(NpcAiAdvancedConfig.MaxTickMilliseconds));
+        ValidatePositive(advanced.MaxBrainsPerLoop, nameof(NpcAiAdvancedConfig.MaxBrainsPerLoop));
+        ValidatePositive(advanced.MaxEventsPerBrainWake, nameof(NpcAiAdvancedConfig.MaxEventsPerBrainWake));
+        ValidatePositive(advanced.MaxMailboxEvents, nameof(NpcAiAdvancedConfig.MaxMailboxEvents));
+        ValidatePositive(advanced.MaxIntentsPerDecision, nameof(NpcAiAdvancedConfig.MaxIntentsPerDecision));
+        ValidatePositive(advanced.InstructionBudget, nameof(NpcAiAdvancedConfig.InstructionBudget));
+
+        if (advanced.MinTickMilliseconds > advanced.MaxTickMilliseconds)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(NpcAiAdvancedConfig.MinTickMilliseconds)} cannot exceed {nameof(NpcAiAdvancedConfig.MaxTickMilliseconds)}."
+            );
+        }
+
+        if (advanced.MaxMailboxEvents < advanced.MaxEventsPerBrainWake)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(NpcAiAdvancedConfig.MaxMailboxEvents)} cannot be smaller than {nameof(NpcAiAdvancedConfig.MaxEventsPerBrainWake)}."
+            );
+        }
+    }
+
+    private static void ValidatePositive(long value, string propertyName)
+    {
+        if (value <= 0)
+        {
+            throw new InvalidOperationException($"{propertyName} must be positive.");
+        }
+    }
+}

--- a/src/Moongate.Server/Services/AI/NpcAiMetrics.cs
+++ b/src/Moongate.Server/Services/AI/NpcAiMetrics.cs
@@ -1,0 +1,159 @@
+using System.Threading;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Services.AI;
+
+public sealed class NpcAiMetrics : INpcAiMetrics
+{
+    private long _activeSectors;
+    private long _graceSectors;
+    private long _sleepingSectors;
+    private long _activeBrains;
+    private long _sleepingBrains;
+    private long _faultBackoffBrains;
+    private long _brainsExecuted;
+    private long _brainsDeferred;
+    private long _hookInvocations;
+    private long _totalHookDurationTicks;
+    private long _maxHookDurationTicks;
+    private long _hookFailures;
+    private long _instructionBudgetBreaches;
+    private long _eventsDelivered;
+    private long _eventsCoalesced;
+    private long _eventsDropped;
+    private long _intentsAccepted;
+    private long _intentsRejected;
+    private long _reloadSuccesses;
+    private long _reloadFallbacks;
+
+    public NpcAiMetricsSnapshot Current => new(
+        Interlocked.Read(ref _activeSectors),
+        Interlocked.Read(ref _graceSectors),
+        Interlocked.Read(ref _sleepingSectors),
+        Interlocked.Read(ref _activeBrains),
+        Interlocked.Read(ref _sleepingBrains),
+        Interlocked.Read(ref _faultBackoffBrains),
+        Interlocked.Read(ref _brainsExecuted),
+        Interlocked.Read(ref _brainsDeferred),
+        Interlocked.Read(ref _hookInvocations),
+        Interlocked.Read(ref _totalHookDurationTicks),
+        Interlocked.Read(ref _maxHookDurationTicks),
+        Interlocked.Read(ref _hookFailures),
+        Interlocked.Read(ref _instructionBudgetBreaches),
+        Interlocked.Read(ref _eventsDelivered),
+        Interlocked.Read(ref _eventsCoalesced),
+        Interlocked.Read(ref _eventsDropped),
+        Interlocked.Read(ref _intentsAccepted),
+        Interlocked.Read(ref _intentsRejected),
+        Interlocked.Read(ref _reloadSuccesses),
+        Interlocked.Read(ref _reloadFallbacks)
+    );
+
+    public void SetActiveSectorCounts(int active, int grace)
+    {
+        Interlocked.Exchange(ref _activeSectors, active);
+        Interlocked.Exchange(ref _graceSectors, grace);
+    }
+
+    public void SetSleepingSectorCount(int sleeping)
+    {
+        Interlocked.Exchange(ref _sleepingSectors, sleeping);
+    }
+
+    public void SetBrainCounts(int active, int sleeping, int faultBackoff)
+    {
+        Interlocked.Exchange(ref _activeBrains, active);
+        Interlocked.Exchange(ref _sleepingBrains, sleeping);
+        Interlocked.Exchange(ref _faultBackoffBrains, faultBackoff);
+    }
+
+    public void RecordBrainExecuted()
+    {
+        Interlocked.Increment(ref _brainsExecuted);
+    }
+
+    public void RecordBrainDeferred()
+    {
+        Interlocked.Increment(ref _brainsDeferred);
+    }
+
+    public void RecordHookInvocation(TimeSpan duration)
+    {
+        Interlocked.Increment(ref _hookInvocations);
+        Interlocked.Add(ref _totalHookDurationTicks, duration.Ticks);
+        UpdateMaximumHookDuration(duration.Ticks);
+    }
+
+    public void RecordHookFailure(bool instructionBudgetExceeded)
+    {
+        Interlocked.Increment(ref _hookFailures);
+
+        if (instructionBudgetExceeded)
+        {
+            Interlocked.Increment(ref _instructionBudgetBreaches);
+        }
+    }
+
+    public void RecordEvent(NpcBrainEventDispositionType disposition)
+    {
+        switch (disposition)
+        {
+            case NpcBrainEventDispositionType.Delivered:
+                Interlocked.Increment(ref _eventsDelivered);
+                break;
+            case NpcBrainEventDispositionType.Coalesced:
+                Interlocked.Increment(ref _eventsCoalesced);
+                break;
+            case NpcBrainEventDispositionType.Dropped:
+                Interlocked.Increment(ref _eventsDropped);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(disposition), disposition, null);
+        }
+    }
+
+    public void RecordIntent(bool accepted)
+    {
+        if (accepted)
+        {
+            Interlocked.Increment(ref _intentsAccepted);
+            return;
+        }
+
+        Interlocked.Increment(ref _intentsRejected);
+    }
+
+    public void RecordReload(bool succeeded)
+    {
+        if (succeeded)
+        {
+            Interlocked.Increment(ref _reloadSuccesses);
+            return;
+        }
+
+        Interlocked.Increment(ref _reloadFallbacks);
+    }
+
+    private void UpdateMaximumHookDuration(long durationTicks)
+    {
+        var currentMaximum = Interlocked.Read(ref _maxHookDurationTicks);
+
+        while (durationTicks > currentMaximum)
+        {
+            var observedMaximum = Interlocked.CompareExchange(
+                ref _maxHookDurationTicks,
+                durationTicks,
+                currentMaximum
+            );
+
+            if (observedMaximum == currentMaximum)
+            {
+                return;
+            }
+
+            currentMaximum = observedMaximum;
+        }
+    }
+}

--- a/src/Moongate.Server/Services/AI/NpcBrainContextFactory.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainContextFactory.cs
@@ -1,0 +1,63 @@
+using Moongate.Core.Geometry;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Server.Services.AI;
+
+public sealed class NpcBrainContextFactory
+{
+    private readonly ISpatialIndexService _spatial;
+    private readonly ISessionManager _sessions;
+    private readonly TimeProvider _timeProvider;
+
+    public NpcBrainContextFactory(
+        ISpatialIndexService spatial,
+        ISessionManager sessions,
+        TimeProvider timeProvider
+    )
+    {
+        _spatial = spatial;
+        _sessions = sessions;
+        _timeProvider = timeProvider;
+    }
+
+    public BrainContext Create(
+        MobileEntity owner,
+        int homeMapId,
+        Point3D homePosition,
+        BrainDescriptor descriptor
+    )
+    {
+        var nearby = _spatial
+            .GetMobilesInRange(owner.MapId, owner.Position, descriptor.PerceptionRange)
+            .Where(mobile => mobile.Id != owner.Id)
+            .Select(ToSnapshot)
+            .OrderBy(snapshot => snapshot.Id)
+            .ToArray();
+
+        return new(
+            _timeProvider.GetUtcNow(),
+            ToSnapshot(owner),
+            homeMapId,
+            homePosition,
+            nearby
+        );
+    }
+
+    private BrainMobileSnapshot ToSnapshot(MobileEntity mobile)
+        => new(
+            mobile.Id,
+            mobile.Name,
+            _sessions.IsCharacterPlayed(mobile.Id),
+            mobile.MapId,
+            mobile.Position,
+            mobile.Hits,
+            mobile.HitsMax,
+            mobile.Warmode,
+            mobile.CombatantId,
+            mobile.Criminal,
+            mobile.Kills
+        );
+}

--- a/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Moongate.Core.Geometry;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
@@ -34,19 +33,22 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private readonly INpcAiMetrics _metrics;
     private readonly Dictionary<Serial, SchedulerEntry> _entries = [];
     private readonly PriorityQueue<(Serial MobileId, long Version), (long DueTicks, long Sequence)> _queue = new();
-    private readonly Dictionary<string, DateTimeOffset> _faultLogs = new(StringComparer.Ordinal);
+    private readonly Dictionary<
+        (string BrainId, Serial MobileId, NpcBrainHookType Hook, string Error),
+        DateTimeOffset
+    > _faultLogs = [];
 
     private string? _timerId;
     private long _nextQueueSequence;
 
     public int MaxHearingRange => _entries.Values
-        .Where(entry => entry.Descriptor is not null)
+        .Where(HasCurrentDescriptor)
         .Select(entry => entry.Descriptor!.HearingRange)
         .DefaultIfEmpty()
         .Max();
 
     public int MaxPerceptionRange => _entries.Values
-        .Where(entry => entry.Descriptor is not null)
+        .Where(HasCurrentDescriptor)
         .Select(entry => entry.Descriptor!.PerceptionRange)
         .DefaultIfEmpty()
         .Max();
@@ -87,9 +89,9 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             if (string.Equals(existing.BrainId, mobile.BrainScriptId, StringComparison.Ordinal))
             {
                 if (_runtime.TryGetDescriptor(mobile.Id, out var currentDescriptor) &&
-                    currentDescriptor is not null)
+                    !TryCacheDescriptor(existing, currentDescriptor))
                 {
-                    existing.Descriptor = currentDescriptor;
+                    existing.Descriptor = null;
                 }
 
                 return;
@@ -120,12 +122,14 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             );
         }
 
-        if (_runtime.TryBind(mobile.Id, mobile.BrainScriptId, out var descriptor, out var error) &&
-            descriptor is not null)
-        {
-            entry.Descriptor = descriptor;
-        }
-        else if (isActive)
+        var isBound = _runtime.TryBind(
+            mobile.Id,
+            mobile.BrainScriptId,
+            out var descriptor,
+            out var error
+        ) && TryCacheDescriptor(entry, descriptor);
+
+        if (!isBound && isActive)
         {
             RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
         }
@@ -138,6 +142,8 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
 
     public void Unbind(Serial mobileId)
     {
+        ClearFaultLogs(mobileId);
+
         if (!_entries.Remove(mobileId))
         {
             return;
@@ -187,11 +193,16 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
 
     public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
     {
+        if (!string.Equals(descriptor.BrainId, brainId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
         foreach (var entry in _entries.Values.Where(
                      entry => string.Equals(entry.BrainId, brainId, StringComparison.Ordinal)
                  ))
         {
-            entry.Descriptor = descriptor;
+            TryCacheDescriptor(entry, descriptor);
         }
     }
 
@@ -201,7 +212,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
 
     public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
     {
-        if (_entries.TryGetValue(mobileId, out var entry) && entry.Descriptor is not null)
+        if (_entries.TryGetValue(mobileId, out var entry) && HasCurrentDescriptor(entry))
         {
             descriptor = entry.Descriptor;
             return true;
@@ -230,6 +241,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     public void Tick()
     {
         var now = _timeProvider.GetUtcNow();
+        PruneFaultLogs(now);
         var executed = 0;
         var woken = new HashSet<Serial>();
         var postponed = new List<(
@@ -317,6 +329,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private void RebindChangedBrain(SchedulerEntry entry, MobileEntity mobile)
     {
         var now = _timeProvider.GetUtcNow();
+        ClearFaultLogs(mobile.Id);
         _runtime.Reset(mobile.Id);
         entry.BrainId = mobile.BrainScriptId;
         entry.Descriptor = null;
@@ -336,12 +349,14 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             );
         }
 
-        if (_runtime.TryBind(mobile.Id, mobile.BrainScriptId, out var descriptor, out var error) &&
-            descriptor is not null)
-        {
-            entry.Descriptor = descriptor;
-        }
-        else if (entry.State == NpcBrainStateType.Active)
+        var isBound = _runtime.TryBind(
+            mobile.Id,
+            mobile.BrainScriptId,
+            out var descriptor,
+            out var error
+        ) && TryCacheDescriptor(entry, descriptor);
+
+        if (!isBound && entry.State == NpcBrainStateType.Active)
         {
             RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
         }
@@ -447,17 +462,14 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private bool EnsureBinding(SchedulerEntry entry, DateTimeOffset now)
     {
         if (_runtime.TryGetDescriptor(entry.MobileId, out var descriptor) &&
-            descriptor is not null &&
-            string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal))
+            TryCacheDescriptor(entry, descriptor))
         {
-            entry.Descriptor = descriptor;
             return true;
         }
 
         if (_runtime.TryBind(entry.MobileId, entry.BrainId, out descriptor, out var error) &&
-            descriptor is not null)
+            TryCacheDescriptor(entry, descriptor))
         {
-            entry.Descriptor = descriptor;
             entry.ConsecutiveFailures = 0;
             return true;
         }
@@ -511,7 +523,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         NpcBrainEvent? brainEvent
     )
     {
-        var started = Stopwatch.GetTimestamp();
+        var started = _timeProvider.GetTimestamp();
 
         try
         {
@@ -524,7 +536,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         }
         finally
         {
-            _metrics.RecordHookInvocation(Stopwatch.GetElapsedTime(started));
+            _metrics.RecordHookInvocation(_timeProvider.GetElapsedTime(started));
         }
     }
 
@@ -592,7 +604,8 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         DateTimeOffset now
     )
     {
-        var key = $"{entry.BrainId}\n{entry.MobileId.Value}\n{(int)hook}\n{error}";
+        PruneFaultLogs(now);
+        var key = (entry.BrainId, entry.MobileId, hook, error);
 
         if (_faultLogs.TryGetValue(key, out var loggedAt) &&
             now - loggedAt < TimeSpan.FromSeconds(FaultLogIntervalSeconds))
@@ -608,6 +621,14 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             hook,
             error
         );
+    }
+
+    private void ClearFaultLogs(Serial mobileId)
+    {
+        foreach (var key in _faultLogs.Keys.Where(key => key.MobileId == mobileId).ToArray())
+        {
+            _faultLogs.Remove(key);
+        }
     }
 
     private void CompleteSleep(SchedulerEntry entry)
@@ -686,6 +707,37 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             mobile.Position.X >> SectorShift,
             mobile.Position.Y >> SectorShift
         );
+
+    private void PruneFaultLogs(DateTimeOffset now)
+    {
+        var interval = TimeSpan.FromSeconds(FaultLogIntervalSeconds);
+
+        foreach (var key in _faultLogs
+                     .Where(entry => now - entry.Value >= interval)
+                     .Select(entry => entry.Key)
+                     .ToArray())
+        {
+            _faultLogs.Remove(key);
+        }
+    }
+
+    private static bool HasCurrentDescriptor(SchedulerEntry entry)
+        => entry.Descriptor is { } descriptor &&
+           string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal);
+
+    private static bool TryCacheDescriptor(SchedulerEntry entry, BrainDescriptor? descriptor)
+    {
+        if (
+            descriptor is null ||
+            !string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal)
+        )
+        {
+            return false;
+        }
+
+        entry.Descriptor = descriptor;
+        return true;
+    }
 
     private static long DueTicks(DateTimeOffset dueAt)
         => dueAt.UtcDateTime.Ticks;

--- a/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
@@ -20,6 +20,8 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private const string TimerName = "npc-brain-scheduler";
     private const int SectorShift = 4;
     private const int FaultLogIntervalSeconds = 60;
+    private const int QueueCompactionFactor = 2;
+    private const int QueueCompactionSlack = 8;
 
     private readonly ILogger _logger = Log.ForContext<NpcBrainScheduler>();
     private readonly IGameLoopContext _loop;
@@ -150,12 +152,25 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         }
 
         _runtime.Unbind(mobileId);
+        CompactQueueIfNeeded();
     }
 
     public void Activate(Serial mobileId)
     {
-        if (!_entries.TryGetValue(mobileId, out var entry) ||
-            entry.State != NpcBrainStateType.Sleeping)
+        if (!_entries.TryGetValue(mobileId, out var entry))
+        {
+            return;
+        }
+
+        if (entry.State == NpcBrainStateType.Deactivating)
+        {
+            entry.State = NpcBrainStateType.Active;
+            entry.Mailbox.Clear();
+            Requeue(entry, entry.NextThinkAt, true);
+            return;
+        }
+
+        if (entry.State != NpcBrainStateType.Sleeping)
         {
             return;
         }
@@ -230,9 +245,9 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             return;
         }
 
-        entry.Mailbox.Enqueue(hook, brainEvent);
+        var schedulingChanged = entry.Mailbox.Enqueue(hook, brainEvent);
 
-        if (entry.State == NpcBrainStateType.Active)
+        if (entry.State == NpcBrainStateType.Active && schedulingChanged)
         {
             Requeue(entry, _timeProvider.GetUtcNow());
         }
@@ -257,9 +272,14 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             var (mobileId, version) = element;
 
             if (!_entries.TryGetValue(mobileId, out var entry) ||
-                entry.QueueVersion != version ||
-                entry.State == NpcBrainStateType.Sleeping)
+                entry.QueueVersion != version)
             {
+                continue;
+            }
+
+            if (entry.State == NpcBrainStateType.Sleeping)
+            {
+                entry.ScheduledDueTicks = null;
                 continue;
             }
 
@@ -269,6 +289,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
                 continue;
             }
 
+            entry.ScheduledDueTicks = null;
             var dueAt = GetDueAt(entry, now);
 
             if (dueAt > now)
@@ -292,6 +313,8 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         {
             _queue.Enqueue(queued.Element, queued.Priority);
         }
+
+        CompactQueueIfNeeded();
 
         if (executed == _advanced.MaxBrainsPerLoop)
         {
@@ -330,6 +353,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     {
         var now = _timeProvider.GetUtcNow();
         ClearFaultLogs(mobile.Id);
+        CancelSchedule(entry);
         _runtime.Reset(mobile.Id);
         entry.BrainId = mobile.BrainScriptId;
         entry.Descriptor = null;
@@ -633,19 +657,71 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
 
     private void CompleteSleep(SchedulerEntry entry)
     {
+        CancelSchedule(entry);
         entry.State = NpcBrainStateType.Sleeping;
         entry.FaultUntil = null;
         entry.ConsecutiveFailures = 0;
         entry.Mailbox.Clear();
     }
 
-    private void Requeue(SchedulerEntry entry, DateTimeOffset dueAt)
+    private void Requeue(
+        SchedulerEntry entry,
+        DateTimeOffset dueAt,
+        bool replaceExisting = false
+    )
     {
+        var dueTicks = DueTicks(dueAt);
+
+        if (!replaceExisting &&
+            entry.ScheduledDueTicks is { } scheduledDueTicks &&
+            scheduledDueTicks <= dueTicks)
+        {
+            return;
+        }
+
         entry.QueueVersion++;
+        entry.ScheduledDueTicks = dueTicks;
         _queue.Enqueue(
             (entry.MobileId, entry.QueueVersion),
-            (DueTicks(dueAt), _nextQueueSequence++)
+            (dueTicks, _nextQueueSequence++)
         );
+        CompactQueueIfNeeded();
+    }
+
+    private void CancelSchedule(SchedulerEntry entry)
+    {
+        if (entry.ScheduledDueTicks is null)
+        {
+            return;
+        }
+
+        entry.QueueVersion++;
+        entry.ScheduledDueTicks = null;
+    }
+
+    private void CompactQueueIfNeeded()
+    {
+        var scheduledCount = _entries.Values.Count(entry => entry.ScheduledDueTicks is not null);
+        var maximumQueueCount = (scheduledCount * QueueCompactionFactor) + QueueCompactionSlack;
+
+        if (_queue.Count <= maximumQueueCount)
+        {
+            return;
+        }
+
+        var current = _queue.UnorderedItems
+            .Where(item =>
+                _entries.TryGetValue(item.Element.MobileId, out var entry) &&
+                entry.QueueVersion == item.Element.Version &&
+                entry.ScheduledDueTicks == item.Priority.DueTicks
+            )
+            .ToArray();
+        _queue.Clear();
+
+        foreach (var item in current)
+        {
+            _queue.Enqueue(item.Element, item.Priority);
+        }
     }
 
     private DateTimeOffset GetDueAt(SchedulerEntry entry, DateTimeOffset now)
@@ -665,6 +741,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             .Where(element =>
                 _entries.TryGetValue(element.MobileId, out var entry) &&
                 entry.QueueVersion == element.Version &&
+                entry.ScheduledDueTicks is not null &&
                 entry.State != NpcBrainStateType.Sleeping &&
                 GetDueAt(entry, now) <= now
             )
@@ -774,6 +851,8 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         public int ConsecutiveFailures { get; set; }
 
         public long QueueVersion { get; set; }
+
+        public long? ScheduledDueTicks { get; set; }
 
         public NpcBrainMailbox Mailbox { get; }
 

--- a/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
@@ -1,0 +1,747 @@
+using System.Diagnostics;
+using Moongate.Core.Geometry;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Data.Internal.AI;
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+using ILogger = Serilog.ILogger;
+
+namespace Moongate.Server.Services.AI;
+
+public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
+{
+    private const string TimerName = "npc-brain-scheduler";
+    private const int SectorShift = 4;
+    private const int FaultLogIntervalSeconds = 60;
+
+    private readonly ILogger _logger = Log.ForContext<NpcBrainScheduler>();
+    private readonly IGameLoopContext _loop;
+    private readonly INpcBrainRuntime _runtime;
+    private readonly IBrainIntentExecutor _intentExecutor;
+    private readonly ISectorActivityService _sectors;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly NpcBrainContextFactory _contextFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly NpcAiAdvancedConfig _advanced;
+    private readonly INpcAiMetrics _metrics;
+    private readonly Dictionary<Serial, SchedulerEntry> _entries = [];
+    private readonly PriorityQueue<(Serial MobileId, long Version), (long DueTicks, long Sequence)> _queue = new();
+    private readonly Dictionary<string, DateTimeOffset> _faultLogs = new(StringComparer.Ordinal);
+
+    private string? _timerId;
+    private long _nextQueueSequence;
+
+    public int MaxHearingRange => _entries.Values
+        .Where(entry => entry.Descriptor is not null)
+        .Select(entry => entry.Descriptor!.HearingRange)
+        .DefaultIfEmpty()
+        .Max();
+
+    public int MaxPerceptionRange => _entries.Values
+        .Where(entry => entry.Descriptor is not null)
+        .Select(entry => entry.Descriptor!.PerceptionRange)
+        .DefaultIfEmpty()
+        .Max();
+
+    public NpcBrainScheduler(
+        IGameLoopContext loop,
+        INpcBrainRuntime runtime,
+        IBrainIntentExecutor intentExecutor,
+        ISectorActivityService sectors,
+        IPersistenceService persistenceService,
+        NpcBrainContextFactory contextFactory,
+        TimeProvider timeProvider,
+        MoongateConfig config,
+        INpcAiMetrics metrics
+    )
+    {
+        _loop = loop;
+        _runtime = runtime;
+        _intentExecutor = intentExecutor;
+        _sectors = sectors;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _contextFactory = contextFactory;
+        _timeProvider = timeProvider;
+        _advanced = config.NpcAi.Advanced;
+        _metrics = metrics;
+    }
+
+    public void Bind(MobileEntity mobile)
+    {
+        if (string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+        {
+            Unbind(mobile.Id);
+            return;
+        }
+
+        if (_entries.TryGetValue(mobile.Id, out var existing))
+        {
+            if (string.Equals(existing.BrainId, mobile.BrainScriptId, StringComparison.Ordinal))
+            {
+                if (_runtime.TryGetDescriptor(mobile.Id, out var currentDescriptor) &&
+                    currentDescriptor is not null)
+                {
+                    existing.Descriptor = currentDescriptor;
+                }
+
+                return;
+            }
+
+            RebindChangedBrain(existing, mobile);
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var isActive = IsSectorActive(mobile);
+        var entry = new SchedulerEntry(
+            mobile.Id,
+            mobile.BrainScriptId,
+            isActive ? NpcBrainStateType.Active : NpcBrainStateType.Sleeping,
+            mobile.MapId,
+            mobile.Position,
+            now,
+            new NpcBrainMailbox(_advanced.MaxMailboxEvents, _metrics)
+        );
+        _entries[mobile.Id] = entry;
+
+        if (isActive)
+        {
+            entry.Mailbox.Enqueue(
+                NpcBrainHookType.Activate,
+                new NpcBrainEvent(NpcBrainEventType.Activate)
+            );
+        }
+
+        if (_runtime.TryBind(mobile.Id, mobile.BrainScriptId, out var descriptor, out var error) &&
+            descriptor is not null)
+        {
+            entry.Descriptor = descriptor;
+        }
+        else if (isActive)
+        {
+            RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
+        }
+
+        if (entry.State != NpcBrainStateType.Sleeping)
+        {
+            Requeue(entry, GetDueAt(entry, now));
+        }
+    }
+
+    public void Unbind(Serial mobileId)
+    {
+        if (!_entries.Remove(mobileId))
+        {
+            return;
+        }
+
+        _runtime.Unbind(mobileId);
+    }
+
+    public void Activate(Serial mobileId)
+    {
+        if (!_entries.TryGetValue(mobileId, out var entry) ||
+            entry.State != NpcBrainStateType.Sleeping)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        entry.State = NpcBrainStateType.Active;
+        entry.NextThinkAt = now;
+        entry.FaultUntil = null;
+        entry.ConsecutiveFailures = 0;
+        entry.Mailbox.Enqueue(
+            NpcBrainHookType.Activate,
+            new NpcBrainEvent(NpcBrainEventType.Activate)
+        );
+        Requeue(entry, now);
+    }
+
+    public void Deactivate(Serial mobileId)
+    {
+        if (!_entries.TryGetValue(mobileId, out var entry) ||
+            entry.State is NpcBrainStateType.Sleeping or NpcBrainStateType.Deactivating)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        entry.State = NpcBrainStateType.Deactivating;
+        entry.FaultUntil = null;
+        entry.Mailbox.Clear();
+        entry.Mailbox.Enqueue(
+            NpcBrainHookType.Deactivate,
+            new NpcBrainEvent(NpcBrainEventType.Deactivate)
+        );
+        Requeue(entry, now);
+    }
+
+    public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
+    {
+        foreach (var entry in _entries.Values.Where(
+                     entry => string.Equals(entry.BrainId, brainId, StringComparison.Ordinal)
+                 ))
+        {
+            entry.Descriptor = descriptor;
+        }
+    }
+
+    public bool IsActive(Serial mobileId)
+        => _entries.TryGetValue(mobileId, out var entry) &&
+           entry.State == NpcBrainStateType.Active;
+
+    public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+    {
+        if (_entries.TryGetValue(mobileId, out var entry) && entry.Descriptor is not null)
+        {
+            descriptor = entry.Descriptor;
+            return true;
+        }
+
+        descriptor = null;
+        return false;
+    }
+
+    public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
+    {
+        if (!_entries.TryGetValue(mobileId, out var entry) ||
+            entry.State is NpcBrainStateType.Sleeping or NpcBrainStateType.Deactivating)
+        {
+            return;
+        }
+
+        entry.Mailbox.Enqueue(hook, brainEvent);
+
+        if (entry.State == NpcBrainStateType.Active)
+        {
+            Requeue(entry, _timeProvider.GetUtcNow());
+        }
+    }
+
+    public void Tick()
+    {
+        var now = _timeProvider.GetUtcNow();
+        var executed = 0;
+        var woken = new HashSet<Serial>();
+        var postponed = new List<(
+            (Serial MobileId, long Version) Element,
+            (long DueTicks, long Sequence) Priority
+        )>();
+
+        while (executed < _advanced.MaxBrainsPerLoop &&
+               _queue.TryPeek(out _, out var priority) &&
+               priority.DueTicks <= DueTicks(now))
+        {
+            _queue.TryDequeue(out var element, out priority);
+            var (mobileId, version) = element;
+
+            if (!_entries.TryGetValue(mobileId, out var entry) ||
+                entry.QueueVersion != version ||
+                entry.State == NpcBrainStateType.Sleeping)
+            {
+                continue;
+            }
+
+            if (woken.Contains(mobileId))
+            {
+                postponed.Add((element, priority));
+                continue;
+            }
+
+            var dueAt = GetDueAt(entry, now);
+
+            if (dueAt > now)
+            {
+                Requeue(entry, dueAt);
+                continue;
+            }
+
+            woken.Add(mobileId);
+            executed++;
+            _metrics.RecordBrainExecuted();
+            ProcessEntry(entry, now);
+
+            if (entry.State != NpcBrainStateType.Sleeping)
+            {
+                Requeue(entry, GetDueAt(entry, now));
+            }
+        }
+
+        foreach (var queued in postponed)
+        {
+            _queue.Enqueue(queued.Element, queued.Priority);
+        }
+
+        if (executed == _advanced.MaxBrainsPerLoop)
+        {
+            RecordDeferred(now, woken);
+        }
+
+        UpdateGauges();
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is null)
+        {
+            _timerId = _loop.ScheduleRepeating(
+                TimerName,
+                TimeSpan.FromMilliseconds(_advanced.MinTickMilliseconds),
+                Tick
+            );
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is not null)
+        {
+            _loop.Cancel(_timerId);
+            _timerId = null;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void RebindChangedBrain(SchedulerEntry entry, MobileEntity mobile)
+    {
+        var now = _timeProvider.GetUtcNow();
+        _runtime.Reset(mobile.Id);
+        entry.BrainId = mobile.BrainScriptId;
+        entry.Descriptor = null;
+        entry.State = IsSectorActive(mobile) ? NpcBrainStateType.Active : NpcBrainStateType.Sleeping;
+        entry.HomeMapId = mobile.MapId;
+        entry.HomePosition = mobile.Position;
+        entry.NextThinkAt = now;
+        entry.FaultUntil = null;
+        entry.ConsecutiveFailures = 0;
+        entry.Mailbox.Clear();
+
+        if (entry.State == NpcBrainStateType.Active)
+        {
+            entry.Mailbox.Enqueue(
+                NpcBrainHookType.Activate,
+                new NpcBrainEvent(NpcBrainEventType.Activate)
+            );
+        }
+
+        if (_runtime.TryBind(mobile.Id, mobile.BrainScriptId, out var descriptor, out var error) &&
+            descriptor is not null)
+        {
+            entry.Descriptor = descriptor;
+        }
+        else if (entry.State == NpcBrainStateType.Active)
+        {
+            RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
+        }
+
+        if (entry.State != NpcBrainStateType.Sleeping)
+        {
+            Requeue(entry, GetDueAt(entry, now));
+        }
+    }
+
+    private void ProcessEntry(SchedulerEntry entry, DateTimeOffset now)
+    {
+        if (entry.State == NpcBrainStateType.FaultBackoff)
+        {
+            if (entry.FaultUntil is { } faultUntil && faultUntil > now)
+            {
+                return;
+            }
+
+            entry.State = NpcBrainStateType.Active;
+            entry.FaultUntil = null;
+        }
+
+        var owner = _mobiles.GetById(entry.MobileId);
+
+        if (owner is null)
+        {
+            if (entry.State == NpcBrainStateType.Deactivating)
+            {
+                CompleteSleep(entry);
+                return;
+            }
+
+            RegisterFailure(entry, NpcBrainHookType.Think, "Brain owner is missing.", now);
+            return;
+        }
+
+        if (!EnsureBinding(entry, now))
+        {
+            if (entry.State == NpcBrainStateType.Deactivating)
+            {
+                CompleteSleep(entry);
+            }
+
+            return;
+        }
+
+        var context = _contextFactory.Create(
+            owner,
+            entry.HomeMapId,
+            entry.HomePosition,
+            entry.Descriptor!
+        );
+
+        if (entry.State == NpcBrainStateType.Deactivating)
+        {
+            ProcessDeactivation(entry, context, now);
+            return;
+        }
+
+        for (var delivered = 0;
+             delivered < _advanced.MaxEventsPerBrainWake && entry.Mailbox.HasEvents;
+             delivered++)
+        {
+            var queued = entry.Mailbox.Dequeue(1)[0];
+            var result = Invoke(entry, queued.Hook, context, queued.Event);
+
+            if (!result.Success)
+            {
+                RegisterFailure(
+                    entry,
+                    queued.Hook,
+                    result.Error ?? "Brain hook failed.",
+                    now
+                );
+                return;
+            }
+
+            ApplySuccess(entry, context, result.Decision, false, now);
+        }
+
+        if (entry.NextThinkAt > now)
+        {
+            return;
+        }
+
+        var thinkResult = Invoke(entry, NpcBrainHookType.Think, context, null);
+
+        if (!thinkResult.Success)
+        {
+            RegisterFailure(
+                entry,
+                NpcBrainHookType.Think,
+                thinkResult.Error ?? "Brain think failed.",
+                now
+            );
+            return;
+        }
+
+        ApplySuccess(entry, context, thinkResult.Decision, true, now);
+    }
+
+    private bool EnsureBinding(SchedulerEntry entry, DateTimeOffset now)
+    {
+        if (_runtime.TryGetDescriptor(entry.MobileId, out var descriptor) &&
+            descriptor is not null &&
+            string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal))
+        {
+            entry.Descriptor = descriptor;
+            return true;
+        }
+
+        if (_runtime.TryBind(entry.MobileId, entry.BrainId, out descriptor, out var error) &&
+            descriptor is not null)
+        {
+            entry.Descriptor = descriptor;
+            entry.ConsecutiveFailures = 0;
+            return true;
+        }
+
+        if (entry.State != NpcBrainStateType.Deactivating)
+        {
+            RegisterFailure(
+                entry,
+                NpcBrainHookType.Think,
+                error ?? "Brain binding failed.",
+                now
+            );
+        }
+        else
+        {
+            LogFailure(entry, NpcBrainHookType.Deactivate, error ?? "Brain binding failed.", now);
+        }
+
+        return false;
+    }
+
+    private void ProcessDeactivation(SchedulerEntry entry, BrainContext context, DateTimeOffset now)
+    {
+        if (entry.Mailbox.HasEvents)
+        {
+            var queued = entry.Mailbox.Dequeue(1)[0];
+            var result = Invoke(entry, queued.Hook, context, queued.Event);
+
+            if (result.Success)
+            {
+                ApplySuccess(entry, context, result.Decision, false, now);
+            }
+            else
+            {
+                LogFailure(
+                    entry,
+                    queued.Hook,
+                    result.Error ?? "Brain deactivation failed.",
+                    now
+                );
+            }
+        }
+
+        CompleteSleep(entry);
+    }
+
+    private NpcBrainInvocationResult Invoke(
+        SchedulerEntry entry,
+        NpcBrainHookType hook,
+        BrainContext context,
+        NpcBrainEvent? brainEvent
+    )
+    {
+        var started = Stopwatch.GetTimestamp();
+
+        try
+        {
+            return _runtime.Invoke(entry.MobileId, hook, context, brainEvent);
+        }
+        catch (Exception exception)
+        {
+            _metrics.RecordHookFailure(false);
+            return NpcBrainInvocationResult.Failed(exception.Message);
+        }
+        finally
+        {
+            _metrics.RecordHookInvocation(Stopwatch.GetElapsedTime(started));
+        }
+    }
+
+    private void ApplySuccess(
+        SchedulerEntry entry,
+        BrainContext context,
+        BrainDecision decision,
+        bool wasThink,
+        DateTimeOffset now
+    )
+    {
+        entry.ConsecutiveFailures = 0;
+        entry.FaultUntil = null;
+
+        if (decision.Intents.Count > 0)
+        {
+            _intentExecutor.Execute(entry.MobileId, context, decision.Intents);
+        }
+
+        if (decision.NextTickMilliseconds is { } nextTick)
+        {
+            entry.NextThinkAt = now + TimeSpan.FromMilliseconds(
+                Math.Clamp(
+                    nextTick,
+                    _advanced.MinTickMilliseconds,
+                    _advanced.MaxTickMilliseconds
+                )
+            );
+        }
+        else if (wasThink)
+        {
+            entry.NextThinkAt = now + TimeSpan.FromMilliseconds(
+                Math.Clamp(
+                    entry.Descriptor!.DefaultTickMilliseconds,
+                    _advanced.MinTickMilliseconds,
+                    _advanced.MaxTickMilliseconds
+                )
+            );
+        }
+    }
+
+    private void RegisterFailure(
+        SchedulerEntry entry,
+        NpcBrainHookType hook,
+        string error,
+        DateTimeOffset now
+    )
+    {
+        entry.ConsecutiveFailures++;
+
+        if (entry.ConsecutiveFailures == 4)
+        {
+            _runtime.Reset(entry.MobileId);
+        }
+
+        entry.State = NpcBrainStateType.FaultBackoff;
+        entry.FaultUntil = now + FailureBackoff(entry.ConsecutiveFailures);
+        LogFailure(entry, hook, error, now);
+    }
+
+    private void LogFailure(
+        SchedulerEntry entry,
+        NpcBrainHookType hook,
+        string error,
+        DateTimeOffset now
+    )
+    {
+        var key = $"{entry.BrainId}\n{entry.MobileId.Value}\n{(int)hook}\n{error}";
+
+        if (_faultLogs.TryGetValue(key, out var loggedAt) &&
+            now - loggedAt < TimeSpan.FromSeconds(FaultLogIntervalSeconds))
+        {
+            return;
+        }
+
+        _faultLogs[key] = now;
+        _logger.Warning(
+            "NPC brain scheduler fault for brain {BrainId}, mobile {MobileId}, hook {Hook}: {Error}",
+            entry.BrainId,
+            entry.MobileId.Value,
+            hook,
+            error
+        );
+    }
+
+    private void CompleteSleep(SchedulerEntry entry)
+    {
+        entry.State = NpcBrainStateType.Sleeping;
+        entry.FaultUntil = null;
+        entry.ConsecutiveFailures = 0;
+        entry.Mailbox.Clear();
+    }
+
+    private void Requeue(SchedulerEntry entry, DateTimeOffset dueAt)
+    {
+        entry.QueueVersion++;
+        _queue.Enqueue(
+            (entry.MobileId, entry.QueueVersion),
+            (DueTicks(dueAt), _nextQueueSequence++)
+        );
+    }
+
+    private DateTimeOffset GetDueAt(SchedulerEntry entry, DateTimeOffset now)
+        => entry.State switch
+        {
+            NpcBrainStateType.Deactivating => now,
+            NpcBrainStateType.FaultBackoff => entry.FaultUntil ?? now,
+            NpcBrainStateType.Active when entry.Mailbox.HasEvents => now,
+            _ => entry.NextThinkAt
+        };
+
+    private void RecordDeferred(DateTimeOffset now, IReadOnlySet<Serial> woken)
+    {
+        var dueMobileIds = _queue.UnorderedItems
+            .Where(item => item.Priority.DueTicks <= DueTicks(now))
+            .Select(item => item.Element)
+            .Where(element =>
+                _entries.TryGetValue(element.MobileId, out var entry) &&
+                entry.QueueVersion == element.Version &&
+                entry.State != NpcBrainStateType.Sleeping &&
+                GetDueAt(entry, now) <= now
+            )
+            .Select(element => element.MobileId)
+            .Where(mobileId => !woken.Contains(mobileId))
+            .Distinct()
+            .ToArray();
+
+        foreach (var _ in dueMobileIds)
+        {
+            _metrics.RecordBrainDeferred();
+        }
+    }
+
+    private void UpdateGauges()
+    {
+        _metrics.SetBrainCounts(
+            _entries.Values.Count(entry => entry.State == NpcBrainStateType.Active),
+            _entries.Values.Count(entry => entry.State == NpcBrainStateType.Sleeping),
+            _entries.Values.Count(entry => entry.State == NpcBrainStateType.FaultBackoff)
+        );
+
+        var sleepingSectors = _entries.Values
+            .Where(entry => entry.State == NpcBrainStateType.Sleeping)
+            .Select(entry => _mobiles.GetById(entry.MobileId))
+            .Where(mobile => mobile is not null)
+            .Select(mobile => (
+                mobile!.MapId,
+                SectorX: mobile.Position.X >> SectorShift,
+                SectorY: mobile.Position.Y >> SectorShift
+            ))
+            .Distinct()
+            .Count();
+        _metrics.SetSleepingSectorCount(sleepingSectors);
+    }
+
+    private bool IsSectorActive(MobileEntity mobile)
+        => _sectors.IsActive(
+            mobile.MapId,
+            mobile.Position.X >> SectorShift,
+            mobile.Position.Y >> SectorShift
+        );
+
+    private static long DueTicks(DateTimeOffset dueAt)
+        => dueAt.UtcDateTime.Ticks;
+
+    private static TimeSpan FailureBackoff(int consecutiveFailures)
+        => TimeSpan.FromSeconds(
+            consecutiveFailures switch
+            {
+                1 => 1,
+                2 => 5,
+                3 => 30,
+                _ => 60
+            }
+        );
+
+    private sealed class SchedulerEntry
+    {
+        public Serial MobileId { get; }
+
+        public string BrainId { get; set; }
+
+        public BrainDescriptor? Descriptor { get; set; }
+
+        public NpcBrainStateType State { get; set; }
+
+        public int HomeMapId { get; set; }
+
+        public Point3D HomePosition { get; set; }
+
+        public DateTimeOffset NextThinkAt { get; set; }
+
+        public DateTimeOffset? FaultUntil { get; set; }
+
+        public int ConsecutiveFailures { get; set; }
+
+        public long QueueVersion { get; set; }
+
+        public NpcBrainMailbox Mailbox { get; }
+
+        public SchedulerEntry(
+            Serial mobileId,
+            string brainId,
+            NpcBrainStateType state,
+            int homeMapId,
+            Point3D homePosition,
+            DateTimeOffset nextThinkAt,
+            NpcBrainMailbox mailbox
+        )
+        {
+            MobileId = mobileId;
+            BrainId = brainId;
+            State = state;
+            HomeMapId = homeMapId;
+            HomePosition = homePosition;
+            NextThinkAt = nextThinkAt;
+            Mailbox = mailbox;
+        }
+    }
+}

--- a/src/Moongate.Server/Services/AI/SectorActivityService.cs
+++ b/src/Moongate.Server/Services/AI/SectorActivityService.cs
@@ -1,0 +1,225 @@
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Services.AI;
+
+/// <summary>
+/// Maintains the 3×3 sector coverage around online players. It is game-loop owned: event subscribers and
+/// its single repeating timer both execute on that loop, so its dictionaries need no synchronization.
+/// </summary>
+public sealed class SectorActivityService : ISectorActivityService, ISquidStdService
+{
+    private const string TimerName = "npc-sector-activity";
+    private const int SectorShift = 4;
+
+    private readonly IGameLoopContext _loop;
+    private readonly IEventBus _eventBus;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _idleGrace;
+    private readonly TimeSpan _tickInterval;
+    private readonly INpcAiMetrics _metrics;
+    private readonly Dictionary<Serial, (int MapId, int SectorX, int SectorY)> _players = [];
+    private readonly Dictionary<(int MapId, int SectorX, int SectorY), SectorState> _sectors = [];
+
+    private string? _timerId;
+
+    public SectorActivityService(
+        IGameLoopContext loop,
+        IEventBus eventBus,
+        TimeProvider timeProvider,
+        MoongateConfig config,
+        INpcAiMetrics metrics
+    )
+    {
+        _loop = loop;
+        _eventBus = eventBus;
+        _timeProvider = timeProvider;
+        _idleGrace = TimeSpan.FromSeconds(config.NpcAi.Advanced.SectorIdleGraceSeconds);
+        _tickInterval = TimeSpan.FromMilliseconds(config.NpcAi.Advanced.MinTickMilliseconds);
+        _metrics = metrics;
+    }
+
+    public SectorActivitySnapshot Current => new(
+        _sectors.Count(pair => pair.Value.ReferenceCount > 0),
+        _sectors.Count(pair => pair.Value.ReferenceCount == 0)
+    );
+
+    public bool IsActive(int mapId, int sectorX, int sectorY)
+        => _sectors.ContainsKey((mapId, sectorX, sectorY));
+
+    public void TrackPlayer(MobileEntity player)
+    {
+        var location = (
+            MapId: player.MapId,
+            SectorX: player.Position.X >> SectorShift,
+            SectorY: player.Position.Y >> SectorShift
+        );
+
+        if (_players.TryGetValue(player.Id, out var previous))
+        {
+            if (previous == location)
+            {
+                return;
+            }
+
+            MovePlayer(player.Id, location.MapId, location.Item2, location.Item3);
+
+            return;
+        }
+
+        _players[player.Id] = location;
+
+        foreach (var sector in Coverage(location))
+        {
+            Acquire(sector);
+        }
+    }
+
+    public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
+    {
+        if (!_players.TryGetValue(playerId, out var previous))
+        {
+            return;
+        }
+
+        var next = (MapId: mapId, SectorX: sectorX, SectorY: sectorY);
+
+        if (previous == next)
+        {
+            return;
+        }
+
+        var previousCoverage = Coverage(previous).ToHashSet();
+        var nextCoverage = Coverage(next).ToHashSet();
+
+        foreach (var sector in previousCoverage.Except(nextCoverage))
+        {
+            Release(sector);
+        }
+
+        foreach (var sector in nextCoverage.Except(previousCoverage))
+        {
+            Acquire(sector);
+        }
+
+        _players[playerId] = next;
+    }
+
+    public void UntrackPlayer(Serial playerId)
+    {
+        if (!_players.Remove(playerId, out var location))
+        {
+            return;
+        }
+
+        foreach (var sector in Coverage(location))
+        {
+            Release(sector);
+        }
+    }
+
+    public void Tick()
+    {
+        var now = _timeProvider.GetUtcNow();
+        var expired = _sectors
+            .Where(pair => pair.Value.ReferenceCount == 0 && pair.Value.DeactivateAt is { } deactivateAt && deactivateAt <= now)
+            .Select(pair => pair.Key)
+            .ToArray();
+
+        foreach (var sector in expired)
+        {
+            _sectors.Remove(sector);
+            _eventBus.Publish(new SectorDeactivatedEvent(sector.MapId, sector.SectorX, sector.SectorY));
+        }
+
+        UpdateMetrics();
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is null)
+        {
+            _timerId = _loop.ScheduleRepeating(TimerName, _tickInterval, Tick);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is not null)
+        {
+            _loop.Cancel(_timerId);
+            _timerId = null;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void Acquire((int MapId, int SectorX, int SectorY) sector)
+    {
+        if (!_sectors.TryGetValue(sector, out var state))
+        {
+            state = new();
+            _sectors[sector] = state;
+        }
+
+        var wasInactive = state.ReferenceCount == 0;
+        state.ReferenceCount++;
+
+        if (wasInactive)
+        {
+            state.DeactivateAt = null;
+            _eventBus.Publish(new SectorActivatedEvent(sector.MapId, sector.SectorX, sector.SectorY));
+        }
+
+        UpdateMetrics();
+    }
+
+    private void Release((int MapId, int SectorX, int SectorY) sector)
+    {
+        var state = _sectors[sector];
+        state.ReferenceCount--;
+
+        if (state.ReferenceCount == 0)
+        {
+            state.DeactivateAt = _timeProvider.GetUtcNow() + _idleGrace;
+        }
+
+        UpdateMetrics();
+    }
+
+    private IEnumerable<(int MapId, int SectorX, int SectorY)> Coverage((int MapId, int SectorX, int SectorY) center)
+    {
+        for (var sectorX = center.SectorX - 1; sectorX <= center.SectorX + 1; sectorX++)
+        {
+            for (var sectorY = center.SectorY - 1; sectorY <= center.SectorY + 1; sectorY++)
+            {
+                yield return (center.MapId, sectorX, sectorY);
+            }
+        }
+    }
+
+    private void UpdateMetrics()
+    {
+        _metrics.SetActiveSectorCounts(
+            _sectors.Count(pair => pair.Value.ReferenceCount > 0),
+            _sectors.Count(pair => pair.Value.ReferenceCount == 0)
+        );
+    }
+
+    private sealed class SectorState
+    {
+        public int ReferenceCount { get; set; }
+
+        public DateTimeOffset? DeactivateAt { get; set; }
+    }
+}

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -5,11 +5,13 @@ using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Network.Packets.Outgoing;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Data.Internal.World;
 using Moongate.UO.Data.Mobiles;
 using Moongate.UO.Data.Types;
+using SquidStd.Core.Interfaces.Events;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.Server.Services.World;
@@ -35,6 +37,7 @@ public sealed class MovementService : IMovementService
     private readonly IWorldService _world;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
     private readonly TimeProvider _timeProvider;
+    private readonly IEventBus _eventBus;
     private readonly ILoopAffinity? _loopAffinity;
 
     public MovementService(
@@ -44,6 +47,7 @@ public sealed class MovementService : IMovementService
         IWorldService world,
         IPersistenceService persistenceService,
         TimeProvider timeProvider,
+        IEventBus eventBus,
         ILoopAffinity? loopAffinity = null
     )
     {
@@ -53,6 +57,7 @@ public sealed class MovementService : IMovementService
         _world = world;
         _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
         _timeProvider = timeProvider;
+        _eventBus = eventBus;
         _loopAffinity = loopAffinity;
     }
 
@@ -156,6 +161,50 @@ public sealed class MovementService : IMovementService
         }
 
         session.SetLastMove(sequence, now);
+        Apply(mobile, decision);
+        Accept(session, mobile, sequence);
+    }
+
+    public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+    {
+        _loopAffinity?.AssertOnLoop("movement.try_move_npc");
+
+        var mobile = _mobiles.GetById(mobileId);
+
+        if (mobile is null || string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+        {
+            return false;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var groundItems = _spatial.GetItemsInRange(mobile.MapId, mobile.Position, 1);
+        var decision = Evaluate(
+            mobile,
+            direction,
+            0,
+            null,
+            DateTimeOffset.MinValue,
+            now,
+            _mapTiles,
+            _regions,
+            groundItems
+        );
+
+        if (!decision.Accepted)
+        {
+            return false;
+        }
+
+        Apply(mobile, decision);
+
+        return true;
+    }
+
+    private void Apply(MobileEntity mobile, MovementDecision decision)
+    {
+        var fromMapId = mobile.MapId;
+        var fromPosition = mobile.Position;
+
         mobile.Direction = decision.NewDirection;
 
         if (decision.PositionChanged)
@@ -166,7 +215,11 @@ public sealed class MovementService : IMovementService
         _mobiles.UpsertAsync(mobile).WaitSync();
         _spatial.AddOrUpdate(mobile);
         Broadcast(mobile);
-        Accept(session, mobile, sequence);
+
+        if (decision.PositionChanged)
+        {
+            _eventBus.Publish(new MobileMovedEvent(mobile.Id, fromMapId, fromPosition, mobile.MapId, mobile.Position));
+        }
     }
 
     private void Accept(PlayerSession session, MobileEntity mobile, byte sequence)

--- a/src/Moongate.Server/Services/World/SpatialIndexService.cs
+++ b/src/Moongate.Server/Services/World/SpatialIndexService.cs
@@ -96,6 +96,28 @@ public sealed class SpatialIndexService : ISpatialIndexService
         return results;
     }
 
+    public IReadOnlyList<MobileEntity> GetMobilesInSector(int mapId, int sectorX, int sectorY)
+    {
+        _loopAffinity.AssertOnLoop(nameof(SpatialIndexService) + "." + nameof(GetMobilesInSector));
+
+        if (!_sectors.TryGetValue((mapId, sectorX, sectorY), out var sector))
+        {
+            return [];
+        }
+
+        var results = new List<MobileEntity>();
+
+        foreach (var serial in sector.Mobiles)
+        {
+            if (_mobiles.GetById(serial) is { } mobile)
+            {
+                results.Add(mobile);
+            }
+        }
+
+        return results;
+    }
+
     public void Remove(Serial serial)
     {
         _loopAffinity.AssertOnLoop(nameof(SpatialIndexService) + "." + nameof(Remove));

--- a/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
+++ b/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
@@ -1,0 +1,576 @@
+using System.Diagnostics.CodeAnalysis;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>Routes canonical world events into active NPC brain mailboxes.</summary>
+public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
+{
+    private const int SectorShift = 4;
+
+    private readonly ISpatialIndexService _spatial;
+    private readonly ISessionManager _sessions;
+    private readonly INpcBrainScheduler _scheduler;
+    private readonly ISectorActivityService _sectors;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly Dictionary<Serial, HashSet<Serial>> _perceivedByObserver = [];
+
+    public NpcBrainEventRouter(
+        ISpatialIndexService spatial,
+        IPersistenceService persistence,
+        ISessionManager sessions,
+        INpcBrainScheduler scheduler,
+        ISectorActivityService sectors
+    )
+    {
+        _spatial = spatial;
+        _sessions = sessions;
+        _scheduler = scheduler;
+        _sectors = sectors;
+        _mobiles = persistence.GetStore<MobileEntity, Serial>();
+    }
+
+    public Task OnMobileSpeech(
+        MobileSpeechEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_mobiles.GetById(message.Speaker) is not { } speaker)
+        {
+            return Task.CompletedTask;
+        }
+
+        var snapshot = ToSnapshot(speaker);
+
+        foreach (var observer in NearbyObservers(
+                     speaker.MapId,
+                     speaker.Position,
+                     _scheduler.MaxHearingRange
+                 ))
+        {
+            if (
+                observer.Id == speaker.Id ||
+                !TryGetActiveDescriptor(observer.Id, out var descriptor) ||
+                !observer.Position.InRange(speaker.Position, descriptor.HearingRange)
+            )
+            {
+                continue;
+            }
+
+            _scheduler.EnqueueEvent(
+                observer.Id,
+                NpcBrainHookType.SpeechHeard,
+                new(
+                    NpcBrainEventType.SpeechHeard,
+                    snapshot,
+                    message.Text,
+                    message.Type
+                )
+            );
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileMoved(
+        MobileMovedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_mobiles.GetById(message.Mobile) is not { } subject)
+        {
+            return Task.CompletedTask;
+        }
+
+        RouteSubjectMovement(subject, message);
+
+        if (!string.IsNullOrWhiteSpace(subject.BrainScriptId))
+        {
+            ReconcileMovedBrain(subject);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileCreated(
+        MobileCreatedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteSubjectArrival(message.Mobile);
+
+        if (!string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
+        {
+            _scheduler.Bind(message.Mobile);
+            ReconcileBrainActivity(message.Mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDeleted(
+        MobileDeletedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RemoveSubject(message.Mobile);
+        _perceivedByObserver.Remove(message.Mobile.Id);
+        _scheduler.Unbind(message.Mobile.Id);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnPlayerEnteredWorld(
+        PlayerEnteredWorldEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteSubjectArrival(message.Mobile, true);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSessionDestroyed(
+        SessionDestroyedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        if (message.Session.Character is { } character)
+        {
+            RemoveSubject(character, true);
+            _perceivedByObserver.Remove(character.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSectorActivated(
+        SectorActivatedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var mobile in _spatial
+                     .GetMobilesInSector(message.MapId, message.SectorX, message.SectorY)
+                     .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+                     .OrderBy(mobile => mobile.Id))
+        {
+            _scheduler.Bind(mobile);
+            _scheduler.Activate(mobile.Id);
+            SeedObserver(mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSectorDeactivated(
+        SectorDeactivatedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var mobile in _spatial
+                     .GetMobilesInSector(message.MapId, message.SectorX, message.SectorY)
+                     .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+                     .OrderBy(mobile => mobile.Id))
+        {
+            _scheduler.Deactivate(mobile.Id);
+            _perceivedByObserver.Remove(mobile.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileAttacked(
+        MobileAttackedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteCombatEvent(
+            message.Defender,
+            message.Attacker,
+            NpcBrainHookType.Attacked,
+            NpcBrainEventType.Attacked
+        );
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDamaged(
+        MobileDamagedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteCombatEvent(
+            message.Mobile,
+            message.Attacker,
+            NpcBrainHookType.Damage,
+            NpcBrainEventType.Damage,
+            message.Amount
+        );
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDied(
+        MobileDiedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteCombatEvent(
+            message.Mobile,
+            message.Killer,
+            NpcBrainHookType.Death,
+            NpcBrainEventType.Death
+        );
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<MobileSpeechEvent>(OnMobileSpeech);
+        eventBus.Subscribe<MobileMovedEvent>(OnMobileMoved);
+        eventBus.Subscribe<MobileCreatedEvent>(OnMobileCreated);
+        eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(OnPlayerEnteredWorld);
+        eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+        eventBus.Subscribe<SectorActivatedEvent>(OnSectorActivated);
+        eventBus.Subscribe<SectorDeactivatedEvent>(OnSectorDeactivated);
+        eventBus.Subscribe<MobileAttackedEvent>(OnMobileAttacked);
+        eventBus.Subscribe<MobileDamagedEvent>(OnMobileDamaged);
+        eventBus.Subscribe<MobileDiedEvent>(OnMobileDied);
+    }
+
+    private IEnumerable<MobileEntity> NearbyObservers(
+        int mapId,
+        Point3D position,
+        int range
+    )
+        => _spatial
+            .GetMobilesInRange(mapId, position, range)
+            .OrderBy(mobile => mobile.Id);
+
+    private void RouteSubjectMovement(MobileEntity subject, MobileMovedEvent movement)
+    {
+        var candidates = _spatial
+            .GetMobilesInRange(
+                movement.FromMapId,
+                movement.FromPosition,
+                _scheduler.MaxPerceptionRange
+            )
+            .Concat(
+                _spatial.GetMobilesInRange(
+                    movement.ToMapId,
+                    movement.ToPosition,
+                    _scheduler.MaxPerceptionRange
+                )
+            )
+            .Where(mobile => mobile.Id != subject.Id)
+            .GroupBy(mobile => mobile.Id)
+            .Select(group => group.First())
+            .OrderBy(mobile => mobile.Id);
+        var snapshot = ToSnapshot(subject);
+
+        foreach (var observer in candidates)
+        {
+            if (!TryGetActiveDescriptor(observer.Id, out var descriptor))
+            {
+                continue;
+            }
+
+            var wasInside = observer.MapId == movement.FromMapId &&
+                            observer.Position.InRange(
+                                movement.FromPosition,
+                                descriptor.PerceptionRange
+                            );
+            var isInside = observer.MapId == movement.ToMapId &&
+                           observer.Position.InRange(
+                               movement.ToPosition,
+                               descriptor.PerceptionRange
+                           );
+
+            if (!wasInside && !isInside)
+            {
+                continue;
+            }
+
+            var perceived = GetPerceived(observer.Id);
+
+            if (!wasInside)
+            {
+                perceived.Add(subject.Id);
+                EnqueuePerception(
+                    observer.Id,
+                    NpcBrainHookType.MobileEnteredRange,
+                    NpcBrainEventType.MobileEnteredRange,
+                    snapshot,
+                    movement
+                );
+                continue;
+            }
+
+            if (isInside)
+            {
+                perceived.Add(subject.Id);
+                EnqueuePerception(
+                    observer.Id,
+                    NpcBrainHookType.MobileMoved,
+                    NpcBrainEventType.MobileMoved,
+                    snapshot,
+                    movement
+                );
+                continue;
+            }
+
+            perceived.Remove(subject.Id);
+            EnqueuePerception(
+                observer.Id,
+                NpcBrainHookType.MobileLeftRange,
+                NpcBrainEventType.MobileLeftRange,
+                snapshot,
+                movement
+            );
+        }
+    }
+
+    private void RouteSubjectArrival(MobileEntity subject, bool? isPlayer = null)
+    {
+        var snapshot = ToSnapshot(subject, isPlayer);
+
+        foreach (var observer in NearbyObservers(
+                     subject.MapId,
+                     subject.Position,
+                     _scheduler.MaxPerceptionRange
+                 ))
+        {
+            if (
+                observer.Id == subject.Id ||
+                !TryGetActiveDescriptor(observer.Id, out var descriptor) ||
+                !observer.Position.InRange(subject.Position, descriptor.PerceptionRange)
+            )
+            {
+                continue;
+            }
+
+            if (!GetPerceived(observer.Id).Add(subject.Id))
+            {
+                continue;
+            }
+
+            _scheduler.EnqueueEvent(
+                observer.Id,
+                NpcBrainHookType.MobileEnteredRange,
+                new(
+                    NpcBrainEventType.MobileEnteredRange,
+                    snapshot,
+                    FromPosition: subject.Position,
+                    ToPosition: subject.Position
+                )
+            );
+        }
+    }
+
+    private void RemoveSubject(MobileEntity subject, bool? isPlayer = null)
+    {
+        var snapshot = ToSnapshot(subject, isPlayer);
+
+        foreach (var (observerId, perceived) in _perceivedByObserver.OrderBy(pair => pair.Key))
+        {
+            if (!perceived.Remove(subject.Id) || !_scheduler.IsActive(observerId))
+            {
+                continue;
+            }
+
+            _scheduler.EnqueueEvent(
+                observerId,
+                NpcBrainHookType.MobileLeftRange,
+                new(
+                    NpcBrainEventType.MobileLeftRange,
+                    snapshot,
+                    FromPosition: subject.Position,
+                    ToPosition: subject.Position
+                )
+            );
+        }
+    }
+
+    private void ReconcileMovedBrain(MobileEntity observer)
+    {
+        _scheduler.Bind(observer);
+        ReconcileBrainActivity(observer);
+    }
+
+    private void ReconcileBrainActivity(MobileEntity observer)
+    {
+        if (_sectors.IsActive(
+                observer.MapId,
+                observer.Position.X >> SectorShift,
+                observer.Position.Y >> SectorShift
+            ))
+        {
+            _scheduler.Activate(observer.Id);
+            SeedObserver(observer);
+            return;
+        }
+
+        _scheduler.Deactivate(observer.Id);
+        _perceivedByObserver.Remove(observer.Id);
+    }
+
+    private void SeedObserver(MobileEntity observer)
+    {
+        if (!TryGetActiveDescriptor(observer.Id, out var descriptor))
+        {
+            _perceivedByObserver.Remove(observer.Id);
+            return;
+        }
+
+        var current = _spatial
+            .GetMobilesInRange(
+                observer.MapId,
+                observer.Position,
+                descriptor.PerceptionRange
+            )
+            .Where(subject => subject.Id != observer.Id)
+            .OrderBy(subject => subject.Id)
+            .ToArray();
+        var previous = _perceivedByObserver.TryGetValue(observer.Id, out var perceived)
+            ? perceived
+            : [];
+        var currentIds = current.Select(subject => subject.Id).ToHashSet();
+
+        foreach (var subjectId in previous.Except(currentIds).Order())
+        {
+            if (_mobiles.GetById(subjectId) is { } subject)
+            {
+                _scheduler.EnqueueEvent(
+                    observer.Id,
+                    NpcBrainHookType.MobileLeftRange,
+                    new(
+                        NpcBrainEventType.MobileLeftRange,
+                        ToSnapshot(subject),
+                        FromPosition: subject.Position,
+                        ToPosition: subject.Position
+                    )
+                );
+            }
+        }
+
+        foreach (var subject in current.Where(subject => !previous.Contains(subject.Id)))
+        {
+            _scheduler.EnqueueEvent(
+                observer.Id,
+                NpcBrainHookType.MobileEnteredRange,
+                new(
+                    NpcBrainEventType.MobileEnteredRange,
+                    ToSnapshot(subject),
+                    FromPosition: subject.Position,
+                    ToPosition: subject.Position
+                )
+            );
+        }
+
+        _perceivedByObserver[observer.Id] = currentIds;
+    }
+
+    private void RouteCombatEvent(
+        Serial affected,
+        Serial other,
+        NpcBrainHookType hook,
+        NpcBrainEventType eventType,
+        int amount = 0
+    )
+    {
+        if (!_scheduler.IsActive(affected))
+        {
+            return;
+        }
+
+        var otherSnapshot = _mobiles.GetById(other) is { } mobile
+            ? ToSnapshot(mobile)
+            : null;
+        _scheduler.EnqueueEvent(
+            affected,
+            hook,
+            new(eventType, otherSnapshot, Amount: amount)
+        );
+    }
+
+    private bool TryGetActiveDescriptor(
+        Serial observerId,
+        [NotNullWhen(true)] out BrainDescriptor? descriptor
+    )
+    {
+        if (
+            _scheduler.IsActive(observerId) &&
+            _scheduler.TryGetDescriptor(observerId, out var found) &&
+            found is not null
+        )
+        {
+            descriptor = found;
+            return true;
+        }
+
+        descriptor = null;
+        return false;
+    }
+
+    private HashSet<Serial> GetPerceived(Serial observerId)
+    {
+        if (!_perceivedByObserver.TryGetValue(observerId, out var perceived))
+        {
+            perceived = [];
+            _perceivedByObserver[observerId] = perceived;
+        }
+
+        return perceived;
+    }
+
+    private void EnqueuePerception(
+        Serial observerId,
+        NpcBrainHookType hook,
+        NpcBrainEventType eventType,
+        BrainMobileSnapshot snapshot,
+        MobileMovedEvent movement
+    )
+    {
+        _scheduler.EnqueueEvent(
+            observerId,
+            hook,
+            new(
+                eventType,
+                snapshot,
+                FromPosition: movement.FromPosition,
+                ToPosition: movement.ToPosition
+            )
+        );
+    }
+
+    private BrainMobileSnapshot ToSnapshot(
+        MobileEntity mobile,
+        bool? isPlayer = null
+    )
+        => new(
+            mobile.Id,
+            mobile.Name,
+            isPlayer ?? _sessions.IsCharacterPlayed(mobile.Id),
+            mobile.MapId,
+            mobile.Position,
+            mobile.Hits,
+            mobile.HitsMax,
+            mobile.Warmode,
+            mobile.CombatantId,
+            mobile.Criminal,
+            mobile.Kills
+        );
+}

--- a/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
+++ b/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
@@ -185,6 +185,43 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         return Task.CompletedTask;
     }
 
+    public Task OnBrainDefinitionReloaded(
+        BrainDefinitionReloadedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!string.Equals(
+                message.BrainId,
+                message.Descriptor.BrainId,
+                StringComparison.Ordinal
+            ))
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var observer in _mobiles
+                     .GetAll()
+                     .Where(mobile =>
+                         string.Equals(
+                             mobile.BrainScriptId,
+                             message.BrainId,
+                             StringComparison.Ordinal
+                         )
+                     )
+                     .OrderBy(mobile => mobile.Id))
+        {
+            if (_scheduler.IsActive(observer.Id))
+            {
+                ReconcileObserverSet(observer, message.Descriptor);
+                continue;
+            }
+
+            _perceivedByObserver.Remove(observer.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
     public Task OnMobileAttacked(
         MobileAttackedEvent message,
         CancellationToken cancellationToken
@@ -241,6 +278,7 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
         eventBus.Subscribe<SectorActivatedEvent>(OnSectorActivated);
         eventBus.Subscribe<SectorDeactivatedEvent>(OnSectorDeactivated);
+        eventBus.Subscribe<BrainDefinitionReloadedEvent>(OnBrainDefinitionReloaded);
         eventBus.Subscribe<MobileAttackedEvent>(OnMobileAttacked);
         eventBus.Subscribe<MobileDamagedEvent>(OnMobileDamaged);
         eventBus.Subscribe<MobileDiedEvent>(OnMobileDied);
@@ -257,7 +295,7 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
 
     private void RouteSubjectMovement(MobileEntity subject, MobileMovedEvent movement)
     {
-        var candidates = _spatial
+        var candidateIds = _spatial
             .GetMobilesInRange(
                 movement.FromMapId,
                 movement.FromPosition,
@@ -270,42 +308,48 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
                     _scheduler.MaxPerceptionRange
                 )
             )
-            .Where(mobile => mobile.Id != subject.Id)
-            .GroupBy(mobile => mobile.Id)
-            .Select(group => group.First())
-            .OrderBy(mobile => mobile.Id);
+            .Select(mobile => mobile.Id)
+            .Concat(
+                _perceivedByObserver
+                    .Where(pair => pair.Value.Contains(subject.Id))
+                    .Select(pair => pair.Key)
+            )
+            .Where(observerId => observerId != subject.Id)
+            .Distinct()
+            .Order()
+            .ToArray();
         var snapshot = ToSnapshot(subject);
 
-        foreach (var observer in candidates)
+        foreach (var observerId in candidateIds)
         {
-            if (!TryGetActiveDescriptor(observer.Id, out var descriptor))
+            if (_mobiles.GetById(observerId) is not { } observer ||
+                !TryGetActiveDescriptor(observerId, out var descriptor))
             {
+                _perceivedByObserver.Remove(observerId);
                 continue;
             }
 
-            var wasInside = observer.MapId == movement.FromMapId &&
-                            observer.Position.InRange(
-                                movement.FromPosition,
-                                descriptor.PerceptionRange
-                            );
+            var wasPerceived = _perceivedByObserver.TryGetValue(
+                observerId,
+                out var perceived
+            ) && perceived.Contains(subject.Id);
             var isInside = observer.MapId == movement.ToMapId &&
                            observer.Position.InRange(
                                movement.ToPosition,
                                descriptor.PerceptionRange
                            );
 
-            if (!wasInside && !isInside)
+            if (!wasPerceived && !isInside)
             {
                 continue;
             }
 
-            var perceived = GetPerceived(observer.Id);
-
-            if (!wasInside)
+            if (!wasPerceived)
             {
+                perceived = GetPerceived(observerId);
                 perceived.Add(subject.Id);
                 EnqueuePerception(
-                    observer.Id,
+                    observerId,
                     NpcBrainHookType.MobileEnteredRange,
                     NpcBrainEventType.MobileEnteredRange,
                     snapshot,
@@ -316,9 +360,8 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
 
             if (isInside)
             {
-                perceived.Add(subject.Id);
                 EnqueuePerception(
-                    observer.Id,
+                    observerId,
                     NpcBrainHookType.MobileMoved,
                     NpcBrainEventType.MobileMoved,
                     snapshot,
@@ -327,9 +370,9 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
                 continue;
             }
 
-            perceived.Remove(subject.Id);
+            _perceivedByObserver[observerId].Remove(subject.Id);
             EnqueuePerception(
-                observer.Id,
+                observerId,
                 NpcBrainHookType.MobileLeftRange,
                 NpcBrainEventType.MobileLeftRange,
                 snapshot,
@@ -425,6 +468,14 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
             return;
         }
 
+        ReconcileObserverSet(observer, descriptor);
+    }
+
+    private void ReconcileObserverSet(
+        MobileEntity observer,
+        BrainDescriptor descriptor
+    )
+    {
         var current = _spatial
             .GetMobilesInRange(
                 observer.MapId,

--- a/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
+++ b/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
@@ -97,7 +97,7 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
 
         if (!string.IsNullOrWhiteSpace(subject.BrainScriptId))
         {
-            ReconcileMovedBrain(subject);
+            RefreshObserverSet(subject);
         }
 
         return Task.CompletedTask;
@@ -112,8 +112,7 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
 
         if (!string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
         {
-            _scheduler.Bind(message.Mobile);
-            ReconcileBrainActivity(message.Mobile);
+            RefreshObserverSet(message.Mobile);
         }
 
         return Task.CompletedTask;
@@ -126,7 +125,6 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
     {
         RemoveSubject(message.Mobile);
         _perceivedByObserver.Remove(message.Mobile.Id);
-        _scheduler.Unbind(message.Mobile.Id);
 
         return Task.CompletedTask;
     }
@@ -165,8 +163,6 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
                      .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
                      .OrderBy(mobile => mobile.Id))
         {
-            _scheduler.Bind(mobile);
-            _scheduler.Activate(mobile.Id);
             SeedObserver(mobile);
         }
 
@@ -183,7 +179,6 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
                      .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
                      .OrderBy(mobile => mobile.Id))
         {
-            _scheduler.Deactivate(mobile.Id);
             _perceivedByObserver.Remove(mobile.Id);
         }
 
@@ -404,26 +399,21 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         }
     }
 
-    private void ReconcileMovedBrain(MobileEntity observer)
+    private void RefreshObserverSet(MobileEntity observer)
     {
-        _scheduler.Bind(observer);
-        ReconcileBrainActivity(observer);
-    }
-
-    private void ReconcileBrainActivity(MobileEntity observer)
-    {
-        if (_sectors.IsActive(
+        if (
+            _scheduler.IsActive(observer.Id) &&
+            _sectors.IsActive(
                 observer.MapId,
                 observer.Position.X >> SectorShift,
                 observer.Position.Y >> SectorShift
-            ))
+            )
+        )
         {
-            _scheduler.Activate(observer.Id);
             SeedObserver(observer);
             return;
         }
 
-        _scheduler.Deactivate(observer.Id);
         _perceivedByObserver.Remove(observer.Id);
     }
 

--- a/src/Moongate.Server/Subscribers/NpcBrainLifecycleSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/NpcBrainLifecycleSubscriber.cs
@@ -1,0 +1,152 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>Coordinates scheduler bindings with NPC, sector and brain-definition lifecycle events.</summary>
+public sealed class NpcBrainLifecycleSubscriber : IEventSubscriberRegistration
+{
+    private const int SectorShift = 4;
+
+    private readonly ISpatialIndexService _spatial;
+    private readonly ISectorActivityService _sectors;
+    private readonly INpcBrainScheduler _scheduler;
+    private readonly IEntityStore<AccountEntity, Serial> _accounts;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+
+    public NpcBrainLifecycleSubscriber(
+        ISpatialIndexService spatial,
+        IPersistenceService persistence,
+        INpcBrainScheduler scheduler,
+        ISectorActivityService sectors
+    )
+    {
+        _spatial = spatial;
+        _sectors = sectors;
+        _scheduler = scheduler;
+        _accounts = persistence.GetStore<AccountEntity, Serial>();
+        _mobiles = persistence.GetStore<MobileEntity, Serial>();
+    }
+
+    public Task OnWorldReady(WorldReadyEvent message, CancellationToken cancellationToken)
+    {
+        var playerCharacters = PlayerCharacters();
+
+        foreach (var mobile in _mobiles.GetAll())
+        {
+            if (playerCharacters.Contains(mobile.Id) || string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+            {
+                continue;
+            }
+
+            BindAndActivateWhenSectorIsActive(mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileCreated(MobileCreatedEvent message, CancellationToken cancellationToken)
+    {
+        if (!IsPlayerCharacter(message.Mobile.Id) && !string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
+        {
+            BindAndActivateWhenSectorIsActive(message.Mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDeleted(MobileDeletedEvent message, CancellationToken cancellationToken)
+    {
+        _scheduler.Unbind(message.Mobile.Id);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileChangedSector(MobileChangedSectorEvent message, CancellationToken cancellationToken)
+    {
+        if (IsPlayerCharacter(message.Mobile))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (_sectors.IsActive(message.ToMapId, message.ToSectorX, message.ToSectorY))
+        {
+            _scheduler.Activate(message.Mobile);
+        }
+        else
+        {
+            _scheduler.Deactivate(message.Mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSectorActivated(SectorActivatedEvent message, CancellationToken cancellationToken)
+    {
+        foreach (var mobile in BrainMobilesInSector(message.MapId, message.SectorX, message.SectorY))
+        {
+            _scheduler.Activate(mobile.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSectorDeactivated(SectorDeactivatedEvent message, CancellationToken cancellationToken)
+    {
+        foreach (var mobile in BrainMobilesInSector(message.MapId, message.SectorX, message.SectorY))
+        {
+            _scheduler.Deactivate(mobile.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnBrainDefinitionReloaded(
+        BrainDefinitionReloadedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        _scheduler.RefreshDescriptor(message.BrainId, message.Descriptor);
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<WorldReadyEvent>(OnWorldReady);
+        eventBus.Subscribe<MobileCreatedEvent>(OnMobileCreated);
+        eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
+        eventBus.Subscribe<MobileChangedSectorEvent>(OnMobileChangedSector);
+        eventBus.Subscribe<SectorActivatedEvent>(OnSectorActivated);
+        eventBus.Subscribe<SectorDeactivatedEvent>(OnSectorDeactivated);
+        eventBus.Subscribe<BrainDefinitionReloadedEvent>(OnBrainDefinitionReloaded);
+    }
+
+    private void BindAndActivateWhenSectorIsActive(MobileEntity mobile)
+    {
+        _scheduler.Bind(mobile);
+
+        if (_sectors.IsActive(mobile.MapId, mobile.Position.X >> SectorShift, mobile.Position.Y >> SectorShift))
+        {
+            _scheduler.Activate(mobile.Id);
+        }
+    }
+
+    private IEnumerable<MobileEntity> BrainMobilesInSector(int mapId, int sectorX, int sectorY)
+        => _spatial
+            .GetMobilesInSector(mapId, sectorX, sectorY)
+            .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId) && !IsPlayerCharacter(mobile.Id))
+            .OrderBy(mobile => mobile.Id);
+
+    private HashSet<Serial> PlayerCharacters()
+        => _accounts.GetAll().SelectMany(account => account.MobileIds).ToHashSet();
+
+    private bool IsPlayerCharacter(Serial mobileId)
+        => _accounts.GetAll().Any(account => account.MobileIds.Contains(mobileId));
+}

--- a/src/Moongate.Server/Subscribers/SectorActivitySubscriber.cs
+++ b/src/Moongate.Server/Subscribers/SectorActivitySubscriber.cs
@@ -1,0 +1,55 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>Feeds player lifecycle and sector-change events into player-driven sector activity.</summary>
+public sealed class SectorActivitySubscriber : IEventSubscriberRegistration
+{
+    private readonly ISectorActivityService _activity;
+    private readonly HashSet<Serial> _players = [];
+
+    public SectorActivitySubscriber(ISectorActivityService activity)
+    {
+        _activity = activity;
+    }
+
+    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent message, CancellationToken cancellationToken)
+    {
+        _players.Add(message.Mobile.Id);
+        _activity.TrackPlayer(message.Mobile);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileChangedSector(MobileChangedSectorEvent message, CancellationToken cancellationToken)
+    {
+        if (_players.Contains(message.Mobile))
+        {
+            _activity.MovePlayer(message.Mobile, message.ToMapId, message.ToSectorX, message.ToSectorY);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSessionDestroyed(SessionDestroyedEvent message, CancellationToken cancellationToken)
+    {
+        if (message.Session.Character is { } character)
+        {
+            _players.Remove(character.Id);
+            _activity.UntrackPlayer(character.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(OnPlayerEnteredWorld);
+        eventBus.Subscribe<MobileChangedSectorEvent>(OnMobileChangedSector);
+        eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+    }
+}

--- a/tests/Moongate.Tests/Persistence/Entities/MobileEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/MobileEntityTests.cs
@@ -1,5 +1,6 @@
 using MessagePack;
 using MessagePack.Resolvers;
+using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.UO.Data.Types;
 
@@ -7,6 +8,12 @@ namespace Moongate.Tests.Persistence.Entities;
 
 public class MobileEntityTests
 {
+    [Fact]
+    public void CombatantId_DefaultsToZero()
+    {
+        Assert.Equal(Serial.Zero, new MobileEntity().CombatantId);
+    }
+
     [Fact]
     public void Deserialize_SaveWrittenBeforeTheNewFieldsExisted_KeepsTheDefaults()
     {

--- a/tests/Moongate.Tests/Scripting/BrainAssetSeederTests.cs
+++ b/tests/Moongate.Tests/Scripting/BrainAssetSeederTests.cs
@@ -1,0 +1,66 @@
+using Moongate.Scripting.AI;
+
+namespace Moongate.Tests.Scripting;
+
+public class BrainAssetSeederTests
+{
+    [Fact]
+    public void SeedMissing_EmptyDirectory_SeedsExactlyBuiltInBrainsAndCleansTemporaryFiles()
+    {
+        var root = CreateRoot();
+        var brainsDirectory = Path.Combine(root, "scripts", "brains");
+
+        try
+        {
+            BrainAssetSeeder.SeedMissing(brainsDirectory);
+
+            var files = Directory
+                .GetFiles(brainsDirectory)
+                .Select(Path.GetFileName)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(["guard.lua", "orion.lua", "vega.lua"], files);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void SeedMissing_ExistingEditedBrain_PreservesBytesAndSeedsOtherBuiltIns()
+    {
+        var root = CreateRoot();
+        var brainsDirectory = Path.Combine(root, "scripts", "brains");
+        Directory.CreateDirectory(brainsDirectory);
+        var guardPath = Path.Combine(brainsDirectory, "guard.lua");
+        var editedBytes = new byte[] { 0, 1, 2, 3, 255 };
+        File.WriteAllBytes(guardPath, editedBytes);
+
+        try
+        {
+            BrainAssetSeeder.SeedMissing(brainsDirectory);
+
+            Assert.Equal(editedBytes, File.ReadAllBytes(guardPath));
+            Assert.True(File.Exists(Path.Combine(brainsDirectory, "orion.lua")));
+            Assert.True(File.Exists(Path.Combine(brainsDirectory, "vega.lua")));
+            Assert.DoesNotContain(
+                Directory.GetFiles(brainsDirectory),
+                path => Path.GetFileName(path).Contains(".tmp", StringComparison.Ordinal)
+            );
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    private static string CreateRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-brain-assets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        return root;
+    }
+}

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -690,6 +690,67 @@ public class LuaNpcBrainRuntimeTests
         );
     }
 
+    [Theory]
+    [InlineData("return 'unsupported'")]
+    [InlineData("return 42")]
+    [InlineData("return true")]
+    [InlineData("return 'first', 'second'")]
+    [InlineData("return function() end")]
+    [InlineData("return brain.say")]
+    public void Invoke_UnsupportedReturnShape_ReturnsNeutralFailure(string returnStatement)
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "unsupported",
+            $$"""
+              return {
+                id = "unsupported",
+                default_tick_ms = 1000,
+                perception_range = 12,
+                hearing_range = 15,
+                think = function()
+                  {{returnStatement}}
+                end
+              }
+              """
+        );
+        fixture.Bind(1, "unsupported");
+
+        var result = fixture.Think(1);
+
+        Assert.False(result.Success);
+        Assert.Equal(BrainDecision.Empty, result.Decision);
+        Assert.Contains("return type", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
+    }
+
+    [Fact]
+    public void Invoke_MalformedIntentTable_RemainsSuccessfulUnknownIntent()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "malformed",
+            """
+            return {
+              id = "malformed",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function()
+                return { text = "missing type" }
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "malformed");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(BrainIntentType.Unknown, Assert.Single(result.Decision.Intents).Type);
+        Assert.Equal(0, fixture.Metrics.Current.HookFailures);
+    }
+
     [Fact]
     public void TryReload_InvalidReplacement_PreservesSharedDefinition()
     {

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -356,6 +356,10 @@ public class LuaNpcBrainRuntimeTests
     [Theory]
     [InlineData("string.rep('x', 4097)")]
     [InlineData("('x'):rep(4097)")]
+    [InlineData("string.rep('', 4097, 'x')")]
+    [InlineData("(''):rep(4097, 'x')")]
+    [InlineData("string.rep('', 4097, '')")]
+    [InlineData("(''):rep(4097, '')")]
     public void Invoke_StringRepAboveNativeLimit_ReturnsStructuredFailure(string nativeCall)
     {
         using var fixture = new BrainRuntimeFixture();
@@ -399,7 +403,9 @@ public class LuaNpcBrainRuntimeTests
               think = function()
                 local values = { "a", "b" }
                 table.insert(values, "c")
-                return brain.say(string.rep(table.concat(values), 2))
+                local direct = string.rep(table.concat(values), 2)
+                local colon = ("xy"):rep(2, ":")
+                return brain.say(direct .. "|" .. colon)
               end
             }
             """
@@ -409,7 +415,7 @@ public class LuaNpcBrainRuntimeTests
         var result = fixture.Think(1);
 
         Assert.True(result.Success, result.Error);
-        Assert.Equal("abcabc", Assert.Single(result.Decision.Intents).Text);
+        Assert.Equal("abcabc|xy:xy", Assert.Single(result.Decision.Intents).Text);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -13,6 +13,7 @@ using MoonSharp.Interpreter;
 using SquidStd.Core.Directories;
 using SquidStd.Scripting.Lua.Data.Config;
 using SquidStd.Scripting.Lua.Services;
+using ISynchronizeInvoke = System.ComponentModel.ISynchronizeInvoke;
 
 namespace Moongate.Tests.Scripting;
 
@@ -839,7 +840,6 @@ public class LuaNpcBrainRuntimeTests
         using var fixture = new BrainRuntimeFixture();
         fixture.WriteBrain("counter", CounterBrain);
         fixture.Bind(1, "counter");
-        await fixture.Runtime.StartAsync();
         var replacement = """
                           return {
                             id = "counter",
@@ -849,18 +849,62 @@ public class LuaNpcBrainRuntimeTests
                             think = function(ctx, state) return brain.say("watched") end
                           }
                           """;
+        fixture.WriteBrain("counter", replacement);
+        await fixture.Runtime.StartAsync();
+        var watcher = Assert.Single(fixture.Watchers);
 
-        fixture.WriteBrain("counter", replacement);
-        fixture.WriteBrain("counter", replacement);
-        fixture.WriteBrain("counter", replacement);
+        watcher.RaiseChanged("counter.lua");
+        watcher.RaiseChanged("counter.lua");
+        watcher.RaiseChanged("counter.lua");
 
-        await WaitUntilAsync(() => fixture.Loop.PostCount > 0);
-        await Task.Delay(400);
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(249));
+        await DrainContinuationsAsync();
+        Assert.Equal(0, fixture.Loop.PostCount);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        await DrainContinuationsAsync(() => fixture.Loop.PostCount == 1);
 
         Assert.Equal(1, fixture.Loop.PostCount);
         Assert.Equal(1, fixture.Metrics.Current.ReloadSuccesses);
         Assert.Single(fixture.Bus.Published);
         Assert.Equal("watched", Assert.Single(fixture.Think(1).Decision.Intents).Text);
+
+        await fixture.Runtime.StopAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_StoppedWatcherCallbackAfterRestart_DoesNotReload()
+    {
+        using var fixture = new BrainRuntimeFixture(queueWatcherCallbacks: true);
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.WriteBrain(
+            "counter",
+            """
+            return {
+              id = "counter",
+              default_tick_ms = 1500,
+              perception_range = 10,
+              hearing_range = 12,
+              think = function() return brain.say("stale") end
+            }
+            """
+        );
+        await fixture.Runtime.StartAsync();
+        var stoppedWatcher = Assert.Single(fixture.Watchers);
+        stoppedWatcher.RaiseChanged("counter.lua");
+        Assert.Equal(1, fixture.WatcherCallbacks.PendingCount);
+
+        await fixture.Runtime.StopAsync();
+        await fixture.Runtime.StartAsync();
+        fixture.WatcherCallbacks.RunNext();
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(250));
+        await DrainContinuationsAsync();
+
+        Assert.Equal(0, fixture.Loop.PostCount);
+        Assert.Equal(0, fixture.Metrics.Current.ReloadSuccesses);
+        Assert.Empty(fixture.Bus.Published);
+        Assert.Equal("1", Assert.Single(fixture.Think(1).Decision.Intents).Text);
 
         await fixture.Runtime.StopAsync();
     }
@@ -908,13 +952,11 @@ public class LuaNpcBrainRuntimeTests
         await fixture.Runtime.StopAsync();
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition)
+    private static async Task DrainContinuationsAsync(Func<bool>? condition = null)
     {
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-        while (!condition())
+        for (var iteration = 0; iteration < 100 && condition?.Invoke() != true; iteration++)
         {
-            await Task.Delay(25, cancellation.Token);
+            await Task.Yield();
         }
     }
 
@@ -936,6 +978,7 @@ public class LuaNpcBrainRuntimeTests
         private readonly Container _container = new();
         private readonly DirectoriesConfig _directories;
         private readonly LuaScriptEngineService _engine;
+        private readonly bool _queueWatcherCallbacks;
         private readonly string _root;
         private readonly string _scripts;
 
@@ -946,6 +989,14 @@ public class LuaNpcBrainRuntimeTests
         public StubEventBus Bus { get; } = new();
 
         public StubGameLoopContext Loop { get; } = new();
+
+        public MutableTimeProvider Time { get; } = new(
+            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
+        );
+
+        public QueueingSynchronizer WatcherCallbacks { get; } = new();
+
+        public List<ControllableFileSystemWatcher> Watchers { get; } = [];
 
         public BrainMobileSnapshot Other { get; } = new(
             new(2),
@@ -963,8 +1014,9 @@ public class LuaNpcBrainRuntimeTests
 
         public LuaNpcBrainRuntime Runtime { get; }
 
-        public BrainRuntimeFixture(int maxIntentsPerDecision = 8)
+        public BrainRuntimeFixture(int maxIntentsPerDecision = 8, bool queueWatcherCallbacks = false)
         {
+            _queueWatcherCallbacks = queueWatcherCallbacks;
             _root = Path.Combine(Path.GetTempPath(), "mg-brain-" + Guid.NewGuid().ToString("N"));
             _directories = new(_root, ["scripts"]);
             _scripts = _directories.GetPath("scripts");
@@ -986,7 +1038,7 @@ public class LuaNpcBrainRuntimeTests
                     }
                 }
             };
-            Runtime = new(_engine, _directories, config, Metrics, Loop, Bus);
+            Runtime = new(_engine, _directories, config, Metrics, Loop, Bus, Time, CreateWatcher);
             var self = new BrainMobileSnapshot(
                 new(1),
                 "Self",
@@ -1054,12 +1106,64 @@ public class LuaNpcBrainRuntimeTests
         public void WriteScript(string relativePath, string content)
             => File.WriteAllText(Path.Combine(_scripts, relativePath), content);
 
+        private FileSystemWatcher CreateWatcher(string path)
+        {
+            var watcher = new ControllableFileSystemWatcher(path);
+
+            if (_queueWatcherCallbacks)
+            {
+                watcher.SynchronizingObject = WatcherCallbacks;
+            }
+
+            Watchers.Add(watcher);
+
+            return watcher;
+        }
+
         public void Dispose()
         {
             Runtime.Dispose();
             _engine.Dispose();
             _container.Dispose();
             Directory.Delete(_root, true);
+        }
+    }
+
+    private sealed class ControllableFileSystemWatcher : FileSystemWatcher
+    {
+        public ControllableFileSystemWatcher(string path) : base(path)
+        {
+        }
+
+        public void RaiseChanged(string fileName)
+            => OnChanged(new(WatcherChangeTypes.Changed, Path, fileName));
+    }
+
+    private sealed class QueueingSynchronizer : ISynchronizeInvoke
+    {
+        private readonly Queue<Action> _pending = [];
+
+        public bool InvokeRequired => true;
+
+        public int PendingCount => _pending.Count;
+
+        public IAsyncResult BeginInvoke(Delegate method, object?[]? arguments)
+        {
+            _pending.Enqueue(() => method.DynamicInvoke(arguments));
+
+            return Task.CompletedTask;
+        }
+
+        public object? EndInvoke(IAsyncResult result)
+            => null;
+
+        public object? Invoke(Delegate method, object?[]? arguments)
+            => method.DynamicInvoke(arguments);
+
+        public void RunNext()
+        {
+            Assert.True(_pending.TryDequeue(out var callback));
+            callback();
         }
     }
 }

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -1,0 +1,851 @@
+using DryIoc;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Scripting.AI;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.AI;
+using Moongate.UO.Data.Types;
+using MoonSharp.Interpreter;
+using SquidStd.Core.Directories;
+using SquidStd.Scripting.Lua.Data.Config;
+using SquidStd.Scripting.Lua.Services;
+
+namespace Moongate.Tests.Scripting;
+
+public class LuaNpcBrainRuntimeTests
+{
+    private const string CounterBrain = """
+                                              return {
+                                                id = "counter",
+                                                default_tick_ms = 1000,
+                                                perception_range = 12,
+                                                hearing_range = 15,
+                                                think = function(ctx, state)
+                                                  state.count = (state.count or 0) + 1
+                                                  return brain.say(tostring(state.count))
+                                                end
+                                              }
+                                              """;
+
+    [Fact]
+    public void TryBind_ResolvesOnlyTheExactBrainsDirectory()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteScript("counter.lua", CounterBrain);
+
+        var outsideResult = fixture.Runtime.TryBind(new(1), "counter", out _, out var outsideError);
+
+        Assert.False(outsideResult);
+        Assert.NotNull(outsideError);
+
+        fixture.WriteBrain("counter", CounterBrain);
+
+        var result = fixture.Runtime.TryBind(new(1), "counter", out var descriptor, out var error);
+
+        Assert.True(result, error);
+        Assert.Equal(new("counter", 1000, 12, 15), descriptor);
+    }
+
+    [Theory]
+    [InlineData("../counter")]
+    [InlineData("Counter")]
+    [InlineData("-counter")]
+    [InlineData("counter.lua")]
+    [InlineData("counter/other")]
+    public void TryBind_InvalidBrainId_IsRejected(string brainId)
+    {
+        using var fixture = new BrainRuntimeFixture();
+
+        var result = fixture.Runtime.TryBind(new(1), brainId, out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("invalid", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_MissingFile_IsRejected()
+    {
+        using var fixture = new BrainRuntimeFixture();
+
+        var result = fixture.Runtime.TryBind(new(1), "missing", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(
+        "other",
+        1000,
+        12,
+        15,
+        "think = function() end",
+        "id"
+    )]
+    [InlineData(
+        "invalid",
+        99,
+        12,
+        15,
+        "think = function() end",
+        "default_tick_ms"
+    )]
+    [InlineData(
+        "invalid",
+        60001,
+        12,
+        15,
+        "think = function() end",
+        "default_tick_ms"
+    )]
+    [InlineData(
+        "invalid",
+        1000,
+        -1,
+        15,
+        "think = function() end",
+        "perception_range"
+    )]
+    [InlineData(
+        "invalid",
+        1000,
+        12,
+        65,
+        "think = function() end",
+        "hearing_range"
+    )]
+    [InlineData(
+        "invalid",
+        1000,
+        12,
+        15,
+        "think = nil",
+        "think"
+    )]
+    [InlineData(
+        "invalid",
+        1000,
+        12,
+        15,
+        "think = function() end, on_activate = 42",
+        "on_activate"
+    )]
+    public void TryBind_InvalidDefinition_IsRejected(
+        string returnedId,
+        int defaultTickMilliseconds,
+        int perceptionRange,
+        int hearingRange,
+        string hooks,
+        string expectedError
+    )
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "invalid",
+            $$"""
+              return {
+                id = "{{returnedId}}",
+                default_tick_ms = {{defaultTickMilliseconds}},
+                perception_range = {{perceptionRange}},
+                hearing_range = {{hearingRange}},
+                {{hooks}}
+              }
+              """
+        );
+
+        var result = fixture.Runtime.TryBind(new(1), "invalid", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains(expectedError, error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_FileLargerThanLimit_IsRejected()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("oversized", new string('-', (256 * 1024) + 1));
+
+        var result = fixture.Runtime.TryBind(new(1), "oversized", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("256", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_SymbolicLinkOutsideBrainsDirectory_IsRejected()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.CreateBrainSymbolicLink(
+            "linked",
+            """
+            return {
+              id = "linked",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function() return brain.idle() end
+            }
+            """
+        );
+
+        var result = fixture.Runtime.TryBind(new(1), "linked", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("link", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_InfiniteTopLevelChunk_ReturnsBudgetFailure()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("infinite", "while true do end");
+
+        var result = fixture.Runtime.TryBind(new(1), "infinite", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("budget", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Invoke_BlackboardsAreIsolatedPerMobile()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Bind(2, "counter");
+
+        var first = fixture.Think(1);
+        var second = fixture.Think(2);
+
+        Assert.Equal("1", Assert.Single(first.Decision.Intents).Text);
+        Assert.Equal("1", Assert.Single(second.Decision.Intents).Text);
+    }
+
+    [Fact]
+    public void Invoke_ReusesOneMobilesBlackboard()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+
+        var first = fixture.Think(1);
+        var second = fixture.Think(1);
+
+        Assert.Equal("1", Assert.Single(first.Decision.Intents).Text);
+        Assert.Equal("2", Assert.Single(second.Decision.Intents).Text);
+    }
+
+    [Fact]
+    public void Reset_ClearsStateWithoutRemovingBinding()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        fixture.Runtime.Reset(new(1));
+        var result = fixture.Think(1);
+
+        Assert.True(fixture.Runtime.TryGetDescriptor(new(1), out _));
+        Assert.Equal("1", Assert.Single(result.Decision.Intents).Text);
+    }
+
+    [Fact]
+    public void UnbindAndRebind_ClearsState()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        fixture.Runtime.Unbind(new(1));
+
+        Assert.False(fixture.Runtime.TryGetDescriptor(new(1), out _));
+
+        fixture.Bind(1, "counter");
+        var result = fixture.Think(1);
+
+        Assert.Equal("1", Assert.Single(result.Decision.Intents).Text);
+    }
+
+    [Fact]
+    public void TryBind_DifferentBrain_ClearsState()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.WriteBrain(
+            "reader",
+            """
+            return {
+              id = "reader",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function(ctx, state)
+                state.count = (state.count or 0) + 1
+                return brain.say(tostring(state.count))
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        fixture.Bind(1, "reader");
+        var result = fixture.Think(1);
+
+        Assert.Equal("1", Assert.Single(result.Decision.Intents).Text);
+    }
+
+    [Fact]
+    public void TryBind_SameBrainPreservesState()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        fixture.Bind(1, "counter");
+        var result = fixture.Think(1);
+
+        Assert.Equal("2", Assert.Single(result.Decision.Intents).Text);
+    }
+
+    [Fact]
+    public void Invoke_InfiniteHook_ReturnsBudgetFailureAndRecordsMetric()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "infinite",
+            """
+            return {
+              id = "infinite",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function() while true do end end
+            }
+            """
+        );
+        fixture.Bind(1, "infinite");
+
+        var result = fixture.Think(1);
+
+        Assert.False(result.Success);
+        Assert.True(result.InstructionBudgetExceeded);
+        Assert.Empty(result.Decision.Intents);
+        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
+        Assert.Equal(1, fixture.Metrics.Current.InstructionBudgetBreaches);
+    }
+
+    [Fact]
+    public void Invoke_AbsentOptionalHook_ReturnsSuccessfulEmptyDecision()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+
+        var result = fixture.Runtime.Invoke(new(1), NpcBrainHookType.Activate, fixture.Context);
+
+        Assert.True(result.Success);
+        Assert.Equal(BrainDecision.Empty, result.Decision);
+        Assert.Equal(0, fixture.Metrics.Current.HookFailures);
+    }
+
+    [Fact]
+    public void Invoke_UnknownHookValue_ReturnsNeutralFailure()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+
+        var result = fixture.Runtime.Invoke(new(1), (NpcBrainHookType)999, fixture.Context);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.Decision.Intents);
+        Assert.Contains("unsupported", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
+    }
+
+    [Fact]
+    public void Invoke_PrivilegedGlobalsAreUnavailableAndCannotMutateWorld()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        var mutationCount = 0;
+        fixture.InstallPrivilegedGlobal("mobile", "set", () => mutationCount++);
+        fixture.InstallPrivilegedGlobal("chat", "say", () => mutationCount++);
+        fixture.InstallPrivilegedGlobal("game", "post", () => mutationCount++);
+        fixture.InstallPrivilegedGlobal("events", "on", () => mutationCount++);
+        fixture.WriteBrain(
+            "sandbox",
+            """
+            return {
+              id = "sandbox",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function()
+                local mobile_ok = pcall(function() mobile.set() end)
+                local chat_ok = pcall(function() chat.say() end)
+                local game_ok = pcall(function() game.post() end)
+                local events_ok = pcall(function() events.on() end)
+                return brain.say(
+                  tostring(mobile_ok) .. "," ..
+                  tostring(chat_ok) .. "," ..
+                  tostring(game_ok) .. "," ..
+                  tostring(events_ok)
+                )
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "sandbox");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("false,false,false,false", Assert.Single(result.Decision.Intents).Text);
+        Assert.Equal(0, mutationCount);
+    }
+
+    [Fact]
+    public void Invoke_ContextConversion_ExposesNeutralSnapshots()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "context",
+            """
+            return {
+              id = "context",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function(ctx)
+                local other = ctx.nearby[1]
+                return brain.say(
+                  table.concat({
+                    tostring(ctx.now_ms),
+                    tostring(ctx.self.id),
+                    ctx.self.name,
+                    tostring(ctx.self.is_player),
+                    tostring(ctx.self.map_id),
+                    tostring(ctx.self.position.x),
+                    tostring(ctx.self.position.y),
+                    tostring(ctx.self.position.z),
+                    tostring(ctx.self.hits),
+                    tostring(ctx.self.hits_max),
+                    tostring(ctx.self.hits_percent),
+                    tostring(ctx.self.warmode),
+                    tostring(ctx.self.combatant_id),
+                    tostring(ctx.self.criminal),
+                    tostring(ctx.self.kills),
+                    tostring(ctx.home.map_id),
+                    tostring(ctx.home.position.x),
+                    tostring(other.id),
+                    tostring(other.combatant_id),
+                    tostring(#ctx.nearby)
+                  }, "|")
+                )
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "context");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(
+            "1714566896789|1|Self|false|3|100|200|7|25|100|25|true|nil|true|5|3|90|2|1|1",
+            Assert.Single(result.Decision.Intents).Text
+        );
+    }
+
+    [Fact]
+    public void Invoke_EventConversionAndHookMapping_ExposeExactFields()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "events",
+            """
+            local function say(value) return brain.say(value) end
+            return {
+              id = "events",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              on_activate = function() return say("activate") end,
+              on_deactivate = function() return say("deactivate") end,
+              on_speech_heard = function(ctx, state, event)
+                return say(table.concat({
+                  tostring(event.speaker_id),
+                  event.speaker_name,
+                  tostring(event.speaker_is_player),
+                  event.speech_type,
+                  event.text
+                }, "|"))
+              end,
+              on_mobile_entered_range = function(ctx, state, event)
+                return say("entered|" .. tostring(event.mobile_id) .. "|" ..
+                  event.mobile_name .. "|" .. tostring(event.mobile_is_player) .. "|" ..
+                  tostring(event.from_position.x) .. "|" .. tostring(event.to_position.y))
+              end,
+              on_mobile_left_range = function(ctx, state, event)
+                return say("left|" .. tostring(event.mobile_id))
+              end,
+              on_mobile_moved = function(ctx, state, event)
+                return say("moved|" .. tostring(event.mobile_id) .. "|" ..
+                  tostring(event.from_position.x) .. "|" .. tostring(event.to_position.y))
+              end,
+              on_attacked = function(ctx, state, event)
+                return say("attacked|" .. tostring(event.attacker_id))
+              end,
+              on_damage = function(ctx, state, event)
+                return say("damage|" .. tostring(event.attacker_id) .. "|" .. tostring(event.amount))
+              end,
+              on_death = function(ctx, state, event)
+                return say("death|" .. tostring(event.killer_id))
+              end,
+              think = function() return say("think") end
+            }
+            """
+        );
+        fixture.Bind(1, "events");
+        var subject = fixture.Other;
+
+        AssertHookText(fixture, NpcBrainHookType.Activate, null, "activate");
+        AssertHookText(fixture, NpcBrainHookType.Deactivate, null, "deactivate");
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.SpeechHeard,
+            new(NpcBrainEventType.SpeechHeard, subject, "hello", ChatMessageType.Regular),
+            "2|Other|true|regular|hello"
+        );
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.MobileEnteredRange,
+            new(
+                NpcBrainEventType.MobileEnteredRange,
+                subject,
+                FromPosition: new(5, 6, 0),
+                ToPosition: new(7, 8, 0)
+            ),
+            "entered|2|Other|true|5|8"
+        );
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.MobileLeftRange,
+            new(NpcBrainEventType.MobileLeftRange, subject),
+            "left|2"
+        );
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.MobileMoved,
+            new(
+                NpcBrainEventType.MobileMoved,
+                subject,
+                FromPosition: new(10, 20, 1),
+                ToPosition: new(30, 40, 2)
+            ),
+            "moved|2|10|40"
+        );
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.Attacked,
+            new(NpcBrainEventType.Attacked, subject),
+            "attacked|2"
+        );
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.Damage,
+            new(NpcBrainEventType.Damage, subject, Amount: 17),
+            "damage|2|17"
+        );
+        AssertHookText(
+            fixture,
+            NpcBrainHookType.Death,
+            new(NpcBrainEventType.Death, subject),
+            "death|2"
+        );
+        AssertHookText(fixture, NpcBrainHookType.Think, null, "think");
+    }
+
+    [Fact]
+    public void Invoke_BrainHelpersAndDecisionConversion_MapAndClampValues()
+    {
+        using var fixture = new BrainRuntimeFixture(maxIntentsPerDecision: 20);
+        fixture.WriteBrain(
+            "helpers",
+            """
+            return {
+              id = "helpers",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function()
+                return brain.decision(1, {
+                  brain.idle(),
+                  brain.say("hello"),
+                  brain.patrol(),
+                  brain.move_toward(2),
+                  brain.move_away(3),
+                  brain.engage(4),
+                  brain.clear_target(),
+                  brain.return_home()
+                })
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "helpers");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(100, result.Decision.NextTickMilliseconds);
+        Assert.Collection(
+            result.Decision.Intents,
+            intent => Assert.Equal(BrainIntentType.Idle, intent.Type),
+            intent =>
+            {
+                Assert.Equal(BrainIntentType.Say, intent.Type);
+                Assert.Equal("hello", intent.Text);
+            },
+            intent => Assert.Equal(BrainIntentType.Patrol, intent.Type),
+            intent =>
+            {
+                Assert.Equal(BrainIntentType.MoveToward, intent.Type);
+                Assert.Equal(new Serial(2), intent.TargetId);
+            },
+            intent =>
+            {
+                Assert.Equal(BrainIntentType.MoveAway, intent.Type);
+                Assert.Equal(new Serial(3), intent.TargetId);
+            },
+            intent =>
+            {
+                Assert.Equal(BrainIntentType.Engage, intent.Type);
+                Assert.Equal(new Serial(4), intent.TargetId);
+            },
+            intent => Assert.Equal(BrainIntentType.ClearTarget, intent.Type),
+            intent => Assert.Equal(BrainIntentType.ReturnHome, intent.Type)
+        );
+    }
+
+    [Fact]
+    public void Invoke_DecisionConversion_AcceptsNilSingleIntentAndUnknownIntents()
+    {
+        using var fixture = new BrainRuntimeFixture(maxIntentsPerDecision: 2);
+        fixture.WriteBrain(
+            "conversion",
+            """
+            return {
+              id = "conversion",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              on_activate = function() return nil end,
+              on_deactivate = function() return brain.say("single") end,
+              think = function()
+                return brain.decision(999999, {
+                  { type = "teleport", target_id = "bad" },
+                  { text = "missing type" },
+                  brain.say("truncated")
+                })
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "conversion");
+
+        var nilResult = fixture.Runtime.Invoke(new(1), NpcBrainHookType.Activate, fixture.Context);
+        var singleResult = fixture.Runtime.Invoke(new(1), NpcBrainHookType.Deactivate, fixture.Context);
+        var decisionResult = fixture.Think(1);
+
+        Assert.True(nilResult.Success);
+        Assert.Equal(BrainDecision.Empty, nilResult.Decision);
+        Assert.Equal(BrainIntentType.Say, Assert.Single(singleResult.Decision.Intents).Type);
+        Assert.Equal("single", Assert.Single(singleResult.Decision.Intents).Text);
+        Assert.Equal(60_000, decisionResult.Decision.NextTickMilliseconds);
+        Assert.Collection(
+            decisionResult.Decision.Intents,
+            intent =>
+            {
+                Assert.Equal(BrainIntentType.Unknown, intent.Type);
+                Assert.Equal("teleport", intent.RawType);
+            },
+            intent =>
+            {
+                Assert.Equal(BrainIntentType.Unknown, intent.Type);
+                Assert.Equal("", intent.RawType);
+            }
+        );
+    }
+
+    [Fact]
+    public void TryReload_InvalidReplacement_PreservesSharedDefinition()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.WriteBrain("counter", "return { id = 'counter' }");
+
+        var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
+        var invocation = fixture.Think(1);
+
+        Assert.False(reloadResult);
+        Assert.Null(descriptor);
+        Assert.NotNull(error);
+        Assert.True(invocation.Success, invocation.Error);
+        Assert.Equal("1", Assert.Single(invocation.Decision.Intents).Text);
+        Assert.Equal(1, fixture.Metrics.Current.ReloadFallbacks);
+    }
+
+    private static void AssertHookText(
+        BrainRuntimeFixture fixture,
+        NpcBrainHookType hook,
+        NpcBrainEvent? brainEvent,
+        string expected
+    )
+    {
+        var result = fixture.Runtime.Invoke(new(1), hook, fixture.Context, brainEvent);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(expected, Assert.Single(result.Decision.Intents).Text);
+    }
+
+    private sealed class BrainRuntimeFixture : IDisposable
+    {
+        private readonly Container _container = new();
+        private readonly DirectoriesConfig _directories;
+        private readonly LuaScriptEngineService _engine;
+        private readonly string _root;
+        private readonly string _scripts;
+
+        public BrainContext Context { get; }
+
+        public NpcAiMetrics Metrics { get; } = new();
+
+        public BrainMobileSnapshot Other { get; } = new(
+            new(2),
+            "Other",
+            true,
+            3,
+            new(105, 205, 7),
+            80,
+            100,
+            false,
+            new(1),
+            false,
+            0
+        );
+
+        public LuaNpcBrainRuntime Runtime { get; }
+
+        public BrainRuntimeFixture(int maxIntentsPerDecision = 8)
+        {
+            _root = Path.Combine(Path.GetTempPath(), "mg-brain-" + Guid.NewGuid().ToString("N"));
+            _directories = new(_root, ["scripts"]);
+            _scripts = _directories.GetPath("scripts");
+            _engine = new(
+                _directories,
+                _container,
+                new LuaEngineConfig(_root, _scripts, "MoongateTests", "1.0.0")
+            );
+            var config = new MoongateConfig
+            {
+                NpcAi = new()
+                {
+                    Advanced = new()
+                    {
+                        MinTickMilliseconds = 100,
+                        MaxTickMilliseconds = 60_000,
+                        MaxIntentsPerDecision = maxIntentsPerDecision,
+                        InstructionBudget = 2_000
+                    }
+                }
+            };
+            Runtime = new(_engine, _directories, config, Metrics);
+            var self = new BrainMobileSnapshot(
+                new(1),
+                "Self",
+                false,
+                3,
+                new(100, 200, 7),
+                25,
+                100,
+                true,
+                Serial.Zero,
+                true,
+                5
+            );
+            Context = new(
+                DateTimeOffset.FromUnixTimeMilliseconds(1_714_566_896_789),
+                self,
+                3,
+                new(90, 190, 0),
+                [Other]
+            );
+        }
+
+        public void Bind(uint mobileId, string brainId)
+        {
+            var result = Runtime.TryBind(new(mobileId), brainId, out _, out var error);
+
+            Assert.True(result, error);
+        }
+
+        public void CreateBrainSymbolicLink(string brainId, string targetContent)
+        {
+            var brainDirectory = Path.Combine(_scripts, "brains");
+            Directory.CreateDirectory(brainDirectory);
+            var targetPath = Path.Combine(_root, brainId + "-outside.lua");
+            File.WriteAllText(targetPath, targetContent);
+            File.CreateSymbolicLink(Path.Combine(brainDirectory, brainId + ".lua"), targetPath);
+        }
+
+        public void InstallPrivilegedGlobal(string moduleName, string functionName, Action callback)
+        {
+            var module = new Table(_engine.LuaScript);
+            module.Set(
+                functionName,
+                DynValue.NewCallback(
+                    (_, _) =>
+                    {
+                        callback();
+                        return DynValue.Nil;
+                    }
+                )
+            );
+            _engine.LuaScript.Globals.Set(moduleName, DynValue.NewTable(module));
+        }
+
+        public NpcBrainInvocationResult Think(uint mobileId)
+            => Runtime.Invoke(new(mobileId), NpcBrainHookType.Think, Context);
+
+        public void WriteBrain(string brainId, string content)
+        {
+            var brainDirectory = Path.Combine(_scripts, "brains");
+            Directory.CreateDirectory(brainDirectory);
+            File.WriteAllText(Path.Combine(brainDirectory, brainId + ".lua"), content);
+        }
+
+        public void WriteScript(string relativePath, string content)
+            => File.WriteAllText(Path.Combine(_scripts, relativePath), content);
+
+        public void Dispose()
+        {
+            _engine.Dispose();
+            _container.Dispose();
+            Directory.Delete(_root, true);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -353,6 +353,65 @@ public class LuaNpcBrainRuntimeTests
         Assert.DoesNotContain(logs.Events, logEvent => logEvent.Level >= LogEventLevel.Warning);
     }
 
+    [Theory]
+    [InlineData("string.rep('x', 4097)")]
+    [InlineData("('x'):rep(4097)")]
+    public void Invoke_StringRepAboveNativeLimit_ReturnsStructuredFailure(string nativeCall)
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "native_limit",
+            $$"""
+              return {
+                id = "native_limit",
+                default_tick_ms = 1000,
+                perception_range = 12,
+                hearing_range = 15,
+                think = function()
+                  return brain.say({{nativeCall}})
+                end
+              }
+              """
+        );
+        fixture.Bind(1, "native_limit");
+
+        var result = fixture.Think(1);
+
+        Assert.False(result.Success);
+        Assert.False(result.InstructionBudgetExceeded);
+        Assert.Equal(BrainDecision.Empty, result.Decision);
+        Assert.Contains("limit", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
+    }
+
+    [Fact]
+    public void Invoke_BoundedNativeLibraryUsage_ReturnsExpectedDecision()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "native_normal",
+            """
+            return {
+              id = "native_normal",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function()
+                local values = { "a", "b" }
+                table.insert(values, "c")
+                return brain.say(string.rep(table.concat(values), 2))
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "native_normal");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("abcabc", Assert.Single(result.Decision.Intents).Text);
+    }
+
     [Fact]
     public void Invoke_AbsentOptionalHook_ReturnsSuccessfulEmptyDecision()
     {

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -10,6 +10,7 @@ using Moongate.Server.Services.AI;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
+using Serilog.Events;
 using SquidStd.Core.Directories;
 using SquidStd.Scripting.Lua.Data.Config;
 using SquidStd.Scripting.Lua.Services;
@@ -17,6 +18,7 @@ using ISynchronizeInvoke = System.ComponentModel.ISynchronizeInvoke;
 
 namespace Moongate.Tests.Scripting;
 
+[Collection(GlobalSerilogCollection.Name)]
 public class LuaNpcBrainRuntimeTests
 {
     private const string CounterBrain = """
@@ -323,8 +325,9 @@ public class LuaNpcBrainRuntimeTests
     }
 
     [Fact]
-    public void Invoke_InfiniteHook_ReturnsBudgetFailureAndRecordsMetric()
+    public void Invoke_InfiniteHook_ReturnsBudgetFailureRecordsMetricAndDoesNotLog()
     {
+        using var logs = new GlobalSerilogCapture();
         using var fixture = new BrainRuntimeFixture();
         fixture.WriteBrain(
             "infinite",
@@ -347,6 +350,7 @@ public class LuaNpcBrainRuntimeTests
         Assert.Empty(result.Decision.Intents);
         Assert.Equal(1, fixture.Metrics.Current.HookFailures);
         Assert.Equal(1, fixture.Metrics.Current.InstructionBudgetBreaches);
+        Assert.DoesNotContain(logs.Events, logEvent => logEvent.Level >= LogEventLevel.Warning);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -4,8 +4,10 @@ using Moongate.Core.Primitives;
 using Moongate.Scripting.AI;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.AI;
+using Moongate.Tests.Support;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
 using SquidStd.Core.Directories;
@@ -752,12 +754,72 @@ public class LuaNpcBrainRuntimeTests
     }
 
     [Fact]
-    public void TryReload_InvalidReplacement_PreservesSharedDefinition()
+    public void TryReload_ValidReplacement_SwapsBehaviorPreservesStateAndPublishesOnce()
     {
         using var fixture = new BrainRuntimeFixture();
         fixture.WriteBrain("counter", CounterBrain);
         fixture.Bind(1, "counter");
-        fixture.WriteBrain("counter", "return { id = 'counter' }");
+        fixture.Think(1);
+        fixture.WriteBrain(
+            "counter",
+            """
+            return {
+              id = "counter",
+              default_tick_ms = 1500,
+              perception_range = 10,
+              hearing_range = 12,
+              think = function(ctx, state)
+                state.count = (state.count or 0) + 1
+                return brain.say("reloaded:" .. tostring(state.count))
+              end
+            }
+            """
+        );
+
+        var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
+        var invocation = fixture.Think(1);
+
+        Assert.True(reloadResult, error);
+        Assert.Equal(new("counter", 1500, 10, 12), descriptor);
+        Assert.True(invocation.Success, invocation.Error);
+        Assert.Equal("reloaded:2", Assert.Single(invocation.Decision.Intents).Text);
+        var reloaded = Assert.IsType<BrainDefinitionReloadedEvent>(Assert.Single(fixture.Bus.Published));
+        Assert.Equal("counter", reloaded.BrainId);
+        Assert.Equal(descriptor, reloaded.Descriptor);
+        Assert.Equal(1, fixture.Metrics.Current.ReloadSuccesses);
+        Assert.Equal(0, fixture.Metrics.Current.ReloadFallbacks);
+    }
+
+    [Theory]
+    [InlineData("return {")]
+    [InlineData(
+        """
+        return {
+          id = "other",
+          default_tick_ms = 1000,
+          perception_range = 12,
+          hearing_range = 15,
+          think = function() return brain.idle() end
+        }
+        """
+    )]
+    [InlineData(
+        """
+        return {
+          id = "counter",
+          default_tick_ms = 1000,
+          perception_range = 12,
+          hearing_range = 15
+        }
+        """
+    )]
+    public void TryReload_InvalidReplacement_PreservesBehaviorAndPublishesNothing(string replacement)
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+        fixture.WriteBrain("counter", replacement);
 
         var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
         var invocation = fixture.Think(1);
@@ -766,8 +828,94 @@ public class LuaNpcBrainRuntimeTests
         Assert.Null(descriptor);
         Assert.NotNull(error);
         Assert.True(invocation.Success, invocation.Error);
-        Assert.Equal("1", Assert.Single(invocation.Decision.Intents).Text);
+        Assert.Equal("2", Assert.Single(invocation.Decision.Intents).Text);
         Assert.Equal(1, fixture.Metrics.Current.ReloadFallbacks);
+        Assert.Empty(fixture.Bus.Published);
+    }
+
+    [Fact]
+    public async Task StartAsync_RapidFileChanges_PostOneReloadToTheGameLoop()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        await fixture.Runtime.StartAsync();
+        var replacement = """
+                          return {
+                            id = "counter",
+                            default_tick_ms = 1500,
+                            perception_range = 10,
+                            hearing_range = 12,
+                            think = function(ctx, state) return brain.say("watched") end
+                          }
+                          """;
+
+        fixture.WriteBrain("counter", replacement);
+        fixture.WriteBrain("counter", replacement);
+        fixture.WriteBrain("counter", replacement);
+
+        await WaitUntilAsync(() => fixture.Loop.PostCount > 0);
+        await Task.Delay(400);
+
+        Assert.Equal(1, fixture.Loop.PostCount);
+        Assert.Equal(1, fixture.Metrics.Current.ReloadSuccesses);
+        Assert.Single(fixture.Bus.Published);
+        Assert.Equal("watched", Assert.Single(fixture.Think(1).Decision.Intents).Text);
+
+        await fixture.Runtime.StopAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_BuiltInBrainsExposeDeterministicDescriptorsAndBehavior()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        await fixture.Runtime.StartAsync();
+
+        Assert.True(fixture.Runtime.TryBind(new(1), "guard", out var guard, out var guardError), guardError);
+        Assert.Equal(new("guard", 1000, 12, 15), guard);
+        var nonPlayerSpeech = fixture.Runtime.Invoke(
+            new(1),
+            NpcBrainHookType.SpeechHeard,
+            fixture.Context,
+            new(NpcBrainEventType.SpeechHeard, fixture.Context.Self, "hello", ChatMessageType.Regular)
+        );
+        var firstPlayerSpeech = fixture.Runtime.Invoke(
+            new(1),
+            NpcBrainHookType.SpeechHeard,
+            fixture.Context,
+            new(NpcBrainEventType.SpeechHeard, fixture.Other, "hello", ChatMessageType.Regular)
+        );
+        var returningPlayerSpeech = fixture.Runtime.Invoke(
+            new(1),
+            NpcBrainHookType.SpeechHeard,
+            fixture.Context,
+            new(NpcBrainEventType.SpeechHeard, fixture.Other, "hello", ChatMessageType.Regular)
+        );
+
+        Assert.Empty(nonPlayerSpeech.Decision.Intents);
+        Assert.Equal("Non ti avevo mai visto prima.", Assert.Single(firstPlayerSpeech.Decision.Intents).Text);
+        Assert.Equal("Bentornato.", Assert.Single(returningPlayerSpeech.Decision.Intents).Text);
+        Assert.Equal(BrainIntentType.Idle, Assert.Single(fixture.Think(1).Decision.Intents).Type);
+
+        Assert.True(fixture.Runtime.TryBind(new(2), "orion", out var orion, out var orionError), orionError);
+        Assert.Equal(new("orion", 1500, 10, 12), orion);
+        Assert.Equal(BrainIntentType.Patrol, Assert.Single(fixture.Think(2).Decision.Intents).Type);
+
+        Assert.True(fixture.Runtime.TryBind(new(3), "vega", out var vega, out var vegaError), vegaError);
+        Assert.Equal(new("vega", 1500, 10, 12), vega);
+        Assert.Equal(BrainIntentType.Patrol, Assert.Single(fixture.Think(3).Decision.Intents).Type);
+
+        await fixture.Runtime.StopAsync();
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        while (!condition())
+        {
+            await Task.Delay(25, cancellation.Token);
+        }
     }
 
     private static void AssertHookText(
@@ -794,6 +942,10 @@ public class LuaNpcBrainRuntimeTests
         public BrainContext Context { get; }
 
         public NpcAiMetrics Metrics { get; } = new();
+
+        public StubEventBus Bus { get; } = new();
+
+        public StubGameLoopContext Loop { get; } = new();
 
         public BrainMobileSnapshot Other { get; } = new(
             new(2),
@@ -834,7 +986,7 @@ public class LuaNpcBrainRuntimeTests
                     }
                 }
             };
-            Runtime = new(_engine, _directories, config, Metrics);
+            Runtime = new(_engine, _directories, config, Metrics, Loop, Bus);
             var self = new BrainMobileSnapshot(
                 new(1),
                 "Self",
@@ -904,6 +1056,7 @@ public class LuaNpcBrainRuntimeTests
 
         public void Dispose()
         {
+            Runtime.Dispose();
             _engine.Dispose();
             _container.Dispose();
             Directory.Delete(_root, true);

--- a/tests/Moongate.Tests/Server/AI/BrainIntentExecutorTests.cs
+++ b/tests/Moongate.Tests/Server/AI/BrainIntentExecutorTests.cs
@@ -1,0 +1,403 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.AI;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.AI;
+
+public class BrainIntentExecutorTests
+{
+    [Fact]
+    public void Execute_Idle_AcceptsWithoutMutation()
+    {
+        var (executor, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Idle)]);
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(new Serial(0x2), stored.CombatantId);
+        Assert.True(stored.Warmode);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+        Assert.Equal(0, metrics.Current.IntentsRejected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Execute_SayBlankText_Rejects(string? text)
+    {
+        var (executor, persistence, chat, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Say, text: text)]);
+
+        Assert.Empty(chat.Messages);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_SayOversizeText_Rejects()
+    {
+        var (executor, persistence, chat, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Say, text: new('a', 129))]);
+
+        Assert.Empty(chat.Messages);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_SayValidText_UsesRegularSpeechDefaultHueAndRange15()
+    {
+        var (executor, persistence, chat, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Say, text: "Halt!")]);
+
+        var message = Assert.Single(chat.Messages);
+        Assert.Equal(owner.Id, message.Speaker);
+        Assert.Equal(ChatMessageType.Regular, message.Type);
+        Assert.Equal("Halt!", message.Text);
+        Assert.Equal(Hue.Default, message.Hue);
+        Assert.Equal(15, message.Range);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Execute_EngageVisibleTarget_SetsCombatPostureWithoutMovingOrAttacking()
+    {
+        var (executor, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 12, 10);
+
+        executor.Execute(owner.Id, Context(owner, nearby: [Snapshot(target)]), [Intent(BrainIntentType.Engage, target.Id)]);
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(target.Id, stored.CombatantId);
+        Assert.True(stored.Warmode);
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Theory]
+    [InlineData(0x1, true, 0)]
+    [InlineData(0x2, false, 0)]
+    [InlineData(0x2, true, 1)]
+    public void Execute_EngageInvalidTarget_Rejects(uint targetId, bool includeNearby, int targetMapId)
+    {
+        var (executor, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = targetId == owner.Id.Value ? owner : AddMobile(persistence, targetId, targetMapId, 12, 10);
+        var nearby = includeNearby ? new[] { Snapshot(target) } : [];
+
+        executor.Execute(owner.Id, Context(owner, nearby: nearby), [Intent(BrainIntentType.Engage, new(targetId))]);
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(Serial.Zero, stored.CombatantId);
+        Assert.False(stored.Warmode);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_EngageMissingTarget_Rejects()
+    {
+        var (executor, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Engage)]);
+
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_ClearTarget_ClearsCombatPostureAndPersists()
+    {
+        var (executor, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.ClearTarget)]);
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(Serial.Zero, stored.CombatantId);
+        Assert.False(stored.Warmode);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Theory]
+    [InlineData(BrainIntentType.MoveToward, 14, 8, DirectionType.NorthEast)]
+    [InlineData(BrainIntentType.MoveAway, 14, 8, DirectionType.SouthWest)]
+    public void Execute_MoveIntent_UsesEightWayDirection(BrainIntentType type, int targetX, int targetY, DirectionType expected)
+    {
+        var (executor, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, targetX, targetY);
+
+        executor.Execute(owner.Id, Context(owner, nearby: [Snapshot(target)]), [Intent(type, target.Id)]);
+
+        Assert.Equal([(owner.Id, expected)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Execute_MoveTowardEqualPosition_AcceptsWithoutDelegating()
+    {
+        var (executor, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 10, 10);
+
+        executor.Execute(owner.Id, Context(owner, nearby: [Snapshot(target)]), [Intent(BrainIntentType.MoveToward, target.Id)]);
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Theory]
+    [InlineData(BrainIntentType.MoveToward)]
+    [InlineData(BrainIntentType.MoveAway)]
+    public void Execute_MoveTargetOutsidePerception_Rejects(BrainIntentType type)
+    {
+        var (executor, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 12, 10);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(type, target.Id)]);
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_ReturnHome_OnHomeMapMovesTowardHome()
+    {
+        var (executor, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        executor.Execute(owner.Id, Context(owner, homePosition: new(8, 12, 0)), [Intent(BrainIntentType.ReturnHome)]);
+
+        Assert.Equal([(owner.Id, DirectionType.SouthWest)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Execute_ReturnHomeOutsideHomeMap_Rejects()
+    {
+        var (executor, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence, mapId: 1);
+
+        executor.Execute(owner.Id, Context(owner, homeMapId: 0), [Intent(BrainIntentType.ReturnHome)]);
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_PatrolWithinLeash_UsesInjectedRandomDirection()
+    {
+        var (executor, persistence, _, movement, metrics) = Build(randomResult: 3);
+        var owner = AddOwner(persistence, x: 12, y: 8);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Patrol)]);
+
+        Assert.Equal([(owner.Id, DirectionType.SouthEast)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Execute_PatrolOutsideLeash_ReturnsTowardHome()
+    {
+        var (executor, persistence, _, movement, metrics) = Build(randomResult: 3);
+        var owner = AddOwner(persistence, x: 19, y: 10);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Patrol)]);
+
+        Assert.Equal([(owner.Id, DirectionType.West)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Execute_UnknownIntent_RejectsWithoutThrowing()
+    {
+        var (executor, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        executor.Execute(owner.Id, Context(owner), [Intent(BrainIntentType.Unknown, rawType: "explode")]);
+
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Execute_OrderedIntents_ExecutesEachInDeclaredOrderAndRevalidates()
+    {
+        var (executor, persistence, chat, movement, metrics) = Build();
+        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
+        var target = AddMobile(persistence, 0x2, 0, 11, 10);
+
+        executor.Execute(
+            owner.Id,
+            Context(owner, nearby: [Snapshot(target)]),
+            [
+                Intent(BrainIntentType.ClearTarget),
+                Intent(BrainIntentType.MoveToward, target.Id),
+                Intent(BrainIntentType.Say, text: "Advance")
+            ]
+        );
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(Serial.Zero, stored.CombatantId);
+        Assert.False(stored.Warmode);
+        Assert.Equal([(owner.Id, DirectionType.East)], movement.Moves);
+        Assert.Equal("Advance", Assert.Single(chat.Messages).Text);
+        Assert.Equal(3, metrics.Current.IntentsAccepted);
+    }
+
+    private static BrainIntentExecutor Build(
+        out FakePersistenceService persistence,
+        out RecordingChatService chat,
+        out RecordingMovementService movement,
+        out NpcAiMetrics metrics,
+        int randomResult = 0
+    )
+    {
+        persistence = new();
+        chat = new();
+        movement = new();
+        metrics = new();
+
+        return new(persistence, movement, chat, new FixedRandom(randomResult), new StubLoopAffinity(), metrics);
+    }
+
+    private static (BrainIntentExecutor Executor, FakePersistenceService Persistence, RecordingChatService Chat, RecordingMovementService Movement, NpcAiMetrics Metrics) Build(int randomResult = 0)
+    {
+        var executor = Build(out var persistence, out var chat, out var movement, out var metrics, randomResult);
+        return (executor, persistence, chat, movement, metrics);
+    }
+
+    private static MobileEntity AddOwner(
+        FakePersistenceService persistence,
+        uint id = 0x1,
+        int mapId = 0,
+        int x = 10,
+        int y = 10,
+        Serial? combatantId = null,
+        bool warmode = false
+    )
+        => AddMobile(persistence, id, mapId, x, y, combatantId, warmode);
+
+    private static MobileEntity AddMobile(
+        FakePersistenceService persistence,
+        uint id,
+        int mapId,
+        int x,
+        int y,
+        Serial? combatantId = null,
+        bool warmode = false
+    )
+    {
+        var mobile = new MobileEntity
+        {
+            Id = new(id),
+            Name = "Test mobile",
+            MapId = mapId,
+            Position = new(x, y, 0),
+            CombatantId = combatantId ?? Serial.Zero,
+            Warmode = warmode
+        };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).AsTask().Wait();
+        return mobile;
+    }
+
+    private static BrainContext Context(
+        MobileEntity owner,
+        int? homeMapId = null,
+        Point3D? homePosition = null,
+        IReadOnlyList<BrainMobileSnapshot>? nearby = null
+    )
+        => new(
+            DateTimeOffset.UtcNow,
+            Snapshot(owner),
+            homeMapId ?? owner.MapId,
+            homePosition ?? new(10, 10, 0),
+            nearby ?? []
+        );
+
+    private static BrainIntent Intent(BrainIntentType type, Serial? targetId = null, string? text = null, string rawType = "test")
+        => new(type, rawType, targetId ?? Serial.Zero, text);
+
+    private static BrainMobileSnapshot Snapshot(MobileEntity mobile)
+        => new(
+            mobile.Id,
+            mobile.Name,
+            false,
+            mobile.MapId,
+            mobile.Position,
+            mobile.Hits,
+            mobile.HitsMax,
+            mobile.Warmode,
+            mobile.CombatantId,
+            mobile.Criminal,
+            mobile.Kills
+        );
+
+    private sealed class RecordingChatService : IChatService
+    {
+        public List<(Serial Speaker, ChatMessageType Type, string Text, Hue Hue, int Range)> Messages { get; } = [];
+
+        public void Broadcast(string text, Hue? hue = null)
+        {
+        }
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        {
+            Messages.Add((speaker.Id, type, text, hue, range));
+        }
+    }
+
+    private sealed class RecordingMovementService : IMovementService
+    {
+        public List<(Serial MobileId, DirectionType Direction)> Moves { get; } = [];
+
+        public void TryMove(Moongate.Server.Abstractions.Data.Session.PlayerSession session, DirectionType direction, byte sequence)
+        {
+        }
+
+        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+        {
+            Moves.Add((mobileId, direction));
+            return true;
+        }
+    }
+
+    private sealed class FixedRandom : Random
+    {
+        private readonly int _result;
+
+        public FixedRandom(int result)
+        {
+            _result = result;
+        }
+
+        public override int Next(int minValue, int maxValue)
+        {
+            return minValue + _result;
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcAiMetricsTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcAiMetricsTests.cs
@@ -1,0 +1,100 @@
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.AI;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcAiMetricsTests
+{
+    [Fact]
+    public void Current_ReflectsSectorAndBrainGauges()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.SetActiveSectorCounts(3, 2);
+        metrics.SetSleepingSectorCount(7);
+        metrics.SetBrainCounts(11, 13, 17);
+
+        var current = metrics.Current;
+
+        Assert.Equal(3, current.ActiveSectors);
+        Assert.Equal(2, current.GraceSectors);
+        Assert.Equal(7, current.SleepingSectors);
+        Assert.Equal(11, current.ActiveBrains);
+        Assert.Equal(13, current.SleepingBrains);
+        Assert.Equal(17, current.FaultBackoffBrains);
+    }
+
+    [Fact]
+    public void RecordEvent_EachDispositionIncrementsItsCounter()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordEvent(NpcBrainEventDispositionType.Delivered);
+        metrics.RecordEvent(NpcBrainEventDispositionType.Coalesced);
+        metrics.RecordEvent(NpcBrainEventDispositionType.Dropped);
+
+        var current = metrics.Current;
+
+        Assert.Equal(1, current.EventsDelivered);
+        Assert.Equal(1, current.EventsCoalesced);
+        Assert.Equal(1, current.EventsDropped);
+    }
+
+    [Fact]
+    public void RecordIntent_AcceptedAndRejectedIncrementSeparateCounters()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordIntent(true);
+        metrics.RecordIntent(false);
+
+        var current = metrics.Current;
+
+        Assert.Equal(1, current.IntentsAccepted);
+        Assert.Equal(1, current.IntentsRejected);
+    }
+
+    [Fact]
+    public void RecordReload_SuccessAndFallbackIncrementSeparateCounters()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordReload(true);
+        metrics.RecordReload(false);
+
+        var current = metrics.Current;
+
+        Assert.Equal(1, current.ReloadSuccesses);
+        Assert.Equal(1, current.ReloadFallbacks);
+    }
+
+    [Fact]
+    public void RecordHookInvocation_TracksCountTotalMaximumAndAverageDuration()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordHookInvocation(TimeSpan.FromTicks(10));
+        metrics.RecordHookInvocation(TimeSpan.FromTicks(30));
+
+        var current = metrics.Current;
+
+        Assert.Equal(2, current.HookInvocations);
+        Assert.Equal(40, current.TotalHookDurationTicks);
+        Assert.Equal(30, current.MaxHookDurationTicks);
+        Assert.Equal(TimeSpan.FromTicks(20), current.AverageHookDuration);
+    }
+
+    [Fact]
+    public void RecordHookFailure_TracksBudgetBreachesSeparately()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordHookFailure(false);
+        metrics.RecordHookFailure(true);
+
+        var current = metrics.Current;
+
+        Assert.Equal(2, current.HookFailures);
+        Assert.Equal(1, current.InstructionBudgetBreaches);
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainContextFactoryTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainContextFactoryTests.cs
@@ -1,0 +1,94 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Services.AI;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcBrainContextFactoryTests
+{
+    [Fact]
+    public async Task Create_WorldState_ProducesDeterministicDetachedSnapshot()
+    {
+        var persistence = new FakePersistenceService();
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), new StubEventBus());
+        var sessions = new StubSessionManager();
+        var time = new MutableTimeProvider(new DateTimeOffset(2026, 7, 24, 10, 30, 0, TimeSpan.Zero));
+        var owner = await AddMobileAsync(persistence, spatial, 0x5, "owner", 0, 10, 10);
+        var laterSerial = await AddMobileAsync(persistence, spatial, 0x9, "later", 0, 12, 10);
+        var earlierSerial = await AddMobileAsync(persistence, spatial, 0x2, "earlier", 0, 11, 10);
+        await AddMobileAsync(persistence, spatial, 0x3, "outside", 0, 20, 10);
+        sessions.Played.Add(laterSerial.Id);
+        var factory = new NpcBrainContextFactory(spatial, sessions, time);
+        var homePosition = new Point3D(4, 5, 6);
+
+        var context = factory.Create(owner, 1, homePosition, new BrainDescriptor("guard", 1000, 3, 15));
+
+        Assert.Equal(time.Now, context.Now);
+        Assert.Equal(owner.Id, context.Self.Id);
+        Assert.Equal("owner", context.Self.Name);
+        Assert.False(context.Self.IsPlayer);
+        Assert.Equal(1, context.HomeMapId);
+        Assert.Equal(homePosition, context.HomePosition);
+        Assert.Equal([earlierSerial.Id, laterSerial.Id], context.Nearby.Select(snapshot => snapshot.Id));
+        Assert.False(context.Nearby[0].IsPlayer);
+        Assert.True(context.Nearby[1].IsPlayer);
+
+        owner.Name = "changed-owner";
+        earlierSerial.Name = "changed-nearby";
+
+        Assert.Equal("owner", context.Self.Name);
+        Assert.Equal("earlier", context.Nearby[0].Name);
+    }
+
+    [Fact]
+    public async Task Create_DescriptorPerceptionRange_ExcludesMobileJustOutsideRange()
+    {
+        var persistence = new FakePersistenceService();
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), new StubEventBus());
+        var owner = await AddMobileAsync(persistence, spatial, 0x1, "owner", 0, 10, 10);
+        var inRange = await AddMobileAsync(persistence, spatial, 0x2, "inside", 0, 14, 10);
+        await AddMobileAsync(persistence, spatial, 0x3, "outside", 0, 15, 10);
+        var factory = new NpcBrainContextFactory(
+            spatial,
+            new StubSessionManager(),
+            new MutableTimeProvider(DateTimeOffset.UnixEpoch)
+        );
+
+        var context = factory.Create(owner, 0, owner.Position, new BrainDescriptor("guard", 1000, 4, 15));
+
+        Assert.Equal([inRange.Id], context.Nearby.Select(snapshot => snapshot.Id));
+    }
+
+    private static async Task<MobileEntity> AddMobileAsync(
+        FakePersistenceService persistence,
+        SpatialIndexService spatial,
+        uint serial,
+        string name,
+        int mapId,
+        int x,
+        int y
+    )
+    {
+        var mobile = new MobileEntity
+        {
+            Id = new Serial(serial),
+            Name = name,
+            MapId = mapId,
+            Position = new Point3D(x, y, 0),
+            Hits = 25,
+            HitsMax = 50,
+            Warmode = true,
+            CombatantId = new Serial(0x20),
+            Criminal = true,
+            Kills = 3
+        };
+        await persistence.Store<MobileEntity>().UpsertAsync(mobile);
+        spatial.AddOrUpdate(mobile);
+
+        return mobile;
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
@@ -1,0 +1,594 @@
+using System.Runtime.CompilerServices;
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Data.Internal.AI;
+using Moongate.Server.Services.AI;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcBrainEventRouterTests
+{
+    [Fact]
+    public async Task OnMobileSpeech_ActiveBrainsInExactHearingRange_ReceivePreservedSpeechSnapshot()
+    {
+        var fixture = new RouterFixture();
+        var speaker = fixture.AddMobile(0x1, "Player One", 0, 10, 10);
+        var shortRange = fixture.AddBrain(0x2, "Short", 0, 15, 10, 8, 5, true);
+        var longRange = fixture.AddBrain(0x3, "Long", 0, 17, 10, 8, 7, true);
+        fixture.AddBrain(0x4, "Outside Exact", 0, 16, 10, 8, 5, true);
+        fixture.AddBrain(0x5, "Sleeping", 0, 11, 10, 8, 20, false);
+        fixture.AddBrain(0x6, "Other Map", 1, 10, 10, 8, 20, true);
+        fixture.Sessions.Played.Add(speaker.Id);
+
+        await fixture.Router.OnMobileSpeech(
+            new(speaker.Id, ChatMessageType.Yell, "Guards!"),
+            CancellationToken.None
+        );
+
+        Assert.Equal([shortRange.Id, longRange.Id], fixture.Scheduler.Events.Select(entry => entry.MobileId));
+        var routed = fixture.Scheduler.Events[0];
+        Assert.Equal(NpcBrainHookType.SpeechHeard, routed.Hook);
+        Assert.Equal(NpcBrainEventType.SpeechHeard, routed.Event.Type);
+        Assert.Equal("Guards!", routed.Event.Text);
+        Assert.Equal(ChatMessageType.Yell, routed.Event.SpeechType);
+        Assert.Equal(speaker.Id, routed.Event.Mobile!.Id);
+        Assert.Equal("Player One", routed.Event.Mobile.Name);
+        Assert.True(routed.Event.Mobile.IsPlayer);
+    }
+
+    [Fact]
+    public async Task OnMobileSpeech_LaterNpcReply_ExcludesEachSpeakerAndOnlyEnqueues()
+    {
+        var fixture = new RouterFixture();
+        var player = fixture.AddMobile(0x1, "Player", 0, 10, 10);
+        var firstNpc = fixture.AddBrain(0x2, "First", 0, 11, 10, 8, 8, true);
+        var secondNpc = fixture.AddBrain(0x3, "Second", 0, 12, 10, 8, 8, true);
+
+        await fixture.Router.OnMobileSpeech(
+            new(player.Id, ChatMessageType.Regular, "hello"),
+            CancellationToken.None
+        );
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.Router.OnMobileSpeech(
+            new(firstNpc.Id, ChatMessageType.Regular, "greetings"),
+            CancellationToken.None
+        );
+
+        var routed = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(secondNpc.Id, routed.MobileId);
+        Assert.Equal(firstNpc.Id, routed.Event.Mobile!.Id);
+        Assert.Equal("greetings", routed.Event.Text);
+        Assert.Equal(0, fixture.Scheduler.TickCalls);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_SubjectCrossesObserverRange_EmitsEnterMoveAndLeaveOnce()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 20, 10);
+
+        await fixture.MoveAsync(subject, 15, 10);
+        await fixture.MoveAsync(subject, 13, 10);
+        await fixture.MoveAsync(subject, 20, 10);
+
+        Assert.Equal(
+            [
+                NpcBrainHookType.MobileEnteredRange,
+                NpcBrainHookType.MobileMoved,
+                NpcBrainHookType.MobileLeftRange
+            ],
+            fixture.Scheduler.Events.Select(entry => entry.Hook)
+        );
+        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(observer.Id, entry.MobileId));
+        Assert.Equal(new Point3D(15, 10, 0), fixture.Scheduler.Events[0].Event.ToPosition);
+        Assert.Equal(new Point3D(13, 10, 0), fixture.Scheduler.Events[1].Event.ToPosition);
+        Assert.Equal(new Point3D(20, 10, 0), fixture.Scheduler.Events[2].Event.ToPosition);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_RepeatedInsideMovement_MailboxRetainsLatestPosition()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 11, 10);
+
+        await fixture.MoveAsync(subject, 12, 10);
+        await fixture.MoveAsync(subject, 13, 10);
+
+        var queued = Assert.Single(fixture.Scheduler.CoalescedEventsFor(observer.Id));
+        Assert.Equal(NpcBrainHookType.MobileMoved, queued.Hook);
+        Assert.Equal(subject.Id, queued.Event.Mobile!.Id);
+        Assert.Equal(new Point3D(12, 10, 0), queued.Event.FromPosition);
+        Assert.Equal(new Point3D(13, 10, 0), queued.Event.ToPosition);
+        Assert.Equal(new Point3D(13, 10, 0), queued.Event.Mobile.Position);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_ActiveBrainObserver_RecomputesStationaryEntriesAndLeaves()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 4, 4, true);
+        var leftBehind = fixture.AddMobile(0x2, "Left", 0, 4, 5);
+        var newlySeen = fixture.AddMobile(0x3, "New", 0, 13, 5);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.MoveAsync(observer, 10, 5);
+
+        Assert.Collection(
+            fixture.Scheduler.Events,
+            entry =>
+            {
+                Assert.Equal(observer.Id, entry.MobileId);
+                Assert.Equal(NpcBrainHookType.MobileLeftRange, entry.Hook);
+                Assert.Equal(leftBehind.Id, entry.Event.Mobile!.Id);
+            },
+            entry =>
+            {
+                Assert.Equal(observer.Id, entry.MobileId);
+                Assert.Equal(NpcBrainHookType.MobileEnteredRange, entry.Hook);
+                Assert.Equal(newlySeen.Id, entry.Event.Mobile!.Id);
+            }
+        );
+    }
+
+    [Fact]
+    public async Task SectorLifecycle_ActivationSeedsAndSleepingObserverRetainsNoPerceptionSet()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, false);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
+        fixture.Sectors.Active.Add((0, 0, 0));
+
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+
+        var initial = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, initial.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, initial.Hook);
+        Assert.Equal(subject.Id, initial.Event.Mobile!.Id);
+
+        fixture.Scheduler.Events.Clear();
+        fixture.Sectors.Active.Remove((0, 0, 0));
+        await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
+        await fixture.MoveAsync(subject, 20, 5);
+        await fixture.MoveAsync(subject, 8, 5);
+        Assert.Empty(fixture.Scheduler.Events);
+
+        fixture.Sectors.Active.Add((0, 0, 0));
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+
+        var reseeded = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, reseeded.Hook);
+        Assert.Equal(subject.Id, reseeded.Event.Mobile!.Id);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_BrainEntersInactiveSector_DeactivatesAndClearsObserverSet()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.MoveAsync(observer, 32, 5);
+        await fixture.MoveAsync(subject, 9, 5);
+
+        Assert.Contains(observer.Id, fixture.Scheduler.DeactivateCalls);
+        Assert.False(fixture.Scheduler.IsActive(observer.Id));
+        Assert.DoesNotContain(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
+
+        fixture.Sectors.Active.Add((0, 2, 0));
+        await fixture.Router.OnSectorActivated(new(0, 2, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+        await fixture.MoveAsync(subject, 33, 5);
+
+        var enter = Assert.Single(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, enter.Hook);
+    }
+
+    [Fact]
+    public async Task PlayerLifecycle_UsesEventSnapshotsBeforeSpatialSubscriberAndEmitsRangeTransitions()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var player = fixture.Mobile(0x2, "Player", 0, 14, 10);
+
+        await fixture.Router.OnPlayerEnteredWorld(
+            new(7, new Serial(0x900), player),
+            CancellationToken.None
+        );
+
+        var enter = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, enter.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, enter.Hook);
+        Assert.True(enter.Event.Mobile!.IsPlayer);
+        fixture.Scheduler.Events.Clear();
+
+        var session = SessionWithCharacter(player);
+        await fixture.Router.OnSessionDestroyed(new(session), CancellationToken.None);
+
+        var leave = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, leave.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
+        Assert.Equal(player.Id, leave.Event.Mobile!.Id);
+    }
+
+    [Fact]
+    public async Task MobileLifecycle_CreateRoutesBothRolesAndDeleteLeavesAndUnbinds()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+        var created = fixture.Mobile(0x2, "Created Brain", 0, 8, 5, "guard");
+        fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
+
+        await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
+
+        Assert.Contains(created.Id, fixture.Scheduler.BindCalls);
+        Assert.Collection(
+            fixture.Scheduler.Events,
+            entry =>
+            {
+                Assert.Equal(observer.Id, entry.MobileId);
+                Assert.Equal(created.Id, entry.Event.Mobile!.Id);
+            },
+            entry =>
+            {
+                Assert.Equal(created.Id, entry.MobileId);
+                Assert.Equal(observer.Id, entry.Event.Mobile!.Id);
+            }
+        );
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.Router.OnMobileDeleted(new(created), CancellationToken.None);
+
+        var leave = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, leave.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
+        Assert.Contains(created.Id, fixture.Scheduler.UnbindCalls);
+    }
+
+    [Fact]
+    public async Task CombatEvents_OnlyActiveAffectedBrainReceivesAttackerAndDamagePayloads()
+    {
+        var fixture = new RouterFixture();
+        var active = fixture.AddBrain(0x1, "Active", 0, 10, 10, 5, 5, true);
+        var sleeping = fixture.AddBrain(0x2, "Sleeping", 0, 10, 10, 5, 5, false);
+        var attacker = fixture.AddMobile(0x3, "Attacker", 0, 11, 10);
+
+        await fixture.Router.OnMobileAttacked(new(active.Id, attacker.Id), CancellationToken.None);
+        await fixture.Router.OnMobileDamaged(new(active.Id, attacker.Id, 17), CancellationToken.None);
+        await fixture.Router.OnMobileDied(new(active.Id, attacker.Id), CancellationToken.None);
+        await fixture.Router.OnMobileAttacked(new(sleeping.Id, attacker.Id), CancellationToken.None);
+        await fixture.Router.OnMobileDamaged(new(sleeping.Id, attacker.Id, 9), CancellationToken.None);
+        await fixture.Router.OnMobileDied(new(sleeping.Id, attacker.Id), CancellationToken.None);
+
+        Assert.Equal(
+            [NpcBrainHookType.Attacked, NpcBrainHookType.Damage, NpcBrainHookType.Death],
+            fixture.Scheduler.Events.Select(entry => entry.Hook)
+        );
+        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(active.Id, entry.MobileId));
+        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(attacker.Id, entry.Event.Mobile!.Id));
+        Assert.Equal(17, fixture.Scheduler.Events[1].Event.Amount);
+    }
+
+    [Fact]
+    public async Task PerceptionTransitions_DifferentMapsNeverInteract()
+    {
+        var fixture = new RouterFixture();
+        fixture.AddBrain(0x1, "Observer", 0, 10, 10, 20, 20, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 1, 10, 10);
+
+        await fixture.MoveAsync(subject, 11, 10);
+        await fixture.Router.OnMobileSpeech(
+            new(subject.Id, ChatMessageType.Regular, "other map"),
+            CancellationToken.None
+        );
+
+        Assert.Empty(fixture.Scheduler.Events);
+    }
+
+    [Fact]
+    public void Subscribe_RegistersAllCanonicalEventHandlers()
+    {
+        var fixture = new RouterFixture();
+        var eventBus = new RecordingSubscriptionEventBus();
+
+        fixture.Router.Subscribe(eventBus);
+
+        Assert.Equal(
+            [
+                typeof(MobileSpeechEvent),
+                typeof(MobileMovedEvent),
+                typeof(MobileCreatedEvent),
+                typeof(MobileDeletedEvent),
+                typeof(PlayerEnteredWorldEvent),
+                typeof(SessionDestroyedEvent),
+                typeof(SectorActivatedEvent),
+                typeof(SectorDeactivatedEvent),
+                typeof(MobileAttackedEvent),
+                typeof(MobileDamagedEvent),
+                typeof(MobileDiedEvent)
+            ],
+            eventBus.EventTypes
+        );
+    }
+
+    private static PlayerSession SessionWithCharacter(MobileEntity character)
+    {
+        var session = (PlayerSession)RuntimeHelpers.GetUninitializedObject(typeof(PlayerSession));
+        var property = typeof(PlayerSession).GetProperty(nameof(PlayerSession.Character)) ??
+                       throw new InvalidOperationException("Player session character property was not found.");
+        property.SetValue(session, character);
+
+        return session;
+    }
+
+    private sealed class RouterFixture
+    {
+        public FakePersistenceService Persistence { get; } = new();
+
+        public StubSessionManager Sessions { get; } = new();
+
+        public RecordingScheduler Scheduler { get; } = new();
+
+        public StubSectorActivityService Sectors { get; } = new();
+
+        public SpatialIndexService Spatial { get; }
+
+        public NpcBrainEventRouter Router { get; }
+
+        public RouterFixture()
+        {
+            Spatial = new(Persistence, new StubLoopAffinity(), new StubEventBus());
+            Router = new(Spatial, Persistence, Sessions, Scheduler, Sectors);
+        }
+
+        public MobileEntity AddBrain(
+            uint serial,
+            string name,
+            int mapId,
+            int x,
+            int y,
+            int perceptionRange,
+            int hearingRange,
+            bool active
+        )
+        {
+            var mobile = AddMobile(serial, name, mapId, x, y, "guard");
+            Scheduler.Descriptors[mobile.Id] = new("guard", 1000, perceptionRange, hearingRange);
+
+            if (active)
+            {
+                Scheduler.Active.Add(mobile.Id);
+            }
+
+            return mobile;
+        }
+
+        public MobileEntity AddMobile(
+            uint serial,
+            string name,
+            int mapId,
+            int x,
+            int y,
+            string brainId = ""
+        )
+        {
+            var mobile = Mobile(serial, name, mapId, x, y, brainId);
+            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            Spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+
+        public MobileEntity Mobile(
+            uint serial,
+            string name,
+            int mapId,
+            int x,
+            int y,
+            string brainId = ""
+        )
+            => new()
+            {
+                Id = new(serial),
+                Name = name,
+                BrainScriptId = brainId,
+                MapId = mapId,
+                Position = new(x, y, 0),
+                Hits = 20,
+                HitsMax = 30
+            };
+
+        public async Task MoveAsync(MobileEntity mobile, int x, int y, int? mapId = null)
+        {
+            var fromMapId = mobile.MapId;
+            var fromPosition = mobile.Position;
+            mobile.MapId = mapId ?? mobile.MapId;
+            mobile.Position = new(x, y, mobile.Position.Z);
+            await Persistence.Store<MobileEntity>().UpsertAsync(mobile);
+            Spatial.AddOrUpdate(mobile);
+            await Router.OnMobileMoved(
+                new(mobile.Id, fromMapId, fromPosition, mobile.MapId, mobile.Position),
+                CancellationToken.None
+            );
+        }
+    }
+
+    private sealed class RecordingScheduler : INpcBrainScheduler
+    {
+        public HashSet<Serial> Active { get; } = [];
+
+        public Dictionary<Serial, BrainDescriptor> Descriptors { get; } = [];
+
+        public List<Serial> BindCalls { get; } = [];
+
+        public List<Serial> UnbindCalls { get; } = [];
+
+        public List<Serial> ActivateCalls { get; } = [];
+
+        public List<Serial> DeactivateCalls { get; } = [];
+
+        public List<(Serial MobileId, NpcBrainHookType Hook, NpcBrainEvent Event)> Events { get; } = [];
+
+        public int TickCalls { get; private set; }
+
+        public int MaxHearingRange => Descriptors.Values.Select(value => value.HearingRange).DefaultIfEmpty().Max();
+
+        public int MaxPerceptionRange => Descriptors.Values.Select(value => value.PerceptionRange).DefaultIfEmpty().Max();
+
+        public void Bind(MobileEntity mobile)
+        {
+            BindCalls.Add(mobile.Id);
+        }
+
+        public void Unbind(Serial mobileId)
+        {
+            UnbindCalls.Add(mobileId);
+            Active.Remove(mobileId);
+            Descriptors.Remove(mobileId);
+        }
+
+        public void Activate(Serial mobileId)
+        {
+            ActivateCalls.Add(mobileId);
+
+            if (Descriptors.ContainsKey(mobileId))
+            {
+                Active.Add(mobileId);
+            }
+        }
+
+        public void Deactivate(Serial mobileId)
+        {
+            DeactivateCalls.Add(mobileId);
+            Active.Remove(mobileId);
+        }
+
+        public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
+        {
+        }
+
+        public bool IsActive(Serial mobileId)
+            => Active.Contains(mobileId);
+
+        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+        {
+            var found = Descriptors.TryGetValue(mobileId, out var value);
+            descriptor = value;
+
+            return found;
+        }
+
+        public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
+        {
+            Events.Add((mobileId, hook, brainEvent));
+        }
+
+        public IReadOnlyList<(NpcBrainHookType Hook, NpcBrainEvent Event)> CoalescedEventsFor(
+            Serial mobileId
+        )
+        {
+            var mailbox = new NpcBrainMailbox(16, new NpcAiMetrics());
+
+            foreach (var entry in Events.Where(entry => entry.MobileId == mobileId))
+            {
+                mailbox.Enqueue(entry.Hook, entry.Event);
+            }
+
+            return mailbox.Dequeue(16);
+        }
+
+        public void Tick()
+        {
+            TickCalls++;
+        }
+    }
+
+    private sealed class StubSectorActivityService : ISectorActivityService
+    {
+        public HashSet<(int MapId, int SectorX, int SectorY)> Active { get; } = [];
+
+        public SectorActivitySnapshot Current => new(Active.Count, 0);
+
+        public bool IsActive(int mapId, int sectorX, int sectorY)
+            => Active.Contains((mapId, sectorX, sectorY));
+
+        public void TrackPlayer(MobileEntity player)
+        {
+        }
+
+        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
+        {
+        }
+
+        public void UntrackPlayer(Serial playerId)
+        {
+        }
+
+        public void Tick()
+        {
+        }
+    }
+
+    private sealed class RecordingSubscriptionEventBus : IEventBus
+    {
+        public List<Type> EventTypes { get; } = [];
+
+        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
+        {
+        }
+
+        public Task PublishAsync<TEvent>(
+            TEvent eventData,
+            CancellationToken cancellationToken = default
+        )
+            where TEvent : IEvent
+            => Task.CompletedTask;
+
+        public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener)
+            where TEvent : IEvent
+            => NoopDisposable.Instance;
+
+        public IDisposable Subscribe<TEvent>(
+            Func<TEvent, CancellationToken, Task> handler
+        )
+            where TEvent : IEvent
+        {
+            EventTypes.Add(typeof(TEvent));
+
+            return NoopDisposable.Instance;
+        }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
@@ -153,7 +153,7 @@ public class NpcBrainEventRouterTests
     public async Task SectorLifecycle_ActivationSeedsAndSleepingObserverRetainsNoPerceptionSet()
     {
         var fixture = new RouterFixture();
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, false);
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
         var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
         fixture.Sectors.Active.Add((0, 0, 0));
 
@@ -165,12 +165,14 @@ public class NpcBrainEventRouterTests
         Assert.Equal(subject.Id, initial.Event.Mobile!.Id);
 
         fixture.Scheduler.Events.Clear();
+        fixture.Scheduler.Active.Remove(observer.Id);
         fixture.Sectors.Active.Remove((0, 0, 0));
         await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
         await fixture.MoveAsync(subject, 20, 5);
         await fixture.MoveAsync(subject, 8, 5);
         Assert.Empty(fixture.Scheduler.Events);
 
+        fixture.Scheduler.Active.Add(observer.Id);
         fixture.Sectors.Active.Add((0, 0, 0));
         await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
 
@@ -180,7 +182,7 @@ public class NpcBrainEventRouterTests
     }
 
     [Fact]
-    public async Task OnMobileMoved_BrainEntersInactiveSector_DeactivatesAndClearsObserverSet()
+    public async Task OnMobileMoved_ExternallySleepingBrain_ClearsObserverSetWithoutLifecycleCall()
     {
         var fixture = new RouterFixture();
         fixture.Sectors.Active.Add((0, 0, 0));
@@ -189,13 +191,15 @@ public class NpcBrainEventRouterTests
         await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
         fixture.Scheduler.Events.Clear();
 
+        fixture.Scheduler.Active.Remove(observer.Id);
         await fixture.MoveAsync(observer, 32, 5);
         await fixture.MoveAsync(subject, 9, 5);
 
-        Assert.Contains(observer.Id, fixture.Scheduler.DeactivateCalls);
         Assert.False(fixture.Scheduler.IsActive(observer.Id));
         Assert.DoesNotContain(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
+        Assert.Empty(fixture.Scheduler.DeactivateCalls);
 
+        fixture.Scheduler.Active.Add(observer.Id);
         fixture.Sectors.Active.Add((0, 2, 0));
         await fixture.Router.OnSectorActivated(new(0, 2, 0), CancellationToken.None);
         fixture.Scheduler.Events.Clear();
@@ -233,7 +237,7 @@ public class NpcBrainEventRouterTests
     }
 
     [Fact]
-    public async Task MobileLifecycle_CreateRoutesBothRolesAndDeleteLeavesAndUnbinds()
+    public async Task MobileLifecycle_ExternallyActiveCreateRoutesBothRolesAndDeleteClearsWithoutLifecycleCalls()
     {
         var fixture = new RouterFixture();
         fixture.Sectors.Active.Add((0, 0, 0));
@@ -242,10 +246,11 @@ public class NpcBrainEventRouterTests
         fixture.Scheduler.Events.Clear();
         var created = fixture.Mobile(0x2, "Created Brain", 0, 8, 5, "guard");
         fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
+        fixture.Scheduler.Active.Add(created.Id);
 
         await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
 
-        Assert.Contains(created.Id, fixture.Scheduler.BindCalls);
+        Assert.Empty(fixture.Scheduler.BindCalls);
         Assert.Collection(
             fixture.Scheduler.Events,
             entry =>
@@ -266,7 +271,31 @@ public class NpcBrainEventRouterTests
         var leave = Assert.Single(fixture.Scheduler.Events);
         Assert.Equal(observer.Id, leave.MobileId);
         Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
-        Assert.Contains(created.Id, fixture.Scheduler.UnbindCalls);
+        Assert.Empty(fixture.Scheduler.UnbindCalls);
+    }
+
+    [Fact]
+    public async Task CanonicalEventHandlers_NeverControlSchedulerLifecycle()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var existing = fixture.AddBrain(0x1, "Existing", 0, 5, 5, 5, 5, true);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+
+        fixture.Scheduler.Active.Remove(existing.Id);
+        await fixture.MoveAsync(existing, 32, 5);
+
+        var created = fixture.Mobile(0x2, "Created", 0, 6, 5, "guard");
+        fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
+        fixture.Scheduler.Active.Add(created.Id);
+        await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
+        await fixture.Router.OnMobileDeleted(new(created), CancellationToken.None);
+        await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
+
+        Assert.Empty(fixture.Scheduler.BindCalls);
+        Assert.Empty(fixture.Scheduler.ActivateCalls);
+        Assert.Empty(fixture.Scheduler.DeactivateCalls);
+        Assert.Empty(fixture.Scheduler.UnbindCalls);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
@@ -105,8 +105,11 @@ public class NpcBrainEventRouterTests
     public async Task OnMobileMoved_RepeatedInsideMovement_MailboxRetainsLatestPosition()
     {
         var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
         var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
         var subject = fixture.AddMobile(0x2, "Subject", 0, 11, 10);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
 
         await fixture.MoveAsync(subject, 12, 10);
         await fixture.MoveAsync(subject, 13, 10);
@@ -117,6 +120,81 @@ public class NpcBrainEventRouterTests
         Assert.Equal(new Point3D(12, 10, 0), queued.Event.FromPosition);
         Assert.Equal(new Point3D(13, 10, 0), queued.Event.ToPosition);
         Assert.Equal(new Point3D(13, 10, 0), queued.Event.Mobile.Position);
+    }
+
+    [Fact]
+    public async Task OnMobileCreated_RouterBeforeBrainBinding_FirstInsideMovementRecoversWithEnter()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddMobile(0x1, "Observer", 0, 5, 5, "guard");
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
+
+        await fixture.Router.OnMobileCreated(new(observer), CancellationToken.None);
+        fixture.Scheduler.Descriptors[observer.Id] = new("guard", 1000, 5, 5);
+        fixture.Scheduler.Active.Add(observer.Id);
+        await fixture.MoveAsync(subject, 9, 5);
+
+        var recovered = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, recovered.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, recovered.Hook);
+        Assert.Equal(subject.Id, recovered.Event.Mobile!.Id);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_UnperceivedSubjectLeavesRange_DoesNotEmitLeave()
+    {
+        var fixture = new RouterFixture();
+        fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 14, 10);
+
+        await fixture.MoveAsync(subject, 20, 10);
+
+        Assert.Empty(fixture.Scheduler.Events);
+    }
+
+    [Fact]
+    public async Task BrainDefinitionReloaded_RouterBeforeLifecycle_ReconcilesExpandedAndShrunkRanges()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var near = fixture.AddMobile(0x2, "Near", 0, 13, 10);
+        var far = fixture.AddMobile(0x3, "Far", 0, 18, 10);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+        var eventBus = new RecordingSubscriptionEventBus();
+        fixture.Router.Subscribe(eventBus);
+        var expanded = new BrainDescriptor("guard", 1000, 10, 5);
+
+        await eventBus.PublishAsync(
+            new BrainDefinitionReloadedEvent("guard", expanded),
+            CancellationToken.None
+        );
+
+        var entered = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, entered.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, entered.Hook);
+        Assert.Equal(far.Id, entered.Event.Mobile!.Id);
+
+        fixture.Scheduler.Descriptors[observer.Id] = expanded;
+        fixture.Scheduler.Events.Clear();
+        await eventBus.PublishAsync(
+            new BrainDefinitionReloadedEvent(
+                "guard",
+                new("guard", 1000, 2, 5)
+            ),
+            CancellationToken.None
+        );
+
+        Assert.Equal(
+            [near.Id, far.Id],
+            fixture.Scheduler.Events.Select(entry => entry.Event.Mobile!.Id)
+        );
+        Assert.All(
+            fixture.Scheduler.Events,
+            entry => Assert.Equal(NpcBrainHookType.MobileLeftRange, entry.Hook)
+        );
     }
 
     [Fact]
@@ -356,6 +434,7 @@ public class NpcBrainEventRouterTests
                 typeof(SessionDestroyedEvent),
                 typeof(SectorActivatedEvent),
                 typeof(SectorDeactivatedEvent),
+                typeof(BrainDefinitionReloadedEvent),
                 typeof(MobileAttackedEvent),
                 typeof(MobileDamagedEvent),
                 typeof(MobileDiedEvent)
@@ -584,6 +663,11 @@ public class NpcBrainEventRouterTests
 
     private sealed class RecordingSubscriptionEventBus : IEventBus
     {
+        private readonly Dictionary<
+            Type,
+            Func<object, CancellationToken, Task>
+        > _handlers = [];
+
         public List<Type> EventTypes { get; } = [];
 
         public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
@@ -595,7 +679,9 @@ public class NpcBrainEventRouterTests
             CancellationToken cancellationToken = default
         )
             where TEvent : IEvent
-            => Task.CompletedTask;
+            => _handlers.TryGetValue(typeof(TEvent), out var handler)
+                ? handler(eventData, cancellationToken)
+                : Task.CompletedTask;
 
         public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener)
             where TEvent : IEvent
@@ -607,6 +693,8 @@ public class NpcBrainEventRouterTests
             where TEvent : IEvent
         {
             EventTypes.Add(typeof(TEvent));
+            _handlers[typeof(TEvent)] = (eventData, cancellationToken) =>
+                handler((TEvent)eventData, cancellationToken);
 
             return NoopDisposable.Instance;
         }

--- a/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
@@ -1,0 +1,275 @@
+using DryIoc;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Scripting.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Services.AI;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+using SquidStd.Core.Directories;
+using SquidStd.Scripting.Lua.Data.Config;
+using SquidStd.Scripting.Lua.Services;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.AI;
+
+public sealed class NpcBrainIntegrationTests
+{
+    private const string FirstMeetingReply = "Non ti avevo mai visto prima.";
+    private const string ReturningPlayerReply = "Bentornato.";
+
+    [Fact]
+    public async Task PlayerSpeech_CompleteGuardLifecycle_RepliesWithRetainedMemory()
+    {
+        using var fixture = new IntegrationFixture();
+
+        // 1. Seed one played character and one guard using the real built-in brain.
+        await fixture.SeedAsync();
+
+        // 2. Indexing mobiles alone does not activate sectors: only player coverage does.
+        fixture.Spatial.AddOrUpdate(fixture.Player);
+        fixture.Spatial.AddOrUpdate(fixture.Guard);
+        Assert.Equal(new(0, 0), fixture.Activity.Current);
+        Assert.False(fixture.Activity.IsActive(0, 2, 2));
+
+        // 3. World lifecycle binds the guard, but its inactive sector leaves it asleep.
+        fixture.Bus.Publish(new WorldReadyEvent());
+        fixture.Scheduler.Tick();
+        Assert.False(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        Assert.True(fixture.Scheduler.TryGetDescriptor(fixture.Guard.Id, out var sleepingDescriptor));
+        Assert.Equal("guard", sleepingDescriptor!.BrainId);
+        Assert.Equal(0, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(0, fixture.Metrics.Current.IntentsAccepted);
+        Assert.Empty(fixture.Chat.Messages);
+
+        // 4. A player activates exactly the same-map 3×3 sector coverage.
+        fixture.Activity.TrackPlayer(fixture.Player);
+        Assert.Equal(new(9, 0), fixture.Activity.Current);
+
+        for (var sectorX = 1; sectorX <= 3; sectorX++)
+        {
+            for (var sectorY = 1; sectorY <= 3; sectorY++)
+            {
+                Assert.True(fixture.Activity.IsActive(0, sectorX, sectorY));
+            }
+        }
+
+        Assert.False(fixture.Activity.IsActive(0, 0, 2));
+        Assert.False(fixture.Activity.IsActive(0, 4, 2));
+        Assert.False(fixture.Activity.IsActive(1, 2, 2));
+
+        // 5. The first wake invokes activate, the seeded range event, and think; think returns idle.
+        var hooksBeforeActivation = fixture.Metrics.Current.HookInvocations;
+        var intentsBeforeActivation = fixture.Metrics.Current.IntentsAccepted;
+        fixture.Scheduler.Tick();
+        Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        Assert.Equal(hooksBeforeActivation + 3, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(intentsBeforeActivation + 1, fixture.Metrics.Current.IntentsAccepted);
+
+        // 6. Speech inside the guard's 15-tile hearing range only reaches its mailbox.
+        var hooksBeforeFirstSpeech = fixture.Metrics.Current.HookInvocations;
+        fixture.Bus.Publish(new MobileSpeechEvent(fixture.Player.Id, ChatMessageType.Regular, "ciao"));
+        Assert.Equal(hooksBeforeFirstSpeech, fixture.Metrics.Current.HookInvocations);
+        Assert.Empty(fixture.Chat.Messages);
+
+        // 7. The scheduler is the component that invokes Lua and applies the returned intent.
+        fixture.Scheduler.Tick();
+
+        // 8. The real C# intent executor performs the single chat mutation.
+        var firstReply = Assert.Single(fixture.Chat.Messages);
+        Assert.Equal(fixture.Guard.Id, firstReply.Speaker);
+        Assert.Equal(ChatMessageType.Regular, firstReply.Type);
+        Assert.Equal(FirstMeetingReply, firstReply.Text);
+        Assert.Equal(15, firstReply.Range);
+
+        // 9. A second routed speech observes the guard's retained per-mobile blackboard.
+        fixture.Bus.Publish(new MobileSpeechEvent(fixture.Player.Id, ChatMessageType.Regular, "ciao"));
+        Assert.Single(fixture.Chat.Messages);
+        fixture.Scheduler.Tick();
+        Assert.Equal(
+            [FirstMeetingReply, ReturningPlayerReply],
+            fixture.Chat.Messages.Select(message => message.Text)
+        );
+
+        // 10. Removing the player starts grace; at 59 seconds the guard remains active and thinks.
+        fixture.Activity.UntrackPlayer(fixture.Player.Id);
+        Assert.Equal(new(0, 9), fixture.Activity.Current);
+        fixture.Time.Advance(TimeSpan.FromSeconds(59));
+        fixture.Activity.Tick();
+        Assert.True(fixture.Activity.IsActive(0, 2, 2));
+        Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        var hooksBeforeGraceTick = fixture.Metrics.Current.HookInvocations;
+        var intentsBeforeGraceTick = fixture.Metrics.Current.IntentsAccepted;
+        fixture.Scheduler.Tick();
+        Assert.Equal(hooksBeforeGraceTick + 1, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(intentsBeforeGraceTick + 1, fixture.Metrics.Current.IntentsAccepted);
+        Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
+
+        // 11. At exactly 60 seconds the sector deactivates; one deactivate hook runs, then it sleeps.
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        var hooksBeforeDeactivation = fixture.Metrics.Current.HookInvocations;
+        fixture.Activity.Tick();
+        Assert.False(fixture.Activity.IsActive(0, 2, 2));
+        Assert.False(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        fixture.Scheduler.Tick();
+        Assert.Equal(hooksBeforeDeactivation + 1, fixture.Metrics.Current.HookInvocations);
+        Assert.False(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        Assert.Equal(1, fixture.Metrics.Current.SleepingBrains);
+        Assert.True(fixture.Scheduler.TryGetDescriptor(fixture.Guard.Id, out var retainedDescriptor));
+        Assert.Equal("guard", retainedDescriptor!.BrainId);
+
+        // 12. Re-tracking wakes the same binding; its blackboard still recognizes the player.
+        fixture.Activity.TrackPlayer(fixture.Player);
+        Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        var hooksBeforeWake = fixture.Metrics.Current.HookInvocations;
+        var intentsBeforeWake = fixture.Metrics.Current.IntentsAccepted;
+        fixture.Scheduler.Tick();
+        Assert.Equal(hooksBeforeWake + 3, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(intentsBeforeWake + 1, fixture.Metrics.Current.IntentsAccepted);
+        fixture.Bus.Publish(new MobileSpeechEvent(fixture.Player.Id, ChatMessageType.Regular, "ciao"));
+        Assert.Equal(2, fixture.Chat.Messages.Count);
+        fixture.Scheduler.Tick();
+        Assert.Equal(
+            [FirstMeetingReply, ReturningPlayerReply, ReturningPlayerReply],
+            fixture.Chat.Messages.Select(message => message.Text)
+        );
+    }
+
+    private sealed class IntegrationFixture : IDisposable
+    {
+        private readonly Container _container = new();
+        private readonly LuaScriptEngineService _engine;
+        private readonly string _root;
+
+        public EventBusService Bus { get; } = new();
+
+        public RecordingChatService Chat { get; } = new();
+
+        public MoongateConfig Config { get; } = new();
+
+        public MobileEntity Guard { get; } = new()
+        {
+            Id = new(0x2),
+            Name = "Guard",
+            BrainScriptId = "guard",
+            MapId = 0,
+            Position = new(40, 32, 0),
+            Hits = 100,
+            HitsMax = 100
+        };
+
+        public StubGameLoopContext Loop { get; } = new();
+
+        public NpcAiMetrics Metrics { get; } = new();
+
+        public FakePersistenceService Persistence { get; } = new();
+
+        public MobileEntity Player { get; } = new()
+        {
+            Id = new(0x1),
+            Name = "Player",
+            MapId = 0,
+            Position = new(32, 32, 0),
+            Hits = 100,
+            HitsMax = 100
+        };
+
+        public StubSessionManager Sessions { get; } = new();
+
+        public MutableTimeProvider Time { get; } = new(
+            new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero)
+        );
+
+        public SectorActivityService Activity { get; }
+
+        public LuaNpcBrainRuntime Runtime { get; }
+
+        public NpcBrainScheduler Scheduler { get; }
+
+        public SpatialIndexService Spatial { get; }
+
+        public IntegrationFixture()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "mg-npc-brain-integration-" + Guid.NewGuid().ToString("N"));
+            var directories = new DirectoriesConfig(_root, ["scripts"]);
+            _engine = new(
+                directories,
+                _container,
+                new LuaEngineConfig(_root, directories.GetPath("scripts"), "MoongateTests", "1.0.0")
+            );
+            BrainAssetSeeder.SeedMissing(Path.Combine(directories.GetPath("scripts"), "brains"));
+
+            var loopAffinity = new StubLoopAffinity();
+            Spatial = new(Persistence, loopAffinity, Bus);
+            Activity = new(Loop, Bus, Time, Config, Metrics);
+            Runtime = new(_engine, directories, Config, Metrics, Loop, Bus, Time);
+            var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
+            var intentExecutor = new BrainIntentExecutor(
+                Persistence,
+                new UnexpectedMovementService(),
+                Chat,
+                new Random(42),
+                loopAffinity,
+                Metrics
+            );
+            Scheduler = new(
+                Loop,
+                Runtime,
+                intentExecutor,
+                Activity,
+                Persistence,
+                contextFactory,
+                Time,
+                Config,
+                Metrics
+            );
+
+            new NpcBrainLifecycleSubscriber(Spatial, Persistence, Scheduler, Activity).Subscribe(Bus);
+            new NpcBrainEventRouter(Spatial, Persistence, Sessions, Scheduler, Activity).Subscribe(Bus);
+        }
+
+        public async Task SeedAsync()
+        {
+            await Persistence.Store<MobileEntity>().UpsertAsync(Player);
+            await Persistence.Store<MobileEntity>().UpsertAsync(Guard);
+            await Persistence.Store<AccountEntity>().UpsertAsync(
+                new()
+                {
+                    Id = new(0x100),
+                    Username = "player",
+                    MobileIds = [Player.Id]
+                }
+            );
+            Sessions.Played.Add(Player.Id);
+        }
+
+        public void Dispose()
+        {
+            Runtime.Dispose();
+            _engine.Dispose();
+            Bus.Dispose();
+            _container.Dispose();
+            Directory.Delete(_root, true);
+        }
+    }
+
+    private sealed class UnexpectedMovementService : IMovementService
+    {
+        public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
+        {
+            throw new InvalidOperationException("The guard integration flow must not move a player.");
+        }
+
+        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+        {
+            throw new InvalidOperationException("The built-in guard flow must not emit movement intents.");
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
@@ -4,14 +4,18 @@ using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
 using Moongate.Scripting.AI;
+using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.AI;
 using Moongate.Server.Services.World;
 using Moongate.Server.Subscribers;
 using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 using SquidStd.Core.Directories;
 using SquidStd.Scripting.Lua.Data.Config;
@@ -29,6 +33,7 @@ public sealed class NpcBrainIntegrationTests
     public async Task PlayerSpeech_CompleteGuardLifecycle_RepliesWithRetainedMemory()
     {
         using var fixture = new IntegrationFixture();
+        var hookOffset = 0;
 
         // 1. Seed one played character and one guard using the real built-in brain.
         await fixture.SeedAsync();
@@ -47,7 +52,9 @@ public sealed class NpcBrainIntegrationTests
         Assert.Equal("guard", sleepingDescriptor!.BrainId);
         Assert.Equal(0, fixture.Metrics.Current.HookInvocations);
         Assert.Equal(0, fixture.Metrics.Current.IntentsAccepted);
+        Assert.Empty(fixture.Runtime.Invocations);
         Assert.Empty(fixture.Chat.Messages);
+        Assert.Empty(fixture.Chat.Broadcasts);
 
         // 4. A player activates exactly the same-map 3×3 sector coverage.
         fixture.Activity.TrackPlayer(fixture.Player);
@@ -66,37 +73,52 @@ public sealed class NpcBrainIntegrationTests
         Assert.False(fixture.Activity.IsActive(1, 2, 2));
 
         // 5. The first wake invokes activate, the seeded range event, and think; think returns idle.
-        var hooksBeforeActivation = fixture.Metrics.Current.HookInvocations;
         var intentsBeforeActivation = fixture.Metrics.Current.IntentsAccepted;
         fixture.Scheduler.Tick();
         Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
-        Assert.Equal(hooksBeforeActivation + 3, fixture.Metrics.Current.HookInvocations);
+        AssertNextHooks(
+            fixture,
+            ref hookOffset,
+            NpcBrainHookType.Activate,
+            NpcBrainHookType.MobileEnteredRange,
+            NpcBrainHookType.Think
+        );
         Assert.Equal(intentsBeforeActivation + 1, fixture.Metrics.Current.IntentsAccepted);
 
         // 6. Speech inside the guard's 15-tile hearing range only reaches its mailbox.
-        var hooksBeforeFirstSpeech = fixture.Metrics.Current.HookInvocations;
+        var hooksBeforeFirstSpeech = fixture.Runtime.Invocations.Count;
         fixture.Bus.Publish(new MobileSpeechEvent(fixture.Player.Id, ChatMessageType.Regular, "ciao"));
-        Assert.Equal(hooksBeforeFirstSpeech, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(hooksBeforeFirstSpeech, fixture.Runtime.Invocations.Count);
         Assert.Empty(fixture.Chat.Messages);
+        Assert.Empty(fixture.Chat.Broadcasts);
 
         // 7. The scheduler is the component that invokes Lua and applies the returned intent.
         fixture.Scheduler.Tick();
+        AssertNextHooks(fixture, ref hookOffset, NpcBrainHookType.SpeechHeard);
 
         // 8. The real C# intent executor performs the single chat mutation.
-        var firstReply = Assert.Single(fixture.Chat.Messages);
-        Assert.Equal(fixture.Guard.Id, firstReply.Speaker);
-        Assert.Equal(ChatMessageType.Regular, firstReply.Type);
-        Assert.Equal(FirstMeetingReply, firstReply.Text);
-        Assert.Equal(15, firstReply.Range);
+        Assert.Equal(
+            [(fixture.Guard.Id, ChatMessageType.Regular, FirstMeetingReply, Hue.Default, 15)],
+            fixture.Chat.Messages
+        );
+        Assert.Empty(fixture.Chat.Broadcasts);
 
         // 9. A second routed speech observes the guard's retained per-mobile blackboard.
         fixture.Bus.Publish(new MobileSpeechEvent(fixture.Player.Id, ChatMessageType.Regular, "ciao"));
-        Assert.Single(fixture.Chat.Messages);
-        fixture.Scheduler.Tick();
         Assert.Equal(
-            [FirstMeetingReply, ReturningPlayerReply],
-            fixture.Chat.Messages.Select(message => message.Text)
+            [(fixture.Guard.Id, ChatMessageType.Regular, FirstMeetingReply, Hue.Default, 15)],
+            fixture.Chat.Messages
         );
+        fixture.Scheduler.Tick();
+        AssertNextHooks(fixture, ref hookOffset, NpcBrainHookType.SpeechHeard);
+        Assert.Equal(
+            [
+                (fixture.Guard.Id, ChatMessageType.Regular, FirstMeetingReply, Hue.Default, 15),
+                (fixture.Guard.Id, ChatMessageType.Regular, ReturningPlayerReply, Hue.Default, 15)
+            ],
+            fixture.Chat.Messages
+        );
+        Assert.Empty(fixture.Chat.Broadcasts);
 
         // 10. Removing the player starts grace; at 59 seconds the guard remains active and thinks.
         fixture.Activity.UntrackPlayer(fixture.Player.Id);
@@ -105,47 +127,84 @@ public sealed class NpcBrainIntegrationTests
         fixture.Activity.Tick();
         Assert.True(fixture.Activity.IsActive(0, 2, 2));
         Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
-        var hooksBeforeGraceTick = fixture.Metrics.Current.HookInvocations;
         var intentsBeforeGraceTick = fixture.Metrics.Current.IntentsAccepted;
         fixture.Scheduler.Tick();
-        Assert.Equal(hooksBeforeGraceTick + 1, fixture.Metrics.Current.HookInvocations);
+        AssertNextHooks(fixture, ref hookOffset, NpcBrainHookType.Think);
         Assert.Equal(intentsBeforeGraceTick + 1, fixture.Metrics.Current.IntentsAccepted);
         Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
+        Assert.Equal(
+            [
+                (fixture.Guard.Id, ChatMessageType.Regular, FirstMeetingReply, Hue.Default, 15),
+                (fixture.Guard.Id, ChatMessageType.Regular, ReturningPlayerReply, Hue.Default, 15)
+            ],
+            fixture.Chat.Messages
+        );
+        Assert.Empty(fixture.Chat.Broadcasts);
 
         // 11. At exactly 60 seconds the sector deactivates; one deactivate hook runs, then it sleeps.
         fixture.Time.Advance(TimeSpan.FromSeconds(1));
-        var hooksBeforeDeactivation = fixture.Metrics.Current.HookInvocations;
         fixture.Activity.Tick();
         Assert.False(fixture.Activity.IsActive(0, 2, 2));
         Assert.False(fixture.Scheduler.IsActive(fixture.Guard.Id));
         fixture.Scheduler.Tick();
-        Assert.Equal(hooksBeforeDeactivation + 1, fixture.Metrics.Current.HookInvocations);
+        AssertNextHooks(fixture, ref hookOffset, NpcBrainHookType.Deactivate);
         Assert.False(fixture.Scheduler.IsActive(fixture.Guard.Id));
         Assert.Equal(1, fixture.Metrics.Current.SleepingBrains);
         Assert.True(fixture.Scheduler.TryGetDescriptor(fixture.Guard.Id, out var retainedDescriptor));
         Assert.Equal("guard", retainedDescriptor!.BrainId);
+        Assert.Equal(
+            [
+                (fixture.Guard.Id, ChatMessageType.Regular, FirstMeetingReply, Hue.Default, 15),
+                (fixture.Guard.Id, ChatMessageType.Regular, ReturningPlayerReply, Hue.Default, 15)
+            ],
+            fixture.Chat.Messages
+        );
+        Assert.Empty(fixture.Chat.Broadcasts);
 
         // 12. Re-tracking wakes the same binding; its blackboard still recognizes the player.
         fixture.Activity.TrackPlayer(fixture.Player);
         Assert.True(fixture.Scheduler.IsActive(fixture.Guard.Id));
-        var hooksBeforeWake = fixture.Metrics.Current.HookInvocations;
         var intentsBeforeWake = fixture.Metrics.Current.IntentsAccepted;
         fixture.Scheduler.Tick();
-        Assert.Equal(hooksBeforeWake + 3, fixture.Metrics.Current.HookInvocations);
+        AssertNextHooks(
+            fixture,
+            ref hookOffset,
+            NpcBrainHookType.Activate,
+            NpcBrainHookType.MobileEnteredRange,
+            NpcBrainHookType.Think
+        );
         Assert.Equal(intentsBeforeWake + 1, fixture.Metrics.Current.IntentsAccepted);
         fixture.Bus.Publish(new MobileSpeechEvent(fixture.Player.Id, ChatMessageType.Regular, "ciao"));
         Assert.Equal(2, fixture.Chat.Messages.Count);
         fixture.Scheduler.Tick();
+        AssertNextHooks(fixture, ref hookOffset, NpcBrainHookType.SpeechHeard);
         Assert.Equal(
-            [FirstMeetingReply, ReturningPlayerReply, ReturningPlayerReply],
-            fixture.Chat.Messages.Select(message => message.Text)
+            [
+                (fixture.Guard.Id, ChatMessageType.Regular, FirstMeetingReply, Hue.Default, 15),
+                (fixture.Guard.Id, ChatMessageType.Regular, ReturningPlayerReply, Hue.Default, 15),
+                (fixture.Guard.Id, ChatMessageType.Regular, ReturningPlayerReply, Hue.Default, 15)
+            ],
+            fixture.Chat.Messages
         );
+        Assert.Empty(fixture.Chat.Broadcasts);
+    }
+
+    private static void AssertNextHooks(
+        IntegrationFixture fixture,
+        ref int offset,
+        params NpcBrainHookType[] expected
+    )
+    {
+        Assert.Equal(expected, fixture.Runtime.Invocations.Skip(offset));
+        offset += expected.Length;
+        Assert.Equal(offset, fixture.Runtime.Invocations.Count);
     }
 
     private sealed class IntegrationFixture : IDisposable
     {
         private readonly Container _container = new();
         private readonly LuaScriptEngineService _engine;
+        private readonly LuaNpcBrainRuntime _luaRuntime;
         private readonly string _root;
 
         public EventBusService Bus { get; } = new();
@@ -189,7 +248,7 @@ public sealed class NpcBrainIntegrationTests
 
         public SectorActivityService Activity { get; }
 
-        public LuaNpcBrainRuntime Runtime { get; }
+        public RecordingLuaNpcBrainRuntime Runtime { get; }
 
         public NpcBrainScheduler Scheduler { get; }
 
@@ -209,7 +268,8 @@ public sealed class NpcBrainIntegrationTests
             var loopAffinity = new StubLoopAffinity();
             Spatial = new(Persistence, loopAffinity, Bus);
             Activity = new(Loop, Bus, Time, Config, Metrics);
-            Runtime = new(_engine, directories, Config, Metrics, Loop, Bus, Time);
+            _luaRuntime = new(_engine, directories, Config, Metrics, Loop, Bus, Time);
+            Runtime = new(_luaRuntime);
             var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
             var intentExecutor = new BrainIntentExecutor(
                 Persistence,
@@ -252,11 +312,64 @@ public sealed class NpcBrainIntegrationTests
 
         public void Dispose()
         {
-            Runtime.Dispose();
+            _luaRuntime.Dispose();
             _engine.Dispose();
             Bus.Dispose();
             _container.Dispose();
             Directory.Delete(_root, true);
+        }
+    }
+
+    private sealed class RecordingLuaNpcBrainRuntime : INpcBrainRuntime
+    {
+        private readonly LuaNpcBrainRuntime _inner;
+        private readonly List<NpcBrainHookType> _invocations = [];
+
+        public IReadOnlyList<NpcBrainHookType> Invocations => _invocations;
+
+        public RecordingLuaNpcBrainRuntime(LuaNpcBrainRuntime inner)
+        {
+            _inner = inner;
+        }
+
+        public bool TryBind(
+            Serial mobileId,
+            string brainId,
+            out BrainDescriptor? descriptor,
+            out string? error
+        )
+            => _inner.TryBind(mobileId, brainId, out descriptor, out error);
+
+        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+            => _inner.TryGetDescriptor(mobileId, out descriptor);
+
+        public NpcBrainInvocationResult Invoke(
+            Serial mobileId,
+            NpcBrainHookType hook,
+            BrainContext context,
+            NpcBrainEvent? brainEvent = null
+        )
+        {
+            _invocations.Add(hook);
+
+            return _inner.Invoke(mobileId, hook, context, brainEvent);
+        }
+
+        public bool TryReload(
+            string brainId,
+            out BrainDescriptor? descriptor,
+            out string? error
+        )
+            => _inner.TryReload(brainId, out descriptor, out error);
+
+        public void Reset(Serial mobileId)
+        {
+            _inner.Reset(mobileId);
+        }
+
+        public void Unbind(Serial mobileId)
+        {
+            _inner.Unbind(mobileId);
         }
     }
 

--- a/tests/Moongate.Tests/Server/AI/NpcBrainLifecycleSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainLifecycleSubscriberTests.cs
@@ -1,0 +1,318 @@
+using Moongate.Core.Primitives;
+using Moongate.Core.Extensions;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Tests.Server.AI;
+
+public sealed class NpcBrainLifecycleSubscriberTests
+{
+    [Fact]
+    public async Task OnWorldReady_AccountOwnedMobileWithBrainId_BindsOnlyNpcBrains()
+    {
+        var fixture = new LifecycleFixture();
+        var npc = fixture.AddMobile(0x1, "guard");
+        var player = fixture.AddMobile(0x2, "guard");
+        await fixture.Persistence.Store<AccountEntity>()
+            .UpsertAsync(new() { Id = new(0x100), Username = "player", MobileIds = [player.Id] });
+
+        await fixture.Subscriber.OnWorldReady(new(), CancellationToken.None);
+
+        Assert.Equal([npc.Id], fixture.Scheduler.Bound);
+        Assert.Empty(fixture.Scheduler.Active);
+    }
+
+    [Fact]
+    public async Task OnMobileCreated_ActiveSector_BindsAndActivatesBrain()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard", x: 32, y: 48);
+        fixture.Sectors.Active.Add((0, 2, 3));
+
+        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
+
+        Assert.Equal([mobile.Id], fixture.Scheduler.Bound);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Active);
+    }
+
+    [Fact]
+    public async Task OnMobileDeleted_BoundBrain_UnbindsIt()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard");
+        fixture.Scheduler.Bound.Add(mobile.Id);
+
+        await fixture.Subscriber.OnMobileDeleted(new(mobile), CancellationToken.None);
+
+        Assert.Empty(fixture.Scheduler.Bound);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Unbound);
+    }
+
+    [Fact]
+    public async Task OnMobileChangedSector_BoundBrain_UsesTargetSectorActivity()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard");
+        fixture.Scheduler.Bound.Add(mobile.Id);
+        fixture.Sectors.Active.Add((0, 1, 1));
+
+        await fixture.Subscriber.OnMobileChangedSector(
+            new(mobile.Id, 0, 0, 0, 0, 1, 1),
+            CancellationToken.None
+        );
+
+        Assert.Equal([mobile.Id], fixture.Scheduler.Active);
+
+        await fixture.Subscriber.OnMobileChangedSector(
+            new(mobile.Id, 0, 1, 1, 0, 2, 2),
+            CancellationToken.None
+        );
+
+        Assert.Empty(fixture.Scheduler.Active);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Deactivated);
+    }
+
+    [Fact]
+    public async Task OnSectorEvents_ExactSector_ActivatesAndDeactivatesBrainMobiles()
+    {
+        var fixture = new LifecycleFixture();
+        var first = fixture.AddMobile(0x1, "guard", x: 5, y: 5);
+        var second = fixture.AddMobile(0x2, "guard", x: 6, y: 6);
+        fixture.AddMobile(0x3, "", x: 7, y: 7);
+        fixture.AddMobile(0x4, "guard", x: 32, y: 5);
+        fixture.Scheduler.Bound.UnionWith([first.Id, second.Id]);
+
+        await fixture.Subscriber.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        await fixture.Subscriber.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
+
+        Assert.Equal([first.Id, second.Id], fixture.Scheduler.Activated);
+        Assert.Equal([first.Id, second.Id], fixture.Scheduler.Deactivated);
+    }
+
+    [Fact]
+    public async Task OnBrainDefinitionReloaded_MatchingDescriptor_RefreshesScheduler()
+    {
+        var fixture = new LifecycleFixture();
+        var descriptor = new BrainDescriptor("guard", 1000, 8, 10);
+
+        await fixture.Subscriber.OnBrainDefinitionReloaded(new("guard", descriptor), CancellationToken.None);
+
+        Assert.Equal([("guard", descriptor)], fixture.Scheduler.Refreshed);
+    }
+
+    [Fact]
+    public async Task DuplicateLifecycleEvents_IdempotentSchedulerOperations_LeaveOneBindingAndStateTransition()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard", x: 16, y: 16);
+        fixture.Sectors.Active.Add((0, 1, 1));
+
+        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
+        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 0, 0, 0, 1, 1), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 0, 0, 0, 1, 1), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 1, 1, 0, 2, 2), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 1, 1, 0, 2, 2), CancellationToken.None);
+
+        Assert.Equal([mobile.Id], fixture.Scheduler.Bound);
+        Assert.Empty(fixture.Scheduler.Active);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Activated);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Deactivated);
+    }
+
+    [Fact]
+    public void Subscribe_RegistersEveryLifecycleEvent()
+    {
+        var fixture = new LifecycleFixture();
+        var eventBus = new RecordingEventBus();
+
+        fixture.Subscriber.Subscribe(eventBus);
+
+        Assert.Equal(
+            [
+                typeof(WorldReadyEvent),
+                typeof(MobileCreatedEvent),
+                typeof(MobileDeletedEvent),
+                typeof(MobileChangedSectorEvent),
+                typeof(SectorActivatedEvent),
+                typeof(SectorDeactivatedEvent),
+                typeof(BrainDefinitionReloadedEvent)
+            ],
+            eventBus.Subscribed
+        );
+    }
+
+    private sealed class LifecycleFixture
+    {
+        public FakePersistenceService Persistence { get; } = new();
+
+        public RecordingScheduler Scheduler { get; } = new();
+
+        public StubSectorActivityService Sectors { get; } = new();
+
+        public SpatialIndexService Spatial { get; }
+
+        public NpcBrainLifecycleSubscriber Subscriber { get; }
+
+        public LifecycleFixture()
+        {
+            Spatial = new(Persistence, new StubLoopAffinity(), new StubEventBus());
+            Subscriber = new(Spatial, Persistence, Scheduler, Sectors);
+        }
+
+        public MobileEntity AddMobile(uint serial, string brainId, int x = 0, int y = 0)
+        {
+            var mobile = new MobileEntity
+            {
+                Id = new(serial),
+                Name = $"mobile-{serial}",
+                BrainScriptId = brainId,
+                MapId = 0,
+                Position = new(x, y, 0)
+            };
+            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            Spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+    }
+
+    private sealed class RecordingScheduler : INpcBrainScheduler
+    {
+        public HashSet<Serial> Bound { get; } = [];
+
+        public HashSet<Serial> Active { get; } = [];
+
+        public List<Serial> Unbound { get; } = [];
+
+        public List<Serial> Activated { get; } = [];
+
+        public List<Serial> Deactivated { get; } = [];
+
+        public List<(string BrainId, BrainDescriptor Descriptor)> Refreshed { get; } = [];
+
+        public int MaxHearingRange => 0;
+
+        public int MaxPerceptionRange => 0;
+
+        public void Bind(MobileEntity mobile)
+        {
+            Bound.Add(mobile.Id);
+        }
+
+        public void Unbind(Serial mobileId)
+        {
+            if (!Bound.Remove(mobileId))
+            {
+                return;
+            }
+
+            Active.Remove(mobileId);
+            Unbound.Add(mobileId);
+        }
+
+        public void Activate(Serial mobileId)
+        {
+            if (Bound.Contains(mobileId) && Active.Add(mobileId))
+            {
+                Activated.Add(mobileId);
+            }
+        }
+
+        public void Deactivate(Serial mobileId)
+        {
+            if (Active.Remove(mobileId))
+            {
+                Deactivated.Add(mobileId);
+            }
+        }
+
+        public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
+        {
+            Refreshed.Add((brainId, descriptor));
+        }
+
+        public bool IsActive(Serial mobileId)
+            => Active.Contains(mobileId);
+
+        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+        {
+            descriptor = null;
+            return false;
+        }
+
+        public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
+        {
+        }
+
+        public void Tick()
+        {
+        }
+    }
+
+    private sealed class StubSectorActivityService : ISectorActivityService
+    {
+        public HashSet<(int MapId, int SectorX, int SectorY)> Active { get; } = [];
+
+        public SectorActivitySnapshot Current => new(Active.Count, 0);
+
+        public bool IsActive(int mapId, int sectorX, int sectorY)
+            => Active.Contains((mapId, sectorX, sectorY));
+
+        public void TrackPlayer(MobileEntity player)
+        {
+        }
+
+        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
+        {
+        }
+
+        public void UntrackPlayer(Serial playerId)
+        {
+        }
+
+        public void Tick()
+        {
+        }
+    }
+
+    private sealed class RecordingEventBus : IEventBus
+    {
+        public List<Type> Subscribed { get; } = [];
+
+        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
+        {
+        }
+
+        public Task PublishAsync<TEvent>(TEvent eventData, CancellationToken cancellationToken = default)
+            where TEvent : IEvent
+            => Task.CompletedTask;
+
+        public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
+            => NoopDisposable.Instance;
+
+        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
+        {
+            Subscribed.Add(typeof(TEvent));
+            return NoopDisposable.Instance;
+        }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainLifecycleSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainLifecycleSubscriberTests.cs
@@ -32,6 +32,19 @@ public sealed class NpcBrainLifecycleSubscriberTests
     }
 
     [Fact]
+    public async Task OnWorldReady_ActiveNpcSector_BindsAndActivatesBrain()
+    {
+        var fixture = new LifecycleFixture();
+        var npc = fixture.AddMobile(0x1, "guard", x: 32, y: 48);
+        fixture.Sectors.Active.Add((0, 2, 3));
+
+        await fixture.Subscriber.OnWorldReady(new(), CancellationToken.None);
+
+        Assert.Equal([npc.Id], fixture.Scheduler.Bound);
+        Assert.Equal([npc.Id], fixture.Scheduler.Activated);
+    }
+
+    [Fact]
     public async Task OnMobileCreated_ActiveSector_BindsAndActivatesBrain()
     {
         var fixture = new LifecycleFixture();

--- a/tests/Moongate.Tests/Server/AI/NpcBrainMailboxTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainMailboxTests.cs
@@ -71,6 +71,40 @@ public class NpcBrainMailboxTests
         Assert.Equal(1, metrics.Current.EventsDelivered);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Enqueue_AlternatingRangeTransitions_RetainsTransitionsAndSuppressesOnlyLatestDuplicate(
+        bool enterFirst
+    )
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(8, metrics);
+        var firstHook = enterFirst
+            ? NpcBrainHookType.MobileEnteredRange
+            : NpcBrainHookType.MobileLeftRange;
+        var firstType = enterFirst
+            ? NpcBrainEventType.MobileEnteredRange
+            : NpcBrainEventType.MobileLeftRange;
+        var secondHook = enterFirst
+            ? NpcBrainHookType.MobileLeftRange
+            : NpcBrainHookType.MobileEnteredRange;
+        var secondType = enterFirst
+            ? NpcBrainEventType.MobileLeftRange
+            : NpcBrainEventType.MobileEnteredRange;
+
+        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
+        mailbox.Enqueue(secondHook, Event(secondType, 0x2));
+        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
+        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
+
+        var delivered = mailbox.Dequeue(8);
+
+        Assert.Equal([firstHook, secondHook, firstHook], delivered.Select(entry => entry.Hook));
+        Assert.Equal(1, metrics.Current.EventsCoalesced);
+        Assert.Equal(3, metrics.Current.EventsDelivered);
+    }
+
     [Fact]
     public void Enqueue_FullMailbox_EvictsMovementBeforeSpeechAndSpeechBeforeLifecycleOrCombat()
     {

--- a/tests/Moongate.Tests/Server/AI/NpcBrainMailboxTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainMailboxTests.cs
@@ -1,0 +1,173 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Data.Internal.AI;
+using Moongate.Server.Services.AI;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcBrainMailboxTests
+{
+    [Fact]
+    public void Dequeue_LifecycleCombatSpeechAndRangeEvents_PreservesFifoOrder()
+    {
+        var mailbox = new NpcBrainMailbox(4, new NpcAiMetrics());
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.Attacked, Event(NpcBrainEventType.Attacked, 0x2));
+        mailbox.Enqueue(NpcBrainHookType.SpeechHeard, Event(NpcBrainEventType.SpeechHeard, 0x3));
+        mailbox.Enqueue(NpcBrainHookType.MobileEnteredRange, Event(NpcBrainEventType.MobileEnteredRange, 0x4));
+
+        var delivered = mailbox.Dequeue(4);
+
+        Assert.Equal(
+            [
+                NpcBrainHookType.Activate,
+                NpcBrainHookType.Attacked,
+                NpcBrainHookType.SpeechHeard,
+                NpcBrainHookType.MobileEnteredRange
+            ],
+            delivered.Select(entry => entry.Hook)
+        );
+    }
+
+    [Fact]
+    public void Enqueue_SecondMovementForSameMobile_ReplacesPendingEventAndRecordsCoalesced()
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x2, new(10, 10, 0), new(11, 10, 0))
+        );
+
+        mailbox.Enqueue(
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x2, new(11, 10, 0), new(12, 10, 0))
+        );
+
+        var delivered = Assert.Single(mailbox.Dequeue(4));
+        Assert.Equal(new Point3D(12, 10, 0), delivered.Event.ToPosition);
+        Assert.Equal(1, metrics.Current.EventsCoalesced);
+        Assert.Equal(1, metrics.Current.EventsDelivered);
+    }
+
+    [Theory]
+    [InlineData(NpcBrainHookType.MobileEnteredRange, NpcBrainEventType.MobileEnteredRange)]
+    [InlineData(NpcBrainHookType.MobileLeftRange, NpcBrainEventType.MobileLeftRange)]
+    public void Enqueue_DuplicateRangeTransition_SuppressesDuplicateAndRecordsCoalesced(
+        NpcBrainHookType hook,
+        NpcBrainEventType type
+    )
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(hook, Event(type, 0x2));
+
+        mailbox.Enqueue(hook, Event(type, 0x2));
+
+        Assert.Single(mailbox.Dequeue(4));
+        Assert.Equal(1, metrics.Current.EventsCoalesced);
+        Assert.Equal(1, metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
+    public void Enqueue_FullMailbox_EvictsMovementBeforeSpeechAndSpeechBeforeLifecycleOrCombat()
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.Attacked, Event(NpcBrainEventType.Attacked, 0x2));
+        mailbox.Enqueue(NpcBrainHookType.SpeechHeard, Event(NpcBrainEventType.SpeechHeard, 0x3));
+        mailbox.Enqueue(NpcBrainHookType.MobileMoved, Event(NpcBrainEventType.MobileMoved, 0x4));
+
+        mailbox.Enqueue(NpcBrainHookType.Death, Event(NpcBrainEventType.Death));
+        mailbox.Enqueue(NpcBrainHookType.Damage, Event(NpcBrainEventType.Damage, 0x5));
+
+        var delivered = mailbox.Dequeue(4);
+        Assert.DoesNotContain(delivered, entry => entry.Hook == NpcBrainHookType.MobileMoved);
+        Assert.DoesNotContain(delivered, entry => entry.Hook == NpcBrainHookType.SpeechHeard);
+        Assert.Equal(
+            [
+                NpcBrainHookType.Activate,
+                NpcBrainHookType.Attacked,
+                NpcBrainHookType.Death,
+                NpcBrainHookType.Damage
+            ],
+            delivered.Select(entry => entry.Hook)
+        );
+        Assert.Equal(2, metrics.Current.EventsDropped);
+        Assert.Equal(4, metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
+    public void Enqueue_LowerPriorityThanFullMailbox_DropsIncomingEvent()
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.Deactivate, Event(NpcBrainEventType.Deactivate));
+        mailbox.Enqueue(NpcBrainHookType.Death, Event(NpcBrainEventType.Death));
+        mailbox.Enqueue(NpcBrainHookType.Attacked, Event(NpcBrainEventType.Attacked, 0x2));
+
+        mailbox.Enqueue(NpcBrainHookType.MobileMoved, Event(NpcBrainEventType.MobileMoved, 0x3));
+
+        Assert.Equal(4, mailbox.Dequeue(8).Count);
+        Assert.Equal(1, metrics.Current.EventsDropped);
+    }
+
+    [Fact]
+    public void Dequeue_LimitBelowCount_DeliversAtMostLimitAndRetainsRemainder()
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.Attacked, Event(NpcBrainEventType.Attacked, 0x2));
+        mailbox.Enqueue(NpcBrainHookType.SpeechHeard, Event(NpcBrainEventType.SpeechHeard, 0x3));
+
+        var first = mailbox.Dequeue(2);
+        var second = mailbox.Dequeue(2);
+
+        Assert.Equal(2, first.Count);
+        Assert.Single(second);
+        Assert.Equal(NpcBrainHookType.SpeechHeard, second[0].Hook);
+        Assert.Equal(3, metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
+    public void Clear_QueuedEvents_RemovesAllWithoutRecordingDelivery()
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.MobileMoved, Event(NpcBrainEventType.MobileMoved, 0x2));
+
+        mailbox.Clear();
+
+        Assert.Empty(mailbox.Dequeue(4));
+        Assert.Equal(0, metrics.Current.EventsDelivered);
+    }
+
+    private static NpcBrainEvent Event(
+        NpcBrainEventType type,
+        uint mobileId = 0,
+        Point3D? from = null,
+        Point3D? to = null
+    )
+        => new(type, mobileId == 0 ? null : Snapshot(mobileId), FromPosition: from, ToPosition: to);
+
+    private static BrainMobileSnapshot Snapshot(uint serial)
+        => new(
+            new Serial(serial),
+            $"mobile-{serial}",
+            false,
+            0,
+            new Point3D(10, 10, 0),
+            10,
+            10,
+            false,
+            Serial.Zero,
+            false,
+            0
+        );
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
@@ -1,0 +1,669 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.AI;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcBrainSchedulerTests
+{
+    [Fact]
+    public void Bind_SleepingSector_BindsAndRetainsRuntimeWithoutInvoking()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddMobile(0x1);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal([(mobile.Id, "guard")], fixture.Runtime.BindCalls);
+        Assert.Empty(fixture.Runtime.Invocations);
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.True(fixture.Scheduler.TryGetDescriptor(mobile.Id, out var descriptor));
+        Assert.Equal("guard", descriptor!.BrainId);
+        Assert.Equal(1, fixture.Metrics.Current.SleepingBrains);
+        Assert.Equal(1, fixture.Metrics.Current.SleepingSectors);
+    }
+
+    [Fact]
+    public void Activate_GraceSector_InvokesActivateBeforeImmediateThink()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddMobile(0x1);
+        fixture.Sectors.SetActive(mobile, true);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(
+            [NpcBrainHookType.Activate, NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Equal(1, fixture.Metrics.Current.ActiveBrains);
+        Assert.Equal(2, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(1, fixture.Metrics.Current.BrainsExecuted);
+    }
+
+    [Fact]
+    public void Deactivate_ActiveBrain_InvokesOnceClearsMailboxAndSleeps()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.SpeechHeard,
+            Event(NpcBrainEventType.SpeechHeard, 0x2)
+        );
+
+        fixture.Scheduler.Deactivate(mobile.Id);
+
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        fixture.Scheduler.Tick();
+        Assert.Equal([NpcBrainHookType.Deactivate], fixture.Runtime.Invocations.Select(invocation => invocation.Hook));
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Equal(1, fixture.Metrics.Current.SleepingBrains);
+
+        fixture.Runtime.Invocations.Clear();
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+        Assert.Equal(
+            [NpcBrainHookType.Activate, NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+    }
+
+    [Fact]
+    public void Deactivate_FailedHook_RecordsInvocationAndStillSleepsWithoutRetry()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Deactivate
+                ? NpcBrainInvocationResult.Failed("deactivate failed")
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+
+        fixture.Scheduler.Deactivate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal([NpcBrainHookType.Deactivate], fixture.Runtime.Invocations.Select(invocation => invocation.Hook));
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Equal(3, fixture.Metrics.Current.HookInvocations);
+
+        fixture.Time.Advance(TimeSpan.FromMinutes(2));
+        fixture.Scheduler.Tick();
+        Assert.Single(fixture.Runtime.Invocations);
+    }
+
+    [Fact]
+    public void SleepWake_Cycle_PreservesBindingAndRuntimeState()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Scheduler.Deactivate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.Single(fixture.Runtime.BindCalls);
+        Assert.Empty(fixture.Runtime.ResetCalls);
+        Assert.Empty(fixture.Runtime.UnbindCalls);
+        Assert.Equal(2, fixture.Runtime.Invocations.Count(invocation => invocation.Hook == NpcBrainHookType.Activate));
+        Assert.Single(fixture.Runtime.Invocations, invocation => invocation.Hook == NpcBrainHookType.Deactivate);
+    }
+
+    [Fact]
+    public void Bind_SameBrainAfterMove_PreservesOriginalHome()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddMobile(0x1, x: 10, y: 10);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Move(mobile, 30, 40);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        var context = Assert.Single(
+            fixture.Runtime.Invocations,
+            invocation => invocation.Hook == NpcBrainHookType.Activate
+        ).Context;
+        Assert.Equal(new Point3D(10, 10, 0), context.HomePosition);
+        Assert.Single(fixture.Runtime.BindCalls);
+    }
+
+    [Fact]
+    public void Bind_ChangedBrain_ResetsRebindsAndRecapturesHome()
+    {
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors["wanderer"] = new("wanderer", 500, 7, 9);
+        var mobile = fixture.AddMobile(0x1, x: 10, y: 10);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Move(mobile, 30, 40);
+        mobile.BrainScriptId = "wanderer";
+        fixture.Sectors.SetActive(mobile, true);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal([mobile.Id], fixture.Runtime.ResetCalls);
+        Assert.Equal([(mobile.Id, "guard"), (mobile.Id, "wanderer")], fixture.Runtime.BindCalls);
+        var activation = Assert.Single(
+            fixture.Runtime.Invocations,
+            invocation => invocation.Hook == NpcBrainHookType.Activate
+        );
+        Assert.Equal(new Point3D(30, 40, 0), activation.Context.HomePosition);
+        Assert.Equal(0, activation.Context.HomeMapId);
+    }
+
+    [Fact]
+    public void Bind_ChangedBrainUnavailable_DoesNotInvokeStaleRuntimeBindingAndRetriesNewBrain()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        mobile.BrainScriptId = "missing";
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+
+        Assert.Empty(fixture.Runtime.Invocations);
+        Assert.Equal(
+            [(mobile.Id, "guard"), (mobile.Id, "missing"), (mobile.Id, "missing")],
+            fixture.Runtime.BindCalls
+        );
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+    }
+
+    [Fact]
+    public void Unbind_BoundBrain_RemovesSchedulerAndRuntimeState()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+
+        fixture.Scheduler.Unbind(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal([mobile.Id], fixture.Runtime.UnbindCalls);
+        Assert.False(fixture.Scheduler.TryGetDescriptor(mobile.Id, out _));
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Empty(fixture.Runtime.Invocations);
+        Assert.Equal(0, fixture.Metrics.Current.ActiveBrains);
+    }
+
+    [Fact]
+    public void Tick_QueuedEventAndThinkDue_InvokesEventsBeforeThink()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.SpeechHeard,
+            Event(NpcBrainEventType.SpeechHeard, 0x2)
+        );
+
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(
+            [NpcBrainHookType.Activate, NpcBrainHookType.SpeechHeard, NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+    }
+
+    [Fact]
+    public void Tick_MoreEventsThanWakeBudget_DefersRemainderToNextWake()
+    {
+        var fixture = new SchedulerFixture(maxEventsPerWake: 2);
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+
+        fixture.EnqueueSpeech(mobile.Id, 0x2);
+        fixture.EnqueueSpeech(mobile.Id, 0x3);
+        fixture.EnqueueSpeech(mobile.Id, 0x4);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, fixture.Runtime.Invocations.Count);
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.Runtime.Invocations.Count);
+        Assert.Equal(4, fixture.Metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
+    public void Tick_MoreDueBrainsThanLoopBudget_PreservesStableFifoAndCountsEachDeferredBrain()
+    {
+        var fixture = new SchedulerFixture(maxBrainsPerLoop: 1);
+        var first = fixture.AddActiveMobile(0x1);
+        var second = fixture.AddActiveMobile(0x2);
+        var third = fixture.AddActiveMobile(0x3);
+        fixture.Scheduler.Bind(first);
+        fixture.Scheduler.Bind(second);
+        fixture.Scheduler.Bind(third);
+
+        fixture.Scheduler.Tick();
+        fixture.Scheduler.Tick();
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(
+            [first.Id, second.Id, third.Id],
+            fixture.Runtime.Invocations
+                .Where(invocation => invocation.Hook == NpcBrainHookType.Activate)
+                .Select(invocation => invocation.MobileId)
+        );
+        Assert.Equal(3, fixture.Metrics.Current.BrainsExecuted);
+        Assert.Equal(3, fixture.Metrics.Current.BrainsDeferred);
+    }
+
+    [Fact]
+    public void Tick_InvalidIntent_DoesNotFaultEntry()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        var invalidIntent = new BrainIntent(BrainIntentType.Unknown, "explode", Serial.Zero, null);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think
+                ? NpcBrainInvocationResult.Succeeded(new(null, [invalidIntent]))
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        var execution = Assert.Single(fixture.Intents.Executions);
+        Assert.Equal(invalidIntent, Assert.Single(execution.Intents));
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Empty(fixture.Runtime.ResetCalls);
+    }
+
+    [Fact]
+    public void Tick_ConsecutiveInvocationFailures_BackOffOneFiveThirtyThenSixtySecondsAndResetFourth()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think
+                ? NpcBrainInvocationResult.Failed("think failed")
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+
+        fixture.Scheduler.Tick();
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Equal(1, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(1, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(5));
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(30));
+        fixture.Scheduler.Tick();
+        Assert.Equal(4, fixture.ThinkCount(mobile.Id));
+        Assert.Equal([mobile.Id], fixture.Runtime.ResetCalls);
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(60));
+        fixture.Scheduler.Tick();
+        Assert.Equal(5, fixture.ThinkCount(mobile.Id));
+        Assert.Equal([mobile.Id], fixture.Runtime.ResetCalls);
+        Assert.Empty(fixture.Intents.Executions);
+    }
+
+    [Fact]
+    public void Tick_SuccessAfterFailures_ResetsNextFailureBackoffToOneSecond()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        var attempts = 0;
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+        {
+            if (hook != NpcBrainHookType.Think)
+            {
+                return NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+            }
+
+            attempts++;
+            return attempts == 3
+                ? NpcBrainInvocationResult.Succeeded(BrainDecision.Empty)
+                : NpcBrainInvocationResult.Failed("think failed");
+        };
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(5));
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(4, attempts);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(4, attempts);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(5, attempts);
+    }
+
+    [Fact]
+    public void Bind_MissingDescriptor_RetriesBindingWithFaultBackoff()
+    {
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors.Remove("guard");
+        var mobile = fixture.AddActiveMobile(0x1);
+
+        fixture.Scheduler.Bind(mobile);
+        Assert.Single(fixture.Runtime.BindCalls);
+        fixture.Scheduler.Tick();
+        Assert.Single(fixture.Runtime.BindCalls);
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.Runtime.BindCalls.Count);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(4999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.Runtime.BindCalls.Count);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.Runtime.BindCalls.Count);
+
+        fixture.Runtime.Descriptors["guard"] = new("guard", 1000, 10, 15);
+        fixture.Time.Advance(TimeSpan.FromSeconds(30));
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(4, fixture.Runtime.BindCalls.Count);
+        Assert.Equal(
+            [NpcBrainHookType.Activate, NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+    }
+
+    [Fact]
+    public void RefreshDescriptor_ChangedRanges_RecomputesGlobalMaximums()
+    {
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors["scout"] = new("scout", 1000, 20, 25);
+        fixture.Scheduler.Bind(fixture.AddMobile(0x1));
+        fixture.Scheduler.Bind(fixture.AddMobile(0x2, brainId: "scout"));
+        Assert.Equal(20, fixture.Scheduler.MaxPerceptionRange);
+        Assert.Equal(25, fixture.Scheduler.MaxHearingRange);
+
+        fixture.Scheduler.RefreshDescriptor("scout", new("scout", 1000, 4, 5));
+
+        Assert.Equal(10, fixture.Scheduler.MaxPerceptionRange);
+        Assert.Equal(15, fixture.Scheduler.MaxHearingRange);
+        Assert.True(fixture.Scheduler.TryGetDescriptor(new Serial(0x2), out var descriptor));
+        Assert.Equal(4, descriptor!.PerceptionRange);
+    }
+
+    [Fact]
+    public void Tick_ThinkOverride_ClampsToConfiguredMinimumAndMaximum()
+    {
+        var fixture = new SchedulerFixture(minTickMilliseconds: 100, maxTickMilliseconds: 1000);
+        var mobile = fixture.AddActiveMobile(0x1);
+        var thinkResults = new Queue<int?>([1, 5000, null]);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think
+                ? NpcBrainInvocationResult.Succeeded(new(thinkResults.Dequeue(), []))
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(99));
+        fixture.Scheduler.Tick();
+        Assert.Equal(1, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.ThinkCount(mobile.Id));
+    }
+
+    [Fact]
+    public void Tick_SleepingBrains_GaugesDistinctCurrentOccupiedSectorsWithoutRetainingEmptyKeys()
+    {
+        var fixture = new SchedulerFixture();
+        var first = fixture.AddMobile(0x1, x: 1, y: 1);
+        var sameSector = fixture.AddMobile(0x2, x: 2, y: 2);
+        var otherSector = fixture.AddMobile(0x3, x: 32, y: 32);
+        fixture.Scheduler.Bind(first);
+        fixture.Scheduler.Bind(sameSector);
+        fixture.Scheduler.Bind(otherSector);
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.Metrics.Current.SleepingBrains);
+        Assert.Equal(2, fixture.Metrics.Current.SleepingSectors);
+
+        fixture.Scheduler.Unbind(otherSector.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, fixture.Metrics.Current.SleepingBrains);
+        Assert.Equal(1, fixture.Metrics.Current.SleepingSectors);
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistersOneSchedulerTimerAndStopAsyncCancelsIt()
+    {
+        var fixture = new SchedulerFixture(minTickMilliseconds: 125);
+
+        await fixture.Scheduler.StartAsync();
+        await fixture.Scheduler.StartAsync();
+
+        Assert.True(fixture.Loop.Repeating.ContainsKey("npc-brain-scheduler"));
+        Assert.Single(fixture.Loop.Repeating);
+        Assert.Equal(TimeSpan.FromMilliseconds(125), fixture.Loop.RepeatingInterval);
+        Assert.Null(fixture.Loop.RepeatingDelay);
+
+        await fixture.Scheduler.StopAsync();
+        Assert.Empty(fixture.Loop.Repeating);
+    }
+
+    private static NpcBrainEvent Event(NpcBrainEventType type, uint subject)
+        => new(type, Snapshot(subject));
+
+    private static BrainMobileSnapshot Snapshot(uint serial)
+        => new(
+            new Serial(serial),
+            $"mobile-{serial}",
+            false,
+            0,
+            new Point3D(10, 10, 0),
+            10,
+            10,
+            false,
+            Serial.Zero,
+            false,
+            0
+        );
+
+    private sealed class SchedulerFixture
+    {
+        public FakePersistenceService Persistence { get; } = new();
+
+        public RecordingNpcBrainRuntime Runtime { get; } = new();
+
+        public RecordingBrainIntentExecutor Intents { get; } = new();
+
+        public StubSectorActivityService Sectors { get; } = new();
+
+        public StubSessionManager Sessions { get; } = new();
+
+        public MutableTimeProvider Time { get; } = new(
+            new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero)
+        );
+
+        public NpcAiMetrics Metrics { get; } = new();
+
+        public StubGameLoopContext Loop { get; } = new();
+
+        public SpatialIndexService Spatial { get; }
+
+        public NpcBrainScheduler Scheduler { get; }
+
+        public SchedulerFixture(
+            int maxBrainsPerLoop = 100,
+            int maxEventsPerWake = 16,
+            int minTickMilliseconds = 100,
+            int maxTickMilliseconds = 60_000
+        )
+        {
+            Runtime.Descriptors["guard"] = new("guard", 1000, 10, 15);
+            Spatial = new(Persistence, new StubLoopAffinity(), new StubEventBus());
+            var config = new MoongateConfig
+            {
+                NpcAi = new()
+                {
+                    Advanced = new()
+                    {
+                        MinTickMilliseconds = minTickMilliseconds,
+                        MaxTickMilliseconds = maxTickMilliseconds,
+                        MaxBrainsPerLoop = maxBrainsPerLoop,
+                        MaxEventsPerBrainWake = maxEventsPerWake,
+                        MaxMailboxEvents = Math.Max(16, maxEventsPerWake)
+                    }
+                }
+            };
+            var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
+            Scheduler = new(
+                Loop,
+                Runtime,
+                Intents,
+                Sectors,
+                Persistence,
+                contextFactory,
+                Time,
+                config,
+                Metrics
+            );
+        }
+
+        public MobileEntity AddMobile(
+            uint serial,
+            string brainId = "guard",
+            int mapId = 0,
+            int x = 10,
+            int y = 10
+        )
+        {
+            var mobile = new MobileEntity
+            {
+                Id = new Serial(serial),
+                Name = $"mobile-{serial}",
+                BrainScriptId = brainId,
+                MapId = mapId,
+                Position = new Point3D(x, y, 0),
+                Hits = 10,
+                HitsMax = 10
+            };
+            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            Spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+
+        public MobileEntity AddActiveMobile(uint serial)
+        {
+            var mobile = AddMobile(serial);
+            Sectors.SetActive(mobile, true);
+
+            return mobile;
+        }
+
+        public void Move(MobileEntity mobile, int x, int y)
+        {
+            mobile.Position = new(x, y, mobile.Position.Z);
+            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            Spatial.AddOrUpdate(mobile);
+        }
+
+        public void EnqueueSpeech(Serial ownerId, uint speakerId)
+        {
+            Scheduler.EnqueueEvent(
+                ownerId,
+                NpcBrainHookType.SpeechHeard,
+                Event(NpcBrainEventType.SpeechHeard, speakerId)
+            );
+        }
+
+        public int ThinkCount(Serial mobileId)
+            => Runtime.Invocations.Count(
+                invocation => invocation.MobileId == mobileId && invocation.Hook == NpcBrainHookType.Think
+            );
+    }
+
+    private sealed class StubSectorActivityService : ISectorActivityService
+    {
+        private readonly HashSet<(int MapId, int SectorX, int SectorY)> _active = [];
+
+        public SectorActivitySnapshot Current => new(_active.Count, 0);
+
+        public bool IsActive(int mapId, int sectorX, int sectorY)
+            => _active.Contains((mapId, sectorX, sectorY));
+
+        public void SetActive(MobileEntity mobile, bool active)
+        {
+            var key = (mobile.MapId, mobile.Position.X >> 4, mobile.Position.Y >> 4);
+
+            if (active)
+            {
+                _active.Add(key);
+                return;
+            }
+
+            _active.Remove(key);
+        }
+
+        public void TrackPlayer(MobileEntity player)
+        {
+        }
+
+        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
+        {
+        }
+
+        public void UntrackPlayer(Serial playerId)
+        {
+        }
+
+        public void Tick()
+        {
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
@@ -132,6 +132,36 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
+    public void Activate_PendingDeactivation_CancelsSleepWithoutTransitionHooks()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(500));
+
+        fixture.Scheduler.Deactivate(mobile.Id);
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Empty(fixture.Runtime.Invocations);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(499));
+        fixture.Scheduler.Tick();
+        Assert.Empty(fixture.Runtime.Invocations);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(
+            [NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+    }
+
+    [Fact]
     public void SleepWake_Cycle_PreservesBindingAndRuntimeState()
     {
         var fixture = new SchedulerFixture();
@@ -295,6 +325,64 @@ public class NpcBrainSchedulerTests
         fixture.Scheduler.Tick();
         Assert.Equal(3, fixture.Runtime.Invocations.Count);
         Assert.Equal(4, fixture.Metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
+    public void EnqueueEvent_CoalescedAndDroppedFlood_KeepsScheduleQueueBounded()
+    {
+        var fixture = new SchedulerFixture(maxEventsPerWake: 2, maxMailboxEvents: 2);
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x2)
+        );
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x2)
+        );
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.Attacked,
+            Event(NpcBrainEventType.Attacked, 0x3)
+        );
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x4)
+        );
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x5)
+        );
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x6)
+        );
+
+        Assert.Equal(1, fixture.Metrics.Current.EventsCoalesced);
+        Assert.Equal(3, fixture.Metrics.Current.EventsDropped);
+        Assert.InRange(ScheduleQueueCount(fixture.Scheduler), 1, 2);
+
+        fixture.Scheduler.Tick();
+
+        for (var index = 0; index < 32; index++)
+        {
+            fixture.Scheduler.EnqueueEvent(
+                mobile.Id,
+                NpcBrainHookType.MobileMoved,
+                Event(NpcBrainEventType.MobileMoved, (uint)(0x10 + index))
+            );
+            fixture.Scheduler.Tick();
+        }
+
+        Assert.InRange(ScheduleQueueCount(fixture.Scheduler), 1, 10);
     }
 
     [Fact]
@@ -657,6 +745,20 @@ public class NpcBrainSchedulerTests
         return entries.Count;
     }
 
+    private static int ScheduleQueueCount(NpcBrainScheduler scheduler)
+    {
+        var field = typeof(NpcBrainScheduler).GetField(
+            "_queue",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
+        ) ?? throw new InvalidOperationException("Scheduler queue was not found.");
+        var queue = field.GetValue(scheduler) ??
+                    throw new InvalidOperationException("Scheduler queue was not initialized.");
+        var count = queue.GetType().GetProperty("Count") ??
+                    throw new InvalidOperationException("Scheduler queue count was not found.");
+
+        return Assert.IsType<int>(count.GetValue(queue));
+    }
+
     private static IReadOnlyList<LogEvent> SchedulerWarnings(GlobalSerilogCapture logs)
         => logs.Events
             .Where(logEvent =>
@@ -710,6 +812,7 @@ public class NpcBrainSchedulerTests
         public SchedulerFixture(
             int maxBrainsPerLoop = 100,
             int maxEventsPerWake = 16,
+            int? maxMailboxEvents = null,
             int minTickMilliseconds = 100,
             int maxTickMilliseconds = 60_000
         )
@@ -726,7 +829,7 @@ public class NpcBrainSchedulerTests
                         MaxTickMilliseconds = maxTickMilliseconds,
                         MaxBrainsPerLoop = maxBrainsPerLoop,
                         MaxEventsPerBrainWake = maxEventsPerWake,
-                        MaxMailboxEvents = Math.Max(16, maxEventsPerWake)
+                        MaxMailboxEvents = maxMailboxEvents ?? Math.Max(16, maxEventsPerWake)
                     }
                 }
             };

--- a/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
@@ -10,9 +10,11 @@ using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.AI;
 using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
+using Serilog.Events;
 
 namespace Moongate.Tests.Server.AI;
 
+[Collection(GlobalSerilogCollection.Name)]
 public class NpcBrainSchedulerTests
 {
     [Fact]
@@ -51,6 +53,26 @@ public class NpcBrainSchedulerTests
         Assert.Equal(1, fixture.Metrics.Current.ActiveBrains);
         Assert.Equal(2, fixture.Metrics.Current.HookInvocations);
         Assert.Equal(1, fixture.Metrics.Current.BrainsExecuted);
+    }
+
+    [Fact]
+    public void Tick_HookInvocation_UsesInjectedTimeProviderForDurationMetrics()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, _, _, _) =>
+        {
+            fixture.Time.Advance(TimeSpan.FromMilliseconds(25));
+            return NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        };
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(TimeSpan.FromMilliseconds(50).Ticks, fixture.Metrics.Current.TotalHookDurationTicks);
+        Assert.Equal(TimeSpan.FromMilliseconds(25).Ticks, fixture.Metrics.Current.MaxHookDurationTicks);
+        Assert.Equal(TimeSpan.FromMilliseconds(25), fixture.Metrics.Current.AverageHookDuration);
     }
 
     [Fact]
@@ -196,6 +218,29 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
+    public void Bind_RepeatedAfterUnavailableBrainChange_DoesNotRestoreOldDescriptorRangesOrRuntime()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        mobile.BrainScriptId = "missing";
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Bind(mobile);
+
+        Assert.False(fixture.Scheduler.TryGetDescriptor(mobile.Id, out _));
+        Assert.Equal(0, fixture.Scheduler.MaxPerceptionRange);
+        Assert.Equal(0, fixture.Scheduler.MaxHearingRange);
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+
+        Assert.Empty(fixture.Runtime.Invocations);
+    }
+
+    [Fact]
     public void Unbind_BoundBrain_RemovesSchedulerAndRuntimeState()
     {
         var fixture = new SchedulerFixture();
@@ -334,6 +379,107 @@ public class NpcBrainSchedulerTests
         Assert.Equal(5, fixture.ThinkCount(mobile.Id));
         Assert.Equal([mobile.Id], fixture.Runtime.ResetCalls);
         Assert.Empty(fixture.Intents.Executions);
+    }
+
+    [Fact]
+    public void Tick_IdenticalFaults_LogsOneSchedulerWarningPerMinute()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think
+                ? NpcBrainInvocationResult.Failed("think failed")
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(5));
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(30));
+        fixture.Scheduler.Tick();
+
+        Assert.Single(SchedulerWarnings(logs));
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(60));
+        fixture.Scheduler.Tick();
+
+        var warnings = SchedulerWarnings(logs);
+        Assert.Equal(2, warnings.Count);
+        var warning = warnings[0];
+        Assert.Equal("guard", Assert.IsType<ScalarValue>(warning.Properties["BrainId"]).Value);
+        Assert.Equal(mobile.Id.Value, Assert.IsType<ScalarValue>(warning.Properties["MobileId"]).Value);
+        Assert.Equal(NpcBrainHookType.Think, Assert.IsType<ScalarValue>(warning.Properties["Hook"]).Value);
+        Assert.Equal("think failed", Assert.IsType<ScalarValue>(warning.Properties["Error"]).Value);
+    }
+
+    [Fact]
+    public void Unbind_AfterFault_ClearsMobileThrottleEntry()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think
+                ? NpcBrainInvocationResult.Failed("think failed")
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        fixture.Scheduler.Unbind(mobile.Id);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, SchedulerWarnings(logs).Count);
+    }
+
+    [Fact]
+    public void Bind_ChangedBrain_ClearsMobileThrottleEntriesBeforeBrainCanReturn()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors["scout"] = new("scout", 1000, 20, 25);
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think
+                ? NpcBrainInvocationResult.Failed("think failed")
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        mobile.BrainScriptId = "scout";
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        mobile.BrainScriptId = "guard";
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(3, SchedulerWarnings(logs).Count);
+    }
+
+    [Fact]
+    public void Tick_ExpiredFaultThrottleEntry_PrunesEntryWithoutAnotherFailure()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        var failThink = true;
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+            hook == NpcBrainHookType.Think && failThink
+                ? NpcBrainInvocationResult.Failed("think failed")
+                : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        Assert.Equal(1, FaultLogCount(fixture.Scheduler));
+
+        failThink = false;
+        fixture.Time.Advance(TimeSpan.FromSeconds(61));
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(0, FaultLogCount(fixture.Scheduler));
+        Assert.Single(SchedulerWarnings(logs));
     }
 
     [Fact]
@@ -497,6 +643,30 @@ public class NpcBrainSchedulerTests
 
     private static NpcBrainEvent Event(NpcBrainEventType type, uint subject)
         => new(type, Snapshot(subject));
+
+    private static int FaultLogCount(NpcBrainScheduler scheduler)
+    {
+        var field = typeof(NpcBrainScheduler).GetField(
+            "_faultLogs",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
+        ) ?? throw new InvalidOperationException("Scheduler fault throttle storage was not found.");
+        var entries = Assert.IsAssignableFrom<System.Collections.IDictionary>(
+            field.GetValue(scheduler)
+        );
+
+        return entries.Count;
+    }
+
+    private static IReadOnlyList<LogEvent> SchedulerWarnings(GlobalSerilogCapture logs)
+        => logs.Events
+            .Where(logEvent =>
+                logEvent.Level == LogEventLevel.Warning &&
+                logEvent.MessageTemplate.Text.StartsWith(
+                    "NPC brain scheduler fault",
+                    StringComparison.Ordinal
+                )
+            )
+            .ToArray();
 
     private static BrainMobileSnapshot Snapshot(uint serial)
         => new(

--- a/tests/Moongate.Tests/Server/AI/SectorActivityServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/SectorActivityServiceTests.cs
@@ -1,0 +1,189 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Services.AI;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.AI;
+
+public class SectorActivityServiceTests
+{
+    [Fact]
+    public void TrackPlayer_OnePlayer_ActivatesNineSectors()
+    {
+        var (service, bus, metrics, _) = Build();
+
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+
+        Assert.Equal(new(9, 0), service.Current);
+        Assert.Equal(9, bus.Published.OfType<SectorActivatedEvent>().Count());
+        Assert.Equal(9, metrics.Current.ActiveSectors);
+        Assert.Equal(0, metrics.Current.GraceSectors);
+        Assert.True(service.IsActive(0, 9, 9));
+        Assert.True(service.IsActive(0, 10, 10));
+        Assert.True(service.IsActive(0, 11, 11));
+    }
+
+    [Fact]
+    public void TrackPlayer_OverlappingPlayers_IncrementsSharedSectorsWithoutDuplicateActivations()
+    {
+        var (service, bus, _, _) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+
+        service.TrackPlayer(Player(0x2, 0, 11, 10));
+
+        Assert.Equal(new(12, 0), service.Current);
+        Assert.Equal(12, bus.Published.OfType<SectorActivatedEvent>().Count());
+        Assert.True(service.IsActive(0, 10, 9));
+        Assert.True(service.IsActive(0, 11, 11));
+    }
+
+    [Fact]
+    public void MovePlayer_OneSectorEast_ActivatesNewColumnAndReleasesOldColumn()
+    {
+        var (service, bus, _, _) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+
+        service.MovePlayer(new(0x1), 0, 11, 10);
+
+        Assert.Equal(new(9, 3), service.Current);
+        Assert.Equal(12, bus.Published.OfType<SectorActivatedEvent>().Count());
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+        Assert.True(service.IsActive(0, 9, 10));
+        Assert.True(service.IsActive(0, 12, 10));
+    }
+
+    [Fact]
+    public void UntrackPlayer_LastReferenceReleased_EntersGraceAndRemainsActive()
+    {
+        var (service, _, metrics, _) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+
+        service.UntrackPlayer(new(0x1));
+
+        Assert.Equal(new(0, 9), service.Current);
+        Assert.Equal(0, metrics.Current.ActiveSectors);
+        Assert.Equal(9, metrics.Current.GraceSectors);
+        Assert.True(service.IsActive(0, 10, 10));
+    }
+
+    [Fact]
+    public void Tick_BeforeGraceExpires_DoesNotDeactivateSectors()
+    {
+        var (service, bus, _, time) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+        service.UntrackPlayer(new(0x1));
+
+        time.Advance(TimeSpan.FromSeconds(59));
+        service.Tick();
+
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+        Assert.True(service.IsActive(0, 10, 10));
+        Assert.Equal(new(0, 9), service.Current);
+    }
+
+    [Fact]
+    public void Tick_AtGraceExpiry_DeactivatesEachExpiredSectorOnce()
+    {
+        var (service, bus, _, time) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+        service.UntrackPlayer(new(0x1));
+
+        time.Advance(TimeSpan.FromSeconds(60));
+        service.Tick();
+
+        Assert.Equal(9, bus.Published.OfType<SectorDeactivatedEvent>().Count());
+        Assert.False(service.IsActive(0, 10, 10));
+        Assert.Equal(new(0, 0), service.Current);
+
+        service.Tick();
+        Assert.Equal(9, bus.Published.OfType<SectorDeactivatedEvent>().Count());
+    }
+
+    [Fact]
+    public void TrackPlayer_DuringGrace_CancelsDeactivation()
+    {
+        var (service, bus, _, time) = Build();
+        var player = Player(0x1, 0, 10, 10);
+        service.TrackPlayer(player);
+        service.UntrackPlayer(player.Id);
+
+        time.Advance(TimeSpan.FromSeconds(30));
+        service.TrackPlayer(player);
+        time.Advance(TimeSpan.FromSeconds(60));
+        service.Tick();
+
+        Assert.Equal(new(9, 0), service.Current);
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+        Assert.True(service.IsActive(0, 10, 10));
+    }
+
+    [Fact]
+    public void UntrackPlayer_Twice_IsIdempotent()
+    {
+        var (service, bus, _, _) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+
+        service.UntrackPlayer(new(0x1));
+        service.UntrackPlayer(new(0x1));
+
+        Assert.Equal(new(0, 9), service.Current);
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+    }
+
+    [Fact]
+    public void TrackPlayer_OnAnotherMap_ReleasesOldCoverageAndActivatesNewCoverage()
+    {
+        var (service, bus, _, _) = Build();
+        var player = Player(0x1, 0, 10, 10);
+        service.TrackPlayer(player);
+
+        service.TrackPlayer(Player(player.Id, 1, 20, 20));
+
+        Assert.Equal(new(9, 9), service.Current);
+        Assert.Equal(18, bus.Published.OfType<SectorActivatedEvent>().Count());
+        Assert.True(service.IsActive(0, 10, 10));
+        Assert.True(service.IsActive(1, 20, 20));
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistersOneGraceTimer_AndStopAsyncCancelsIt()
+    {
+        var (service, _, _, _) = Build();
+        var loop = new StubGameLoopContext();
+        service = Create(loop, new StubEventBus(), new NpcAiMetrics(), MutableTimeProvider.StartingNow());
+
+        await service.StartAsync();
+
+        Assert.True(loop.Repeating.ContainsKey("npc-sector-activity"));
+        Assert.Equal(TimeSpan.FromMilliseconds(100), loop.RepeatingInterval);
+        Assert.Null(loop.RepeatingDelay);
+
+        await service.StopAsync();
+
+        Assert.False(loop.Repeating.ContainsKey("npc-sector-activity"));
+    }
+
+    private static (SectorActivityService Service, StubEventBus Bus, NpcAiMetrics Metrics, MutableTimeProvider Time) Build()
+    {
+        var bus = new StubEventBus();
+        var metrics = new NpcAiMetrics();
+        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var service = Create(new StubGameLoopContext(), bus, metrics, time);
+
+        return (service, bus, metrics, time);
+    }
+
+    private static SectorActivityService Create(
+        StubGameLoopContext loop,
+        StubEventBus bus,
+        NpcAiMetrics metrics,
+        MutableTimeProvider time
+    )
+        => new(loop, bus, time, new MoongateConfig(), metrics);
+
+    private static MobileEntity Player(uint serial, int mapId, int sectorX, int sectorY)
+        => new() { Id = new(serial), MapId = mapId, Position = new Point3D(sectorX << 4, sectorY << 4, 0) };
+}

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -776,7 +776,7 @@ public class LoginFlowIntegrationTests
                 opl,
                 sessions
             );
-            var movement = new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System);
+            var movement = new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System, eventBus);
 
             // CharacterServiceFixture.Create wires its own MobileFactoryService, whose starting-city
             // lookup is independent of the city StartServerWithMovementAsync registers for the

--- a/tests/Moongate.Tests/Server/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/MobileModuleTests.cs
@@ -1,5 +1,7 @@
+using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Scripting;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
@@ -29,9 +31,24 @@ public class MobileModuleTests
     }
 
     [Fact]
+    public void Create_PublishesCreatedEventAndIndexesMobile()
+    {
+        var (module, persistence, spatial, bus) = BuildWithObserved();
+
+        var serial = module.Create("Guard", 1, 100, 200, 5);
+
+        Assert.NotNull(serial);
+        var stored = persistence.Store<MobileEntity>().GetById((Serial)serial!.Value)!;
+        var created = Assert.Single(bus.Published.OfType<MobileCreatedEvent>());
+        Assert.Equal(stored.Id, created.Mobile.Id);
+        Assert.Equal(stored.Position, created.Mobile.Position);
+        Assert.Single(spatial.GetMobilesInSector(1, 6, 12));
+    }
+
+    [Fact]
     public void CreateFromTemplate_PersistsMobileAndEquipsItems()
     {
-        var (module, persistence, templates) = BuildWithTemplates();
+        var (module, persistence, templates, _, bus) = BuildWithTemplates();
         templates.Register(
             new()
             {
@@ -52,6 +69,9 @@ public class MobileModuleTests
         Assert.Equal(400, mobile.Body);
         Assert.Equal(900, mobile.Skills[40].Value);
         Assert.Equal(mobile.EquippedItemIds[LayerType.InnerTorso], Assert.Single(mobile.EquippedItemIds).Value);
+
+        var created = Assert.Single(bus.Published.OfType<MobileCreatedEvent>());
+        Assert.Equal(mobile.EquippedItemIds, created.Mobile.EquippedItemIds);
     }
 
     [Fact]
@@ -69,6 +89,21 @@ public class MobileModuleTests
 
         Assert.True(module.Delete(serial));
         Assert.Null(persistence.Store<MobileEntity>().GetById((Serial)serial));
+    }
+
+    [Fact]
+    public void Delete_PublishesDeletedEventAndRemovesMobileFromSpatialIndex()
+    {
+        var (module, persistence, spatial, bus) = BuildWithObserved();
+        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
+
+        Assert.True(module.Delete(serial));
+
+        var deleted = Assert.Single(bus.Published.OfType<MobileDeletedEvent>());
+        Assert.Equal((Serial)serial, deleted.Mobile.Id);
+        Assert.Equal(new(100, 200, 5), deleted.Mobile.Position);
+        Assert.Null(persistence.Store<MobileEntity>().GetById((Serial)serial));
+        Assert.Empty(spatial.GetMobilesInSector(1, 6, 12));
     }
 
     [Fact]
@@ -104,6 +139,53 @@ public class MobileModuleTests
         Assert.Equal(10, m.Position.X);
         Assert.Equal(20, m.Position.Y);
         Assert.Equal(1, m.MapId);
+    }
+
+    [Fact]
+    public void Move_PublishesMovedEventAndRelocatesMobileInSpatialIndex()
+    {
+        var (module, persistence, spatial, bus) = BuildWithObserved();
+        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
+
+        Assert.True(module.Move(serial, 10, 20, 0));
+
+        var moved = Assert.Single(bus.Published.OfType<MobileMovedEvent>());
+        Assert.Equal((Serial)serial, moved.Mobile);
+        Assert.Equal((1, new Point3D(100, 200, 5)), (moved.FromMapId, moved.FromPosition));
+        Assert.Equal((1, new Point3D(10, 20, 0)), (moved.ToMapId, moved.ToPosition));
+        Assert.Empty(spatial.GetMobilesInSector(1, 6, 12));
+        Assert.Single(spatial.GetMobilesInSector(1, 0, 1));
+        Assert.Equal((Serial)serial, persistence.Store<MobileEntity>().GetById((Serial)serial)!.Id);
+    }
+
+    [Fact]
+    public void Move_UnchangedPosition_ReindexesWithoutPublishingMovedEvent()
+    {
+        var (module, _, spatial, bus) = BuildWithObserved();
+        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
+        spatial.Remove((Serial)serial);
+
+        Assert.True(module.Move(serial, 100, 200, 5));
+
+        Assert.Single(spatial.GetMobilesInSector(1, 6, 12));
+        Assert.Empty(bus.Published.OfType<MobileMovedEvent>());
+    }
+
+    [Fact]
+    public void Set_MapChange_PublishesMovedEventAndRelocatesMobileInSpatialIndex()
+    {
+        var (module, _, spatial, bus) = BuildWithObserved();
+        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
+        var fields = new Table(new());
+        fields["map"] = 2;
+
+        Assert.True(module.Set(serial, fields));
+
+        var moved = Assert.Single(bus.Published.OfType<MobileMovedEvent>());
+        Assert.Equal((1, new Point3D(100, 200, 5)), (moved.FromMapId, moved.FromPosition));
+        Assert.Equal((2, new Point3D(100, 200, 5)), (moved.ToMapId, moved.ToPosition));
+        Assert.Empty(spatial.GetMobilesInSector(1, 6, 12));
+        Assert.Single(spatial.GetMobilesInSector(2, 6, 12));
     }
 
     [Fact]
@@ -206,12 +288,23 @@ public class MobileModuleTests
     }
 
     private static (MobileModule Module, FakePersistenceService Persistence) Build()
-        => BuildWith(new());
+    {
+        var (module, persistence, _, _) = BuildWith(new());
 
-    private static (MobileModule Module, FakePersistenceService Persistence) BuildWith(MobileTemplateService mobileTemplates)
+        return (module, persistence);
+    }
+
+    private static (
+        MobileModule Module,
+        FakePersistenceService Persistence,
+        SpatialIndexService Spatial,
+        StubEventBus Bus
+    ) BuildWith(MobileTemplateService mobileTemplates)
     {
         var persistence = new FakePersistenceService();
         var random = new Random(1);
+        var bus = new StubEventBus();
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), bus);
 
         var itemTemplates = new ItemTemplateService();
         itemTemplates.Register(new() { Id = "plate_chest", Name = "Plate Chest", Category = "Armor", ItemId = 5141 });
@@ -220,15 +313,25 @@ public class MobileModuleTests
         var itemFactory = new ItemFactoryService(itemTemplates, random);
         var items = new ItemService(persistence);
 
-        return (new(factory, itemFactory, items, persistence), persistence);
+        return (new(factory, itemFactory, items, persistence, spatial, bus), persistence, spatial, bus);
     }
 
-    private static (MobileModule Module, FakePersistenceService Persistence, MobileTemplateService Templates)
+    private static (MobileModule Module, FakePersistenceService Persistence, SpatialIndexService Spatial, StubEventBus Bus)
+        BuildWithObserved()
+        => BuildWith(new());
+
+    private static (
+        MobileModule Module,
+        FakePersistenceService Persistence,
+        MobileTemplateService Templates,
+        SpatialIndexService Spatial,
+        StubEventBus Bus
+    )
         BuildWithTemplates()
     {
         var templates = new MobileTemplateService();
-        var (module, persistence) = BuildWith(templates);
+        var (module, persistence, spatial, bus) = BuildWith(templates);
 
-        return (module, persistence, templates);
+        return (module, persistence, templates, spatial, bus);
     }
 }

--- a/tests/Moongate.Tests/Server/MoongateConfigTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateConfigTests.cs
@@ -1,4 +1,5 @@
 using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Services.AI;
 
 namespace Moongate.Tests.Server;
 
@@ -13,5 +14,53 @@ public class MoongateConfigTests
         Assert.Equal(2593, config.Network.Port);
         Assert.Equal("127.0.0.1", config.Network.PublicAddress);
         Assert.False(string.IsNullOrEmpty(config.ShardName));
+    }
+
+    [Fact]
+    public void Defaults_IncludeSafeNpcAiLimits()
+    {
+        var advanced = new MoongateConfig().NpcAi.Advanced;
+
+        Assert.Equal(60, advanced.SectorIdleGraceSeconds);
+        Assert.Equal(100, advanced.MinTickMilliseconds);
+        Assert.Equal(60_000, advanced.MaxTickMilliseconds);
+        Assert.Equal(100, advanced.MaxBrainsPerLoop);
+        Assert.Equal(16, advanced.MaxEventsPerBrainWake);
+        Assert.Equal(64, advanced.MaxMailboxEvents);
+        Assert.Equal(8, advanced.MaxIntentsPerDecision);
+        Assert.Equal(50_000, advanced.InstructionBudget);
+    }
+
+    [Fact]
+    public void Validate_NonPositiveLimit_ThrowsWithPropertyName()
+    {
+        var config = new NpcAiConfig();
+        config.Advanced.MaxBrainsPerLoop = 0;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => NpcAiConfigValidator.Validate(config));
+
+        Assert.Contains(nameof(NpcAiAdvancedConfig.MaxBrainsPerLoop), exception.Message);
+    }
+
+    [Fact]
+    public void Validate_MinTickExceedsMaxTick_ThrowsWithPropertyName()
+    {
+        var config = new NpcAiConfig();
+        config.Advanced.MinTickMilliseconds = config.Advanced.MaxTickMilliseconds + 1;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => NpcAiConfigValidator.Validate(config));
+
+        Assert.Contains(nameof(NpcAiAdvancedConfig.MinTickMilliseconds), exception.Message);
+    }
+
+    [Fact]
+    public void Validate_MailboxSmallerThanWakeBudget_ThrowsWithPropertyName()
+    {
+        var config = new NpcAiConfig();
+        config.Advanced.MaxMailboxEvents = config.Advanced.MaxEventsPerBrainWake - 1;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => NpcAiConfigValidator.Validate(config));
+
+        Assert.Contains(nameof(NpcAiAdvancedConfig.MaxMailboxEvents), exception.Message);
     }
 }

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -1,0 +1,105 @@
+using DryIoc;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Scripting;
+using Moongate.Scripting.AI;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Plugins;
+using Moongate.Server.Services.AI;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+using SquidStd.Core.Data.Bootstrap;
+using SquidStd.Core.Directories;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Plugin.Abstractions.Data;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Tests.Server;
+
+public sealed class MoongateNpcAiPluginTests
+{
+    [Fact]
+    public void Configure_RegistersAiServicesAndSubscribers()
+    {
+        var container = new Container();
+
+        new MoongateNpcAiPlugin().Configure(container, new PluginContext());
+
+        Assert.IsType<NpcAiMetrics>(container.Resolve<INpcAiMetrics>());
+        Assert.True(container.IsRegistered<ISectorActivityService>());
+        Assert.True(container.IsRegistered<IBrainIntentExecutor>());
+        Assert.True(container.IsRegistered<NpcBrainContextFactory>());
+        Assert.True(container.IsRegistered<INpcBrainScheduler>());
+        var subscribers = container.GetServiceRegistrations()
+            .Where(registration => registration.ServiceType == typeof(IEventSubscriberRegistration))
+            .Select(registration => registration.ImplementationType)
+            .ToArray();
+        Assert.Equal(
+            [typeof(SectorActivitySubscriber), typeof(NpcBrainLifecycleSubscriber), typeof(NpcBrainEventRouter)],
+            subscribers
+        );
+    }
+
+    [Fact]
+    public void Configure_ProductionDependencies_ResolvesBrainRuntimeAndHostedAiServices()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-npc-ai-plugin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "scripts"));
+        var container = new Container();
+        var persistence = new FakePersistenceService();
+        var eventBus = new StubEventBus();
+        var loopAffinity = new StubLoopAffinity();
+        container.RegisterInstance(new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" });
+        container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
+        container.RegisterInstance(new MoongateConfig());
+        container.RegisterInstance<IPersistenceService>(persistence);
+        container.RegisterInstance<IEventBus>(eventBus);
+        container.RegisterInstance<IGameLoopContext>(new StubGameLoopContext());
+        container.RegisterInstance<ILoopAffinity>(loopAffinity);
+        container.RegisterInstance<ISessionManager>(new StubSessionManager());
+        container.RegisterInstance<ISpatialIndexService>(new SpatialIndexService(persistence, loopAffinity, eventBus));
+        container.RegisterInstance<IMovementService>(new StubMovementService());
+        container.RegisterInstance<IChatService>(new StubChatService());
+        container.RegisterInstance(Random.Shared);
+        container.RegisterInstance<TimeProvider>(TimeProvider.System);
+
+        new MoongateScriptingPlugin().Configure(container, new PluginContext());
+        new MoongateNpcAiPlugin().Configure(container, new PluginContext());
+
+        Assert.IsType<LuaNpcBrainRuntime>(container.Resolve<INpcBrainRuntime>());
+        Assert.IsType<SectorActivityService>(container.Resolve<ISectorActivityService>());
+        Assert.IsType<BrainIntentExecutor>(container.Resolve<IBrainIntentExecutor>());
+        Assert.IsType<NpcBrainScheduler>(container.Resolve<INpcBrainScheduler>());
+    }
+
+    private sealed class StubMovementService : IMovementService
+    {
+        public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
+        {
+        }
+
+        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+            => true;
+    }
+
+    private sealed class StubChatService : IChatService
+    {
+        public void Broadcast(string text, Hue? hue = null)
+        {
+        }
+
+        public void Say(Moongate.Persistence.Entities.MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        {
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -31,7 +31,7 @@ public sealed class MoongateNpcAiPluginTests
     [Fact]
     public void Configure_RegistersAiServicesAndSubscribers()
     {
-        var container = new Container();
+        using var container = new Container();
 
         new MoongateNpcAiPlugin().Configure(container, new PluginContext());
 
@@ -54,32 +54,47 @@ public sealed class MoongateNpcAiPluginTests
     public void Configure_ProductionDependencies_ResolvesBrainRuntimeAndHostedAiServices()
     {
         var root = Path.Combine(Path.GetTempPath(), "mg-npc-ai-plugin-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(root, "scripts"));
-        var container = new Container();
-        var persistence = new FakePersistenceService();
-        var eventBus = new StubEventBus();
-        var loopAffinity = new StubLoopAffinity();
-        container.RegisterInstance(new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" });
-        container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
-        container.RegisterInstance(new MoongateConfig());
-        container.RegisterInstance<IPersistenceService>(persistence);
-        container.RegisterInstance<IEventBus>(eventBus);
-        container.RegisterInstance<IGameLoopContext>(new StubGameLoopContext());
-        container.RegisterInstance<ILoopAffinity>(loopAffinity);
-        container.RegisterInstance<ISessionManager>(new StubSessionManager());
-        container.RegisterInstance<ISpatialIndexService>(new SpatialIndexService(persistence, loopAffinity, eventBus));
-        container.RegisterInstance<IMovementService>(new StubMovementService());
-        container.RegisterInstance<IChatService>(new StubChatService());
-        container.RegisterInstance(Random.Shared);
-        container.RegisterInstance<TimeProvider>(TimeProvider.System);
 
-        new MoongateScriptingPlugin().Configure(container, new PluginContext());
-        new MoongateNpcAiPlugin().Configure(container, new PluginContext());
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "scripts"));
+            using var container = new Container();
+            var persistence = new FakePersistenceService();
+            var eventBus = new StubEventBus();
+            var loopAffinity = new StubLoopAffinity();
+            container.RegisterInstance(
+                new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" }
+            );
+            container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
+            container.RegisterInstance(new MoongateConfig());
+            container.RegisterInstance<IPersistenceService>(persistence);
+            container.RegisterInstance<IEventBus>(eventBus);
+            container.RegisterInstance<IGameLoopContext>(new StubGameLoopContext());
+            container.RegisterInstance<ILoopAffinity>(loopAffinity);
+            container.RegisterInstance<ISessionManager>(new StubSessionManager());
+            container.RegisterInstance<ISpatialIndexService>(
+                new SpatialIndexService(persistence, loopAffinity, eventBus)
+            );
+            container.RegisterInstance<IMovementService>(new StubMovementService());
+            container.RegisterInstance<IChatService>(new StubChatService());
+            container.RegisterInstance(Random.Shared);
+            container.RegisterInstance<TimeProvider>(TimeProvider.System);
 
-        Assert.IsType<LuaNpcBrainRuntime>(container.Resolve<INpcBrainRuntime>());
-        Assert.IsType<SectorActivityService>(container.Resolve<ISectorActivityService>());
-        Assert.IsType<BrainIntentExecutor>(container.Resolve<IBrainIntentExecutor>());
-        Assert.IsType<NpcBrainScheduler>(container.Resolve<INpcBrainScheduler>());
+            new MoongateScriptingPlugin().Configure(container, new PluginContext());
+            new MoongateNpcAiPlugin().Configure(container, new PluginContext());
+
+            Assert.IsType<LuaNpcBrainRuntime>(container.Resolve<INpcBrainRuntime>());
+            Assert.IsType<SectorActivityService>(container.Resolve<ISectorActivityService>());
+            Assert.IsType<BrainIntentExecutor>(container.Resolve<IBrainIntentExecutor>());
+            Assert.IsType<NpcBrainScheduler>(container.Resolve<INpcBrainScheduler>());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
     }
 
     private sealed class StubMovementService : IMovementService

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -90,10 +90,7 @@ public sealed class MoongateNpcAiPluginTests
         }
         finally
         {
-            if (Directory.Exists(root))
-            {
-                Directory.Delete(root, true);
-            }
+            TestDirectoryCleanup.TryDelete(root);
         }
     }
 

--- a/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
@@ -2,6 +2,7 @@ using DryIoc;
 using Moongate.Scripting;
 using Moongate.Scripting.AI;
 using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Tests.Support;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Directories;
 using SquidStd.Plugin.Abstractions.Data;
@@ -36,10 +37,7 @@ public sealed class MoongateScriptingPluginTests
         }
         finally
         {
-            if (Directory.Exists(root))
-            {
-                Directory.Delete(root, true);
-            }
+            TestDirectoryCleanup.TryDelete(root);
         }
     }
 }

--- a/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
@@ -1,0 +1,32 @@
+using DryIoc;
+using Moongate.Scripting;
+using Moongate.Scripting.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using SquidStd.Core.Data.Bootstrap;
+using SquidStd.Core.Directories;
+using SquidStd.Plugin.Abstractions.Data;
+
+namespace Moongate.Tests.Server.Scripting;
+
+public sealed class MoongateScriptingPluginTests
+{
+    [Fact]
+    public void Configure_RegistersLuaNpcBrainRuntime()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-scripting-plugin-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "scripts"));
+        var container = new Container();
+        container.RegisterInstance(new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" });
+        container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
+
+        new MoongateScriptingPlugin().Configure(container, new PluginContext());
+
+        Assert.True(container.IsRegistered<INpcBrainRuntime>());
+        Assert.Equal(
+            typeof(LuaNpcBrainRuntime),
+            container.GetServiceRegistrations()
+                .Single(registration => registration.ServiceType == typeof(INpcBrainRuntime))
+                .ImplementationType
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
@@ -14,19 +14,32 @@ public sealed class MoongateScriptingPluginTests
     public void Configure_RegistersLuaNpcBrainRuntime()
     {
         var root = Path.Combine(Path.GetTempPath(), "mg-scripting-plugin-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(root, "scripts"));
-        var container = new Container();
-        container.RegisterInstance(new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" });
-        container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
 
-        new MoongateScriptingPlugin().Configure(container, new PluginContext());
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "scripts"));
+            using var container = new Container();
+            container.RegisterInstance(
+                new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" }
+            );
+            container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
 
-        Assert.True(container.IsRegistered<INpcBrainRuntime>());
-        Assert.Equal(
-            typeof(LuaNpcBrainRuntime),
-            container.GetServiceRegistrations()
-                .Single(registration => registration.ServiceType == typeof(INpcBrainRuntime))
-                .ImplementationType
-        );
+            new MoongateScriptingPlugin().Configure(container, new PluginContext());
+
+            Assert.True(container.IsRegistered<INpcBrainRuntime>());
+            Assert.Equal(
+                typeof(LuaNpcBrainRuntime),
+                container.GetServiceRegistrations()
+                    .Single(registration => registration.ServiceType == typeof(INpcBrainRuntime))
+                    .ImplementationType
+            );
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
     }
 }

--- a/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
@@ -1,5 +1,12 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
 using Moongate.Core.Types;
+using Moongate.Network.Interfaces;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
 using Moongate.Ultima.Io;
@@ -195,6 +202,46 @@ public class MovementServiceTests
         Assert.False(decision.Accepted);
     }
 
+    [Fact]
+    public void TryMoveNpc_BrainMobile_StepsAndPublishesMovedEvent()
+    {
+        var (service, persistence, spatial, bus) = BuildMovementService();
+        var mobile = Mobile();
+        mobile.BrainScriptId = "guard";
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+        spatial.AddOrUpdate(mobile);
+
+        Assert.True(service.TryMoveNpc(mobile.Id, DirectionType.East));
+
+        var stored = persistence.Store<MobileEntity>().GetById(mobile.Id)!;
+        Assert.Equal(new Point3D(2, 1, 0), stored.Position);
+        var moved = Assert.Single(bus.Published.OfType<MobileMovedEvent>());
+        Assert.Equal(mobile.Id, moved.Mobile);
+        Assert.Equal((0, new Point3D(1, 1, 0)), (moved.FromMapId, moved.FromPosition));
+        Assert.Equal((0, new Point3D(2, 1, 0)), (moved.ToMapId, moved.ToPosition));
+    }
+
+    [Fact]
+    public void TryMoveNpc_MissingMobile_ReturnsFalse()
+    {
+        var (service, _, _, bus) = BuildMovementService();
+
+        Assert.False(service.TryMoveNpc(new(0xDEAD), DirectionType.East));
+        Assert.Empty(bus.Published.OfType<MobileMovedEvent>());
+    }
+
+    [Fact]
+    public void TryMoveNpc_MobileWithoutBrain_ReturnsFalse()
+    {
+        var (service, persistence, spatial, bus) = BuildMovementService();
+        var mobile = Mobile();
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+        spatial.AddOrUpdate(mobile);
+
+        Assert.False(service.TryMoveNpc(mobile.Id, DirectionType.East));
+        Assert.Empty(bus.Published.OfType<MobileMovedEvent>());
+    }
+
     private static (MapTileService MapTiles, RegionService Regions) Build(bool withWall = false)
     {
         var tileData = UltimaFixtures.BuildTileData();
@@ -220,6 +267,41 @@ public class MovementServiceTests
         return (new(provider), new());
     }
 
+    private static (
+        MovementService Service,
+        FakePersistenceService Persistence,
+        SpatialIndexService Spatial,
+        StubEventBus Bus
+    ) BuildMovementService()
+    {
+        var (mapTiles, regions) = Build();
+        var persistence = new FakePersistenceService();
+        var bus = new StubEventBus();
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), bus);
+        var world = new StubWorldService();
+
+        return (new(mapTiles, regions, spatial, world, persistence, TimeProvider.System, bus, new StubLoopAffinity()), persistence, spatial, bus);
+    }
+
     private static MobileEntity Mobile(int x = 1, int y = 1, int z = 0, DirectionType direction = DirectionType.East)
         => new() { Id = new(0x1), MapId = 0, Position = new(x, y, z), Direction = direction };
+
+    private sealed class StubWorldService : IWorldService
+    {
+        public int Broadcast<TPacket>(TPacket packet) where TPacket : IOutgoingPacket
+            => 0;
+
+        public void SendEnterWorld(PlayerSession session, MobileEntity mobile)
+        {
+        }
+
+        public int SendToPlayersInRange<TPacket>(
+            int mapId,
+            Point3D center,
+            int range,
+            TPacket packet,
+            Serial? exclude = null
+        ) where TPacket : IOutgoingPacket
+            => 0;
+    }
 }

--- a/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.World;
@@ -79,6 +80,19 @@ public class SpatialIndexServiceTests
         index.AddOrUpdate(SeedMobile(persistence, 0x1, 0, 100, 100));
 
         Assert.Empty(index.GetMobilesInRange(0, new(300, 300, 0), 18));
+    }
+
+    [Fact]
+    public void GetMobilesInSector_ExactSector_ReturnsOnlyMobilesOnRequestedMap()
+    {
+        var (index, persistence) = Build();
+        index.AddOrUpdate(SeedMobile(persistence, 0x1, 0, 100, 100));
+
+        var sectorSix = index.GetMobilesInSector(0, 6, 6);
+
+        Assert.Single(sectorSix);
+        Assert.Equal(new Serial(0x1), sectorSix[0].Id);
+        Assert.Empty(index.GetMobilesInSector(1, 6, 6));
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Support/GlobalSerilogCapture.cs
+++ b/tests/Moongate.Tests/Support/GlobalSerilogCapture.cs
@@ -1,0 +1,68 @@
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Captures events from components that create contextual loggers from <see cref="Log.Logger" />.</summary>
+public sealed class GlobalSerilogCapture : IDisposable
+{
+    private readonly CaptureSink _sink = new();
+    private readonly ILogger _logger;
+    private readonly ILogger _previous;
+
+    private bool _disposed;
+
+    public IReadOnlyList<LogEvent> Events => _sink.Events;
+
+    public GlobalSerilogCapture()
+    {
+        _previous = Log.Logger;
+        _logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(_sink)
+            .CreateLogger();
+        Log.Logger = _logger;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Log.Logger = _previous;
+        if (_logger is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    private sealed class CaptureSink : ILogEventSink
+    {
+        private readonly Lock _sync = new();
+        private readonly List<LogEvent> _events = [];
+
+        public IReadOnlyList<LogEvent> Events
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _events.ToArray();
+                }
+            }
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            lock (_sync)
+            {
+                _events.Add(logEvent);
+            }
+        }
+    }
+}

--- a/tests/Moongate.Tests/Support/GlobalSerilogCollection.cs
+++ b/tests/Moongate.Tests/Support/GlobalSerilogCollection.cs
@@ -1,0 +1,7 @@
+namespace Moongate.Tests.Support;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class GlobalSerilogCollection
+{
+    public const string Name = "GlobalSerilog";
+}

--- a/tests/Moongate.Tests/Support/MutableTimeProvider.cs
+++ b/tests/Moongate.Tests/Support/MutableTimeProvider.cs
@@ -10,6 +10,7 @@ public sealed class MutableTimeProvider : TimeProvider
     private readonly List<MutableTimer> _timers = [];
 
     private DateTimeOffset _now;
+    private long _timestamp;
 
     public MutableTimeProvider(DateTimeOffset now)
     {
@@ -42,15 +43,25 @@ public sealed class MutableTimeProvider : TimeProvider
         {
             lock (_sync)
             {
-                _now = value;
+                SetNow(value);
             }
         }
     }
 
     public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
 
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
     public override DateTimeOffset GetUtcNow()
         => Now;
+
+    public override long GetTimestamp()
+    {
+        lock (_sync)
+        {
+            return _timestamp;
+        }
+    }
 
     public override ITimer CreateTimer(
         TimerCallback callback,
@@ -88,16 +99,22 @@ public sealed class MutableTimeProvider : TimeProvider
 
                 if (timer is null)
                 {
-                    _now = target;
+                    SetNow(target);
                     return;
                 }
 
-                _now = timer.NextDue!.Value;
+                SetNow(timer.NextDue!.Value);
                 timer.PrepareCallback();
             }
 
             timer.InvokeCallback();
         }
+    }
+
+    private void SetNow(DateTimeOffset value)
+    {
+        _timestamp += (value - _now).Ticks;
+        _now = value;
     }
 
     private static void ValidateTimerDuration(TimeSpan value, string parameterName)

--- a/tests/Moongate.Tests/Support/MutableTimeProvider.cs
+++ b/tests/Moongate.Tests/Support/MutableTimeProvider.cs
@@ -6,9 +6,14 @@ namespace Moongate.Tests.Support;
 /// </summary>
 public sealed class MutableTimeProvider : TimeProvider
 {
+    private readonly object _sync = new();
+    private readonly List<MutableTimer> _timers = [];
+
+    private DateTimeOffset _now;
+
     public MutableTimeProvider(DateTimeOffset now)
     {
-        Now = now;
+        _now = now;
     }
 
     /// <summary>
@@ -24,13 +29,160 @@ public sealed class MutableTimeProvider : TimeProvider
     public static MutableTimeProvider StartingNow()
         => new(DateTimeOffset.UtcNow);
 
-    public DateTimeOffset Now { get; set; }
+    public DateTimeOffset Now
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _now;
+            }
+        }
+        set
+        {
+            lock (_sync)
+            {
+                _now = value;
+            }
+        }
+    }
 
     public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
 
     public override DateTimeOffset GetUtcNow()
         => Now;
 
+    public override ITimer CreateTimer(
+        TimerCallback callback,
+        object? state,
+        TimeSpan dueTime,
+        TimeSpan period
+    )
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        var timer = new MutableTimer(this, callback, state);
+
+        lock (_sync)
+        {
+            _timers.Add(timer);
+            ChangeTimer(timer, dueTime, period);
+        }
+
+        return timer;
+    }
+
     public void Advance(TimeSpan delta)
-        => Now += delta;
+    {
+        var target = Now + delta;
+
+        while (true)
+        {
+            MutableTimer? timer;
+
+            lock (_sync)
+            {
+                timer = _timers
+                    .Where(candidate => candidate.NextDue is { } due && due <= target)
+                    .MinBy(candidate => candidate.NextDue);
+
+                if (timer is null)
+                {
+                    _now = target;
+                    return;
+                }
+
+                _now = timer.NextDue!.Value;
+                timer.PrepareCallback();
+            }
+
+            timer.InvokeCallback();
+        }
+    }
+
+    private static void ValidateTimerDuration(TimeSpan value, string parameterName)
+    {
+        if (value < Timeout.InfiniteTimeSpan || value.TotalMilliseconds > uint.MaxValue - 1)
+        {
+            throw new ArgumentOutOfRangeException(parameterName);
+        }
+    }
+
+    private bool ChangeTimer(MutableTimer timer, TimeSpan dueTime, TimeSpan period)
+    {
+        ValidateTimerDuration(dueTime, nameof(dueTime));
+        ValidateTimerDuration(period, nameof(period));
+
+        lock (_sync)
+        {
+            if (timer.IsDisposed)
+            {
+                return false;
+            }
+
+            timer.Period = period;
+            timer.NextDue = dueTime == Timeout.InfiniteTimeSpan ? null : _now + dueTime;
+
+            return true;
+        }
+    }
+
+    private void DisposeTimer(MutableTimer timer)
+    {
+        lock (_sync)
+        {
+            timer.IsDisposed = true;
+            timer.NextDue = null;
+            _timers.Remove(timer);
+        }
+    }
+
+    private sealed class MutableTimer : ITimer
+    {
+        private readonly TimerCallback _callback;
+        private readonly MutableTimeProvider _owner;
+        private readonly object? _state;
+
+        public bool IsDisposed { get; set; }
+
+        public DateTimeOffset? NextDue { get; set; }
+
+        public TimeSpan Period { get; set; }
+
+        public MutableTimer(MutableTimeProvider owner, TimerCallback callback, object? state)
+        {
+            _callback = callback;
+            _owner = owner;
+            _state = state;
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+            => _owner.ChangeTimer(this, dueTime, period);
+
+        public void InvokeCallback()
+            => _callback(_state);
+
+        public void PrepareCallback()
+        {
+            if (Period > TimeSpan.Zero)
+            {
+                NextDue += Period;
+                return;
+            }
+
+            NextDue = null;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+
+            return ValueTask.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _owner.DisposeTimer(this);
+        }
+    }
 }

--- a/tests/Moongate.Tests/Support/MutableTimeProviderTests.cs
+++ b/tests/Moongate.Tests/Support/MutableTimeProviderTests.cs
@@ -1,0 +1,69 @@
+namespace Moongate.Tests.Support;
+
+public class MutableTimeProviderTests
+{
+    [Fact]
+    public void Advance_OneShotTimer_FiresAtDueTimeOnce()
+    {
+        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var callbackCount = 0;
+        using var timer = time.CreateTimer(
+            _ => callbackCount++,
+            null,
+            TimeSpan.FromMilliseconds(250),
+            Timeout.InfiniteTimeSpan
+        );
+
+        time.Advance(TimeSpan.FromMilliseconds(249));
+        Assert.Equal(0, callbackCount);
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
+        Assert.Equal(1, callbackCount);
+
+        time.Advance(TimeSpan.FromSeconds(1));
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public void Change_PeriodicTimer_UsesReplacementSchedule()
+    {
+        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var callbackCount = 0;
+        using var timer = time.CreateTimer(
+            _ => callbackCount++,
+            null,
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromMilliseconds(20)
+        );
+
+        Assert.True(timer.Change(TimeSpan.FromMilliseconds(200), TimeSpan.FromMilliseconds(75)));
+
+        time.Advance(TimeSpan.FromMilliseconds(199));
+        Assert.Equal(0, callbackCount);
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
+        Assert.Equal(1, callbackCount);
+
+        time.Advance(TimeSpan.FromMilliseconds(225));
+        Assert.Equal(4, callbackCount);
+    }
+
+    [Fact]
+    public void Dispose_PendingTimer_PreventsCallbackAndChange()
+    {
+        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var callbackCount = 0;
+        var timer = time.CreateTimer(
+            _ => callbackCount++,
+            null,
+            TimeSpan.FromMilliseconds(250),
+            Timeout.InfiniteTimeSpan
+        );
+
+        timer.Dispose();
+        time.Advance(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(0, callbackCount);
+        Assert.False(timer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan));
+    }
+}

--- a/tests/Moongate.Tests/Support/MutableTimeProviderTests.cs
+++ b/tests/Moongate.Tests/Support/MutableTimeProviderTests.cs
@@ -3,6 +3,17 @@ namespace Moongate.Tests.Support;
 public class MutableTimeProviderTests
 {
     [Fact]
+    public void GetElapsedTime_AfterAdvance_ReportsDeterministicDuration()
+    {
+        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var started = time.GetTimestamp();
+
+        time.Advance(TimeSpan.FromMilliseconds(25));
+
+        Assert.Equal(TimeSpan.FromMilliseconds(25), time.GetElapsedTime(started));
+    }
+
+    [Fact]
     public void Advance_OneShotTimer_FiresAtDueTimeOnce()
     {
         var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));

--- a/tests/Moongate.Tests/Support/RecordingBrainIntentExecutor.cs
+++ b/tests/Moongate.Tests/Support/RecordingBrainIntentExecutor.cs
@@ -1,0 +1,16 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Records scheduler-to-intent-executor handoffs without applying world mutations.</summary>
+public sealed class RecordingBrainIntentExecutor : IBrainIntentExecutor
+{
+    public List<(Serial MobileId, BrainContext Context, IReadOnlyList<BrainIntent> Intents)> Executions { get; } = [];
+
+    public void Execute(Serial mobileId, BrainContext context, IReadOnlyList<BrainIntent> intents)
+    {
+        Executions.Add((mobileId, context, intents.ToArray()));
+    }
+}

--- a/tests/Moongate.Tests/Support/RecordingChatService.cs
+++ b/tests/Moongate.Tests/Support/RecordingChatService.cs
@@ -1,0 +1,28 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.UO.Data.Hues;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Records chat mutations at the final <see cref="IChatService" /> boundary.</summary>
+public sealed class RecordingChatService : IChatService
+{
+    private readonly List<(string Text, Hue? Hue)> _broadcasts = [];
+    private readonly List<(Serial Speaker, ChatMessageType Type, string Text, Hue Hue, int Range)> _messages = [];
+
+    public IReadOnlyList<(string Text, Hue? Hue)> Broadcasts => _broadcasts;
+
+    public IReadOnlyList<(Serial Speaker, ChatMessageType Type, string Text, Hue Hue, int Range)> Messages => _messages;
+
+    public void Broadcast(string text, Hue? hue = null)
+    {
+        _broadcasts.Add((text, hue));
+    }
+
+    public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+    {
+        _messages.Add((speaker.Id, type, text, hue, range));
+    }
+}

--- a/tests/Moongate.Tests/Support/RecordingNpcBrainRuntime.cs
+++ b/tests/Moongate.Tests/Support/RecordingNpcBrainRuntime.cs
@@ -1,0 +1,97 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Configurable in-memory NPC runtime that records bindings, invocations, resets and removals.</summary>
+public sealed class RecordingNpcBrainRuntime : INpcBrainRuntime
+{
+    public Dictionary<string, BrainDescriptor> Descriptors { get; } = new(StringComparer.Ordinal);
+
+    public Dictionary<Serial, string> Bindings { get; } = [];
+
+    public HashSet<string> BrokenBrainIds { get; } = new(StringComparer.Ordinal);
+
+    public Queue<NpcBrainInvocationResult> Results { get; } = [];
+
+    public List<(Serial MobileId, string BrainId)> BindCalls { get; } = [];
+
+    public List<(Serial MobileId, NpcBrainHookType Hook, BrainContext Context, NpcBrainEvent? Event)> Invocations { get; } = [];
+
+    public List<Serial> ResetCalls { get; } = [];
+
+    public List<Serial> UnbindCalls { get; } = [];
+
+    public Func<Serial, NpcBrainHookType, BrainContext, NpcBrainEvent?, NpcBrainInvocationResult>?
+        InvocationHandler
+    { get; set; }
+
+    public bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error)
+    {
+        BindCalls.Add((mobileId, brainId));
+
+        if (BrokenBrainIds.Contains(brainId) || !Descriptors.TryGetValue(brainId, out descriptor))
+        {
+            descriptor = null;
+            error = $"Brain '{brainId}' is unavailable.";
+            return false;
+        }
+
+        Bindings[mobileId] = brainId;
+        error = null;
+
+        return true;
+    }
+
+    public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+    {
+        descriptor = null;
+
+        return Bindings.TryGetValue(mobileId, out var brainId) &&
+               Descriptors.TryGetValue(brainId, out descriptor);
+    }
+
+    public NpcBrainInvocationResult Invoke(
+        Serial mobileId,
+        NpcBrainHookType hook,
+        BrainContext context,
+        NpcBrainEvent? brainEvent = null
+    )
+    {
+        Invocations.Add((mobileId, hook, context, brainEvent));
+
+        if (InvocationHandler is not null)
+        {
+            return InvocationHandler(mobileId, hook, context, brainEvent);
+        }
+
+        return Results.TryDequeue(out var result)
+            ? result
+            : NpcBrainInvocationResult.Succeeded(BrainDecision.Empty);
+    }
+
+    public bool TryReload(string brainId, out BrainDescriptor? descriptor, out string? error)
+    {
+        if (Descriptors.TryGetValue(brainId, out descriptor))
+        {
+            error = null;
+            return true;
+        }
+
+        error = $"Brain '{brainId}' is unavailable.";
+        return false;
+    }
+
+    public void Reset(Serial mobileId)
+    {
+        ResetCalls.Add(mobileId);
+    }
+
+    public void Unbind(Serial mobileId)
+    {
+        UnbindCalls.Add(mobileId);
+        Bindings.Remove(mobileId);
+    }
+}

--- a/tests/Moongate.Tests/Support/TestDirectoryCleanup.cs
+++ b/tests/Moongate.Tests/Support/TestDirectoryCleanup.cs
@@ -1,0 +1,18 @@
+namespace Moongate.Tests.Support;
+
+internal static class TestDirectoryCleanup
+{
+    public static void TryDelete(string path)
+    {
+        try
+        {
+            Directory.Delete(path, true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a deterministic Lua NPC brain system while keeping all authoritative world mutations in C#.

- introduces neutral AI contracts, configuration, metrics, lifecycle events, and validated intents
- adds player-driven 3×3 sector activation with a configurable 60-second default grace period
- runs shared Lua strategy definitions with isolated per-mobile state and bind-time home context
- adds bounded mailboxes, scheduling, failure backoff, perception/speech/combat routing, and lifecycle wiring
- supports validated last-known-good brain reloads and built-in brain assets
- adds a complete player-speech-to-guard-reply integration flow with state retained across sleep/wake
- documents brain authoring, hooks, payloads, helper return tables, limits, reloads, and sleep behavior

## Why

NPC AI needs deterministic policy that shard authors can extend without allowing scripts to mutate server state directly. The feature places Lua behind a neutral runtime port: Lua returns decisions and intents, while C# validates and executes every mutation.

Player presence activates only the current sector and its eight same-map neighbors. Empty coverage enters grace and then sleeps Lua AI, reducing work without pausing persistence or the rest of the simulation.

## Developer impact

A mobile can bind a brain through `BrainScriptId`; lookup is convention-based at `scripts/brains/<brainId>.lua`. Brain definitions are shared and must remain stateless. All NPC-specific memory belongs in the supplied `state` table.

Brain scripts should be treated as trusted local shard code. The selected shared `IScriptEngineService` / `Script.LoadFile` design intentionally retains the documented concrete-engine coupling and path check/use limitations; write access to `scripts/brains` should remain restricted to trusted administrators.

## Validation

- `dotnet build Moongate.slnx` — passed, 0 errors (18 existing analyzer warnings)
- `dotnet test Moongate.slnx --no-build` — 1,604 passed, 0 failed
- `dotnet docfx docs/docfx.json --warningsAsErrors` — passed, 0 warnings/errors
- final whole-branch review and scoped fix re-review — no remaining Critical or Important findings
- merge-tree check against current `origin/develop` — no conflicts detected

Closes #99