### PR TITLE
feat: add public account registration

### DIFF
--- a/docs/getting-started/notifications.md
+++ b/docs/getting-started/notifications.md
@@ -44,7 +44,7 @@ subject = "Verify your " + shard_name + " account"
 Hello {{ username }},
 
 Confirm your account:
-{{ website }}/verify?token={{ token }}
+{{ verification_url }}
 ```
 
 Channels without a subject simply omit the front matter block.
@@ -65,24 +65,38 @@ a mistyped `htlm` costs you a plain-text mail rather than a lost notification.
 An HTML mail is sent as a single HTML part, not as HTML with a plain-text
 alternative.
 
-Note that the verification URL is composed **here**, not in the server: its
-shape belongs to your website, so changing it costs an edit rather than a
-release.
+Moongate builds `verification_url` from the persisted `Contacts.Website` portal
+base. It preserves the base path, removes trailing `/` characters, appends
+`/verify`, replaces any existing query with the escaped `token` query parameter,
+and removes any fragment. For example, a base ending in
+`/portal/?old=true#section` produces `/portal/verify?token=...`.
 
 ## Available templates
 
 | Template | Raised when | Model |
 |---|---|---|
-| `account_verification` | A web registration creates a pending account | `username`, `email`, `token`, `website`, `shard_name` |
+| `account_verification` | A web registration creates a pending account or rotates its token on resend | `username`, `email`, `token`, `website`, `verification_url`, `shard_name` |
 
-`website` comes from the shard's **Website** contact in the server settings; if
-it is unset the value is empty, and any link built from it will be broken.
+All account-verification fields remain available to custom templates:
+
+| Field | Meaning |
+|---|---|
+| `username` | Pending account username. |
+| `email` | Destination email address. |
+| `token` | Raw single-use token, retained for legacy custom templates. Prefer `verification_url` for links. |
+| `website` | Unmodified `Contacts.Website` portal base, retained for legacy custom templates. |
+| `verification_url` | Canonical, escaped verification URL built by Moongate. |
+| `shard_name` | Shard name from `moongate.ShardName`. |
+
+Public registration is not ready unless `website` is an absolute HTTP(S) URL
+with a host, so newly queued registration messages always receive a usable
+`verification_url`.
 
 ## Channels
 
-`log` writes the rendered notification to the server log. It always works, which
-makes it the channel a shard falls back on before a real transport is set up,
-and it is where the account verification token appears by default.
+`log` writes the rendered notification to the server log. It always works and
+remains useful for notification development, but public registration readiness
+requires account verification to be routed to `email`.
 
 `email` is provided by the SMTP plugin, described below. Addressing a channel
 that is not registered logs a warning and drops the notification.
@@ -101,7 +115,8 @@ name.
 ## Sending email
 
 Email is delivered by `Moongate.Smtp.Plugin`, configured in
-`<root>/plugins/configs/smtp.yaml`:
+`<root>/plugins/configs/smtp.yaml`. The keys below belong under the file's
+top-level `smtp` section:
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
@@ -117,8 +132,9 @@ Email is delivered by `Moongate.Smtp.Plugin`, configured in
 > [!IMPORTANT]
 > **Configuring SMTP is not enough to send verification mail.** Point
 > `notifications.AccountVerificationChannel` in `moongate.yaml` at `email` as
-> well. The server states which channel it will use at startup, and warns when
-> that channel is not registered — check the log if nothing arrives.
+> well, then restart. The server states which channel it will use at startup,
+> and warns when that channel is not registered — check the log if nothing
+> arrives.
 
 > [!WARNING]
 > **`Auto` does not guarantee encryption.** It selects implicit TLS only on port 465; on every other
@@ -152,6 +168,20 @@ The `notifications` section of `moongate.yaml`:
 | `AccountVerificationChannel` | string | `log` | Which channel account verification is delivered on. |
 | `MaxAttempts` | int | `3` | Total delivery attempts per notification. |
 | `RetryDelaySeconds` | int | `5` | Wait between one attempt and the next. |
+
+## Registration readiness and delivery
+
+The registration readiness reported by the HTTP API is deliberately local. It
+means that:
+
+- `Contacts.Website` is an absolute HTTP(S) URL with a host;
+- `notifications.AccountVerificationChannel` selects `email`; and
+- the SMTP plugin registered the `email` channel because `Host` and
+  `FromAddress` were present when Moongate started.
+
+Readiness does **not** connect to the SMTP server, validate credentials, prove
+that the destination accepts mail, or guarantee durable delivery. It therefore
+does not replace startup-log checks or delivery monitoring.
 
 > [!WARNING]
 > **Delivery is best-effort.** Notifications are delivered on a worker thread and

--- a/docs/getting-started/server-settings-and-web-registration.md
+++ b/docs/getting-started/server-settings-and-web-registration.md
@@ -44,7 +44,7 @@ its image.
 ```bash
 curl -X PUT https://your-shard:8933/api/v1/admin/server-settings \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-  -d '{ "description": "A friendly shard.", "registrationEnabled": true,
+  -d '{ "description": "A friendly shard.",
         "contacts": { "website": "https://example.com", "discord": "https://discord.gg/xxxx" } }'
 ```
 
@@ -70,44 +70,130 @@ curl -X POST https://your-shard:8933/api/v1/admin/server-settings/assets/logo \
 
 ## Web registration
 
-Registration is **disabled by default**. Turn it on by setting
-`registrationEnabled: true` (see the `PUT` above). While enabled, the public
-endpoint creates accounts:
+Registration is **disabled by default**. Opening it requires both the persisted
+`registrationEnabled` toggle and all local email-verification prerequisites.
+The public endpoints are:
 
 ```
-POST /api/v1/register        { "username": "...", "password": "...", "email": "..." }
+POST /api/v1/register         { "username": "...", "password": "...", "email": "..." }
+POST /api/v1/register/resend  { "username": "...", "email": "..." }
 POST /api/v1/register/verify  { "token": "..." }
 ```
 
-The flow:
+### Credential rules
 
-1. `POST /api/v1/register` validates the input (username free, password present,
-   **email required and well-formed**), then creates an **inactive** `Player`
-   account carrying a single-use verification token, and answers `202 Accepted`.
-   The account **cannot log in until it is verified**.
-2. `POST /api/v1/register/verify` consumes the token, activates the account, and
-   answers `200`. The token is single-use — a consumed or unknown token answers
-   `400`.
+Leading and trailing whitespace is removed from usernames and email addresses.
+Password whitespace is significant and is not removed.
 
-Responses: `403` when registration is disabled, `409` for a taken username, `400`
-for a missing/invalid field, and `429` when the caller is rate-limited.
+| Field | Rules |
+|---|---|
+| `username` | 3–30 ASCII letters, digits, `.`, `_` or `-`; it must not already be in use. |
+| `password` | 8–30 printable ASCII characters (space through `~`). |
+| `email` | Required, syntactically valid, and unique across active and pending accounts. Email uniqueness is case-insensitive. |
 
-> [!NOTE]
-> **Email sending is not part of this feature yet.** Registration is *predisposed*
-> for email verification: it creates the token and raises an
-> `AccountRegistrationRequestedEvent` (carrying the account, email and token) that
-> a future email feature will subscribe to in order to send the verification link.
-> Until then no mail is sent: the request goes through the
-> [notification pipeline](notifications.md) and is delivered on the `log`
-> channel, so the token appears in the server log and the verify endpoint works
-> with whatever token you hold.
+Duplicate usernames and email addresses share the same generic `409` response;
+the response does not reveal which field matched.
+
+### Verification lifecycle
+
+1. `POST /api/v1/register` creates one inactive `Player` account, queues its
+   verification email, and answers `202 Accepted`. The account cannot log in
+   until it is verified.
+2. The raw single-use token is a random 64-character hexadecimal value. Only its
+   64-character SHA-256 hexadecimal hash is persisted. The raw value exists only
+   long enough to enter the notification pipeline.
+3. The token expires exactly 24 hours after creation. At the expiry instant it
+   is already expired.
+4. `POST /api/v1/register/verify` consumes a valid token, clears its persisted
+   hash and expiry, activates the account, and answers `200`.
+
+An expired token answers `410 Gone` and its state is cleared. An unknown,
+already-used or blank token answers `400`. Verification does not depend on the
+registration toggle or readiness, so an already-issued link still works after
+an operator closes registration or an email prerequisite becomes unavailable.
+
+Pending accounts created by an older version may still carry a plaintext token.
+Those legacy tokens cannot activate an account: attempting to verify one answers
+`410` and clears it. A matching resend rotates a legacy pending account to a new
+hashed token with a fresh 24-hour lifetime.
+
+### Resending without account enumeration
+
+`POST /api/v1/register/resend` validates the username and email shapes, then
+answers the same empty `202 Accepted` whether they match a pending account, an
+active account or no account. Only a matching pending account gets a newly
+rotated token and verification email. This prevents the response from becoming
+an account-discovery oracle.
+
+Resend is available even while the persisted registration toggle is off, so a
+pending user can recover after registrations close. It still requires email
+readiness: an unavailable prerequisite answers `503`. Malformed input answers
+`400`, and a rate limit answers `429`.
 
 ### Abuse protection
 
-Two guards, on top of the off-by-default toggle:
+The registration endpoint has a fixed-window limit per client IP. Resend has
+separate fixed-window limits per client IP and per normalized username/email
+target; the target key is hashed rather than stored in the limiter as raw
+account data. The `http` keys below control the permit count and window for all
+of these budgets.
 
-- Accounts are inactive until verified, so spam produces only inert records.
-- `POST /api/v1/register` is **rate-limited per client IP** (fixed window).
+Accounts also remain inactive until verification, so accepted but abandoned
+registrations cannot log in.
+
+### Readiness and the persisted toggle
+
+The staff settings response keeps the operator's persisted
+`registrationEnabled` value and adds a `registrationReadiness` object:
+
+| Field | Meaning |
+|---|---|
+| `ready` | All three local prerequisites below are true. |
+| `websiteValid` | `Contacts.Website` is an absolute `http` or `https` URL with a host. |
+| `emailChannelSelected` | `notifications.AccountVerificationChannel` is `email` (case-insensitive). |
+| `emailChannelAvailable` | The SMTP plugin registered the `email` channel at startup. |
+
+By contrast, public `GET /api/v1/server-info` reports an **effective**
+`registrationEnabled`: the persisted toggle must be true **and** readiness must
+be true. The portal therefore hides registration when email verification cannot
+be configured locally, even if the stored toggle remains on.
+
+Enabling the toggle while readiness is false is rejected as a validation
+problem. If readiness is lost after registration was enabled, new registration
+and resend requests answer `503 Service Unavailable`; staff can still set the
+persisted toggle to false. “Ready” covers local configuration only, not SMTP
+server reachability or durable delivery; see
+[Notifications](notifications.md#registration-readiness-and-delivery).
+
+### Enable registration in this order
+
+1. Configure the SMTP plugin in `<root>/plugins/configs/smtp.yaml`, including
+   real `Host` and `FromAddress` values and the appropriate transport/security
+   settings. Follow the [SMTP configuration and secrets
+   guidance](notifications.md#sending-email).
+2. Set `notifications.AccountVerificationChannel: email` in
+   `<root>/moongate.yaml`.
+3. Restart Moongate so both configuration files are loaded and the SMTP plugin
+   can register the `email` channel. Confirm the startup log says account
+   verification will use `email`.
+4. Through `PUT /api/v1/admin/server-settings`, set `Contacts.Website` to the
+   absolute HTTP(S) base URL of the player portal. Moongate appends the
+   normalized `/verify?token=...` route to this base.
+5. Read `GET /api/v1/admin/server-settings` and confirm all four
+   `registrationReadiness` fields are `true`.
+6. Only then set `registrationEnabled: true` with another staff settings update.
+
+If a prerequisite fails later, disable the persisted toggle first, repair the
+configuration, restart when a file-based setting changed, confirm readiness,
+and re-enable it.
+
+### HTTP responses
+
+| Endpoint | Responses |
+|---|---|
+| `POST /api/v1/register` | `202` created pending; `400` invalid input; generic `409` duplicate username/email; `403` persisted toggle off; `429` rate-limited; `503` readiness unavailable. |
+| `POST /api/v1/register/resend` | Generic `202` for matching or non-matching valid identities; `400` invalid input; `429` rate-limited; `503` readiness unavailable. |
+| `POST /api/v1/register/verify` | `200` activated; `400` unknown/already-used token; `410` expired or legacy plaintext token. |
 
 ## `http` config keys
 

--- a/plugins/Moongate.Http.Plugin/Data/Api/Registration/ResendVerificationRequest.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Registration/ResendVerificationRequest.cs
@@ -1,0 +1,4 @@
+namespace Moongate.Http.Plugin.Data.Api.Registration;
+
+/// <summary>Identifies a pending public registration for a verification-message resend.</summary>
+public sealed record ResendVerificationRequest(string Username, string Email);

--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/RegistrationReadinessResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/RegistrationReadinessResponse.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Http.Plugin.Data.Api.ServerInfo;
+
+/// <summary>The local prerequisites behind public account registration availability.</summary>
+public sealed record RegistrationReadinessResponse(
+    bool Ready,
+    bool WebsiteValid,
+    bool EmailChannelSelected,
+    bool EmailChannelAvailable
+);

--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerInfoResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerInfoResponse.cs
@@ -1,6 +1,6 @@
 namespace Moongate.Http.Plugin.Data.Api.ServerInfo;
 
-/// <summary>The public server profile a website or launcher reads: identity, contacts, assets, and whether registration is open.</summary>
+/// <summary>The public server profile a website or launcher reads: identity, contacts, assets, and effective registration availability.</summary>
 public sealed record ServerInfoResponse(
     string ShardName,
     string? Description,

--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerSettingsResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerSettingsResponse.cs
@@ -1,10 +1,11 @@
 namespace Moongate.Http.Plugin.Data.Api.ServerInfo;
 
-/// <summary>The full settings view returned to staff (identical fields to the public info minus the shard name).</summary>
+/// <summary>The full settings view returned to staff, including persisted registration state and readiness.</summary>
 public sealed record ServerSettingsResponse(
     string? Description,
     string? Tagline,
     ServerContactsResponse Contacts,
     bool RegistrationEnabled,
+    RegistrationReadinessResponse RegistrationReadiness,
     IReadOnlyDictionary<string, string> Assets
 );

--- a/plugins/Moongate.Http.Plugin/Data/Registration/RegistrationReadiness.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Registration/RegistrationReadiness.cs
@@ -1,0 +1,12 @@
+namespace Moongate.Http.Plugin.Data.Registration;
+
+/// <summary>The local prerequisites that make public account registration available.</summary>
+public sealed record RegistrationReadiness(
+    bool WebsiteValid,
+    bool EmailChannelSelected,
+    bool EmailChannelAvailable
+)
+{
+    /// <summary>Whether every local registration prerequisite is met.</summary>
+    public bool Ready => WebsiteValid && EmailChannelSelected && EmailChannelAvailable;
+}

--- a/plugins/Moongate.Http.Plugin/Endpoints/Registration/RegistrationEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Registration/RegistrationEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -15,14 +17,19 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
 {
     private readonly IAccountService _accounts;
     private readonly IServerSettingsService _settings;
+    private readonly IRegistrationReadinessService _registrationReadiness;
     private readonly IRegistrationRateLimiter _rateLimiter;
 
     public RegistrationEndpoints(
-        IAccountService accounts, IServerSettingsService settings, IRegistrationRateLimiter rateLimiter
+        IAccountService accounts,
+        IServerSettingsService settings,
+        IRegistrationReadinessService registrationReadiness,
+        IRegistrationRateLimiter rateLimiter
     )
     {
         _accounts = accounts;
         _settings = settings;
+        _registrationReadiness = registrationReadiness;
         _rateLimiter = rateLimiter;
     }
 
@@ -31,12 +38,29 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
         routes.MapPost("/api/v1/register", RegisterAccount)
             .WithName("RegisterAccount")
             .Produces(StatusCodes.Status202Accepted)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
             .WithTags("registration")
             .AllowAnonymous();
         routes.MapPost("/api/v1/register/verify", Verify)
             .WithName("VerifyRegistration")
             .WithTags("registration")
             .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status410Gone)
+            .AllowAnonymous();
+        routes.MapPost("/api/v1/register/resend", ResendVerification)
+            .WithName("ResendRegistrationVerification")
+            .WithTags("registration")
+            .Produces(StatusCodes.Status202Accepted)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status429TooManyRequests)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
             .AllowAnonymous();
     }
 
@@ -48,14 +72,24 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
     /// </remarks>
     private IResult RegisterAccount(RegisterRequest request, HttpContext context)
     {
-        if (!_settings.Get().RegistrationEnabled)
+        var settings = _settings.Get();
+
+        if (!settings.RegistrationEnabled)
         {
             return Results.Problem("Web registration is disabled.", statusCode: StatusCodes.Status403Forbidden);
         }
 
+        if (!_registrationReadiness.Evaluate(settings.Contacts.Website).Ready)
+        {
+            return Results.Problem(
+                "Registration email is temporarily unavailable.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
         var clientKey = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 
-        if (!_rateLimiter.TryAcquire(clientKey))
+        if (!_rateLimiter.TryAcquire($"register:ip:{clientKey}"))
         {
             return Results.Problem(
                 "Too many registration attempts; try again later.",
@@ -68,39 +102,94 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
         return result.Result switch
         {
             AccountRegisterResultType.Created => Results.Accepted(),
-            AccountRegisterResultType.UsernameTaken => Results.Problem(
-                $"An account named '{request.Username}' already exists.",
+            AccountRegisterResultType.UsernameTaken or AccountRegisterResultType.EmailTaken => Results.Problem(
+                "An account already uses those registration details.",
                 statusCode: StatusCodes.Status409Conflict
             ),
-            AccountRegisterResultType.UsernameEmpty => Results.Problem(
-                "Username is required.",
-                statusCode: StatusCodes.Status400BadRequest
-            ),
-            AccountRegisterResultType.PasswordEmpty => Results.Problem(
-                "Password is required.",
-                statusCode: StatusCodes.Status400BadRequest
-            ),
-            AccountRegisterResultType.EmailEmpty => Results.Problem(
-                "Email is required.",
-                statusCode: StatusCodes.Status400BadRequest
-            ),
-            AccountRegisterResultType.EmailInvalid => Results.Problem(
-                "Email is not valid.",
-                statusCode: StatusCodes.Status400BadRequest
-            ),
+            AccountRegisterResultType.UsernameEmpty => ValidationProblem("username", "Username is required."),
+            AccountRegisterResultType.UsernameInvalid => ValidationProblem("username", "Username is not valid."),
+            AccountRegisterResultType.PasswordEmpty => ValidationProblem("password", "Password is required."),
+            AccountRegisterResultType.PasswordInvalid => ValidationProblem("password", "Password is not valid."),
+            AccountRegisterResultType.EmailEmpty => ValidationProblem("email", "Email is required."),
+            AccountRegisterResultType.EmailInvalid => ValidationProblem("email", "Email is not valid."),
             _ => Results.Problem("Unknown registration result.", statusCode: StatusCodes.Status500InternalServerError)
         };
     }
 
     /// <summary>Verifies an account's email with its token, activating the account.</summary>
-    /// <remarks>Answers 400 for an unknown or already-used token.</remarks>
+    /// <remarks>Answers 410 for an expired token and 400 for an unknown or already-used token.</remarks>
     private IResult Verify(VerifyEmailRequest request)
         => _accounts.VerifyEmail(request.Token) switch
         {
             AccountVerifyResultType.Verified => Results.Ok(),
+            AccountVerifyResultType.ExpiredToken => Results.Problem(
+                "Verification token expired.",
+                statusCode: StatusCodes.Status410Gone
+            ),
             _ => Results.Problem(
                 "Invalid or already-used verification token.",
                 statusCode: StatusCodes.Status400BadRequest
             )
         };
+
+    /// <summary>Resends the verification message for a matching pending public registration.</summary>
+    /// <remarks>
+    /// Answers 202 whether or not the supplied identity matches a pending account, so callers cannot
+    /// discover registered usernames or email addresses.
+    /// </remarks>
+    private IResult ResendVerification(ResendVerificationRequest request, HttpContext context)
+    {
+        if (!_registrationReadiness.Evaluate(_settings.Get().Contacts.Website).Ready)
+        {
+            return Results.Problem(
+                "Registration email is temporarily unavailable.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        var clientKey = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+        if (!_rateLimiter.TryAcquire($"resend:ip:{clientKey}"))
+        {
+            return Results.Problem(
+                "Too many verification resend attempts; try again later.",
+                statusCode: StatusCodes.Status429TooManyRequests
+            );
+        }
+
+        if (!_rateLimiter.TryAcquire(BuildResendTargetKey(request)))
+        {
+            return Results.Problem(
+                "Too many verification resend attempts; try again later.",
+                statusCode: StatusCodes.Status429TooManyRequests
+            );
+        }
+
+        return _accounts.ResendVerification(request.Username, request.Email) switch
+        {
+            AccountResendResultType.Sent or AccountResendResultType.Ignored => Results.Accepted(),
+            AccountResendResultType.UsernameInvalid => ValidationProblem(
+                "username",
+                "Username is not valid."
+            ),
+            AccountResendResultType.EmailInvalid => ValidationProblem("email", "Email is not valid."),
+            _ => Results.Problem(
+                "Unknown verification resend result.",
+                statusCode: StatusCodes.Status500InternalServerError
+            )
+        };
+    }
+
+    private static string BuildResendTargetKey(ResendVerificationRequest request)
+    {
+        var username = (request.Username ?? string.Empty).Trim();
+        var email = (request.Email ?? string.Empty).Trim().ToUpperInvariant();
+        var target = $"{username}\n{email}";
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(target));
+
+        return $"resend:target:{Convert.ToHexString(digest)}";
+    }
+
+    private static IResult ValidationProblem(string field, string message)
+        => Results.ValidationProblem(new Dictionary<string, string[]> { [field] = [message] });
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Routing;
 using Moongate.Http.Plugin.Data.Api.ServerInfo;
 using Moongate.Http.Plugin.Interfaces.Assets;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Registration;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Interfaces.Server;
@@ -17,12 +18,19 @@ public sealed class ServerInfoEndpoints : IApiEndpointRegistration
     private readonly MoongateConfig _config;
     private readonly IServerSettingsService _settings;
     private readonly IServerAssetFileStore _assets;
+    private readonly IRegistrationReadinessService _registrationReadiness;
 
-    public ServerInfoEndpoints(MoongateConfig config, IServerSettingsService settings, IServerAssetFileStore assets)
+    public ServerInfoEndpoints(
+        MoongateConfig config,
+        IServerSettingsService settings,
+        IServerAssetFileStore assets,
+        IRegistrationReadinessService registrationReadiness
+    )
     {
         _config = config;
         _settings = settings;
         _assets = assets;
+        _registrationReadiness = registrationReadiness;
     }
 
     public void Register(IEndpointRouteBuilder routes)
@@ -42,26 +50,31 @@ public sealed class ServerInfoEndpoints : IApiEndpointRegistration
             .AllowAnonymous();
     }
 
-    internal static ServerInfoResponse ToResponse(string shardName, ServerSettingsEntity settings)
+    internal static ServerInfoResponse ToResponse(
+        string shardName,
+        ServerSettingsEntity settings,
+        IRegistrationReadinessService registrationReadiness
+    )
     {
         var assets = settings.Assets.Keys.ToDictionary(
             slot => slot,
             slot => $"/api/v1/server-info/assets/{slot.ToLowerInvariant()}"
         );
+        var readiness = registrationReadiness.Evaluate(settings.Contacts.Website);
 
         return new(
             shardName,
             settings.Description,
             settings.Tagline,
             new(settings.Contacts.Website, settings.Contacts.Email, settings.Contacts.Discord),
-            settings.RegistrationEnabled,
+            settings.RegistrationEnabled && readiness.Ready,
             assets
         );
     }
 
     /// <summary>Returns the shard's public profile: name, description, contacts, asset URLs and whether registration is open.</summary>
     private IResult Get()
-        => Results.Ok(ToResponse(_config.ShardName, _settings.Get()));
+        => Results.Ok(ToResponse(_config.ShardName, _settings.Get(), _registrationReadiness));
 
     /// <summary>Streams a visual asset (logo, favicon or banner) by slot.</summary>
     /// <remarks>Answers 400 for an unknown slot and 404 when the slot has no asset.</remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
@@ -44,7 +44,10 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
             .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapGet("/", Get).WithName("GetServerSettings").Produces<ServerSettingsResponse>();
-        group.MapPut("/", Update).WithName("UpdateServerSettings").Produces<ServerSettingsResponse>();
+        group.MapPut("/", Update)
+            .WithName("UpdateServerSettings")
+            .Produces<ServerSettingsResponse>()
+            .ProducesValidationProblem();
         group.MapPost("/assets/{slot}", UploadAsset)
             .WithName("UploadServerAsset")
             .DisableAntiforgery()

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
@@ -5,6 +5,7 @@ using Moongate.Http.Plugin.Data.Api.ServerInfo;
 using Moongate.Http.Plugin.Data.Config;
 using Moongate.Http.Plugin.Interfaces.Assets;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Registration;
 using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Types;
@@ -21,14 +22,19 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
     private readonly IServerSettingsService _settings;
     private readonly IServerAssetFileStore _assets;
     private readonly MoongateHttpConfig _config;
+    private readonly IRegistrationReadinessService _registrationReadiness;
 
     public ServerSettingsAdminEndpoints(
-        IServerSettingsService settings, IServerAssetFileStore assets, MoongateHttpConfig config
+        IServerSettingsService settings,
+        IServerAssetFileStore assets,
+        MoongateHttpConfig config,
+        IRegistrationReadinessService registrationReadiness
     )
     {
         _settings = settings;
         _assets = assets;
         _config = config;
+        _registrationReadiness = registrationReadiness;
     }
 
     public void Register(IEndpointRouteBuilder routes)
@@ -48,22 +54,49 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
             .Produces(StatusCodes.Status204NoContent);
     }
 
-    internal static ServerSettingsResponse ToResponse(ServerSettingsEntity settings)
-        => new(
+    internal static ServerSettingsResponse ToResponse(
+        ServerSettingsEntity settings,
+        IRegistrationReadinessService registrationReadiness
+    )
+    {
+        var readiness = registrationReadiness.Evaluate(settings.Contacts.Website);
+
+        return new(
             settings.Description,
             settings.Tagline,
             new(settings.Contacts.Website, settings.Contacts.Email, settings.Contacts.Discord),
             settings.RegistrationEnabled,
+            new(
+                readiness.Ready,
+                readiness.WebsiteValid,
+                readiness.EmailChannelSelected,
+                readiness.EmailChannelAvailable
+            ),
             settings.Assets.Keys.ToDictionary(slot => slot, slot => $"/api/v1/server-info/assets/{slot.ToLowerInvariant()}")
         );
+    }
 
     /// <summary>Returns the full server settings.</summary>
     private IResult Get()
-        => Results.Ok(ToResponse(_settings.Get()));
+        => Results.Ok(ToResponse(_settings.Get(), _registrationReadiness));
 
     /// <summary>Updates the server settings; every field is optional and an omitted one is left unchanged.</summary>
     private IResult Update(UpdateServerSettingsRequest request)
     {
+        var current = _settings.Get();
+        var resultingWebsite = request.Contacts is null ? current.Contacts.Website : request.Contacts.Website;
+        var resultingRegistrationEnabled = request.RegistrationEnabled ?? current.RegistrationEnabled;
+
+        if (resultingRegistrationEnabled && !_registrationReadiness.Evaluate(resultingWebsite).Ready)
+        {
+            return Results.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["registrationEnabled"] = ["Registration requires a valid website and an available email channel."]
+                }
+            );
+        }
+
         _settings.Update(
             new ServerSettingsUpdate
             {
@@ -81,7 +114,7 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
             }
         );
 
-        return Results.Ok(ToResponse(_settings.Get()));
+        return Results.Ok(ToResponse(_settings.Get(), _registrationReadiness));
     }
 
     /// <summary>Uploads the image for a slot (logo, favicon or banner), replacing any previous one.</summary>
@@ -112,7 +145,7 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
             new ServerAssetMeta { FileName = $"{parsed}.{validation.Extension}", ContentType = file.ContentType }
         );
 
-        return Results.Ok(ToResponse(_settings.Get()));
+        return Results.Ok(ToResponse(_settings.Get(), _registrationReadiness));
     }
 
     /// <summary>Removes the image for a slot.</summary>

--- a/plugins/Moongate.Http.Plugin/Interfaces/Registration/IRegistrationReadinessService.cs
+++ b/plugins/Moongate.Http.Plugin/Interfaces/Registration/IRegistrationReadinessService.cs
@@ -1,0 +1,10 @@
+using Moongate.Http.Plugin.Data.Registration;
+
+namespace Moongate.Http.Plugin.Interfaces.Registration;
+
+/// <summary>Evaluates whether local configuration makes public account registration available.</summary>
+public interface IRegistrationReadinessService
+{
+    /// <summary>Evaluates the readiness prerequisites for the supplied public website.</summary>
+    RegistrationReadiness Evaluate(string? website);
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -66,6 +66,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterConfigSection<MoongateHttpConfig>("http");
 
         container.Register<IJwtTokenService, JwtTokenService>(Reuse.Singleton);
+        container.Register<IRegistrationReadinessService, RegistrationReadinessService>(Reuse.Singleton);
 
         // The catalog reads the UO client files through Moongate.Ultima's process-wide statics, which
         // FilesLoaderService initialises at startup. It carries no state of its own, so a singleton costs

--- a/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationReadinessService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationReadinessService.cs
@@ -24,6 +24,7 @@ public sealed class RegistrationReadinessService : IRegistrationReadinessService
     public RegistrationReadiness Evaluate(string? website)
     {
         var websiteValid = Uri.TryCreate(website, UriKind.Absolute, out var uri)
+            && !string.IsNullOrEmpty(uri.Host)
             && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
         var emailChannelSelected = string.Equals(

--- a/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationReadinessService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationReadinessService.cs
@@ -1,0 +1,42 @@
+using Moongate.Http.Plugin.Data.Registration;
+using Moongate.Http.Plugin.Interfaces.Registration;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+
+namespace Moongate.Http.Plugin.Services.Registration;
+
+/// <summary>Evaluates the local configuration prerequisites for public account registration.</summary>
+public sealed class RegistrationReadinessService : IRegistrationReadinessService
+{
+    private readonly NotificationConfig _notificationConfig;
+    private readonly IEnumerable<INotificationChannel> _notificationChannels;
+
+    public RegistrationReadinessService(
+        NotificationConfig notificationConfig,
+        IEnumerable<INotificationChannel> notificationChannels
+    )
+    {
+        _notificationConfig = notificationConfig;
+        _notificationChannels = notificationChannels;
+    }
+
+    /// <inheritdoc />
+    public RegistrationReadiness Evaluate(string? website)
+    {
+        var websiteValid = Uri.TryCreate(website, UriKind.Absolute, out var uri)
+            && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
+        var emailChannelSelected = string.Equals(
+            _notificationConfig.AccountVerificationChannel,
+            "email",
+            StringComparison.OrdinalIgnoreCase
+        );
+        var emailChannelAvailable = _notificationChannels.Any(channel => string.Equals(
+            channel.Id,
+            "email",
+            StringComparison.OrdinalIgnoreCase
+        ));
+
+        return new(websiteValid, emailChannelSelected, emailChannelAvailable);
+    }
+}

--- a/src/Moongate.Persistence/Entities/AccountEntity.cs
+++ b/src/Moongate.Persistence/Entities/AccountEntity.cs
@@ -22,6 +22,8 @@ public class AccountEntity : ISerialIdEntity
 
     public DateTimeOffset? ActivationTokenExpiresAtUtc { get; set; }
 
+    public bool IsPublicRegistrationPending { get; set; }
+
     public AccountLevelType AccountLevel { get; set; }
 
     public List<Serial> MobileIds { get; set; } = new();

--- a/src/Moongate.Persistence/Entities/AccountEntity.cs
+++ b/src/Moongate.Persistence/Entities/AccountEntity.cs
@@ -16,7 +16,11 @@ public class AccountEntity : ISerialIdEntity
 
     public bool IsActive { get; set; }
 
-    public string ActivationToken { get; set; }
+    public string ActivationToken { get; set; } = string.Empty;
+
+    public string ActivationTokenHash { get; set; } = string.Empty;
+
+    public DateTimeOffset? ActivationTokenExpiresAtUtc { get; set; }
 
     public AccountLevelType AccountLevel { get; set; }
 

--- a/src/Moongate.Server.Abstractions/Data/AccountRegisterResult.cs
+++ b/src/Moongate.Server.Abstractions/Data/AccountRegisterResult.cs
@@ -3,8 +3,8 @@ using Moongate.Server.Abstractions.Types;
 namespace Moongate.Server.Abstractions.Data;
 
 /// <summary>
-/// A registration outcome plus, on success, the verification token — the future email feature needs the
-/// token to build a verify link; today it is only logged and carried on the domain event.
+/// A registration outcome plus, on success, the raw verification token that the caller must deliver to
+/// the registrant. The account persistence stores only a hash of that token.
 /// </summary>
 public sealed class AccountRegisterResult
 {

--- a/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
@@ -34,6 +34,13 @@ public interface IAccountService
     AccountRegisterResult RegisterPending(string username, string password, string email);
 
     /// <summary>
+    /// Reissues a verification token for a pending account whose normalized username and email match.
+    /// Valid requests that do not match a pending account return <see cref="AccountResendResultType.Ignored" />
+    /// so callers do not disclose account state.
+    /// </summary>
+    AccountResendResultType ResendVerification(string username, string email);
+
+    /// <summary>
     /// Activates the account holding an unexpired <paramref name="token" /> and clears its token state.
     /// Consumed, expired, or unknown tokens cannot activate an account.
     /// </summary>

--- a/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
@@ -38,7 +38,8 @@ public interface IAccountService
     /// Valid requests that do not match a pending account return <see cref="AccountResendResultType.Ignored" />
     /// so callers do not disclose account state.
     /// </summary>
-    AccountResendResultType ResendVerification(string username, string email);
+    AccountResendResultType ResendVerification(string username, string email)
+        => AccountResendResultType.Ignored;
 
     /// <summary>
     /// Activates the account holding an unexpired <paramref name="token" /> and clears its token state.

--- a/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
@@ -26,15 +26,16 @@ public interface IAccountService
 
     /// <summary>
     /// Creates a pending Player account for web self-registration: inactive, carrying a single-use
-    /// verification token, with the (required, validated) email stored. Publishes
+    /// verification token stored as a hash with a 24-hour expiry, with the required, validated email
+    /// stored. Publishes
     /// <see cref="Moongate.Server.Abstractions.Data.Events.AccountRegistrationRequestedEvent" />. The
     /// account cannot log in until verified.
     /// </summary>
     AccountRegisterResult RegisterPending(string username, string password, string email);
 
     /// <summary>
-    /// Activates the account holding <paramref name="token" /> and clears the token. Idempotent by
-    /// construction: a consumed or unknown token matches nothing.
+    /// Activates the account holding an unexpired <paramref name="token" /> and clears its token state.
+    /// Consumed, expired, or unknown tokens cannot activate an account.
     /// </summary>
     AccountVerifyResultType VerifyEmail(string token);
 

--- a/src/Moongate.Server.Abstractions/Types/AccountRegisterResultType.cs
+++ b/src/Moongate.Server.Abstractions/Types/AccountRegisterResultType.cs
@@ -6,7 +6,10 @@ public enum AccountRegisterResultType
     Created,
     UsernameTaken,
     UsernameEmpty,
+    UsernameInvalid,
     PasswordEmpty,
+    PasswordInvalid,
     EmailEmpty,
-    EmailInvalid
+    EmailInvalid,
+    EmailTaken
 }

--- a/src/Moongate.Server.Abstractions/Types/AccountResendResultType.cs
+++ b/src/Moongate.Server.Abstractions/Types/AccountResendResultType.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Server.Abstractions.Types;
+
+public enum AccountResendResultType
+{
+    Sent,
+    Ignored,
+    UsernameInvalid,
+    EmailInvalid
+}

--- a/src/Moongate.Server.Abstractions/Types/AccountVerifyResultType.cs
+++ b/src/Moongate.Server.Abstractions/Types/AccountVerifyResultType.cs
@@ -4,5 +4,6 @@ namespace Moongate.Server.Abstractions.Types;
 public enum AccountVerifyResultType
 {
     Verified,
-    InvalidToken
+    InvalidToken,
+    ExpiredToken
 }

--- a/src/Moongate.Server/Assets/Notification/Templates/email/account_verification.mgtmpl
+++ b/src/Moongate.Server/Assets/Notification/Templates/email/account_verification.mgtmpl
@@ -4,6 +4,6 @@ subject = "Verify your " + shard_name + " account"
 Hello {{ username }},
 
 Confirm your account:
-{{ website }}/verify?token={{ token }}
+{{ verification_url }}
 
 If you did not register, ignore this message.

--- a/src/Moongate.Server/Assets/Notification/Templates/log/account_verification.mgtmpl
+++ b/src/Moongate.Server/Assets/Notification/Templates/log/account_verification.mgtmpl
@@ -1,1 +1,1 @@
-Verification token for {{ username }} <{{ email }}>: {{ token }}
+Verification link for {{ username }} <{{ email }}>: {{ verification_url }}

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -166,6 +166,43 @@ public class AccountService : IAccountService
         return new() { Result = AccountRegisterResultType.Created, Token = token };
     }
 
+    public AccountResendResultType ResendVerification(string username, string email)
+    {
+        var normalizedUsername = PublicRegistrationValidator.NormalizeUsername(username);
+        var normalizedEmail = PublicRegistrationValidator.NormalizeEmail(email);
+
+        if (!PublicRegistrationValidator.IsUsernameValid(normalizedUsername))
+        {
+            return AccountResendResultType.UsernameInvalid;
+        }
+
+        if (!PublicRegistrationValidator.IsEmailValid(normalizedEmail))
+        {
+            return AccountResendResultType.EmailInvalid;
+        }
+
+        var account = _accountStore.Query().FirstOrDefault(candidate =>
+            !candidate.IsActive
+            && candidate.Username == normalizedUsername
+            && string.Equals(candidate.Email, normalizedEmail, StringComparison.OrdinalIgnoreCase)
+        );
+
+        if (account is null)
+        {
+            return AccountResendResultType.Ignored;
+        }
+
+        var token = RandomNumberGenerator.GetHexString(64);
+        ClearActivationTokenState(account);
+        account.ActivationTokenHash = HashActivationToken(token);
+        account.ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime);
+        _accountStore.UpsertAsync(account).WaitSync();
+
+        _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token));
+
+        return AccountResendResultType.Sent;
+    }
+
     public AccountVerifyResultType VerifyEmail(string token)
     {
         if (string.IsNullOrWhiteSpace(token))

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Text;
 using Moongate.Core.Extensions;
 using Moongate.Core.Primitives;
 using Moongate.Core.Types;
@@ -17,24 +18,29 @@ namespace Moongate.Server.Services.Accounts;
 
 public class AccountService : IAccountService
 {
+    private static readonly TimeSpan VerificationLifetime = TimeSpan.FromHours(24);
+
     private readonly ILogger _logger = Log.ForContext<AccountService>();
 
     private readonly IEntityStore<AccountEntity, Serial> _accountStore;
     private readonly ICharacterService _characterService;
     private readonly ISessionManager _sessions;
     private readonly IEventBus _eventBus;
+    private readonly TimeProvider _timeProvider;
 
     public AccountService(
         IPersistenceService persistenceService,
         ICharacterService characterService,
         ISessionManager sessions,
-        IEventBus eventBus
+        IEventBus eventBus,
+        TimeProvider timeProvider
     )
     {
         _accountStore = persistenceService.GetStore<AccountEntity, Serial>();
         _characterService = characterService;
         _sessions = sessions;
         _eventBus = eventBus;
+        _timeProvider = timeProvider;
     }
 
     public AccountAuthResult Authenticate(string username, string password)
@@ -91,7 +97,10 @@ public class AccountService : IAccountService
 
     public AccountRegisterResult RegisterPending(string username, string password, string email)
     {
-        if (string.IsNullOrWhiteSpace(username))
+        var normalizedUsername = PublicRegistrationValidator.NormalizeUsername(username);
+        var normalizedEmail = PublicRegistrationValidator.NormalizeEmail(email);
+
+        if (string.IsNullOrEmpty(normalizedUsername))
         {
             return new() { Result = AccountRegisterResultType.UsernameEmpty };
         }
@@ -101,37 +110,58 @@ public class AccountService : IAccountService
             return new() { Result = AccountRegisterResultType.PasswordEmpty };
         }
 
-        if (string.IsNullOrWhiteSpace(email))
+        if (string.IsNullOrEmpty(normalizedEmail))
         {
             return new() { Result = AccountRegisterResultType.EmailEmpty };
         }
 
-        if (!System.Net.Mail.MailAddress.TryCreate(email, out _))
+        if (!PublicRegistrationValidator.IsUsernameValid(normalizedUsername))
+        {
+            return new() { Result = AccountRegisterResultType.UsernameInvalid };
+        }
+
+        if (!PublicRegistrationValidator.IsPasswordValid(password))
+        {
+            return new() { Result = AccountRegisterResultType.PasswordInvalid };
+        }
+
+        if (!PublicRegistrationValidator.IsEmailValid(normalizedEmail))
         {
             return new() { Result = AccountRegisterResultType.EmailInvalid };
         }
 
-        if (GetByUsername(username) is not null)
+        if (GetByUsername(normalizedUsername) is not null)
         {
             return new() { Result = AccountRegisterResultType.UsernameTaken };
+        }
+
+        if (_accountStore.Query().Any(account => string.Equals(
+                account.Email,
+                normalizedEmail,
+                StringComparison.OrdinalIgnoreCase
+            )))
+        {
+            return new() { Result = AccountRegisterResultType.EmailTaken };
         }
 
         var token = RandomNumberGenerator.GetHexString(64);
 
         var account = new AccountEntity
         {
-            Username = username,
-            Email = email,
+            Username = normalizedUsername,
+            Email = normalizedEmail,
             PasswordHash = HashUtils.HashPassword(password),
             IsActive = false,
-            ActivationToken = token,
+            ActivationToken = string.Empty,
+            ActivationTokenHash = HashActivationToken(token),
+            ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime),
             AccountLevel = AccountLevelType.Player
         };
 
         _accountStore.UpsertAsync(account).WaitSync();
 
-        _logger.Information("Web registration pending for {Username}; awaiting email verification", username);
-        _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, username, email, token));
+        _logger.Information("Web registration pending for {Username}; awaiting email verification", normalizedUsername);
+        _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token));
 
         return new() { Result = AccountRegisterResultType.Created, Token = token };
     }
@@ -143,7 +173,31 @@ public class AccountService : IAccountService
             return AccountVerifyResultType.InvalidToken;
         }
 
+        var tokenHash = HashActivationToken(token);
         var account = _accountStore
+            .Query()
+            .FirstOrDefault(a => a.ActivationTokenHash == tokenHash);
+
+        if (account is not null)
+        {
+            if (account.ActivationTokenExpiresAtUtc is null || account.ActivationTokenExpiresAtUtc <= _timeProvider.GetUtcNow())
+            {
+                ClearActivationTokenState(account);
+                _accountStore.UpsertAsync(account).WaitSync();
+
+                return AccountVerifyResultType.ExpiredToken;
+            }
+
+            account.IsActive = true;
+            ClearActivationTokenState(account);
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _logger.Information("Account {Username} verified and activated", account.Username);
+
+            return AccountVerifyResultType.Verified;
+        }
+
+        account = _accountStore
             .Query()
             .FirstOrDefault(a => !string.IsNullOrEmpty(a.ActivationToken) && a.ActivationToken == token);
 
@@ -152,13 +206,10 @@ public class AccountService : IAccountService
             return AccountVerifyResultType.InvalidToken;
         }
 
-        account.IsActive = true;
-        account.ActivationToken = string.Empty;
+        ClearActivationTokenState(account);
         _accountStore.UpsertAsync(account).WaitSync();
 
-        _logger.Information("Account {Username} verified and activated", account.Username);
-
-        return AccountVerifyResultType.Verified;
+        return AccountVerifyResultType.ExpiredToken;
     }
 
     public AccountDeleteResultType Delete(string username)
@@ -255,5 +306,15 @@ public class AccountService : IAccountService
         _logger.Information("Password changed for account {Username}", username);
 
         return true;
+    }
+
+    private static string HashActivationToken(string token)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+
+    private static void ClearActivationTokenState(AccountEntity account)
+    {
+        account.ActivationToken = string.Empty;
+        account.ActivationTokenHash = string.Empty;
+        account.ActivationTokenExpiresAtUtc = null;
     }
 }

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -22,6 +22,7 @@ public class AccountService : IAccountService
 
     private readonly ILogger _logger = Log.ForContext<AccountService>();
 
+    private readonly object _registrationTransitionLock = new();
     private readonly IEntityStore<AccountEntity, Serial> _accountStore;
     private readonly ICharacterService _characterService;
     private readonly ISessionManager _sessions;
@@ -74,25 +75,28 @@ public class AccountService : IAccountService
             return AccountCreateResultType.PasswordEmpty;
         }
 
-        if (GetByUsername(username) is not null)
+        lock (_registrationTransitionLock)
         {
-            return AccountCreateResultType.UsernameTaken;
+            if (GetByUsername(username) is not null)
+            {
+                return AccountCreateResultType.UsernameTaken;
+            }
+
+            var account = new AccountEntity
+            {
+                Username = username,
+                Email = email,
+                PasswordHash = HashUtils.HashPassword(password),
+                IsActive = true,
+                AccountLevel = level
+            };
+
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _logger.Information("Account created: {Username} at level {Level}", username, level);
+
+            return AccountCreateResultType.Created;
         }
-
-        var account = new AccountEntity
-        {
-            Username = username,
-            Email = email,
-            PasswordHash = HashUtils.HashPassword(password),
-            IsActive = true,
-            AccountLevel = level
-        };
-
-        _accountStore.UpsertAsync(account).WaitSync();
-
-        _logger.Information("Account created: {Username} at level {Level}", username, level);
-
-        return AccountCreateResultType.Created;
     }
 
     public AccountRegisterResult RegisterPending(string username, string password, string email)
@@ -130,40 +134,49 @@ public class AccountService : IAccountService
             return new() { Result = AccountRegisterResultType.EmailInvalid };
         }
 
-        if (GetByUsername(normalizedUsername) is not null)
+        lock (_registrationTransitionLock)
         {
-            return new() { Result = AccountRegisterResultType.UsernameTaken };
+            if (GetByUsername(normalizedUsername) is not null)
+            {
+                return new() { Result = AccountRegisterResultType.UsernameTaken };
+            }
+
+            if (_accountStore.Query().Any(account => string.Equals(
+                    account.Email,
+                    normalizedEmail,
+                    StringComparison.OrdinalIgnoreCase
+                )))
+            {
+                return new() { Result = AccountRegisterResultType.EmailTaken };
+            }
+
+            var token = RandomNumberGenerator.GetHexString(64);
+
+            var account = new AccountEntity
+            {
+                Username = normalizedUsername,
+                Email = normalizedEmail,
+                PasswordHash = HashUtils.HashPassword(password),
+                IsActive = false,
+                ActivationToken = string.Empty,
+                ActivationTokenHash = HashActivationToken(token),
+                ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime),
+                IsPublicRegistrationPending = true,
+                AccountLevel = AccountLevelType.Player
+            };
+
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _logger.Information(
+                "Web registration pending for {Username}; awaiting email verification",
+                normalizedUsername
+            );
+            _eventBus.Publish(
+                new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token)
+            );
+
+            return new() { Result = AccountRegisterResultType.Created, Token = token };
         }
-
-        if (_accountStore.Query().Any(account => string.Equals(
-                account.Email,
-                normalizedEmail,
-                StringComparison.OrdinalIgnoreCase
-            )))
-        {
-            return new() { Result = AccountRegisterResultType.EmailTaken };
-        }
-
-        var token = RandomNumberGenerator.GetHexString(64);
-
-        var account = new AccountEntity
-        {
-            Username = normalizedUsername,
-            Email = normalizedEmail,
-            PasswordHash = HashUtils.HashPassword(password),
-            IsActive = false,
-            ActivationToken = string.Empty,
-            ActivationTokenHash = HashActivationToken(token),
-            ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime),
-            AccountLevel = AccountLevelType.Player
-        };
-
-        _accountStore.UpsertAsync(account).WaitSync();
-
-        _logger.Information("Web registration pending for {Username}; awaiting email verification", normalizedUsername);
-        _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token));
-
-        return new() { Result = AccountRegisterResultType.Created, Token = token };
     }
 
     public AccountResendResultType ResendVerification(string username, string email)
@@ -181,26 +194,34 @@ public class AccountService : IAccountService
             return AccountResendResultType.EmailInvalid;
         }
 
-        var account = _accountStore.Query().FirstOrDefault(candidate =>
-            !candidate.IsActive
-            && candidate.Username == normalizedUsername
-            && string.Equals(candidate.Email, normalizedEmail, StringComparison.OrdinalIgnoreCase)
-        );
-
-        if (account is null)
+        lock (_registrationTransitionLock)
         {
-            return AccountResendResultType.Ignored;
+            var account = _accountStore.Query().FirstOrDefault(candidate =>
+                !candidate.IsActive
+                && candidate.AccountLevel == AccountLevelType.Player
+                && (candidate.IsPublicRegistrationPending || !string.IsNullOrEmpty(candidate.ActivationToken))
+                && candidate.Username == normalizedUsername
+                && string.Equals(candidate.Email, normalizedEmail, StringComparison.OrdinalIgnoreCase)
+            );
+
+            if (account is null)
+            {
+                return AccountResendResultType.Ignored;
+            }
+
+            var token = RandomNumberGenerator.GetHexString(64);
+            ClearActivationTokenState(account);
+            account.ActivationTokenHash = HashActivationToken(token);
+            account.ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime);
+            account.IsPublicRegistrationPending = true;
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _eventBus.Publish(
+                new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token)
+            );
+
+            return AccountResendResultType.Sent;
         }
-
-        var token = RandomNumberGenerator.GetHexString(64);
-        ClearActivationTokenState(account);
-        account.ActivationTokenHash = HashActivationToken(token);
-        account.ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime);
-        _accountStore.UpsertAsync(account).WaitSync();
-
-        _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token));
-
-        return AccountResendResultType.Sent;
     }
 
     public AccountVerifyResultType VerifyEmail(string token)
@@ -211,42 +232,55 @@ public class AccountService : IAccountService
         }
 
         var tokenHash = HashActivationToken(token);
-        var account = _accountStore
-            .Query()
-            .FirstOrDefault(a => a.ActivationTokenHash == tokenHash);
 
-        if (account is not null)
+        lock (_registrationTransitionLock)
         {
-            if (account.ActivationTokenExpiresAtUtc is null || account.ActivationTokenExpiresAtUtc <= _timeProvider.GetUtcNow())
+            var account = _accountStore.Query().FirstOrDefault(candidate =>
+                !candidate.IsActive
+                && candidate.AccountLevel == AccountLevelType.Player
+                && candidate.IsPublicRegistrationPending
+                && candidate.ActivationTokenHash == tokenHash
+            );
+
+            if (account is not null)
             {
+                if (account.ActivationTokenExpiresAtUtc is null
+                    || account.ActivationTokenExpiresAtUtc <= _timeProvider.GetUtcNow())
+                {
+                    ClearActivationTokenState(account);
+                    _accountStore.UpsertAsync(account).WaitSync();
+
+                    return AccountVerifyResultType.ExpiredToken;
+                }
+
+                account.IsActive = true;
                 ClearActivationTokenState(account);
+                account.IsPublicRegistrationPending = false;
                 _accountStore.UpsertAsync(account).WaitSync();
 
-                return AccountVerifyResultType.ExpiredToken;
+                _logger.Information("Account {Username} verified and activated", account.Username);
+
+                return AccountVerifyResultType.Verified;
             }
 
-            account.IsActive = true;
+            account = _accountStore.Query().FirstOrDefault(candidate =>
+                !candidate.IsActive
+                && candidate.AccountLevel == AccountLevelType.Player
+                && !string.IsNullOrEmpty(candidate.ActivationToken)
+                && candidate.ActivationToken == token
+            );
+
+            if (account is null)
+            {
+                return AccountVerifyResultType.InvalidToken;
+            }
+
             ClearActivationTokenState(account);
+            account.IsPublicRegistrationPending = true;
             _accountStore.UpsertAsync(account).WaitSync();
 
-            _logger.Information("Account {Username} verified and activated", account.Username);
-
-            return AccountVerifyResultType.Verified;
+            return AccountVerifyResultType.ExpiredToken;
         }
-
-        account = _accountStore
-            .Query()
-            .FirstOrDefault(a => !string.IsNullOrEmpty(a.ActivationToken) && a.ActivationToken == token);
-
-        if (account is null)
-        {
-            return AccountVerifyResultType.InvalidToken;
-        }
-
-        ClearActivationTokenState(account);
-        _accountStore.UpsertAsync(account).WaitSync();
-
-        return AccountVerifyResultType.ExpiredToken;
     }
 
     public AccountDeleteResultType Delete(string username)
@@ -302,32 +336,44 @@ public class AccountService : IAccountService
 
     public bool SetActive(string username, bool isActive)
     {
-        if (GetByUsername(username) is not { } account)
+        lock (_registrationTransitionLock)
         {
-            return false;
+            if (GetByUsername(username) is not { } account)
+            {
+                return false;
+            }
+
+            account.IsActive = isActive;
+            ClearPublicRegistrationState(account);
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _logger.Information("Account {Username} is now {State}", username, isActive ? "active" : "blocked");
+
+            return true;
         }
-
-        account.IsActive = isActive;
-        _accountStore.UpsertAsync(account).WaitSync();
-
-        _logger.Information("Account {Username} is now {State}", username, isActive ? "active" : "blocked");
-
-        return true;
     }
 
     public bool SetLevel(string username, AccountLevelType level)
     {
-        if (GetByUsername(username) is not { } account)
+        lock (_registrationTransitionLock)
         {
-            return false;
+            if (GetByUsername(username) is not { } account)
+            {
+                return false;
+            }
+
+            account.AccountLevel = level;
+            if (level != AccountLevelType.Player)
+            {
+                ClearPublicRegistrationState(account);
+            }
+
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _logger.Information("Account {Username} set to level {Level}", username, level);
+
+            return true;
         }
-
-        account.AccountLevel = level;
-        _accountStore.UpsertAsync(account).WaitSync();
-
-        _logger.Information("Account {Username} set to level {Level}", username, level);
-
-        return true;
     }
 
     public bool SetPassword(string username, string password)
@@ -353,5 +399,11 @@ public class AccountService : IAccountService
         account.ActivationToken = string.Empty;
         account.ActivationTokenHash = string.Empty;
         account.ActivationTokenExpiresAtUtc = null;
+    }
+
+    private static void ClearPublicRegistrationState(AccountEntity account)
+    {
+        ClearActivationTokenState(account);
+        account.IsPublicRegistrationPending = false;
     }
 }

--- a/src/Moongate.Server/Services/Accounts/PublicRegistrationValidator.cs
+++ b/src/Moongate.Server/Services/Accounts/PublicRegistrationValidator.cs
@@ -5,9 +5,6 @@ namespace Moongate.Server.Services.Accounts;
 
 internal static partial class PublicRegistrationValidator
 {
-    [GeneratedRegex("^[A-Za-z0-9._-]{3,30}$", RegexOptions.CultureInvariant)]
-    private static partial Regex UsernameRegex();
-
     public static string NormalizeUsername(string? username)
         => username?.Trim() ?? string.Empty;
 
@@ -23,4 +20,7 @@ internal static partial class PublicRegistrationValidator
 
     public static bool IsEmailValid(string email)
         => MailAddress.TryCreate(email, out _);
+
+    [GeneratedRegex("^[A-Za-z0-9._-]{3,30}$", RegexOptions.CultureInvariant)]
+    private static partial Regex UsernameRegex();
 }

--- a/src/Moongate.Server/Services/Accounts/PublicRegistrationValidator.cs
+++ b/src/Moongate.Server/Services/Accounts/PublicRegistrationValidator.cs
@@ -1,0 +1,26 @@
+using System.Net.Mail;
+using System.Text.RegularExpressions;
+
+namespace Moongate.Server.Services.Accounts;
+
+internal static partial class PublicRegistrationValidator
+{
+    [GeneratedRegex("^[A-Za-z0-9._-]{3,30}$", RegexOptions.CultureInvariant)]
+    private static partial Regex UsernameRegex();
+
+    public static string NormalizeUsername(string? username)
+        => username?.Trim() ?? string.Empty;
+
+    public static string NormalizeEmail(string? email)
+        => email?.Trim() ?? string.Empty;
+
+    public static bool IsUsernameValid(string username)
+        => UsernameRegex().IsMatch(username);
+
+    public static bool IsPasswordValid(string? password)
+        => password is { Length: >= 8 and <= 30 }
+           && password.All(character => character is >= ' ' and <= '~');
+
+    public static bool IsEmailValid(string email)
+        => MailAddress.TryCreate(email, out _);
+}

--- a/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
@@ -63,8 +63,8 @@ public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
         CancellationToken cancellationToken
     )
     {
-        // The verify URL is composed by the template, not here: its shape belongs to the website, and
-        // changing it should cost an edit rather than a release.
+        var website = _settings.Get().Contacts.Website ?? string.Empty;
+
         _notifications.Notify(
             TemplateId,
             new(_channelId, message.Email),
@@ -73,11 +73,30 @@ public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
                 message.Username,
                 message.Email,
                 message.Token,
-                Website = _settings.Get().Contacts.Website ?? string.Empty,
+                Website = website,
+                VerificationUrl = BuildVerificationUrl(website, message.Token),
                 _config.ShardName
             }
         );
 
         return Task.CompletedTask;
+    }
+
+    internal static string BuildVerificationUrl(string website, string token)
+    {
+        if (!Uri.TryCreate(website, UriKind.Absolute, out var websiteUri)
+            || (websiteUri.Scheme != Uri.UriSchemeHttp && websiteUri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("Website must be an absolute HTTP(S) URI.", nameof(website));
+        }
+
+        var uriBuilder = new UriBuilder(websiteUri)
+        {
+            Path = string.Concat(websiteUri.AbsolutePath.TrimEnd('/'), "/verify"),
+            Query = $"token={Uri.EscapeDataString(token)}",
+            Fragment = string.Empty
+        };
+
+        return uriBuilder.Uri.AbsoluteUri;
     }
 }

--- a/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
@@ -85,6 +85,7 @@ public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
     internal static string BuildVerificationUrl(string website, string token)
     {
         if (!Uri.TryCreate(website, UriKind.Absolute, out var websiteUri)
+            || string.IsNullOrEmpty(websiteUri.Host)
             || (websiteUri.Scheme != Uri.UriSchemeHttp && websiteUri.Scheme != Uri.UriSchemeHttps))
         {
             throw new ArgumentException("Website must be an absolute HTTP(S) URI.", nameof(website));

--- a/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Moongate.Core.Types;
 using Moongate.Http.Plugin.Data.Api.Registration;
 using Moongate.Server.Abstractions.Data;
 using Moongate.Tests.Support;
@@ -169,6 +172,64 @@ public sealed class RegistrationEndpointsTests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
+    }
+
+    [Fact]
+    public async Task VerifyAndResend_AdminBlockedPendingAccount_CannotReactivateOrRotate()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+
+        Assert.True(server.Accounts.SetActive("newbie", false));
+
+        var verify = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/verify",
+            new VerifyEmailRequest(token)
+        );
+        var resend = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "newbie", email = "new@bie.test" }
+        );
+        var account = server.Accounts.GetByUsername("newbie")!;
+
+        Assert.Equal(HttpStatusCode.BadRequest, verify.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, resend.StatusCode);
+        Assert.False(account.IsActive);
+        Assert.False(account.IsPublicRegistrationPending);
+        Assert.Empty(account.ActivationTokenHash);
+        Assert.Null(account.ActivationTokenExpiresAtUtc);
+    }
+
+    [Fact]
+    public async Task VerifyAndResend_PrivilegedAccount_CannotReactivateOrRotate()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+        server.Accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
+        server.Accounts.SetActive("staff", false);
+        var account = server.Accounts.GetByUsername("staff")!;
+        account.IsPublicRegistrationPending = true;
+        account.ActivationTokenHash = HashToken("staff-token");
+        account.ActivationTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddHours(1);
+
+        var verify = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/verify",
+            new VerifyEmailRequest("staff-token")
+        );
+        var resend = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "staff", email = "staff@bie.test" }
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, verify.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, resend.StatusCode);
+        Assert.False(account.IsActive);
+        Assert.Equal(HashToken("staff-token"), account.ActivationTokenHash);
     }
 
     [Fact]
@@ -391,4 +452,7 @@ public sealed class RegistrationEndpointsTests
                 { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
         );
     }
+
+    private static string HashToken(string token)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
@@ -16,7 +16,7 @@ public sealed class RegistrationEndpointsTests
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/register",
-            new RegisterRequest("newbie", "secret", "new@bie.test")
+            new RegisterRequest("newbie", "secret99", "new@bie.test")
         );
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -30,7 +30,7 @@ public sealed class RegistrationEndpointsTests
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/register",
-            new RegisterRequest("newbie", "secret", "new@bie.test")
+            new RegisterRequest("newbie", "secret99", "new@bie.test")
         );
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
@@ -42,7 +42,7 @@ public sealed class RegistrationEndpointsTests
     {
         await using var server = await TestApiServer.StartAsync();
         server.ServerSettings.Update(new ServerSettingsUpdate { RegistrationEnabled = true });
-        var token = server.Accounts.RegisterPending("newbie", "secret", "new@bie.test").Token!;
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
 
         var response = await server.Client.PostAsJsonAsync("/api/v1/register/verify", new VerifyEmailRequest(token));
 

--- a/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
@@ -26,7 +26,10 @@ public sealed class RegistrationEndpointsTests
     public async Task Register_WhenEnabled_CreatesInactive_202()
     {
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(new ServerSettingsUpdate { RegistrationEnabled = true });
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate
+                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        );
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/register",
@@ -41,7 +44,10 @@ public sealed class RegistrationEndpointsTests
     public async Task Verify_ActivatesAccount()
     {
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(new ServerSettingsUpdate { RegistrationEnabled = true });
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate
+                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        );
         var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
 
         var response = await server.Client.PostAsJsonAsync("/api/v1/register/verify", new VerifyEmailRequest(token));
@@ -65,7 +71,10 @@ public sealed class RegistrationEndpointsTests
     {
         // The fixture seeds a limiter of 2/window; the 3rd call from the same loopback IP is throttled.
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(new ServerSettingsUpdate { RegistrationEnabled = true });
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate
+                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        );
 
         await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("a", "secret", "a@b.test"));
         await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("b", "secret", "b@b.test"));

--- a/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Moongate.Http.Plugin.Data.Api.Registration;
 using Moongate.Server.Abstractions.Data;
 using Moongate.Tests.Support;
@@ -12,7 +14,8 @@ public sealed class RegistrationEndpointsTests
     [Fact]
     public async Task Register_WhenDisabled_Is403()
     {
-        await using var server = await TestApiServer.StartAsync(); // default: registration disabled
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
 
         var response = await server.Client.PostAsJsonAsync(
             "/api/v1/register",
@@ -20,6 +23,7 @@ public sealed class RegistrationEndpointsTests
         );
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Empty(limiter.Keys);
     }
 
     [Fact]
@@ -41,6 +45,86 @@ public sealed class RegistrationEndpointsTests
     }
 
     [Fact]
+    public async Task Register_WhenRuntimeEmailIsUnavailable_Is503()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(
+            emailChannelReady: false,
+            registrationRateLimiter: limiter
+        );
+        EnableRegistration(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("newbie", "secret99", "new@bie.test")
+        );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Empty(limiter.Keys);
+    }
+
+    [Fact]
+    public async Task Register_InvalidUsername_IsValidationProblem400()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        EnableRegistration(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("ab", "secret99", "new@bie.test")
+        );
+
+        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("username", problem!.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task Register_InvalidPassword_IsValidationProblem400()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        EnableRegistration(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("newbie", "short", "new@bie.test")
+        );
+
+        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("password", problem!.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task Register_DuplicateUsernameOrEmail_IsGeneric409()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        EnableRegistration(server);
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("newbie", "secret99", "new@bie.test")
+        );
+
+        var duplicateUsername = await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("newbie", "secret99", "other@bie.test")
+        );
+        var duplicateEmail = await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("othername", "secret99", "new@bie.test")
+        );
+        var usernameProblem = await duplicateUsername.Content.ReadFromJsonAsync<ProblemDetails>();
+        var emailProblem = await duplicateEmail.Content.ReadFromJsonAsync<ProblemDetails>();
+
+        Assert.Equal(HttpStatusCode.Conflict, duplicateUsername.StatusCode);
+        Assert.Equal(HttpStatusCode.Conflict, duplicateEmail.StatusCode);
+        Assert.Equal(usernameProblem!.Detail, emailProblem!.Detail);
+        Assert.DoesNotContain("newbie", usernameProblem.Detail!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("new@bie.test", usernameProblem.Detail!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Verify_ActivatesAccount()
     {
         await using var server = await TestApiServer.StartAsync();
@@ -51,6 +135,37 @@ public sealed class RegistrationEndpointsTests
         var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
 
         var response = await server.Client.PostAsJsonAsync("/api/v1/register/verify", new VerifyEmailRequest(token));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
+    }
+
+    [Fact]
+    public async Task Verify_ExpiredToken_Is410()
+    {
+        var clock = MutableTimeProvider.StartingNow();
+        await using var server = await TestApiServer.StartAsync(clock: clock);
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        clock.Advance(TimeSpan.FromHours(24));
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/verify",
+            new VerifyEmailRequest(token)
+        );
+
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Verify_WhenRegistrationWasDisabledAfterCreation_StillActivates()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/verify",
+            new VerifyEmailRequest(token)
+        );
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
@@ -76,10 +191,204 @@ public sealed class RegistrationEndpointsTests
                 { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
         );
 
-        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("a", "secret", "a@b.test"));
-        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("b", "secret", "b@b.test"));
-        var third = await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("c", "secret", "c@b.test"));
+        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("first", "secret99", "a@b.test"));
+        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("second", "secret99", "b@b.test"));
+        var third = await server.Client.PostAsJsonAsync(
+            "/api/v1/register",
+            new RegisterRequest("third", "secret99", "c@b.test")
+        );
 
         Assert.Equal(HttpStatusCode.TooManyRequests, third.StatusCode);
+    }
+
+    [Fact]
+    public async Task Resend_MatchingPendingAccount_RotatesToken_202()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+        var originalHash = server.Accounts.GetByUsername("newbie")!.ActivationTokenHash;
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "newbie", email = "new@bie.test" }
+        );
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.NotEqual(originalHash, server.Accounts.GetByUsername("newbie")!.ActivationTokenHash);
+    }
+
+    [Theory]
+    [InlineData("missing", "missing@bie.test")]
+    [InlineData("tom", "tom@bie.test")]
+    [InlineData("newbie", "other@bie.test")]
+    public async Task Resend_MissingActiveOrMismatched_IsAlways202(string username, string email)
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username, email }
+        );
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("ab", "new@bie.test", "username")]
+    [InlineData("newbie", "not-an-email", "email")]
+    public async Task Resend_InvalidInput_Is400(string username, string email, string expectedKey)
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username, email }
+        );
+        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(expectedKey, problem!.Errors.Keys);
+        Assert.Equal(2, limiter.Keys.Count);
+        Assert.StartsWith("resend:ip:", limiter.Keys[0], StringComparison.Ordinal);
+        Assert.StartsWith("resend:target:", limiter.Keys[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Resend_WhenRegistrationDisabled_StillQueuesForPendingAccount()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+        var originalHash = server.Accounts.GetByUsername("newbie")!.ActivationTokenHash;
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "newbie", email = "new@bie.test" }
+        );
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
+        Assert.NotEqual(originalHash, server.Accounts.GetByUsername("newbie")!.ActivationTokenHash);
+    }
+
+    [Fact]
+    public async Task Resend_WhenEmailUnavailable_Is503()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(
+            emailChannelReady: false,
+            registrationRateLimiter: limiter
+        );
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "newbie", email = "new@bie.test" }
+        );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Empty(limiter.Keys);
+    }
+
+    [Fact]
+    public async Task Resend_ThirdIpAttempt_Is429()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "first", email = "first@bie.test" }
+        );
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "second", email = "second@bie.test" }
+        );
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "third", email = "third@bie.test" }
+        );
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Resend_TargetBudgetIsIndependentFromIpBudget()
+    {
+        var limiter = new RecordingRegistrationRateLimiter(
+            (key, attempt) => key.StartsWith("resend:ip:", StringComparison.Ordinal) || attempt <= 2
+        );
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+
+        var first = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = " newbie ", email = " new@bie.test " }
+        );
+        var second = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = " newbie ", email = " NEW@BIE.TEST " }
+        );
+        var third = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = " newbie ", email = " new@bie.test " }
+        );
+        var targetKeys = limiter.Keys.Where(key => key.StartsWith("resend:target:", StringComparison.Ordinal)).ToArray();
+
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, second.StatusCode);
+        Assert.Equal(HttpStatusCode.TooManyRequests, third.StatusCode);
+        Assert.Equal(3, targetKeys.Length);
+        Assert.Single(targetKeys.Distinct(StringComparer.Ordinal));
+        Assert.DoesNotContain("newbie", targetKeys[0], StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("new@bie.test", targetKeys[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Resend_NullInput_Is400()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
+        );
+
+        var response = await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = (string?)null, email = (string?)null }
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(2, limiter.Keys.Count);
+        Assert.StartsWith("resend:target:", limiter.Keys[1], StringComparison.Ordinal);
+    }
+
+    private static void EnableRegistration(TestApiServer server)
+    {
+        server.ServerSettings.Update(
+            new ServerSettingsUpdate
+                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        );
     }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
@@ -15,7 +15,12 @@ public sealed class ServerInfoEndpointsTests
         await using var server = await TestApiServer.StartAsync();
         server.ServerSettings.Update(
             new ServerSettingsUpdate
-                { Description = "A fun shard", Tagline = "Sosaria never sleeps.", RegistrationEnabled = true }
+            {
+                Description = "A fun shard",
+                Tagline = "Sosaria never sleeps.",
+                RegistrationEnabled = true,
+                Contacts = new() { Website = "https://shard.example" }
+            }
         );
 
         var response = await server.Client.GetAsync("/api/v1/server-info"); // no auth header
@@ -26,6 +31,48 @@ public sealed class ServerInfoEndpointsTests
         Assert.Equal("A fun shard", info.Description);
         Assert.Equal("Sosaria never sleeps.", info.Tagline);
         Assert.True(info.RegistrationEnabled);
+    }
+
+    [Fact]
+    public async Task ServerInfo_EnabledWithoutWebsite_ReportsRegistrationClosed()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(new ServerSettingsUpdate { RegistrationEnabled = true });
+
+        var response = await server.Client.GetAsync("/api/v1/server-info");
+        var info = await response.Content.ReadFromJsonAsync<ServerInfoResponse>();
+
+        Assert.False(info!.RegistrationEnabled);
+    }
+
+    [Theory]
+    [InlineData(true, "email", true, true)]
+    [InlineData(false, "email", true, false)]
+    [InlineData(true, "log", true, false)]
+    [InlineData(true, "email", false, false)]
+    public async Task ServerInfo_ReportsRegistrationOpenOnlyWhenToggleAndPrerequisitesAreReady(
+        bool registrationEnabled,
+        string accountVerificationChannel,
+        bool emailChannelReady,
+        bool expectedRegistrationEnabled
+    )
+    {
+        await using var server = await TestApiServer.StartAsync(
+            emailChannelReady: emailChannelReady,
+            accountVerificationChannel: accountVerificationChannel
+        );
+        server.ServerSettings.Update(
+            new()
+            {
+                RegistrationEnabled = registrationEnabled,
+                Contacts = new() { Website = "https://shard.example" }
+            }
+        );
+
+        var response = await server.Client.GetAsync("/api/v1/server-info");
+        var info = await response.Content.ReadFromJsonAsync<ServerInfoResponse>();
+
+        Assert.Equal(expectedRegistrationEnabled, info!.RegistrationEnabled);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Moongate.Http.Plugin.Data.Api.ServerInfo;
 using Moongate.Persistence.Entities;
@@ -115,6 +116,29 @@ public sealed class ServerSettingsAdminEndpointsTests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.False(server.ServerSettings.Get().RegistrationEnabled);
+    }
+
+    [Fact]
+    public async Task OpenApi_UpdateDocumentsValidationProblemResponse()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var document = await server.Client.GetStringAsync("/swagger/v1/swagger.json");
+        using var json = JsonDocument.Parse(document);
+        var responses = json.RootElement
+            .GetProperty("paths")
+            .GetProperty("/api/v1/admin/server-settings")
+            .GetProperty("put")
+            .GetProperty("responses");
+        var schemaReference = responses
+            .GetProperty("400")
+            .GetProperty("content")
+            .GetProperty("application/problem+json")
+            .GetProperty("schema")
+            .GetProperty("$ref")
+            .GetString();
+
+        Assert.Equal("#/components/schemas/HttpValidationProblemDetails", schemaReference);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
 using Moongate.Http.Plugin.Data.Api.ServerInfo;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Types;
@@ -28,13 +29,92 @@ public sealed class ServerSettingsAdminEndpointsTests
 
         var response = await server.Client.PutAsJsonAsync(
             "/api/v1/admin/server-settings",
-            new UpdateServerSettingsRequest { RegistrationEnabled = true, Description = "Hi", Tagline = "Welcome" }
+            new UpdateServerSettingsRequest
+            {
+                RegistrationEnabled = true,
+                Description = "Hi",
+                Tagline = "Welcome",
+                Contacts = new("https://shard.example", null, null)
+            }
         );
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         Assert.True(server.ServerSettings.Get().RegistrationEnabled);
         Assert.Equal("Hi", server.ServerSettings.Get().Description);
         Assert.Equal("Welcome", server.ServerSettings.Get().Tagline);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsPersistedToggleAndRegistrationReadiness()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+        server.ServerSettings.Update(
+            new()
+            {
+                RegistrationEnabled = true,
+                Contacts = new() { Website = "https://shard.example" }
+            }
+        );
+
+        var response = await server.Client.GetAsync("/api/v1/admin/server-settings");
+        var settings = await response.Content.ReadFromJsonAsync<ServerSettingsResponse>();
+
+        Assert.True(settings!.RegistrationEnabled);
+        Assert.True(settings.RegistrationReadiness.Ready);
+        Assert.True(settings.RegistrationReadiness.WebsiteValid);
+        Assert.True(settings.RegistrationReadiness.EmailChannelSelected);
+        Assert.True(settings.RegistrationReadiness.EmailChannelAvailable);
+    }
+
+    [Theory]
+    [InlineData("ftp://shard.example", "email", true)]
+    [InlineData("https://shard.example", "log", true)]
+    [InlineData("https://shard.example", "email", false)]
+    public async Task Put_EnablingWithoutReadiness_RejectsAndPersistsNothing(
+        string website,
+        string accountVerificationChannel,
+        bool emailChannelReady
+    )
+    {
+        await using var server = await TestApiServer.StartAsync(
+            emailChannelReady: emailChannelReady,
+            accountVerificationChannel: accountVerificationChannel
+        );
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.PutAsJsonAsync(
+            "/api/v1/admin/server-settings",
+            new UpdateServerSettingsRequest
+            {
+                Description = "Must not persist",
+                RegistrationEnabled = true,
+                Contacts = new(website, null, null)
+            }
+        );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        Assert.Contains("registrationEnabled", problem!.Errors.Keys);
+        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
+        Assert.Null(server.ServerSettings.Get().Description);
+        Assert.Null(server.ServerSettings.Get().Contacts.Website);
+    }
+
+    [Fact]
+    public async Task Put_DisablingAnUnhealthyEnabledState_Succeeds()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+        server.ServerSettings.Update(new() { RegistrationEnabled = true });
+
+        var response = await server.Client.PutAsJsonAsync(
+            "/api/v1/admin/server-settings",
+            new UpdateServerSettingsRequest { RegistrationEnabled = false }
+        );
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
@@ -32,6 +32,36 @@ public sealed class RegistrationReadinessServiceTests
     }
 
     [Theory]
+    [InlineData(null, "email", "email", false, true, true)]
+    [InlineData("https://shard.example", "log", "email", true, false, true)]
+    [InlineData("https://shard.example", "email", null, true, true, false)]
+    [InlineData("https://shard.example", "EMAIL", "EMAIL", true, true, true)]
+    public void Evaluate_ReportsEveryReadinessProperty(
+        string? website,
+        string selected,
+        string? registeredChannel,
+        bool websiteValid,
+        bool emailChannelSelected,
+        bool emailChannelAvailable
+    )
+    {
+        INotificationChannel[] channels = registeredChannel is null
+            ? []
+            : [new RecordingNotificationChannel(registeredChannel)];
+        var service = new RegistrationReadinessService(
+            new NotificationConfig { AccountVerificationChannel = selected },
+            channels
+        );
+
+        var readiness = service.Evaluate(website);
+
+        Assert.Equal(websiteValid, readiness.WebsiteValid);
+        Assert.Equal(emailChannelSelected, readiness.EmailChannelSelected);
+        Assert.Equal(emailChannelAvailable, readiness.EmailChannelAvailable);
+        Assert.Equal(websiteValid && emailChannelSelected && emailChannelAvailable, readiness.Ready);
+    }
+
+    [Theory]
     [InlineData("http:/portal")]
     [InlineData("https:/portal")]
     [InlineData("http:portal")]

--- a/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
@@ -30,4 +30,22 @@ public sealed class RegistrationReadinessServiceTests
 
         Assert.Equal(expected, service.Evaluate(website).Ready);
     }
+
+    [Theory]
+    [InlineData("http:/portal")]
+    [InlineData("https:/portal")]
+    [InlineData("http:portal")]
+    [InlineData("http:///portal")]
+    public void Evaluate_HostlessHttpWebsite_IsNotValidOrReady(string website)
+    {
+        var service = new RegistrationReadinessService(
+            new NotificationConfig { AccountVerificationChannel = "email" },
+            [new RecordingNotificationChannel("email")]
+        );
+
+        var readiness = service.Evaluate(website);
+
+        Assert.False(readiness.WebsiteValid);
+        Assert.False(readiness.Ready);
+    }
 }

--- a/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
@@ -1,0 +1,33 @@
+using Moongate.Http.Plugin.Services.Registration;
+using Moongate.Server.Abstractions.Data.Config;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Tests.Support;
+using Xunit;
+
+namespace Moongate.Tests.Http.Services.Registration;
+
+public sealed class RegistrationReadinessServiceTests
+{
+    [Theory]
+    [InlineData("https://shard.example", "email", true, true)]
+    [InlineData("http://shard.example/moongate", "EMAIL", true, true)]
+    [InlineData(null, "email", true, false)]
+    [InlineData("ftp://shard.example", "email", true, false)]
+    [InlineData("https://shard.example", "log", true, false)]
+    [InlineData("https://shard.example", "email", false, false)]
+    public void Evaluate_RequiresWebsiteSelectedEmailAndRegisteredChannel(
+        string? website,
+        string selected,
+        bool channelRegistered,
+        bool expected
+    )
+    {
+        INotificationChannel[] channels = channelRegistered ? [new RecordingNotificationChannel("email")] : [];
+        var service = new RegistrationReadinessService(
+            new NotificationConfig { AccountVerificationChannel = selected },
+            channels
+        );
+
+        Assert.Equal(expected, service.Evaluate(website).Ready);
+    }
+}

--- a/tests/Moongate.Tests/Persistence/Entities/AccountEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/AccountEntityTests.cs
@@ -1,0 +1,32 @@
+using MessagePack;
+using MessagePack.Resolvers;
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Tests.Persistence.Entities;
+
+public sealed class AccountEntityTests
+{
+    [Fact]
+    public void Deserialize_SaveWrittenBeforeVerificationTokenFieldsExisted_DefaultsTheNewFields()
+    {
+        var oldSave = new Dictionary<string, object>
+        {
+            ["Username"] = "old-account",
+            ["ActivationToken"] = "legacy-token"
+        };
+
+        var account = RoundTrip<Dictionary<string, object>, AccountEntity>(oldSave);
+
+        Assert.Equal("old-account", account.Username);
+        Assert.Equal("legacy-token", account.ActivationToken);
+        Assert.Empty(account.ActivationTokenHash);
+        Assert.Null(account.ActivationTokenExpiresAtUtc);
+    }
+
+    // Mirrors the persistence layer, which registers MessagePack's contractless resolver.
+    private static TOut RoundTrip<TIn, TOut>(TIn value)
+        => MessagePackSerializer.Deserialize<TOut>(
+            MessagePackSerializer.Serialize(value, ContractlessStandardResolver.Options),
+            ContractlessStandardResolver.Options
+        );
+}

--- a/tests/Moongate.Tests/Persistence/Entities/AccountEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/AccountEntityTests.cs
@@ -21,6 +21,29 @@ public sealed class AccountEntityTests
         Assert.Equal("legacy-token", account.ActivationToken);
         Assert.Empty(account.ActivationTokenHash);
         Assert.Null(account.ActivationTokenExpiresAtUtc);
+        Assert.False(account.IsPublicRegistrationPending);
+    }
+
+    [Fact]
+    public void RoundTrip_CurrentVerificationState_PreservesHashedPendingRegistration()
+    {
+        var expiresAt = new DateTimeOffset(2026, 7, 26, 12, 0, 0, TimeSpan.Zero);
+        var original = new AccountEntity
+        {
+            Username = "pending-account",
+            PasswordHash = "password-hash",
+            ActivationToken = string.Empty,
+            ActivationTokenHash = new string('A', 64),
+            ActivationTokenExpiresAtUtc = expiresAt,
+            IsPublicRegistrationPending = true
+        };
+
+        var restored = RoundTrip<AccountEntity, AccountEntity>(original);
+
+        Assert.Equal(original.ActivationTokenHash, restored.ActivationTokenHash);
+        Assert.Equal(expiresAt, restored.ActivationTokenExpiresAtUtc);
+        Assert.True(restored.IsPublicRegistrationPending);
+        Assert.Empty(restored.ActivationToken);
     }
 
     // Mirrors the persistence layer, which registers MessagePack's contractless resolver.

--- a/tests/Moongate.Tests/Server/Accounts/AccountServiceGetAllTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/AccountServiceGetAllTests.cs
@@ -32,7 +32,8 @@ public class AccountServiceGetAllTests
             persistence,
             CharacterServiceFixture.Create(persistence, bus),
             new StubSessionManager(),
-            bus
+            bus,
+            TimeProvider.System
         );
     }
 }

--- a/tests/Moongate.Tests/Server/Accounts/AccountServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/AccountServiceTests.cs
@@ -282,7 +282,8 @@ public class AccountServiceTests
             persistence,
             characters ?? CharacterServiceFixture.Create(persistence, bus),
             sessions ?? new StubSessionManager(),
-            bus
+            bus,
+            TimeProvider.System
         );
     }
 }

--- a/tests/Moongate.Tests/Server/Accounts/IAccountServiceContractTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/IAccountServiceContractTests.cs
@@ -1,0 +1,17 @@
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Tests.Support;
+using Xunit;
+
+namespace Moongate.Tests.Server.Accounts;
+
+public sealed class IAccountServiceContractTests
+{
+    [Fact]
+    public void ResendVerification_ImplementerWithoutOverride_ReturnsIgnored()
+    {
+        IAccountService service = new StubAccountService();
+
+        Assert.Equal(AccountResendResultType.Ignored, service.ResendVerification("newbie", "new@bie.test"));
+    }
+}

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -328,7 +328,7 @@ public class LoginFlowIntegrationTests
             }
         );
         var characters = CharacterServiceFixture.Create(persistence, eventBus, sessions, testCities);
-        var accounts = new AccountService(persistence, characters, sessions, eventBus);
+        var accounts = new AccountService(persistence, characters, sessions, eventBus, TimeProvider.System);
         // Mirrors the runtime path: register the command declaratively (name/level/help) instead of
         // scanning an attribute. The resolver is a throwaway container — the registration below closes
         // over an already-built instance, so it never actually resolves through it.

--- a/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
@@ -10,17 +10,23 @@ namespace Moongate.Tests.Server.Notifications;
 public sealed class AccountRegistrationSubscriberTests
 {
     [Fact]
-    public async Task RegistrationEvent_SendsTheVerificationOnTheConfiguredChannel()
+    public async Task RegistrationEvent_SendsCanonicalVerificationUrlAndPreservesCustomTemplateFields()
     {
         var channel = new RecordingNotificationChannel("log");
         var bus = Wire(channel, "log");
 
-        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc123"));
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc+123"));
 
         var (recipient, content) = Assert.Single(channel.Sent);
         Assert.Equal("tom@example.com", recipient.Address);
         Assert.Equal("log", recipient.ChannelId);
-        Assert.Equal("tom/tom@example.com/abc123/https://shard.example/Britannia", content.Body.Trim());
+        Assert.Contains(
+            "https://shard.example/moongate/verify?token=abc%2B123",
+            content.Body,
+            StringComparison.Ordinal
+        );
+        Assert.Contains("tom/abc+123/https://shard.example/moongate/", content.Body, StringComparison.Ordinal);
+        Assert.Contains("/Britannia", content.Body, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -36,6 +42,22 @@ public sealed class AccountRegistrationSubscriberTests
     }
 
     [Fact]
+    public async Task RegistrationEvent_ReplacesWebsiteQueryAndFragment()
+    {
+        var channel = new RecordingNotificationChannel("log");
+        var bus = Wire(channel, "log", "https://shard.example/moongate%20portal/?legacy=true#old");
+
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc+123"));
+
+        var content = Assert.Single(channel.Sent).Content;
+        Assert.Contains(
+            "/https://shard.example/moongate%20portal/verify?token=abc%2B123/Britannia",
+            content.Body,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
     public async Task UnregisteredChannel_DoesNotDeliver_AndDoesNotThrow()
     {
         var channel = new RecordingNotificationChannel("log");
@@ -48,19 +70,23 @@ public sealed class AccountRegistrationSubscriberTests
     }
 
     /// <summary>Wires the subscriber over one channel, with the verification routed at <paramref name="routeTo" />.</summary>
-    private static EventBusService Wire(RecordingNotificationChannel channel, string routeTo)
+    private static EventBusService Wire(
+        RecordingNotificationChannel channel,
+        string routeTo,
+        string website = "https://shard.example/moongate/"
+    )
     {
         var templates = new NotificationTemplateService();
         templates.Register(
             channel.Id,
             "account_verification",
-            "{{ username }}/{{ email }}/{{ token }}/{{ website }}/{{ shard_name }}"
+            "{{ username }}/{{ token }}/{{ website }}/{{ verification_url }}/{{ shard_name }}"
         );
 
         var notifications = new NotificationService(templates, [channel], new StubJobSystem(), new());
 
         var settings = new ServerSettingsService(new FakePersistenceService());
-        settings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+        settings.Update(new() { Contacts = new() { Website = website } });
 
         var bus = new EventBusService();
         new AccountRegistrationSubscriber(

--- a/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.Notifications;
 using Moongate.Server.Services.Server;
@@ -55,6 +57,32 @@ public sealed class AccountRegistrationSubscriberTests
             content.Body,
             StringComparison.Ordinal
         );
+    }
+
+    [Theory]
+    [InlineData("http:/portal")]
+    [InlineData("https:/portal")]
+    [InlineData("http:portal")]
+    [InlineData("http:///portal")]
+    public void BuildVerificationUrl_HostlessHttpWebsite_ThrowsArgumentException(string website)
+    {
+        var method = typeof(AccountRegistrationSubscriber).GetMethod(
+            "BuildVerificationUrl",
+            BindingFlags.Static | BindingFlags.NonPublic
+        );
+
+        if (method is null)
+        {
+            throw new InvalidOperationException("BuildVerificationUrl was not found.");
+        }
+
+        var invocationException = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, [website, "abc123"])
+        );
+        var exception = Assert.IsType<ArgumentException>(invocationException.InnerException);
+
+        Assert.Equal("website", exception.ParamName);
+        Assert.Contains("absolute HTTP(S) URI", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
@@ -38,8 +38,10 @@ public sealed class NotificationTemplatesLoaderTests
             var log = templates.Render("log", "account_verification", model);
             var email = templates.Render("email", "account_verification", model);
 
-            Assert.Contains(model.VerificationUrl, log!.Body, StringComparison.Ordinal);
-            Assert.Contains(model.VerificationUrl, email!.Body, StringComparison.Ordinal);
+            Assert.NotNull(log);
+            Assert.NotNull(email);
+            Assert.Contains(model.VerificationUrl, log.Body, StringComparison.Ordinal);
+            Assert.Contains(model.VerificationUrl, email.Body, StringComparison.Ordinal);
         }
         finally
         {
@@ -66,7 +68,8 @@ public sealed class NotificationTemplatesLoaderTests
             // The directory is the channel id and the file name is the template id — no registry, no
             // configuration: a plugin channel ships its own directory and is picked up.
             var content = templates.Render("discord", "shard_online", new { ShardName = "Britannia" });
-            Assert.Equal("Britannia is up", content!.Body.Trim());
+            Assert.NotNull(content);
+            Assert.Equal("Britannia is up", content.Body.Trim());
         }
         finally
         {

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
@@ -25,9 +25,21 @@ public sealed class NotificationTemplatesLoaderTests
             Assert.True(File.Exists(Path.Combine(templatesDirectory, "email", "account_verification.mgtmpl")));
 
             Assert.Equal(2, templates.Count);
-            Assert.NotNull(
-                templates.Render("log", "account_verification", new { Username = "tom", Email = "t@x", Token = "abc" })
-            );
+            var model = new
+            {
+                Username = "tom",
+                Email = "t@x",
+                Token = "abc+123",
+                Website = "https://shard.example/moongate/",
+                VerificationUrl = "https://shard.example/moongate/verify?token=abc%2B123",
+                ShardName = "Britannia"
+            };
+
+            var log = templates.Render("log", "account_verification", model);
+            var email = templates.Render("email", "account_verification", model);
+
+            Assert.Contains(model.VerificationUrl, log!.Body, StringComparison.Ordinal);
+            Assert.Contains(model.VerificationUrl, email!.Body, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/Moongate.Tests/Server/Scripting/AccountModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/AccountModuleTests.cs
@@ -178,7 +178,8 @@ public class AccountModuleTests
             persistence,
             CharacterServiceFixture.Create(persistence, bus),
             new StubSessionManager(),
-            bus
+            bus,
+            TimeProvider.System
         );
 
         return (new(accounts), accounts);

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -10,35 +10,69 @@ namespace Moongate.Tests.Server.Services.Accounts;
 
 public sealed class AccountRegistrationTests
 {
-    private static (AccountService accounts, EventBusService bus) Create()
+    private static readonly DateTimeOffset Now = new(2026, 7, 25, 12, 0, 0, TimeSpan.Zero);
+
+    public static TheoryData<string, string, string, AccountRegisterResultType> PublicRegistrationInputs()
+        => new()
+        {
+            { "ab", "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
+            { "abc", "secret99", "new@bie.test", AccountRegisterResultType.Created },
+            { new string('a', 30), "secret99", "new@bie.test", AccountRegisterResultType.Created },
+            { new string('a', 31), "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
+            { "naïve", "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
+            { "new!bie", "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
+            { "newbie", "1234567", "new@bie.test", AccountRegisterResultType.PasswordInvalid },
+            { "newbie", "12345678", "new@bie.test", AccountRegisterResultType.Created },
+            { "newbie", new string('p', 30), "new@bie.test", AccountRegisterResultType.Created },
+            { "newbie", new string('p', 31), "new@bie.test", AccountRegisterResultType.PasswordInvalid },
+            { "newbie", "secret\n9", "new@bie.test", AccountRegisterResultType.PasswordInvalid },
+            { "newbie", "pässword", "new@bie.test", AccountRegisterResultType.PasswordInvalid }
+        };
+
+    private static (
+        AccountService Accounts,
+        EventBusService Bus,
+        FakePersistenceService Persistence,
+        CharacterService Characters,
+        StubSessionManager Sessions
+    ) Create(TimeProvider? timeProvider = null)
     {
         var persistence = new FakePersistenceService();
         var sessions = new StubSessionManager();
         var bus = new EventBusService();
         var characters = CharacterServiceFixture.Create(persistence, bus, sessions);
 
-        return (new AccountService(persistence, characters, sessions, bus), bus);
+        return (
+            new AccountService(persistence, characters, sessions, bus, timeProvider ?? new FixedTimeProvider(Now)),
+            bus,
+            persistence,
+            characters,
+            sessions
+        );
     }
 
     [Fact]
-    public void RegisterPending_CreatesInactiveAccountWithToken()
+    public void RegisterPending_StoresOnlyAHashAndA24HourExpiry()
     {
-        var (accounts, _) = Create();
+        var (accounts, _, _, _, _) = Create();
 
-        var result = accounts.RegisterPending("newbie", "secret", "new@bie.test");
+        var result = accounts.RegisterPending("newbie", "secret99", "new@bie.test");
 
         Assert.Equal(AccountRegisterResultType.Created, result.Result);
-        Assert.False(string.IsNullOrWhiteSpace(result.Token));
+        Assert.NotNull(result.Token);
+        Assert.Matches("^[0-9A-Fa-f]{64}$", result.Token);
         var account = accounts.GetByUsername("newbie");
         Assert.NotNull(account);
         Assert.False(account!.IsActive);
-        Assert.Equal(result.Token, account.ActivationToken);
+        Assert.Empty(account.ActivationToken);
+        Assert.NotEqual(result.Token, account.ActivationTokenHash);
+        Assert.Equal(Now.AddHours(24), account.ActivationTokenExpiresAtUtc);
     }
 
     [Fact]
     public void RegisterPending_PublishesEvent()
     {
-        var (accounts, bus) = Create();
+        var (accounts, bus, _, _, _) = Create();
         AccountRegistrationRequestedEvent? seen = null;
         bus.Subscribe<AccountRegistrationRequestedEvent>((e, _) =>
             {
@@ -48,54 +82,157 @@ public sealed class AccountRegistrationTests
             }
         );
 
-        var result = accounts.RegisterPending("newbie", "secret", "new@bie.test");
+        var result = accounts.RegisterPending("newbie", "secret99", "new@bie.test");
 
         Assert.NotNull(seen);
         Assert.Equal("newbie", seen!.Username);
         Assert.Equal(result.Token, seen.Token);
     }
 
-    [Theory]
-    [InlineData("", "p", "e@e.test", AccountRegisterResultType.UsernameEmpty)]
-    [InlineData("u", "", "e@e.test", AccountRegisterResultType.PasswordEmpty)]
-    [InlineData("u", "p", "", AccountRegisterResultType.EmailEmpty)]
-    [InlineData("u", "p", "not-an-email", AccountRegisterResultType.EmailInvalid)]
-    public void RegisterPending_Validates(string user, string pass, string email, AccountRegisterResultType expected)
+    [Theory, MemberData(nameof(PublicRegistrationInputs))]
+    public void RegisterPending_PublicCredentialRules_ReturnsExpectedResult(
+        string username,
+        string password,
+        string email,
+        AccountRegisterResultType expected
+    )
     {
-        var (accounts, _) = Create();
+        var (accounts, _, _, _, _) = Create();
 
-        Assert.Equal(expected, accounts.RegisterPending(user, pass, email).Result);
+        Assert.Equal(expected, accounts.RegisterPending(username, password, email).Result);
+    }
+
+    [Theory]
+    [InlineData("", "secret99", "new@bie.test", AccountRegisterResultType.UsernameEmpty)]
+    [InlineData("newbie", "", "new@bie.test", AccountRegisterResultType.PasswordEmpty)]
+    [InlineData("newbie", "secret99", "", AccountRegisterResultType.EmailEmpty)]
+    [InlineData("newbie", "secret99", "not-an-email", AccountRegisterResultType.EmailInvalid)]
+    public void RegisterPending_MissingOrInvalidInputs_ReturnsExpectedResult(
+        string username,
+        string password,
+        string email,
+        AccountRegisterResultType expected
+    )
+    {
+        var (accounts, _, _, _, _) = Create();
+
+        Assert.Equal(expected, accounts.RegisterPending(username, password, email).Result);
+    }
+
+    [Fact]
+    public void RegisterPending_TrimmedUsernameAndEmail_StoresNormalizedValues()
+    {
+        var (accounts, _, _, _, _) = Create();
+
+        var result = accounts.RegisterPending(" newbie ", "secret99", " new@bie.test ");
+        var account = accounts.GetByUsername("newbie");
+
+        Assert.Equal(AccountRegisterResultType.Created, result.Result);
+        Assert.NotNull(account);
+        Assert.Equal("newbie", account!.Username);
+        Assert.Equal("new@bie.test", account.Email);
+    }
+
+    [Fact]
+    public void RegisterPending_PreservesPasswordWhitespace()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var password = " secret99 ";
+        var token = accounts.RegisterPending("newbie", password, "new@bie.test").Token!;
+
+        Assert.Equal(AccountVerifyResultType.Verified, accounts.VerifyEmail(token));
+        Assert.True(accounts.Authenticate("newbie", password).Success);
+        Assert.False(accounts.Authenticate("newbie", password.Trim()).Success);
     }
 
     [Fact]
     public void RegisterPending_UsernameTaken()
     {
-        var (accounts, _) = Create();
+        var (accounts, _, _, _, _) = Create();
         accounts.Create("taken", "pw", null, AccountLevelType.Player);
 
         Assert.Equal(
             AccountRegisterResultType.UsernameTaken,
-            accounts.RegisterPending("taken", "pw", "e@e.test").Result
+            accounts.RegisterPending("taken", "secret99", "e@e.test").Result
         );
     }
 
     [Fact]
-    public void VerifyEmail_ActivatesAndIsSingleUse()
+    public void RegisterPending_EmailTakenForActiveAndInactiveAccounts()
     {
-        var (accounts, _) = Create();
-        var token = accounts.RegisterPending("newbie", "secret", "new@bie.test").Token!;
+        var (accounts, _, _, _, _) = Create();
+        accounts.Create("active", "pw", "taken@example.test", AccountLevelType.Player);
+        Assert.Equal(
+            AccountRegisterResultType.EmailTaken,
+            accounts.RegisterPending("another", "secret99", "TAKEN@example.test").Result
+        );
+
+        Assert.Equal(
+            AccountRegisterResultType.Created,
+            accounts.RegisterPending("inactive", "secret99", "inactive@example.test").Result
+        );
+        Assert.Equal(
+            AccountRegisterResultType.EmailTaken,
+            accounts.RegisterPending("other", "secret99", "INACTIVE@example.test").Result
+        );
+    }
+
+    [Fact]
+    public void VerifyEmail_BeforeExpiry_ActivatesAndIsSingleUse()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
 
         Assert.Equal(AccountVerifyResultType.Verified, accounts.VerifyEmail(token));
         Assert.True(accounts.GetByUsername("newbie")!.IsActive);
+        Assert.Empty(accounts.GetByUsername("newbie")!.ActivationTokenHash);
+        Assert.Null(accounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
 
         // consumed token no longer matches
         Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail(token));
     }
 
     [Fact]
+    public void VerifyEmail_AtExpiry_ReturnsExpiredTokenAndClearsTokenState()
+    {
+        var (accounts, bus, persistence, characters, sessions) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var atExpiry = new AccountService(
+            persistence,
+            characters,
+            sessions,
+            bus,
+            new FixedTimeProvider(Now.AddHours(24))
+        );
+
+        Assert.Equal(AccountVerifyResultType.ExpiredToken, atExpiry.VerifyEmail(token));
+        var account = atExpiry.GetByUsername("newbie")!;
+        Assert.False(account.IsActive);
+        Assert.Empty(account.ActivationToken);
+        Assert.Empty(account.ActivationTokenHash);
+        Assert.Null(account.ActivationTokenExpiresAtUtc);
+    }
+
+    [Fact]
+    public void VerifyEmail_LegacyPlaintextToken_ReturnsExpiredTokenAndClearsLegacyState()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var account = accounts.GetByUsername("newbie");
+        Assert.Null(account);
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        account = accounts.GetByUsername("newbie")!;
+        account.IsActive = false;
+        account.ActivationToken = "legacy-token";
+
+        Assert.Equal(AccountVerifyResultType.ExpiredToken, accounts.VerifyEmail("legacy-token"));
+        Assert.False(accounts.GetByUsername("newbie")!.IsActive);
+        Assert.Empty(accounts.GetByUsername("newbie")!.ActivationToken);
+    }
+
+    [Fact]
     public void VerifyEmail_UnknownOrBlankToken_IsInvalid()
     {
-        var (accounts, _) = Create();
+        var (accounts, _, _, _, _) = Create();
 
         Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("nope"));
         Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("  "));

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Types;
@@ -66,6 +68,11 @@ public sealed class AccountRegistrationTests
         Assert.False(account!.IsActive);
         Assert.Empty(account.ActivationToken);
         Assert.NotEqual(result.Token, account.ActivationTokenHash);
+        Assert.Equal(
+            Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(result.Token))),
+            account.ActivationTokenHash
+        );
+        Assert.Matches("^[0-9A-F]{64}$", account.ActivationTokenHash);
         Assert.Equal(Now.AddHours(24), account.ActivationTokenExpiresAtUtc);
     }
 

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using Moongate.Core.Types;
@@ -57,6 +58,29 @@ public sealed class AccountRegistrationTests
     private static string Hash(string token)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
 
+    private static async Task<TResult[]> RunConcurrently<TResult>(params Func<TResult>[] actions)
+    {
+        using var start = new Barrier(actions.Length + 1);
+        var tasks = actions
+            .Select(action =>
+                Task.Factory.StartNew(
+                    () =>
+                    {
+                        start.SignalAndWait();
+                        return action();
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default
+                )
+            )
+            .ToArray();
+
+        start.SignalAndWait();
+
+        return await Task.WhenAll(tasks);
+    }
+
     [Fact]
     public void ResendVerification_RotatesTokenAndPublishesOneEvent()
     {
@@ -82,6 +106,7 @@ public sealed class AccountRegistrationTests
         Assert.Equal(upsertsBefore + 1, accountStore.UpsertCount);
         Assert.NotEqual(first, resent!.Token);
         Assert.Equal(Hash(resent.Token), accounts.GetByUsername("newbie")!.ActivationTokenHash);
+        Assert.True(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
     }
 
     [Fact]
@@ -127,6 +152,65 @@ public sealed class AccountRegistrationTests
         Assert.Null(resent);
         Assert.Equal(upsertsBefore, accountStore.UpsertCount);
         Assert.True(accounts.GetByUsername("newbie")!.IsActive);
+    }
+
+    [Fact]
+    public void ResendVerification_BlockedPlayer_IsIgnoredWithoutRotatingOrPublishingAnEvent()
+    {
+        var (accounts, bus, persistence, _, _) = Create();
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        accounts.SetActive("newbie", false);
+        var account = accounts.GetByUsername("newbie")!;
+        account.ActivationTokenHash = Hash("blocked-token");
+        account.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+        var originalHash = account.ActivationTokenHash;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
+            {
+                eventCount++;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Equal(0, eventCount);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
+        Assert.Equal(originalHash, account.ActivationTokenHash);
+        Assert.False(account.IsActive);
+    }
+
+    [Fact]
+    public void ResendVerification_PrivilegedAccount_IsIgnoredEvenWithPendingMarker()
+    {
+        var (accounts, bus, persistence, _, _) = Create();
+        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
+        accounts.SetActive("staff", false);
+        var account = accounts.GetByUsername("staff")!;
+        account.IsPublicRegistrationPending = true;
+        account.ActivationTokenHash = Hash("staff-token");
+        account.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+        var originalHash = account.ActivationTokenHash;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
+            {
+                eventCount++;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("staff", "staff@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Equal(0, eventCount);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
+        Assert.Equal(originalHash, account.ActivationTokenHash);
+        Assert.False(account.IsActive);
     }
 
     [Fact]
@@ -198,6 +282,7 @@ public sealed class AccountRegistrationTests
         Assert.NotNull(resent);
         Assert.Empty(account.ActivationToken);
         Assert.Equal(Hash(resent!.Token), account.ActivationTokenHash);
+        Assert.True(account.IsPublicRegistrationPending);
     }
 
     [Fact]
@@ -241,6 +326,7 @@ public sealed class AccountRegistrationTests
         );
         Assert.Matches("^[0-9A-F]{64}$", account.ActivationTokenHash);
         Assert.Equal(Now.AddHours(24), account.ActivationTokenExpiresAtUtc);
+        Assert.True(account.IsPublicRegistrationPending);
     }
 
     [Fact]
@@ -361,6 +447,7 @@ public sealed class AccountRegistrationTests
         Assert.True(accounts.GetByUsername("newbie")!.IsActive);
         Assert.Empty(accounts.GetByUsername("newbie")!.ActivationTokenHash);
         Assert.Null(accounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
+        Assert.False(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
 
         // consumed token no longer matches
         Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail(token));
@@ -385,6 +472,7 @@ public sealed class AccountRegistrationTests
         Assert.Empty(account.ActivationToken);
         Assert.Empty(account.ActivationTokenHash);
         Assert.Null(account.ActivationTokenExpiresAtUtc);
+        Assert.True(account.IsPublicRegistrationPending);
     }
 
     [Fact]
@@ -401,6 +489,187 @@ public sealed class AccountRegistrationTests
         Assert.Equal(AccountVerifyResultType.ExpiredToken, accounts.VerifyEmail("legacy-token"));
         Assert.False(accounts.GetByUsername("newbie")!.IsActive);
         Assert.Empty(accounts.GetByUsername("newbie")!.ActivationToken);
+        Assert.True(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
+    }
+
+    [Fact]
+    public void VerifyEmail_BlockedPlayerAndPrivilegedAccount_CannotBeReactivated()
+    {
+        var (accounts, _, _, _, _) = Create();
+        accounts.Create("blocked", "secret99", "blocked@bie.test", AccountLevelType.Player);
+        accounts.SetActive("blocked", false);
+        var blocked = accounts.GetByUsername("blocked")!;
+        blocked.ActivationTokenHash = Hash("blocked-token");
+        blocked.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+
+        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
+        accounts.SetActive("staff", false);
+        var staff = accounts.GetByUsername("staff")!;
+        staff.IsPublicRegistrationPending = true;
+        staff.ActivationTokenHash = Hash("staff-token");
+        staff.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("blocked-token"));
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("staff-token"));
+        Assert.False(blocked.IsActive);
+        Assert.False(staff.IsActive);
+        Assert.Equal(Hash("blocked-token"), blocked.ActivationTokenHash);
+        Assert.Equal(Hash("staff-token"), staff.ActivationTokenHash);
+    }
+
+    [Fact]
+    public void SetActive_BlocksPendingRegistrationAndClearsVerificationState()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+
+        Assert.True(accounts.SetActive("newbie", false));
+
+        var account = accounts.GetByUsername("newbie")!;
+        Assert.False(account.IsPublicRegistrationPending);
+        Assert.Empty(account.ActivationTokenHash);
+        Assert.Null(account.ActivationTokenExpiresAtUtc);
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail(token));
+        Assert.Equal(AccountResendResultType.Ignored, accounts.ResendVerification("newbie", "new@bie.test"));
+    }
+
+    [Fact]
+    public void SetLevel_PromotingPendingRegistrationClearsVerificationState()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+
+        Assert.True(accounts.SetLevel("newbie", AccountLevelType.Administrator));
+
+        var account = accounts.GetByUsername("newbie")!;
+        Assert.False(account.IsPublicRegistrationPending);
+        Assert.Empty(account.ActivationTokenHash);
+        Assert.Null(account.ActivationTokenExpiresAtUtc);
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail(token));
+    }
+
+    [Fact]
+    public void LegacyPlaintextToken_PrivilegedAccountCannotMigrateOrVerify()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
+        accounts.SetActive("staff", false);
+        var staff = accounts.GetByUsername("staff")!;
+        staff.ActivationToken = "legacy-staff-token";
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
+            {
+                eventCount++;
+                return Task.CompletedTask;
+            }
+        );
+
+        Assert.Equal(AccountResendResultType.Ignored, accounts.ResendVerification("staff", "staff@bie.test"));
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("legacy-staff-token"));
+        Assert.Equal("legacy-staff-token", staff.ActivationToken);
+        Assert.False(staff.IsActive);
+        Assert.Equal(0, eventCount);
+    }
+
+    [Fact]
+    public async Task RegisterPending_ConcurrentDuplicateUsername_CreatesOnlyOneAccount()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        var events = new ConcurrentQueue<AccountRegistrationRequestedEvent>();
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                events.Enqueue(message);
+                return Task.CompletedTask;
+            }
+        );
+
+        var results = await RunConcurrently(
+            () => accounts.RegisterPending("newbie", "secret99", "one@bie.test").Result,
+            () => accounts.RegisterPending("newbie", "secret99", "two@bie.test").Result
+        );
+
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.Created));
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.UsernameTaken));
+        Assert.Single(accounts.GetAll());
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public async Task RegisterPending_ConcurrentDuplicateEmail_CreatesOnlyOneAccount()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        var events = new ConcurrentQueue<AccountRegistrationRequestedEvent>();
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                events.Enqueue(message);
+                return Task.CompletedTask;
+            }
+        );
+
+        var results = await RunConcurrently(
+            () => accounts.RegisterPending("first", "secret99", "same@bie.test").Result,
+            () => accounts.RegisterPending("second", "secret99", "SAME@BIE.TEST").Result
+        );
+
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.Created));
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.EmailTaken));
+        Assert.Single(accounts.GetAll());
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_ConcurrentRequests_ConsumeTokenExactlyOnce()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var actions = Enumerable
+            .Range(0, 16)
+            .Select(_ => (Func<AccountVerifyResultType>)(() => accounts.VerifyEmail(token)))
+            .ToArray();
+
+        var results = await RunConcurrently(actions);
+
+        Assert.Equal(1, results.Count(result => result == AccountVerifyResultType.Verified));
+        Assert.Equal(15, results.Count(result => result == AccountVerifyResultType.InvalidToken));
+        Assert.True(accounts.GetByUsername("newbie")!.IsActive);
+    }
+
+    [Fact]
+    public async Task VerifyAndResend_ConcurrentRequests_LeaveOneConsistentTransition()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var resendEvents = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
+            {
+                Interlocked.Increment(ref resendEvents);
+                return Task.CompletedTask;
+            }
+        );
+
+        var results = await RunConcurrently(
+            () => $"verify:{accounts.VerifyEmail(token)}",
+            () => $"resend:{accounts.ResendVerification("newbie", "new@bie.test")}"
+        );
+        var account = accounts.GetByUsername("newbie")!;
+
+        var verifiedFirst = results.Contains("verify:Verified") && results.Contains("resend:Ignored");
+        var resentFirst = results.Contains("resend:Sent") && results.Contains("verify:InvalidToken");
+        Assert.True(verifiedFirst || resentFirst);
+
+        if (verifiedFirst)
+        {
+            Assert.True(account.IsActive);
+            Assert.False(account.IsPublicRegistrationPending);
+            Assert.Equal(0, resendEvents);
+        }
+        else
+        {
+            Assert.False(account.IsActive);
+            Assert.True(account.IsPublicRegistrationPending);
+            Assert.NotEmpty(account.ActivationTokenHash);
+            Assert.Equal(1, resendEvents);
+        }
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.Accounts;
@@ -59,8 +60,10 @@ public sealed class AccountRegistrationTests
     [Fact]
     public void ResendVerification_RotatesTokenAndPublishesOneEvent()
     {
-        var (accounts, bus, _, _, _) = Create();
+        var (accounts, bus, persistence, _, _) = Create();
         var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
         AccountRegistrationRequestedEvent? resent = null;
         var eventCount = 0;
         bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
@@ -76,6 +79,7 @@ public sealed class AccountRegistrationTests
         Assert.Equal(AccountResendResultType.Sent, result);
         Assert.NotNull(resent);
         Assert.Equal(1, eventCount);
+        Assert.Equal(upsertsBefore + 1, accountStore.UpsertCount);
         Assert.NotEqual(first, resent!.Token);
         Assert.Equal(Hash(resent.Token), accounts.GetByUsername("newbie")!.ActivationTokenHash);
     }
@@ -83,7 +87,9 @@ public sealed class AccountRegistrationTests
     [Fact]
     public void ResendVerification_MissingAccount_IsIgnoredWithoutPublishingAnEvent()
     {
-        var (accounts, bus, _, _, _) = Create();
+        var (accounts, bus, persistence, _, _) = Create();
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
         AccountRegistrationRequestedEvent? resent = null;
         bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
             {
@@ -96,14 +102,17 @@ public sealed class AccountRegistrationTests
 
         Assert.Equal(AccountResendResultType.Ignored, result);
         Assert.Null(resent);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
         Assert.Null(accounts.GetByUsername("newbie"));
     }
 
     [Fact]
     public void ResendVerification_ActiveAccount_IsIgnoredWithoutPublishingAnEvent()
     {
-        var (accounts, bus, _, _, _) = Create();
+        var (accounts, bus, persistence, _, _) = Create();
         accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
         AccountRegistrationRequestedEvent? resent = null;
         bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
             {
@@ -116,14 +125,17 @@ public sealed class AccountRegistrationTests
 
         Assert.Equal(AccountResendResultType.Ignored, result);
         Assert.Null(resent);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
         Assert.True(accounts.GetByUsername("newbie")!.IsActive);
     }
 
     [Fact]
     public void ResendVerification_MismatchedEmail_IsIgnoredWithoutChangingTokenOrPublishingAnEvent()
     {
-        var (accounts, bus, _, _, _) = Create();
+        var (accounts, bus, persistence, _, _) = Create();
         var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
         AccountRegistrationRequestedEvent? resent = null;
         bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
             {
@@ -136,6 +148,7 @@ public sealed class AccountRegistrationTests
 
         Assert.Equal(AccountResendResultType.Ignored, result);
         Assert.Null(resent);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
         Assert.Equal(Hash(first), accounts.GetByUsername("newbie")!.ActivationTokenHash);
     }
 

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -53,6 +53,160 @@ public sealed class AccountRegistrationTests
         );
     }
 
+    private static string Hash(string token)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+
+    [Fact]
+    public void ResendVerification_RotatesTokenAndPublishesOneEvent()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        AccountRegistrationRequestedEvent? resent = null;
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                resent = message;
+                eventCount++;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "NEW@BIE.TEST");
+
+        Assert.Equal(AccountResendResultType.Sent, result);
+        Assert.NotNull(resent);
+        Assert.Equal(1, eventCount);
+        Assert.NotEqual(first, resent!.Token);
+        Assert.Equal(Hash(resent.Token), accounts.GetByUsername("newbie")!.ActivationTokenHash);
+    }
+
+    [Fact]
+    public void ResendVerification_MissingAccount_IsIgnoredWithoutPublishingAnEvent()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                resent = message;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Null(resent);
+        Assert.Null(accounts.GetByUsername("newbie"));
+    }
+
+    [Fact]
+    public void ResendVerification_ActiveAccount_IsIgnoredWithoutPublishingAnEvent()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                resent = message;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Null(resent);
+        Assert.True(accounts.GetByUsername("newbie")!.IsActive);
+    }
+
+    [Fact]
+    public void ResendVerification_MismatchedEmail_IsIgnoredWithoutChangingTokenOrPublishingAnEvent()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                resent = message;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "other@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Null(resent);
+        Assert.Equal(Hash(first), accounts.GetByUsername("newbie")!.ActivationTokenHash);
+    }
+
+    [Theory]
+    [InlineData("ab", "new@bie.test", AccountResendResultType.UsernameInvalid)]
+    [InlineData("newbie", "not-an-email", AccountResendResultType.EmailInvalid)]
+    public void ResendVerification_InvalidInput_ReturnsValidationResultWithoutPublishingAnEvent(
+        string username,
+        string email,
+        AccountResendResultType expected
+    )
+    {
+        var (accounts, bus, _, _, _) = Create();
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                resent = message;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification(username, email);
+
+        Assert.Equal(expected, result);
+        Assert.Null(resent);
+    }
+
+    [Fact]
+    public void ResendVerification_LegacyPendingAccount_MigratesToHashedToken()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        var account = accounts.GetByUsername("newbie")!;
+        account.IsActive = false;
+        account.ActivationToken = "legacy-token";
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+            {
+                resent = message;
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Sent, result);
+        Assert.NotNull(resent);
+        Assert.Empty(account.ActivationToken);
+        Assert.Equal(Hash(resent!.Token), account.ActivationTokenHash);
+    }
+
+    [Fact]
+    public void ResendVerification_ResetsExpiryToTwentyFourHoursFromCurrentTime()
+    {
+        var (accounts, bus, persistence, characters, sessions) = Create();
+        accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+        var later = Now.AddHours(1);
+        var resendingAccounts = new AccountService(
+            persistence,
+            characters,
+            sessions,
+            bus,
+            new FixedTimeProvider(later)
+        );
+
+        var result = resendingAccounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Sent, result);
+        Assert.Equal(later.AddHours(24), resendingAccounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
+    }
+
     [Fact]
     public void RegisterPending_StoresOnlyAHashAndA24HourExpiry()
     {

--- a/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
+++ b/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
@@ -18,6 +18,8 @@ public sealed class InMemoryEntityStore<TEntity> : IEntityStore<TEntity, Serial>
     private readonly Dictionary<Serial, TEntity> _items = new();
     private uint _nextId = typeof(TEntity) == typeof(ItemEntity) ? Serial.MinItem : 1;
 
+    public int UpsertCount { get; private set; }
+
     public int Count()
         => _items.Count;
 
@@ -69,6 +71,8 @@ public sealed class InMemoryEntityStore<TEntity> : IEntityStore<TEntity, Serial>
 
     public ValueTask UpsertAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
+        UpsertCount++;
+
         if (entity.Id == Serial.Zero)
         {
             entity.Id = (Serial)_nextId++;

--- a/tests/Moongate.Tests/Support/RecordingRegistrationRateLimiter.cs
+++ b/tests/Moongate.Tests/Support/RecordingRegistrationRateLimiter.cs
@@ -1,0 +1,27 @@
+using Moongate.Http.Plugin.Interfaces.Registration;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Records registration throttle keys while allowing a test to decide each attempt.</summary>
+public sealed class RecordingRegistrationRateLimiter : IRegistrationRateLimiter
+{
+    private readonly Func<string, int, bool> _decision;
+    private readonly Dictionary<string, int> _attempts = new();
+    private readonly List<string> _keys = [];
+
+    public IReadOnlyList<string> Keys => _keys;
+
+    public RecordingRegistrationRateLimiter(Func<string, int, bool> decision)
+    {
+        _decision = decision;
+    }
+
+    public bool TryAcquire(string clientKey)
+    {
+        var attempt = _attempts.GetValueOrDefault(clientKey) + 1;
+        _attempts[clientKey] = attempt;
+        _keys.Add(clientKey);
+
+        return _decision(clientKey, attempt);
+    }
+}

--- a/tests/Moongate.Tests/Support/SeededAccountService.cs
+++ b/tests/Moongate.Tests/Support/SeededAccountService.cs
@@ -54,6 +54,9 @@ public sealed class SeededAccountService : IAccountService
     public AccountRegisterResult RegisterPending(string username, string password, string email)
         => throw new NotSupportedException();
 
+    public AccountResendResultType ResendVerification(string username, string email)
+        => throw new NotSupportedException();
+
     public AccountVerifyResultType VerifyEmail(string token)
         => throw new NotSupportedException();
 

--- a/tests/Moongate.Tests/Support/StubAccountService.cs
+++ b/tests/Moongate.Tests/Support/StubAccountService.cs
@@ -32,9 +32,6 @@ public sealed class StubAccountService : IAccountService
     public AccountRegisterResult RegisterPending(string username, string password, string email)
         => throw new NotSupportedException();
 
-    public AccountResendResultType ResendVerification(string username, string email)
-        => throw new NotSupportedException();
-
     public AccountVerifyResultType VerifyEmail(string token)
         => throw new NotSupportedException();
 

--- a/tests/Moongate.Tests/Support/StubAccountService.cs
+++ b/tests/Moongate.Tests/Support/StubAccountService.cs
@@ -32,6 +32,9 @@ public sealed class StubAccountService : IAccountService
     public AccountRegisterResult RegisterPending(string username, string password, string email)
         => throw new NotSupportedException();
 
+    public AccountResendResultType ResendVerification(string username, string email)
+        => throw new NotSupportedException();
+
     public AccountVerifyResultType VerifyEmail(string token)
         => throw new NotSupportedException();
 

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -118,7 +118,8 @@ public sealed class TestApiServer : IAsyncDisposable
         TimeProvider? clock = null,
         string? uiDistPath = null,
         bool emailChannelReady = true,
-        string accountVerificationChannel = "email"
+        string accountVerificationChannel = "email",
+        IRegistrationRateLimiter? registrationRateLimiter = null
     )
     {
         var container = new Container();
@@ -197,13 +198,17 @@ public sealed class TestApiServer : IAsyncDisposable
             new ServerSettingsAdminEndpoints(serverSettings, assetStore, config, registrationReadiness)
         );
 
-        // A low limit (2/window) so a test can prove the throttle without flooding: the 3rd call is denied.
-        var rateLimiter = new RegistrationRateLimiter(
-            TimeProvider.System,
-            permitPerWindow: 2,
-            window: TimeSpan.FromMinutes(10)
+        // The default is deliberately low so a test can prove the throttle without flooding; callers can
+        // inject a recording limiter when exact budget keys or independent budgets are the behavior at stake.
+        var rateLimiter = registrationRateLimiter
+            ?? new RegistrationRateLimiter(
+                TimeProvider.System,
+                permitPerWindow: 2,
+                window: TimeSpan.FromMinutes(10)
+            );
+        container.RegisterApiEndpointInstance(
+            new RegistrationEndpoints(accounts, serverSettings, registrationReadiness, rateLimiter)
         );
-        container.RegisterApiEndpointInstance(new RegistrationEndpoints(accounts, serverSettings, rateLimiter));
 
         var stats = new StubServerStatsService();
         container.RegisterInstance<IServerStatsService>(stats);

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -17,6 +17,7 @@ using Moongate.Http.Plugin.Endpoints.Stats;
 using Moongate.Http.Plugin.Endpoints.Version;
 using Moongate.Http.Plugin.Interfaces.Assets;
 using Moongate.Http.Plugin.Interfaces.Auth;
+using Moongate.Http.Plugin.Interfaces.Registration;
 using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Http.Plugin.Services.Auth;
 using Moongate.Http.Plugin.Services.Hosting;
@@ -25,6 +26,7 @@ using Moongate.Http.Plugin.Services.Registration;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Abstractions.Interfaces.Server;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Plugins;
@@ -114,7 +116,9 @@ public sealed class TestApiServer : IAsyncDisposable
         TimeSpan? deleteTimeout = null,
         Action<IContainer>? configure = null,
         TimeProvider? clock = null,
-        string? uiDistPath = null
+        string? uiDistPath = null,
+        bool emailChannelReady = true,
+        string accountVerificationChannel = "email"
     )
     {
         var container = new Container();
@@ -180,8 +184,18 @@ public sealed class TestApiServer : IAsyncDisposable
         );
         container.RegisterInstance<IServerSettingsService>(serverSettings);
         container.RegisterInstance<IServerAssetFileStore>(assetStore);
-        container.RegisterApiEndpointInstance(new ServerInfoEndpoints(moongateConfig, serverSettings, assetStore));
-        container.RegisterApiEndpointInstance(new ServerSettingsAdminEndpoints(serverSettings, assetStore, config));
+        INotificationChannel[] channels = emailChannelReady ? [new RecordingNotificationChannel("email")] : [];
+        var registrationReadiness = new RegistrationReadinessService(
+            new NotificationConfig { AccountVerificationChannel = accountVerificationChannel },
+            channels
+        );
+        container.RegisterInstance<IRegistrationReadinessService>(registrationReadiness);
+        container.RegisterApiEndpointInstance(
+            new ServerInfoEndpoints(moongateConfig, serverSettings, assetStore, registrationReadiness)
+        );
+        container.RegisterApiEndpointInstance(
+            new ServerSettingsAdminEndpoints(serverSettings, assetStore, config, registrationReadiness)
+        );
 
         // A low limit (2/window) so a test can prove the throttle without flooding: the 3rd call is denied.
         var rateLimiter = new RegistrationRateLimiter(

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -122,7 +122,10 @@ public sealed class TestApiServer : IAsyncDisposable
         var sessions = new StubSessionManager();
         var bus = new EventBusService();
         var characters = CharacterServiceFixture.Create(persistence, bus, sessions);
-        var accounts = new AccountService(persistence, characters, sessions, bus);
+
+        // A test that needs to move time forward passes its own; everything else gets the real clock.
+        var timeProvider = clock ?? TimeProvider.System;
+        var accounts = new AccountService(persistence, characters, sessions, bus, timeProvider);
         accounts.Create("tom", "secret", null, level);
 
         var config = new MoongateHttpConfig
@@ -140,9 +143,6 @@ public sealed class TestApiServer : IAsyncDisposable
         var moongateConfig = new MoongateConfig { ShardName = "Moongate", UltimaDirectory = "/tmp" };
 
         container.RegisterInstance(config);
-
-        // A test that needs to move time forward passes its own; everything else gets the real clock.
-        var timeProvider = clock ?? TimeProvider.System;
 
         container.RegisterInstance(timeProvider);
         container.RegisterInstance(moongateConfig);

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -1560,6 +1560,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -1286,6 +1286,66 @@
         "responses": {
           "202": {
             "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -1296,7 +1356,7 @@
           "registration"
         ],
         "summary": "Verifies an account's email with its token, activating the account.",
-        "description": "Answers 400 for an unknown or already-used token.",
+        "description": "Answers 410 for an expired token and 400 for an unknown or already-used token.",
         "operationId": "VerifyRegistration",
         "requestBody": {
           "content": {
@@ -1311,6 +1371,91 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/register/resend": {
+      "post": {
+        "tags": [
+          "registration"
+        ],
+        "summary": "Resends the verification message for a matching pending public registration.",
+        "description": "Answers 202 whether or not the supplied identity matches a pending account, so callers cannot\ndiscover registered usernames or email addresses.",
+        "operationId": "ResendRegistrationVerification",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResendVerificationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -2114,6 +2259,45 @@
         "additionalProperties": false,
         "description": "One page of results, and what a caller needs to walk the rest."
       },
+      "HttpValidationProblemDetails": {
+        "required": [
+          "errors"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "additionalProperties": {}
+      },
       "ItemImageExportStatus": {
         "required": [
           "done",
@@ -2743,6 +2927,33 @@
         "additionalProperties": false,
         "description": "One HTTP route a plugin declares. `policy` is null when the route is open."
       },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": {}
+      },
       "RegisterRequest": {
         "required": [
           "email",
@@ -2763,6 +2974,48 @@
         },
         "additionalProperties": false,
         "description": "A web self-registration request."
+      },
+      "RegistrationReadinessResponse": {
+        "required": [
+          "emailChannelAvailable",
+          "emailChannelSelected",
+          "ready",
+          "websiteValid"
+        ],
+        "type": "object",
+        "properties": {
+          "ready": {
+            "type": "boolean"
+          },
+          "websiteValid": {
+            "type": "boolean"
+          },
+          "emailChannelSelected": {
+            "type": "boolean"
+          },
+          "emailChannelAvailable": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "The local prerequisites behind public account registration availability."
+      },
+      "ResendVerificationRequest": {
+        "required": [
+          "email",
+          "username"
+        ],
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Identifies a pending public registration for a verification-message resend."
       },
       "ServerContactsResponse": {
         "type": "object",
@@ -2817,13 +3070,14 @@
           }
         },
         "additionalProperties": false,
-        "description": "The public server profile a website or launcher reads: identity, contacts, assets, and whether registration is open."
+        "description": "The public server profile a website or launcher reads: identity, contacts, assets, and effective registration availability."
       },
       "ServerSettingsResponse": {
         "required": [
           "assets",
           "contacts",
-          "registrationEnabled"
+          "registrationEnabled",
+          "registrationReadiness"
         ],
         "type": "object",
         "properties": {
@@ -2841,6 +3095,9 @@
           "registrationEnabled": {
             "type": "boolean"
           },
+          "registrationReadiness": {
+            "$ref": "#/components/schemas/RegistrationReadinessResponse"
+          },
           "assets": {
             "type": "object",
             "additionalProperties": {
@@ -2849,7 +3106,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "The full settings view returned to staff (identical fields to the public info minus the shard name)."
+        "description": "The full settings view returned to staff, including persisted registration state and readiness."
       },
       "ServerStatsResponse": {
         "required": [

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import i18n from './lib/i18n'
+import { App } from './App'
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function servePublicApi() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input)
+
+    if (url.endsWith('/api/v1/server-info')) {
+      return json({
+        shardName: 'Moongate',
+        description: null,
+        tagline: null,
+        contacts: { website: null, email: null, discord: null },
+        registrationEnabled: true,
+        assets: {},
+      })
+    }
+
+    if (url.endsWith('/api/v1/stats')) {
+      return json({
+        generatedAt: '2026-07-25T00:00:00Z',
+        uptimeSeconds: 1,
+        players: { online: 0, connections: 0 },
+        accounts: { total: 0, active: 0, characters: 0 },
+        world: { npcs: 0, items: 0 },
+        content: {},
+      })
+    }
+
+    if (url.endsWith('/api/v1/version')) {
+      return json({ shardName: 'Moongate', version: '1.0.0' })
+    }
+
+    return json({})
+  })
+}
+
+describe('App public registration routes', () => {
+  beforeEach(async () => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+    await i18n.changeLanguage('en')
+  })
+
+  it.each([
+    ['/register', /create account/i],
+    ['/register/pending', /check your email/i],
+    ['/verify', /verification link invalid/i],
+  ])('routes %s to its public screen', async (path, expected) => {
+    const fetchSpy = servePublicApi()
+    window.history.pushState({}, '', path)
+
+    render(<App />)
+
+    expect(await screen.findByRole('heading', { name: expected })).toBeInTheDocument()
+    if (path === '/verify') {
+      expect(
+        fetchSpy.mock.calls.filter(
+          ([input, init]) =>
+            String(input).endsWith('/api/v1/register/verify') && (init as RequestInit | undefined)?.method === 'POST',
+        ),
+      ).toHaveLength(0)
+    }
+  })
+})

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,9 @@ import { AppShell } from './components/AppShell'
 import { RequireAuth } from './routes/RequireAuth'
 import { RequireAdmin } from './routes/RequireAdmin'
 import { LoginScreen } from './routes/LoginScreen'
+import { RegisterScreen } from './routes/RegisterScreen'
+import { RegistrationPendingScreen } from './routes/RegistrationPendingScreen'
+import { VerifyRegistrationScreen } from './routes/VerifyRegistrationScreen'
 import { DashboardScreen } from './routes/DashboardScreen'
 import { AdminScreen } from './routes/AdminScreen'
 import { MapScreen } from './routes/MapScreen'
@@ -25,6 +28,9 @@ export function App() {
         <AuthProvider>
           <Routes>
             <Route path="/login" element={<LoginScreen />} />
+            <Route path="/register" element={<RegisterScreen />} />
+            <Route path="/register/pending" element={<RegistrationPendingScreen />} />
+            <Route path="/verify" element={<VerifyRegistrationScreen />} />
             <Route
               path="/"
               element={

--- a/ui/src/components/PublicAuthLayout.test.tsx
+++ b/ui/src/components/PublicAuthLayout.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import '../lib/i18n'
+import { AuthProvider } from '../lib/auth'
+import { PublicAuthLayout } from './PublicAuthLayout'
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function serveApi() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input)
+
+    if (url.endsWith('/api/v1/stats')) {
+      return json({
+        players: { online: 184, connections: 190 },
+        accounts: { total: 7, active: 5, characters: 19 },
+      })
+    }
+    if (url.endsWith('/api/v1/version')) {
+      return json({ shardName: 'Moongate', version: '9.9.9' })
+    }
+    if (url.endsWith('/api/v1/server-info')) {
+      return json({
+        shardName: 'Moongate',
+        tagline: null,
+        contacts: { website: null, email: null, discord: null },
+        registrationEnabled: false,
+        assets: { Logo: '/api/v1/server-info/assets/logo' },
+      })
+    }
+    return json({ username: 'tom', level: 'Player' })
+  })
+}
+
+function renderLayout() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <QueryClientProvider client={client}>
+        <AuthProvider>
+          <Routes>
+            <Route
+              path="/login"
+              element={
+                <PublicAuthLayout>
+                  <p>form content</p>
+                </PublicAuthLayout>
+              }
+            />
+            <Route path="/" element={<p>dashboard</p>} />
+          </Routes>
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('PublicAuthLayout', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('renders public shard details around its form content', async () => {
+    serveApi()
+    renderLayout()
+
+    expect(await screen.findByRole('img', { name: /shard logo/i })).toHaveAttribute(
+      'src',
+      expect.stringContaining('/api/v1/server-info/assets/logo'),
+    )
+    expect(screen.getByText(/Sosaria never sleeps\./)).toBeInTheDocument()
+    expect(screen.getByText(/184 adventurers online right now/)).toBeInTheDocument()
+    expect(screen.getByText(/Moongate · v9\.9\.9/)).toBeInTheDocument()
+    expect(screen.getByText('form content')).toBeInTheDocument()
+  })
+
+  it('redirects an authenticated session to the dashboard', async () => {
+    localStorage.setItem(
+      'mg-token',
+      JSON.stringify({ token: 't', expiresAt: new Date(Date.now() + 3.6e6).toISOString() }),
+    )
+    serveApi()
+    renderLayout()
+
+    expect(await screen.findByText('dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('form content')).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/components/PublicAuthLayout.tsx
+++ b/ui/src/components/PublicAuthLayout.tsx
@@ -1,0 +1,65 @@
+import type { PropsWithChildren } from 'react'
+import { Navigate } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { useSession } from '../lib/auth'
+import { useServerInfo, useStats, useVersion } from '../lib/queries'
+import heroArt from '../assets/login-hero.jpg'
+
+export function PublicAuthLayout({ children }: PropsWithChildren) {
+  const { t } = useTranslation()
+  const { status } = useSession()
+  const stats = useStats()
+  const version = useVersion()
+  const serverInfo = useServerInfo()
+
+  // The assets map is keyed in PascalCase ("Logo") while the slot is lowercase — match case-insensitively.
+  const logoUrl = Object.entries(serverInfo.data?.assets ?? {}).find(([key]) => key.toLowerCase() === 'logo')?.[1]
+
+  if (status === 'authenticated') {
+    return <Navigate to="/" replace />
+  }
+
+  return (
+    <div className="flex min-h-screen bg-surface">
+      {/* Full-bleed hero art, cropped to fill the tall panel rather than letterboxed inside it. */}
+      <div
+        className="relative hidden flex-[1.3] flex-col justify-end border-r border-border-subtle bg-cover bg-center p-10 lg:flex"
+        style={{ backgroundImage: `url(${heroArt})` }}
+      >
+        {/* A bottom-up scrim: the art is bright and busy, so the quote and count need a dark ground under
+            them to stay legible. */}
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/85 via-black/35 to-transparent" />
+
+        {/* The shard's own tagline when it has set one, otherwise the bundled default. */}
+        <p className="relative font-display text-[18px] text-gold">
+          &ldquo;{serverInfo.data?.tagline || t('login.quote')}&rdquo;
+        </p>
+
+        {/* Real, and public: /api/v1/stats is anonymous, so the count is readable before anyone signs in.
+            Rendered only once the reply lands — a zero here means an empty shard, which is worth saying,
+            but saying it before asking would be a guess. */}
+        {stats.data !== undefined && (
+          <p className="relative mt-1 text-sm text-muted">{t('login.online', { count: stats.data.players.online })}</p>
+        )}
+      </div>
+
+      <div className="flex w-full max-w-[420px] flex-col justify-center gap-4 px-12">
+        {/* The shard's own logo, if it has uploaded one — public and anonymous, so it brands the page
+            before anyone signs in. Absent by default, so a fresh shard just shows the wordmark title. */}
+        {logoUrl !== undefined && (
+          <img src={logoUrl} alt={t('login.logoAlt')} className="mb-1 max-h-16 max-w-[220px] object-contain" />
+        )}
+
+        {children}
+
+        {/* Data from the anonymous /api/v1/version, not UI copy — no i18n key needed. Rendered only once
+            it resolves, so an unreached shard shows nothing rather than "undefined". */}
+        {version.data?.version !== undefined && (
+          <p className="text-xs text-faint">
+            {version.data.shardName} · v{version.data.version}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -2718,6 +2718,15 @@ export interface operations {
                     "application/json": components["schemas"]["ServerSettingsResponse"];
                 };
             };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["HttpValidationProblemDetails"];
+                };
+            };
         };
     };
     UploadServerAsset: {

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -731,9 +731,30 @@ export interface paths {
         put?: never;
         /**
          * Verifies an account's email with its token, activating the account.
-         * @description Answers 400 for an unknown or already-used token.
+         * @description Answers 410 for an expired token and 400 for an unknown or already-used token.
          */
         post: operations["VerifyRegistration"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/register/resend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resends the verification message for a matching pending public registration.
+         * @description Answers 202 whether or not the supplied identity matches a pending account, so callers cannot
+         *     discover registered usernames or email addresses.
+         */
+        post: operations["ResendRegistrationVerification"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1111,6 +1132,19 @@ export interface components {
              */
             totalPages: number;
         };
+        HttpValidationProblemDetails: {
+            type?: string | null;
+            title?: string | null;
+            /** Format: int32 */
+            status?: number | null;
+            detail?: string | null;
+            instance?: string | null;
+            errors: {
+                [key: string]: string[];
+            };
+        } & {
+            [key: string]: unknown;
+        };
         /** @description How far the bulk item-image export has got. */
         ItemImageExportStatus: {
             /** @description Idle, Running, Completed or Failed. */
@@ -1385,10 +1419,32 @@ export interface components {
             path: string;
             policy?: string | null;
         };
+        ProblemDetails: {
+            type?: string | null;
+            title?: string | null;
+            /** Format: int32 */
+            status?: number | null;
+            detail?: string | null;
+            instance?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** @description A web self-registration request. */
         RegisterRequest: {
             username: string;
             password: string;
+            email: string;
+        };
+        /** @description The local prerequisites behind public account registration availability. */
+        RegistrationReadinessResponse: {
+            ready: boolean;
+            websiteValid: boolean;
+            emailChannelSelected: boolean;
+            emailChannelAvailable: boolean;
+        };
+        /** @description Identifies a pending public registration for a verification-message resend. */
+        ResendVerificationRequest: {
+            username: string;
             email: string;
         };
         /** @description The shard's public contact points. */
@@ -1397,7 +1453,7 @@ export interface components {
             email?: string | null;
             discord?: string | null;
         };
-        /** @description The public server profile a website or launcher reads: identity, contacts, assets, and whether registration is open. */
+        /** @description The public server profile a website or launcher reads: identity, contacts, assets, and effective registration availability. */
         ServerInfoResponse: {
             shardName: string;
             description?: string | null;
@@ -1408,12 +1464,13 @@ export interface components {
                 [key: string]: string;
             };
         };
-        /** @description The full settings view returned to staff (identical fields to the public info minus the shard name). */
+        /** @description The full settings view returned to staff, including persisted registration state and readiness. */
         ServerSettingsResponse: {
             description?: string | null;
             tagline?: string | null;
             contacts: components["schemas"]["ServerContactsResponse"];
             registrationEnabled: boolean;
+            registrationReadiness: components["schemas"]["RegistrationReadinessResponse"];
             assets: {
                 [key: string]: string;
             };
@@ -2423,6 +2480,60 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["HttpValidationProblemDetails"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
         };
     };
     VerifyRegistration: {
@@ -2444,6 +2555,82 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Gone */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+        };
+    };
+    ResendRegistrationVerification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendVerificationRequest"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["HttpValidationProblemDetails"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
             };
         };
     };

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -101,6 +101,15 @@ describe('apiFetch', () => {
     await expect(apiFetch<void>('/api/v1/admin/console', { method: 'POST', body: '{}' })).resolves.toBeUndefined()
   })
 
+  it('treats a successful zero-byte response stream as an empty body', async () => {
+    // Kestrel can return 200 with Content-Length: 0, which Fetch exposes as a non-null empty stream.
+    const response = new Response('', { status: 200 })
+    expect(response.body).not.toBeNull()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response)
+
+    await expect(apiFetch<void>('/api/v1/register/verify', { method: 'POST', body: '{}' })).resolves.toBeUndefined()
+  })
+
   it('apiStream sends the bearer and event-stream accept, returning the response', async () => {
     const streamResponse = new Response(new ReadableStream(), {
       status: 200,

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -35,6 +35,33 @@ describe('apiFetch', () => {
     await expect(apiFetch('/api/v1/nope')).rejects.toBeInstanceOf(ApiError)
   })
 
+  it.each(['application/json; charset=utf-8', 'application/problem+json; charset=utf-8'])(
+    'attaches %s problem details to an API error',
+    async (contentType) => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ errors: { username: ['invalid'] } }), {
+          status: 400,
+          headers: { 'content-type': contentType },
+        }),
+      )
+
+      await expect(apiFetch('/api/v1/register')).rejects.toMatchObject({
+        status: 400,
+        problem: { errors: { username: ['invalid'] } },
+      })
+    },
+  )
+
+  it.each([
+    ['an empty body', new Response(null, { status: 400, headers: { 'content-type': 'application/json' } })],
+    ['a non-JSON body', new Response('invalid', { status: 400, headers: { 'content-type': 'text/plain' } })],
+    ['a malformed JSON body', new Response('{', { status: 400, headers: { 'content-type': 'application/json' } })],
+  ])('keeps problem undefined for %s', async (_, response) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response)
+
+    await expect(apiFetch('/api/v1/register')).rejects.toMatchObject({ status: 400, problem: undefined })
+  })
+
   it('runs the unauthorized handler on 401 and still throws', async () => {
     respond(401)
     const onUnauthorized = vi.fn()
@@ -99,5 +126,19 @@ describe('apiFetch', () => {
       ApiError,
     )
     expect(onUnauthorized).toHaveBeenCalledOnce()
+  })
+
+  it('apiStream attaches JSON problem details to an API error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ title: 'Rate limited' }), {
+        status: 429,
+        headers: { 'content-type': 'application/problem+json' },
+      }),
+    )
+
+    await expect(apiStream('/api/v1/admin/console/stream', new AbortController().signal)).rejects.toMatchObject({
+      status: 429,
+      problem: { title: 'Rate limited' },
+    })
   })
 })

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -84,7 +84,8 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
     return undefined as T
   }
 
-  return (await response.json()) as T
+  const body = await response.text()
+  return body === '' ? (undefined as T) : (JSON.parse(body) as T)
 }
 
 /**

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,10 +1,17 @@
 // Transport only: no React, no cache, no component state. Keeping this layer ignorant of React is what
 // makes the server-state layer above it replaceable without touching a line here.
 
+export type ApiProblem = {
+  title?: string
+  detail?: string
+  errors?: Record<string, string[]>
+}
+
 export class ApiError extends Error {
   constructor(
     readonly status: number,
     message: string,
+    readonly problem?: ApiProblem,
   ) {
     super(message)
     this.name = 'ApiError'
@@ -13,6 +20,23 @@ export class ApiError extends Error {
 
 let authToken: string | null = null
 let onUnauthorized: () => void = () => {}
+
+function acceptsJsonProblem(contentType: string | null): boolean {
+  const mediaType = contentType?.split(';', 1)[0]?.trim().toLowerCase()
+  return mediaType === 'application/json' || mediaType === 'application/problem+json'
+}
+
+async function readProblem(response: Response): Promise<ApiProblem | undefined> {
+  if (!acceptsJsonProblem(response.headers.get('content-type'))) {
+    return undefined
+  }
+
+  try {
+    return (await response.json()) as ApiProblem
+  } catch {
+    return undefined
+  }
+}
 
 export function setAuthToken(token: string | null): void {
   authToken = token
@@ -44,17 +68,19 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
 
   const response = await fetch(path, { ...init, headers })
 
-  if (response.status === 401) {
-    onUnauthorized()
-    throw new ApiError(401, 'unauthorized')
-  }
-
   if (!response.ok) {
-    throw new ApiError(response.status, `${init.method ?? 'GET'} ${path} failed with ${response.status}`)
+    const problem = await readProblem(response)
+
+    if (response.status === 401) {
+      onUnauthorized()
+      throw new ApiError(401, 'unauthorized', problem)
+    }
+
+    throw new ApiError(response.status, `${init.method ?? 'GET'} ${path} failed with ${response.status}`, problem)
   }
 
   // 204 No Content and 202 Accepted (the console POST) have no JSON body to parse.
-  if (response.status === 204 || response.status === 202) {
+  if (response.status === 204 || response.status === 202 || response.body === null) {
     return undefined as T
   }
 
@@ -74,12 +100,18 @@ export async function apiStream(path: string, signal: AbortSignal): Promise<Resp
 
   const response = await fetch(path, { headers, signal })
 
-  if (response.status === 401) {
-    onUnauthorized()
-    throw new ApiError(401, 'unauthorized')
+  if (!response.ok) {
+    const problem = await readProblem(response)
+
+    if (response.status === 401) {
+      onUnauthorized()
+      throw new ApiError(401, 'unauthorized', problem)
+    }
+
+    throw new ApiError(response.status, `GET ${path} stream failed with ${response.status}`, problem)
   }
 
-  if (!response.ok || response.body === null) {
+  if (response.body === null) {
     throw new ApiError(response.status, `GET ${path} stream failed with ${response.status}`)
   }
 

--- a/ui/src/lib/registration.test.tsx
+++ b/ui/src/lib/registration.test.tsx
@@ -1,0 +1,121 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import {
+  useRegisterAccount,
+  useResendVerification,
+  useVerifyRegistration,
+  validateRegistration,
+  validateResend,
+} from './registration'
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+describe('registration data module', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('reports independently derived registration validation errors', () => {
+    expect(
+      validateRegistration({
+        username: 'ab',
+        email: 'bad',
+        password: 'short',
+        confirmation: 'different',
+      }),
+    ).toEqual({
+      username: 'invalid',
+      email: 'invalid',
+      password: 'invalid',
+      confirmation: 'mismatch',
+    })
+  })
+
+  it.each([
+    ['username shorter than three characters', { username: 'ab' }, { username: 'invalid' }],
+    ['username longer than thirty characters', { username: 'a'.repeat(31) }, { username: 'invalid' }],
+    ['username containing a non-ASCII character', { username: 'naïve' }, { username: 'invalid' }],
+    ['password shorter than eight characters', { password: 'pass123' }, { password: 'invalid' }],
+    ['password longer than thirty characters', { password: 'a'.repeat(31) }, { password: 'invalid' }],
+    ['password containing a control character', { password: 'pass\nword' }, { password: 'invalid' }],
+    ['password containing a non-ASCII character', { password: 'pässword' }, { password: 'invalid' }],
+  ])('rejects %s', (_, changes, expected) => {
+    const data = {
+      username: 'newbie',
+      email: 'newbie@example.test',
+      password: 'password',
+      confirmation: 'password',
+      ...changes,
+      ...('password' in changes ? { confirmation: changes.password } : {}),
+    }
+
+    expect(validateRegistration(data)).toEqual(expected)
+  })
+
+  it('trims username and email but preserves the password', () => {
+    expect(
+      validateRegistration({
+        username: '  newbie  ',
+        email: '  newbie@example.test  ',
+        password: ' pass word ',
+        confirmation: ' pass word ',
+      }),
+    ).toEqual({})
+  })
+
+  it('validates the resend identity with the same trimmed username and email rules', () => {
+    expect(validateResend({ username: '  ab  ', email: 'bad' })).toEqual({ username: 'invalid', email: 'invalid' })
+    expect(validateResend({ username: '  newbie  ', email: '  newbie@example.test  ' })).toEqual({})
+  })
+
+  it('useRegisterAccount POSTs the generated request body and resolves void', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }))
+    const { result } = renderHook(() => useRegisterAccount(), { wrapper: wrapper() })
+
+    await expect(
+      result.current.mutateAsync({ username: 'newbie', password: 'password', email: 'newbie@example.test' }),
+    ).resolves.toBeUndefined()
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/register')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      username: 'newbie',
+      password: 'password',
+      email: 'newbie@example.test',
+    })
+  })
+
+  it('useResendVerification POSTs the generated request body and resolves void', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }))
+    const { result } = renderHook(() => useResendVerification(), { wrapper: wrapper() })
+
+    await expect(
+      result.current.mutateAsync({ username: 'newbie', email: 'newbie@example.test' }),
+    ).resolves.toBeUndefined()
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/register/resend')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      username: 'newbie',
+      email: 'newbie@example.test',
+    })
+  })
+
+  it('useVerifyRegistration POSTs the generated request body and resolves void', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+    const { result } = renderHook(() => useVerifyRegistration(), { wrapper: wrapper() })
+
+    await expect(result.current.mutateAsync({ token: 'verification-token' })).resolves.toBeUndefined()
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/v1/register/verify')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ token: 'verification-token' })
+  })
+})

--- a/ui/src/lib/registration.test.tsx
+++ b/ui/src/lib/registration.test.tsx
@@ -72,6 +72,18 @@ describe('registration data module', () => {
     expect(validateResend({ username: '  newbie  ', email: '  newbie@example.test  ' })).toEqual({})
   })
 
+  it('matches backend email validation for dot atoms and quoted local parts', () => {
+    expect(
+      validateRegistration({
+        username: 'newbie',
+        email: 'a..b@example.com',
+        password: 'password',
+        confirmation: 'password',
+      }),
+    ).toEqual({ email: 'invalid' })
+    expect(validateResend({ username: 'newbie', email: '"quoted.local"@example.com' })).toEqual({})
+  })
+
   it('useRegisterAccount POSTs the generated request body and resolves void', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }))
     const { result } = renderHook(() => useRegisterAccount(), { wrapper: wrapper() })
@@ -108,7 +120,9 @@ describe('registration data module', () => {
   })
 
   it('useVerifyRegistration POSTs the generated request body and resolves void', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+    const response = new Response('', { status: 200 })
+    expect(response.body).not.toBeNull()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response)
     const { result } = renderHook(() => useVerifyRegistration(), { wrapper: wrapper() })
 
     await expect(result.current.mutateAsync({ token: 'verification-token' })).resolves.toBeUndefined()

--- a/ui/src/lib/registration.test.tsx
+++ b/ui/src/lib/registration.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import {
@@ -9,8 +9,7 @@ import {
   validateResend,
 } from './registration'
 
-function wrapper() {
-  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+function wrapper(client = new QueryClient({ defaultOptions: { mutations: { retry: false } } })) {
   return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   )
@@ -54,6 +53,22 @@ describe('registration data module', () => {
     }
 
     expect(validateRegistration(data)).toEqual(expected)
+  })
+
+  it.each([
+    ['three-character username', { username: 'abc' }],
+    ['thirty-character username', { username: 'a'.repeat(30) }],
+    ['thirty-character password', { password: 'p'.repeat(30), confirmation: 'p'.repeat(30) }],
+  ])('accepts the %s boundary', (_, changes) => {
+    expect(
+      validateRegistration({
+        username: 'newbie',
+        email: 'newbie@example.test',
+        password: 'password',
+        confirmation: 'password',
+        ...changes,
+      }),
+    ).toEqual({})
   })
 
   it('trims username and email but preserves the password', () => {
@@ -131,5 +146,30 @@ describe('registration data module', () => {
     expect(url).toBe('/api/v1/register/verify')
     expect((init as RequestInit).method).toBe('POST')
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({ token: 'verification-token' })
+  })
+
+  it('keeps a pending verification bearer out of the mutation cache', async () => {
+    const token = 'pending-verification-token'
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>(() => {
+          // Intentionally pending: the assertion observes the in-flight request.
+        }),
+    )
+    const { result, unmount } = renderHook(() => useVerifyRegistration(), { wrapper: wrapper(client) })
+
+    act(() => {
+      void result.current.mutateAsync({ token })
+    })
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledOnce())
+
+    const tokenBearingMutations = client
+      .getMutationCache()
+      .getAll()
+      .filter((mutation) => (mutation.state.variables as { token?: unknown } | undefined)?.token === token)
+    expect(tokenBearingMutations).toHaveLength(0)
+
+    unmount()
   })
 })

--- a/ui/src/lib/registration.ts
+++ b/ui/src/lib/registration.ts
@@ -1,0 +1,78 @@
+import { useMutation } from '@tanstack/react-query'
+import { apiFetch } from './api'
+import type { components } from './api-types'
+
+export type RegisterAccount = components['schemas']['RegisterRequest']
+export type ResendVerification = components['schemas']['ResendVerificationRequest']
+export type VerifyRegistration = components['schemas']['VerifyEmailRequest']
+
+export type RegistrationField = 'username' | 'email' | 'password' | 'confirmation'
+export type RegistrationValidationCode = 'invalid' | 'mismatch'
+export type RegistrationValidationErrors = Partial<Record<RegistrationField, RegistrationValidationCode>>
+
+type RegistrationInput = RegisterAccount & { confirmation: string }
+
+const USERNAME_PATTERN = /^[A-Za-z0-9._-]{3,30}$/
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+$/
+const PRINTABLE_ASCII_PATTERN = /^[ -~]{8,30}$/
+
+function isEmailValid(email: string): boolean {
+  return EMAIL_PATTERN.test(email)
+}
+
+export function validateRegistration(input: RegistrationInput): RegistrationValidationErrors {
+  const errors: RegistrationValidationErrors = {}
+
+  if (!USERNAME_PATTERN.test(input.username.trim())) {
+    errors.username = 'invalid'
+  }
+
+  if (!isEmailValid(input.email.trim())) {
+    errors.email = 'invalid'
+  }
+
+  if (!PRINTABLE_ASCII_PATTERN.test(input.password)) {
+    errors.password = 'invalid'
+  }
+
+  if (input.confirmation !== input.password) {
+    errors.confirmation = 'mismatch'
+  }
+
+  return errors
+}
+
+export function validateResend(input: ResendVerification): RegistrationValidationErrors {
+  const errors: RegistrationValidationErrors = {}
+
+  if (!USERNAME_PATTERN.test(input.username.trim())) {
+    errors.username = 'invalid'
+  }
+
+  if (!isEmailValid(input.email.trim())) {
+    errors.email = 'invalid'
+  }
+
+  return errors
+}
+
+export function useRegisterAccount() {
+  return useMutation({
+    mutationFn: (body: RegisterAccount) =>
+      apiFetch<void>('/api/v1/register', { method: 'POST', body: JSON.stringify(body) }),
+  })
+}
+
+export function useResendVerification() {
+  return useMutation({
+    mutationFn: (body: ResendVerification) =>
+      apiFetch<void>('/api/v1/register/resend', { method: 'POST', body: JSON.stringify(body) }),
+  })
+}
+
+export function useVerifyRegistration() {
+  return useMutation({
+    mutationFn: (body: VerifyRegistration) =>
+      apiFetch<void>('/api/v1/register/verify', { method: 'POST', body: JSON.stringify(body) }),
+  })
+}

--- a/ui/src/lib/registration.ts
+++ b/ui/src/lib/registration.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useId, useMemo } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import { apiFetch } from './api'
 import type { components } from './api-types'
 
@@ -84,25 +84,39 @@ export function useResendVerification() {
 }
 
 export function useVerifyRegistration() {
-  const client = useQueryClient()
-  const scopeId = useId()
-  const mutationKey = useMemo(() => ['registration-verification', scopeId] as const, [scopeId])
-  const removeScopedMutations = useCallback(() => {
-    const cache = client.getMutationCache()
-
-    for (const mutation of cache.findAll({ mutationKey, exact: true })) {
-      cache.remove(mutation)
-    }
-  }, [client, mutationKey])
+  const [isPending, setIsPending] = useState(false)
+  const requestId = useRef(0)
+  const mounted = useRef(true)
 
   useEffect(() => {
-    return removeScopedMutations
-  }, [removeScopedMutations])
+    mounted.current = true
 
-  return useMutation({
-    mutationKey,
-    mutationFn: (body: VerifyRegistration) =>
-      apiFetch<void>('/api/v1/register/verify', { method: 'POST', body: JSON.stringify(body) }),
-    onSettled: removeScopedMutations,
-  })
+    return () => {
+      mounted.current = false
+      requestId.current += 1
+    }
+  }, [])
+
+  const mutateAsync = useCallback(async (body: VerifyRegistration) => {
+    const currentRequest = ++requestId.current
+    setIsPending(true)
+
+    try {
+      await apiFetch<void>('/api/v1/register/verify', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+    } finally {
+      if (mounted.current && requestId.current === currentRequest) {
+        setIsPending(false)
+      }
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    requestId.current += 1
+    setIsPending(false)
+  }, [])
+
+  return { mutateAsync, reset, isPending }
 }

--- a/ui/src/lib/registration.ts
+++ b/ui/src/lib/registration.ts
@@ -1,4 +1,5 @@
-import { useMutation } from '@tanstack/react-query'
+import { useCallback, useEffect, useId, useMemo } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from './api'
 import type { components } from './api-types'
 
@@ -83,8 +84,25 @@ export function useResendVerification() {
 }
 
 export function useVerifyRegistration() {
+  const client = useQueryClient()
+  const scopeId = useId()
+  const mutationKey = useMemo(() => ['registration-verification', scopeId] as const, [scopeId])
+  const removeScopedMutations = useCallback(() => {
+    const cache = client.getMutationCache()
+
+    for (const mutation of cache.findAll({ mutationKey, exact: true })) {
+      cache.remove(mutation)
+    }
+  }, [client, mutationKey])
+
+  useEffect(() => {
+    return removeScopedMutations
+  }, [removeScopedMutations])
+
   return useMutation({
+    mutationKey,
     mutationFn: (body: VerifyRegistration) =>
       apiFetch<void>('/api/v1/register/verify', { method: 'POST', body: JSON.stringify(body) }),
+    onSettled: removeScopedMutations,
   })
 }

--- a/ui/src/lib/registration.ts
+++ b/ui/src/lib/registration.ts
@@ -13,11 +13,23 @@ export type RegistrationValidationErrors = Partial<Record<RegistrationField, Reg
 type RegistrationInput = RegisterAccount & { confirmation: string }
 
 const USERNAME_PATTERN = /^[A-Za-z0-9._-]{3,30}$/
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+$/
+const UNQUOTED_EMAIL_LOCAL_PART_PATTERN = /^[^\s@.]+(?:\.[^\s@.]+)*$/
+const QUOTED_EMAIL_LOCAL_PART_PATTERN = /^"(?:[^"\\\r\n]|\\.)*"$/
+const EMAIL_DOMAIN_PATTERN = /^[^\s@]+$/
 const PRINTABLE_ASCII_PATTERN = /^[ -~]{8,30}$/
 
 function isEmailValid(email: string): boolean {
-  return EMAIL_PATTERN.test(email)
+  const separator = email.lastIndexOf('@')
+  if (separator <= 0 || separator === email.length - 1) {
+    return false
+  }
+
+  const localPart = email.slice(0, separator)
+  const domain = email.slice(separator + 1)
+  return (
+    EMAIL_DOMAIN_PATTERN.test(domain) &&
+    (UNQUOTED_EMAIL_LOCAL_PART_PATTERN.test(localPart) || QUOTED_EMAIL_LOCAL_PART_PATTERN.test(localPart))
+  )
 }
 
 export function validateRegistration(input: RegistrationInput): RegistrationValidationErrors {

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -211,7 +211,23 @@
       "assetRemoved": "Image removed.",
       "notImage": "That file is not an image.",
       "tooLarge": "That image is too large.",
-      "tagline": "Tagline"
+      "tagline": "Tagline",
+      "readiness": {
+        "title": "Registration readiness",
+        "overall": "Overall",
+        "website": "Website",
+        "emailSelected": "Verification channel",
+        "emailAvailable": "Email channel",
+        "ready": "Ready",
+        "notReady": "Not ready",
+        "valid": "Valid",
+        "invalid": "Invalid",
+        "selected": "Selected",
+        "notSelected": "Not selected",
+        "available": "Available",
+        "unavailable": "Unavailable",
+        "guidance": "Set notifications.AccountVerificationChannel to email in moongate.yaml. Configure the email plugin through plugins/configs/smtp.yaml or environment variables, then restart the server."
+      }
     },
     "console": {
       "title": "Console",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -50,6 +50,21 @@
         "emailUnavailable": "Verification email is temporarily unavailable."
       }
     },
+    "verify": {
+      "verifyingTitle": "Verifying your account",
+      "verifyingBody": "Please wait while we confirm your email address.",
+      "verifiedTitle": "Email verified",
+      "verifiedBody": "Your account is ready. You can now sign in.",
+      "expiredTitle": "Verification link expired",
+      "expiredBody": "This verification link has expired. Request a new email to continue.",
+      "invalidTitle": "Verification link invalid",
+      "invalidBody": "This verification link is invalid. Request a new email or sign in.",
+      "unavailableTitle": "Verification temporarily unavailable",
+      "unavailableBody": "We could not verify your email right now. Please try again.",
+      "resend": "Request another email",
+      "signIn": "Sign in",
+      "retry": "Try again"
+    },
     "errors": {
       "username": "Enter a valid account name.",
       "email": "Enter a valid email address.",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -27,6 +27,28 @@
     "logoAlt": "Shard logo",
     "createAccount": "Create account"
   },
+  "register": {
+    "title": "Create account",
+    "subtitle": "Create your player account and verify it by email.",
+    "username": "Account name",
+    "email": "Email",
+    "password": "Password",
+    "confirmation": "Confirm password",
+    "requirements": "Use 3–30 letters, numbers, dots, underscores or hyphens. Passwords must be 8–30 printable characters.",
+    "submit": "Create account",
+    "unavailableTitle": "Registration is unavailable",
+    "unavailableBody": "This shard is not accepting public registrations right now.",
+    "errors": {
+      "username": "Enter a valid account name.",
+      "email": "Enter a valid email address.",
+      "password": "Enter a valid password.",
+      "confirmation": "Passwords do not match.",
+      "conflict": "That username or email is unavailable.",
+      "disabled": "Registration is no longer available.",
+      "rateLimited": "Too many attempts. Try again later.",
+      "emailUnavailable": "Verification email is temporarily unavailable."
+    }
+  },
   "dashboard": {
     "welcome": "Welcome back, {{name}}",
     "characters": "Your characters",
@@ -68,7 +90,8 @@
   },
   "common": {
     "signOut": "Sign out",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "backToLogin": "Back to sign in"
   },
   "error": {
     "generic": "Something went wrong. Please try again."

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -38,6 +38,18 @@
     "submit": "Create account",
     "unavailableTitle": "Registration is unavailable",
     "unavailableBody": "This shard is not accepting public registrations right now.",
+    "pending": {
+      "title": "Check your email",
+      "guidance": "Look for a verification email in your inbox. You can request another message below.",
+      "resendTitle": "Resend verification email",
+      "resendSubmit": "Resend verification email",
+      "confirmation": "Your request has been received. Check your inbox for a verification email.",
+      "errors": {
+        "invalidDetails": "Check the account name and email and try again.",
+        "rateLimited": "Too many resend attempts. Try again later.",
+        "emailUnavailable": "Verification email is temporarily unavailable."
+      }
+    },
     "errors": {
       "username": "Enter a valid account name.",
       "email": "Enter a valid email address.",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -24,7 +24,8 @@
     "remember": "Remember me on this device",
     "online": "{{count}} adventurers online right now",
     "artAlt": "The Moongate — a runic portal standing open",
-    "logoAlt": "Shard logo"
+    "logoAlt": "Shard logo",
+    "createAccount": "Create account"
   },
   "dashboard": {
     "welcome": "Welcome back, {{name}}",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -50,6 +50,21 @@
         "emailUnavailable": "L’email di verifica è temporaneamente non disponibile."
       }
     },
+    "verify": {
+      "verifyingTitle": "Verifica dell’account in corso",
+      "verifyingBody": "Attendi mentre confermiamo il tuo indirizzo email.",
+      "verifiedTitle": "Email verificata",
+      "verifiedBody": "Il tuo account è pronto. Ora puoi accedere.",
+      "expiredTitle": "Link di verifica scaduto",
+      "expiredBody": "Questo link di verifica è scaduto. Richiedi una nuova email per continuare.",
+      "invalidTitle": "Link di verifica non valido",
+      "invalidBody": "Questo link di verifica non è valido. Richiedi una nuova email oppure accedi.",
+      "unavailableTitle": "Verifica temporaneamente non disponibile",
+      "unavailableBody": "Non è stato possibile verificare la tua email. Riprova.",
+      "resend": "Richiedi un’altra email",
+      "signIn": "Accedi",
+      "retry": "Riprova"
+    },
     "errors": {
       "username": "Inserisci un nome account valido.",
       "email": "Inserisci un indirizzo email valido.",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -24,7 +24,8 @@
     "remember": "Ricordami su questo dispositivo",
     "online": "{{count}} avventurieri online in questo momento",
     "artAlt": "Il Moongate — un portale runico aperto",
-    "logoAlt": "Logo dello shard"
+    "logoAlt": "Logo dello shard",
+    "createAccount": "Crea un account"
   },
   "dashboard": {
     "welcome": "Bentornato, {{name}}",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -211,7 +211,23 @@
       "assetRemoved": "Immagine rimossa.",
       "notImage": "Il file non è un'immagine.",
       "tooLarge": "L'immagine è troppo grande.",
-      "tagline": "Slogan"
+      "tagline": "Slogan",
+      "readiness": {
+        "title": "Preparazione della registrazione",
+        "overall": "Stato generale",
+        "website": "Sito web",
+        "emailSelected": "Canale di verifica",
+        "emailAvailable": "Canale email",
+        "ready": "Pronto",
+        "notReady": "Non pronto",
+        "valid": "Valido",
+        "invalid": "Non valido",
+        "selected": "Selezionato",
+        "notSelected": "Non selezionato",
+        "available": "Disponibile",
+        "unavailable": "Non disponibile",
+        "guidance": "Imposta notifications.AccountVerificationChannel su email in moongate.yaml. Configura il plugin email tramite plugins/configs/smtp.yaml o variabili d'ambiente, quindi riavvia il server."
+      }
     },
     "console": {
       "title": "Console",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -38,6 +38,18 @@
     "submit": "Crea account",
     "unavailableTitle": "Registrazione non disponibile",
     "unavailableBody": "Questo shard al momento non accetta registrazioni pubbliche.",
+    "pending": {
+      "title": "Controlla la tua email",
+      "guidance": "Cerca un’email di verifica nella tua casella. Puoi richiedere un altro messaggio qui sotto.",
+      "resendTitle": "Reinvia email di verifica",
+      "resendSubmit": "Reinvia email di verifica",
+      "confirmation": "La tua richiesta è stata ricevuta. Controlla la tua casella per un’email di verifica.",
+      "errors": {
+        "invalidDetails": "Controlla il nome account e l’email, poi riprova.",
+        "rateLimited": "Troppi tentativi di reinvio. Riprova più tardi.",
+        "emailUnavailable": "L’email di verifica è temporaneamente non disponibile."
+      }
+    },
     "errors": {
       "username": "Inserisci un nome account valido.",
       "email": "Inserisci un indirizzo email valido.",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -27,6 +27,28 @@
     "logoAlt": "Logo dello shard",
     "createAccount": "Crea un account"
   },
+  "register": {
+    "title": "Crea account",
+    "subtitle": "Crea il tuo account giocatore e verificalo via email.",
+    "username": "Nome account",
+    "email": "Email",
+    "password": "Password",
+    "confirmation": "Conferma password",
+    "requirements": "Usa 3–30 lettere, numeri, punti, trattini bassi o trattini. La password deve contenere 8–30 caratteri stampabili.",
+    "submit": "Crea account",
+    "unavailableTitle": "Registrazione non disponibile",
+    "unavailableBody": "Questo shard al momento non accetta registrazioni pubbliche.",
+    "errors": {
+      "username": "Inserisci un nome account valido.",
+      "email": "Inserisci un indirizzo email valido.",
+      "password": "Inserisci una password valida.",
+      "confirmation": "Le password non coincidono.",
+      "conflict": "Il nome account o l’email non sono disponibili.",
+      "disabled": "La registrazione non è più disponibile.",
+      "rateLimited": "Troppi tentativi. Riprova più tardi.",
+      "emailUnavailable": "L’email di verifica è temporaneamente non disponibile."
+    }
+  },
   "dashboard": {
     "welcome": "Bentornato, {{name}}",
     "characters": "I tuoi personaggi",
@@ -68,7 +90,8 @@
   },
   "common": {
     "signOut": "Esci",
-    "loading": "Caricamento…"
+    "loading": "Caricamento…",
+    "backToLogin": "Torna all’accesso"
   },
   "error": {
     "generic": "Qualcosa è andato storto. Riprova."

--- a/ui/src/routes/LoginScreen.test.tsx
+++ b/ui/src/routes/LoginScreen.test.tsx
@@ -6,9 +6,7 @@ import '../lib/i18n'
 import { AuthProvider } from '../lib/auth'
 import { LoginScreen } from './LoginScreen'
 
-function renderLogin() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-
+function renderLogin(client = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
   return render(
     <MemoryRouter>
       <QueryClientProvider client={client}>
@@ -28,6 +26,7 @@ describe('LoginScreen', () => {
     assets = {}
     tagline = null
     registrationEnabled = false
+    serverInfoAvailable = true
   })
 
   function json(body: unknown, status = 200) {
@@ -59,6 +58,10 @@ describe('LoginScreen', () => {
         return json({ shardName: 'Moongate', version: '9.9.9' })
       }
       if (url.endsWith('/api/v1/server-info')) {
+        if (!serverInfoAvailable) {
+          throw new TypeError('offline')
+        }
+
         return json({
           shardName: 'Moongate',
           tagline,
@@ -75,6 +78,7 @@ describe('LoginScreen', () => {
   let assets: Record<string, string> = {}
   let tagline: string | null = null
   let registrationEnabled = false
+  let serverInfoAvailable = true
 
   it('shows the server version once it resolves', async () => {
     serveApi()
@@ -130,6 +134,26 @@ describe('LoginScreen', () => {
 
     await screen.findByText(/Moongate · v9\.9\.9/)
     expect(screen.queryByRole('link', { name: /create account/i })).not.toBeInTheDocument()
+  })
+
+  it('hides registration when cached enabled server info fails to refetch', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    client.setQueryData(['server-info'], {
+      shardName: 'Moongate',
+      tagline: null,
+      contacts: { website: null, email: null, discord: null },
+      registrationEnabled: true,
+      assets: {},
+    })
+    serverInfoAvailable = false
+    const fetchSpy = serveApi()
+
+    renderLogin(client)
+
+    await waitFor(() =>
+      expect(fetchSpy.mock.calls.some(([input]) => String(input).endsWith('/api/v1/server-info'))).toBe(true),
+    )
+    await waitFor(() => expect(screen.queryByRole('link', { name: /create account/i })).not.toBeInTheDocument())
   })
 
   it('sends the credentials and stores the issued token', async () => {

--- a/ui/src/routes/LoginScreen.test.tsx
+++ b/ui/src/routes/LoginScreen.test.tsx
@@ -27,6 +27,7 @@ describe('LoginScreen', () => {
     vi.restoreAllMocks()
     assets = {}
     tagline = null
+    registrationEnabled = false
   })
 
   function json(body: unknown, status = 200) {
@@ -62,7 +63,7 @@ describe('LoginScreen', () => {
           shardName: 'Moongate',
           tagline,
           contacts: { website: null, email: null, discord: null },
-          registrationEnabled: false,
+          registrationEnabled,
           assets,
         })
       }
@@ -73,6 +74,7 @@ describe('LoginScreen', () => {
   // What the /server-info mock reports; tests override these before rendering.
   let assets: Record<string, string> = {}
   let tagline: string | null = null
+  let registrationEnabled = false
 
   it('shows the server version once it resolves', async () => {
     serveApi()
@@ -112,6 +114,22 @@ describe('LoginScreen', () => {
     renderLogin()
 
     expect(await screen.findByText(/Sosaria never sleeps\./)).toBeInTheDocument()
+  })
+
+  it('links to registration only when the server reports it available', async () => {
+    registrationEnabled = true
+    serveApi()
+    renderLogin()
+
+    expect(await screen.findByRole('link', { name: /create account/i })).toHaveAttribute('href', '/register')
+  })
+
+  it('does not link to registration when the server reports it unavailable', async () => {
+    serveApi()
+    renderLogin()
+
+    await screen.findByText(/Moongate · v9\.9\.9/)
+    expect(screen.queryByRole('link', { name: /create account/i })).not.toBeInTheDocument()
   })
 
   it('sends the credentials and stores the issued token', async () => {

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -1,23 +1,19 @@
 import { useState, type FormEvent } from 'react'
-import { Navigate } from 'react-router'
+import { Link } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { ApiError } from '../lib/api'
 import { useSession } from '../lib/auth'
-import { useServerInfo, useStats, useVersion } from '../lib/queries'
+import { useServerInfo } from '../lib/queries'
+import { PublicAuthLayout } from '../components/PublicAuthLayout'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
-import heroArt from '../assets/login-hero.jpg'
 
 export function LoginScreen() {
   const { t } = useTranslation()
-  const { status, signIn } = useSession()
-  const stats = useStats()
-  const version = useVersion()
+  const { signIn } = useSession()
   const serverInfo = useServerInfo()
 
-  // The assets map is keyed in PascalCase ("Logo") while the slot is lowercase — match case-insensitively.
-  const logoUrl = Object.entries(serverInfo.data?.assets ?? {}).find(([key]) => key.toLowerCase() === 'logo')?.[1]
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [remember, setRemember] = useState(true)
@@ -41,41 +37,9 @@ export function LoginScreen() {
     }
   }
 
-  if (status === 'authenticated') {
-    return <Navigate to="/" replace />
-  }
-
   return (
-    <div className="flex min-h-screen bg-surface">
-      {/* Full-bleed hero art, cropped to fill the tall panel rather than letterboxed inside it. */}
-      <div
-        className="relative hidden flex-[1.3] flex-col justify-end border-r border-border-subtle bg-cover bg-center p-10 lg:flex"
-        style={{ backgroundImage: `url(${heroArt})` }}
-      >
-        {/* A bottom-up scrim: the art is bright and busy, so the quote and count need a dark ground under
-            them to stay legible. */}
-        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/85 via-black/35 to-transparent" />
-
-        {/* The shard's own tagline when it has set one, otherwise the bundled default. */}
-        <p className="relative font-display text-[18px] text-gold">
-          &ldquo;{serverInfo.data?.tagline || t('login.quote')}&rdquo;
-        </p>
-
-        {/* Real, and public: /api/v1/stats is anonymous, so the count is readable before anyone signs in.
-            Rendered only once the reply lands — a zero here means an empty shard, which is worth saying,
-            but saying it before asking would be a guess. */}
-        {stats.data !== undefined && (
-          <p className="relative mt-1 text-sm text-muted">{t('login.online', { count: stats.data.players.online })}</p>
-        )}
-      </div>
-
-      <form onSubmit={submit} className="flex w-full max-w-[420px] flex-col justify-center gap-4 px-12">
-        {/* The shard's own logo, if it has uploaded one — public and anonymous, so it brands the page
-            before anyone signs in. Absent by default, so a fresh shard just shows the wordmark title. */}
-        {logoUrl !== undefined && (
-          <img src={logoUrl} alt={t('login.logoAlt')} className="mb-1 max-h-16 max-w-[220px] object-contain" />
-        )}
-
+    <PublicAuthLayout>
+      <form onSubmit={submit} className="flex flex-col gap-4">
         <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">{t('login.title')}</h1>
         <p className="text-sm text-muted">{t('login.subtitle')}</p>
 
@@ -125,14 +89,12 @@ export function LoginScreen() {
 
         <p className="border-t border-border-subtle pt-4 text-xs leading-relaxed text-faint">{t('login.staffNote')}</p>
 
-        {/* Data from the anonymous /api/v1/version, not UI copy — no i18n key needed. Rendered only once
-            it resolves, so an unreached shard shows nothing rather than "undefined". */}
-        {version.data?.version !== undefined && (
-          <p className="text-xs text-faint">
-            {version.data.shardName} · v{version.data.version}
-          </p>
+        {serverInfo.data?.registrationEnabled === true && (
+          <Link to="/register" className="text-center text-sm text-gold hover:text-gold-hi">
+            {t('login.createAccount')}
+          </Link>
         )}
       </form>
-    </div>
+    </PublicAuthLayout>
   )
 }

--- a/ui/src/routes/LoginScreen.tsx
+++ b/ui/src/routes/LoginScreen.tsx
@@ -89,7 +89,7 @@ export function LoginScreen() {
 
         <p className="border-t border-border-subtle pt-4 text-xs leading-relaxed text-faint">{t('login.staffNote')}</p>
 
-        {serverInfo.data?.registrationEnabled === true && (
+        {!serverInfo.isError && !serverInfo.isRefetchError && serverInfo.data?.registrationEnabled === true && (
           <Link to="/register" className="text-center text-sm text-gold hover:text-gold-hi">
             {t('login.createAccount')}
           </Link>

--- a/ui/src/routes/RegisterScreen.test.tsx
+++ b/ui/src/routes/RegisterScreen.test.tsx
@@ -1,0 +1,294 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import i18n from '../lib/i18n'
+import { AuthProvider } from '../lib/auth'
+import { RegisterScreen } from './RegisterScreen'
+
+type RegisterResult =
+  | { status: number; problem?: unknown }
+  | {
+      status: 'network'
+    }
+
+type PublicApiOptions = {
+  registrationEnabled?: boolean
+  serverInfoAvailable?: boolean
+  registerResults?: RegisterResult[]
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function servePublicApi({
+  registrationEnabled = true,
+  serverInfoAvailable = true,
+  registerResults = [{ status: 202 }],
+}: PublicApiOptions = {}) {
+  let registerAttempt = 0
+
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input)
+
+    if (url.endsWith('/api/v1/server-info')) {
+      if (!serverInfoAvailable) {
+        throw new TypeError('offline')
+      }
+
+      return json({
+        shardName: 'Moongate',
+        tagline: null,
+        contacts: { website: null, email: null, discord: null },
+        registrationEnabled,
+        assets: {},
+      })
+    }
+
+    if (url.endsWith('/api/v1/stats')) {
+      return json({
+        players: { online: 0, connections: 0 },
+        accounts: { total: 0, active: 0, characters: 0 },
+      })
+    }
+
+    if (url.endsWith('/api/v1/version')) {
+      return json({ shardName: 'Moongate', version: '1.0.0' })
+    }
+
+    if (url.endsWith('/api/v1/register')) {
+      const result = registerResults[Math.min(registerAttempt, registerResults.length - 1)]
+      registerAttempt += 1
+
+      if (result.status === 'network') {
+        throw new TypeError('offline')
+      }
+
+      return result.status === 202
+        ? new Response(null, { status: 202 })
+        : json(result.problem ?? { title: 'request failed' }, result.status)
+    }
+
+    return json({})
+  })
+}
+
+function PendingProbe() {
+  const location = useLocation()
+  return <pre>{JSON.stringify(location.state)}</pre>
+}
+
+function renderRegister() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <MemoryRouter initialEntries={['/register']}>
+      <QueryClientProvider client={client}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/register" element={<RegisterScreen />} />
+            <Route path="/register/pending" element={<PendingProbe />} />
+          </Routes>
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+async function fillRegistration({
+  username = 'player.one',
+  email = 'player@example.test',
+  password = 'correct horse',
+  confirmation = password,
+}: {
+  username?: string
+  email?: string
+  password?: string
+  confirmation?: string
+} = {}) {
+  await userEvent.type(await screen.findByLabelText(/account name/i), username)
+  await userEvent.type(screen.getByLabelText(/^email$/i), email)
+  await userEvent.type(screen.getByLabelText(/^password$/i), password)
+  await userEvent.type(screen.getByLabelText(/confirm password/i), confirmation)
+}
+
+function registerCalls(fetchSpy: ReturnType<typeof servePublicApi>) {
+  return fetchSpy.mock.calls.filter(([input]) => String(input).endsWith('/api/v1/register'))
+}
+
+describe('RegisterScreen', () => {
+  beforeEach(async () => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+    await i18n.changeLanguage('en')
+  })
+
+  it.each([
+    ['disabled', { registrationEnabled: false }],
+    ['unreachable', { serverInfoAvailable: false }],
+  ])('shows an informational state and login link when registration is %s', async (_, options) => {
+    servePublicApi(options)
+    renderRegister()
+
+    expect(await screen.findByRole('heading', { name: /registration is unavailable/i })).toBeInTheDocument()
+    expect(screen.getByText(/not accepting public registrations/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to sign in/i })).toHaveAttribute('href', '/login')
+    expect(screen.queryByRole('form')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /create account/i })).not.toBeInTheDocument()
+  })
+
+  it('shows visible requirements and the exact registration autocomplete values', async () => {
+    servePublicApi()
+    renderRegister()
+
+    const username = await screen.findByLabelText(/account name/i)
+    const email = screen.getByLabelText(/^email$/i)
+    const password = screen.getByLabelText(/^password$/i)
+    const confirmation = screen.getByLabelText(/confirm password/i)
+
+    expect(username).toHaveAttribute('autocomplete', 'username')
+    expect(email).toHaveAttribute('autocomplete', 'email')
+    expect(password).toHaveAttribute('autocomplete', 'new-password')
+    expect(confirmation).toHaveAttribute('autocomplete', 'new-password')
+    expect(screen.getByText(/3–30 letters/i)).toBeVisible()
+    expect(screen.getByText(/8–30 printable characters/i)).toBeVisible()
+  })
+
+  it('submits the exact normalized payload and navigates with identity state only', async () => {
+    const fetchSpy = servePublicApi()
+    renderRegister()
+
+    await fillRegistration({
+      username: '  player.one  ',
+      email: '  player@example.test  ',
+    })
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    const state = await screen.findByText('{"username":"player.one","email":"player@example.test"}', undefined, {
+      timeout: 2000,
+    })
+    const calls = registerCalls(fetchSpy)
+    expect(calls).toHaveLength(1)
+    expect(JSON.parse(String((calls[0][1] as RequestInit).body))).toEqual({
+      username: 'player.one',
+      email: 'player@example.test',
+      password: 'correct horse',
+    })
+    expect(state).not.toHaveTextContent(/password|correct horse/i)
+    expect(localStorage.length).toBe(0)
+    expect(sessionStorage.length).toBe(0)
+  })
+
+  it('attaches every client validation error to its field without submitting', async () => {
+    const fetchSpy = servePublicApi()
+    renderRegister()
+
+    await fillRegistration({
+      username: 'ab',
+      email: 'invalid',
+      password: 'short',
+      confirmation: 'different',
+    })
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    const expectedErrors = [
+      ['account name', /valid account name/i],
+      ['email', /valid email address/i],
+      ['password', /valid password/i],
+      ['confirm password', /passwords do not match/i],
+    ] as const
+
+    for (const [label, message] of expectedErrors) {
+      const input = screen.getByLabelText(new RegExp(`^${label}$`, 'i'))
+      const errorId = input.getAttribute('aria-describedby')
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+      expect(errorId).toBeTruthy()
+      const alert = document.getElementById(errorId ?? '')
+      expect(alert).toHaveAttribute('role', 'alert')
+      expect(alert).toHaveTextContent(message)
+    }
+
+    expect(registerCalls(fetchSpy)).toHaveLength(0)
+  })
+
+  it('maps backend validation keys to localized field errors without trusting backend copy', async () => {
+    servePublicApi({
+      registerResults: [
+        {
+          status: 400,
+          problem: {
+            detail: 'sensitive backend detail',
+            errors: {
+              username: ['backend username copy'],
+              email: ['backend email copy'],
+              password: ['backend password copy'],
+            },
+          },
+        },
+      ],
+    })
+    renderRegister()
+    await fillRegistration()
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    const form = await screen.findByRole('form', { name: /create account/i })
+    expect(within(form).getByText(/valid account name/i)).toHaveAttribute('role', 'alert')
+    expect(within(form).getByText(/valid email address/i)).toHaveAttribute('role', 'alert')
+    expect(within(form).getByText(/valid password/i)).toHaveAttribute('role', 'alert')
+    expect(screen.queryByText(/backend .* copy|sensitive backend detail/i)).not.toBeInTheDocument()
+  })
+
+  it.each([
+    [409, /username or email is unavailable/i],
+    [429, /too many attempts/i],
+    [403, /no longer available/i],
+    [503, /verification email is temporarily unavailable/i],
+  ] as const)('maps registration status %s to a polite localized form error', async (status, message) => {
+    servePublicApi({ registerResults: [{ status }] })
+    renderRegister()
+    await fillRegistration()
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    const error = await screen.findByText(message)
+    expect(error).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getAllByText(message)).toHaveLength(1)
+  })
+
+  it('maps a network error to generic localized copy and retries with every typed value retained', async () => {
+    const fetchSpy = servePublicApi({
+      registerResults: [{ status: 'network' }, { status: 202 }],
+    })
+    renderRegister()
+    await fillRegistration()
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    const formError = await screen.findByText(/something went wrong/i)
+    expect(formError).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByLabelText(/account name/i)).toHaveValue('player.one')
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('player@example.test')
+    expect(screen.getByLabelText(/^password$/i)).toHaveValue('correct horse')
+    expect(screen.getByLabelText(/confirm password/i)).toHaveValue('correct horse')
+
+    await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => expect(registerCalls(fetchSpy)).toHaveLength(2))
+    for (const call of registerCalls(fetchSpy)) {
+      expect(JSON.parse(String((call[1] as RequestInit).body))).toEqual({
+        username: 'player.one',
+        email: 'player@example.test',
+        password: 'correct horse',
+      })
+    }
+    expect(await screen.findByText('{"username":"player.one","email":"player@example.test"}')).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/RegisterScreen.test.tsx
+++ b/ui/src/routes/RegisterScreen.test.tsx
@@ -82,14 +82,13 @@ function PendingProbe() {
   return <pre>{JSON.stringify(location.state)}</pre>
 }
 
-function renderRegister() {
-  const client = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
+function createTestClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
+}
 
+function renderRegister(client = createTestClient()) {
   return render(
     <MemoryRouter initialEntries={['/register']}>
       <QueryClientProvider client={client}>
@@ -145,6 +144,27 @@ describe('RegisterScreen', () => {
     expect(screen.getByRole('link', { name: /back to sign in/i })).toHaveAttribute('href', '/login')
     expect(screen.queryByRole('form')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /create account/i })).not.toBeInTheDocument()
+  })
+
+  it('hides a cached enabled form when the current server-info refetch fails', async () => {
+    const client = createTestClient()
+    client.setQueryData(['server-info'], {
+      shardName: 'Moongate',
+      tagline: null,
+      contacts: { website: null, email: null, discord: null },
+      registrationEnabled: true,
+      assets: {},
+    })
+    const fetchSpy = servePublicApi({ serverInfoAvailable: false })
+
+    renderRegister(client)
+
+    await waitFor(() =>
+      expect(fetchSpy.mock.calls.some(([input]) => String(input).endsWith('/api/v1/server-info'))).toBe(true),
+    )
+    expect(await screen.findByRole('heading', { name: /registration is unavailable/i })).toBeInTheDocument()
+    expect(screen.queryByRole('form', { name: /create account/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to sign in/i })).toHaveAttribute('href', '/login')
   })
 
   it('shows visible requirements and the exact registration autocomplete values', async () => {

--- a/ui/src/routes/RegisterScreen.tsx
+++ b/ui/src/routes/RegisterScreen.tsx
@@ -93,7 +93,7 @@ export function RegisterScreen() {
     }
   }
 
-  if (serverInfo.data?.registrationEnabled !== true) {
+  if (serverInfo.isError || serverInfo.isRefetchError || serverInfo.data?.registrationEnabled !== true) {
     return (
       <PublicAuthLayout>
         <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">

--- a/ui/src/routes/RegisterScreen.tsx
+++ b/ui/src/routes/RegisterScreen.tsx
@@ -1,0 +1,222 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { PublicAuthLayout } from '../components/PublicAuthLayout'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { ApiError } from '../lib/api'
+import { useServerInfo } from '../lib/queries'
+import {
+  useRegisterAccount,
+  validateRegistration,
+  type RegistrationField,
+  type RegistrationValidationCode,
+  type RegistrationValidationErrors,
+} from '../lib/registration'
+
+const REGISTRATION_FIELDS: RegistrationField[] = ['username', 'email', 'password', 'confirmation']
+
+function backendFieldErrors(error: ApiError): RegistrationValidationErrors {
+  const errors: RegistrationValidationErrors = {}
+
+  for (const key of Object.keys(error.problem?.errors ?? {})) {
+    const field = key.toLowerCase()
+    if (REGISTRATION_FIELDS.includes(field as RegistrationField)) {
+      errors[field as RegistrationField] = field === 'confirmation' ? 'mismatch' : 'invalid'
+    }
+  }
+
+  return errors
+}
+
+export function RegisterScreen() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const serverInfo = useServerInfo()
+  const registerAccount = useRegisterAccount()
+
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmation, setConfirmation] = useState('')
+  const [fieldErrors, setFieldErrors] = useState<RegistrationValidationErrors>({})
+  const [formError, setFormError] = useState<string | null>(null)
+
+  function fieldMessage(field: RegistrationField, code: RegistrationValidationCode): string {
+    return code === 'mismatch' ? t('register.errors.confirmation') : t(`register.errors.${field}`)
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setFormError(null)
+
+    const errors = validateRegistration({ username, email, password, confirmation })
+    setFieldErrors(errors)
+    if (Object.keys(errors).length > 0) {
+      return
+    }
+
+    try {
+      await registerAccount.mutateAsync({
+        username: username.trim(),
+        email: email.trim(),
+        password,
+      })
+      setPassword('')
+      setConfirmation('')
+      navigate('/register/pending', {
+        state: { username: username.trim(), email: email.trim() },
+      })
+    } catch (caught) {
+      if (!(caught instanceof ApiError)) {
+        setFormError(t('error.generic'))
+        return
+      }
+
+      if (caught.status === 400) {
+        const backendErrors = backendFieldErrors(caught)
+        setFieldErrors(backendErrors)
+        if (Object.keys(backendErrors).length === 0) {
+          setFormError(t('error.generic'))
+        }
+        return
+      }
+
+      const errorKey = {
+        403: 'disabled',
+        409: 'conflict',
+        429: 'rateLimited',
+        503: 'emailUnavailable',
+      }[caught.status]
+      setFormError(errorKey === undefined ? t('error.generic') : t(`register.errors.${errorKey}`))
+    }
+  }
+
+  if (serverInfo.data?.registrationEnabled !== true) {
+    return (
+      <PublicAuthLayout>
+        <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">
+          {t('register.unavailableTitle')}
+        </h1>
+        <p className="text-sm text-muted">{t('register.unavailableBody')}</p>
+        <Link to="/login" className="text-sm text-gold hover:text-gold-hi">
+          {t('common.backToLogin')}
+        </Link>
+      </PublicAuthLayout>
+    )
+  }
+
+  return (
+    <PublicAuthLayout>
+      <form aria-labelledby="register-title" onSubmit={submit} noValidate className="flex flex-col gap-4">
+        <h1 id="register-title" className="font-display text-[25px] font-bold tracking-wider text-gold">
+          {t('register.title')}
+        </h1>
+        <p className="text-sm text-muted">{t('register.subtitle')}</p>
+        <p className="text-xs leading-relaxed text-faint">{t('register.requirements')}</p>
+
+        <RegistrationFieldControl
+          id="username"
+          label={t('register.username')}
+          value={username}
+          autoComplete="username"
+          error={fieldErrors.username}
+          errorMessage={fieldErrors.username === undefined ? undefined : fieldMessage('username', fieldErrors.username)}
+          onChange={setUsername}
+        />
+        <RegistrationFieldControl
+          id="email"
+          label={t('register.email')}
+          type="email"
+          value={email}
+          autoComplete="email"
+          error={fieldErrors.email}
+          errorMessage={fieldErrors.email === undefined ? undefined : fieldMessage('email', fieldErrors.email)}
+          onChange={setEmail}
+        />
+        <RegistrationFieldControl
+          id="password"
+          label={t('register.password')}
+          type="password"
+          value={password}
+          autoComplete="new-password"
+          error={fieldErrors.password}
+          errorMessage={fieldErrors.password === undefined ? undefined : fieldMessage('password', fieldErrors.password)}
+          onChange={setPassword}
+        />
+        <RegistrationFieldControl
+          id="confirmation"
+          label={t('register.confirmation')}
+          type="password"
+          value={confirmation}
+          autoComplete="new-password"
+          error={fieldErrors.confirmation}
+          errorMessage={
+            fieldErrors.confirmation === undefined ? undefined : fieldMessage('confirmation', fieldErrors.confirmation)
+          }
+          onChange={setConfirmation}
+        />
+
+        {formError !== null && (
+          <p aria-live="polite" aria-atomic="true" className="text-sm text-danger-text">
+            {formError}
+          </p>
+        )}
+
+        <Button type="submit" disabled={registerAccount.isPending} className="py-3 text-sm tracking-[0.14em]">
+          {t('register.submit')}
+        </Button>
+
+        <Link to="/login" className="text-center text-sm text-gold hover:text-gold-hi">
+          {t('common.backToLogin')}
+        </Link>
+      </form>
+    </PublicAuthLayout>
+  )
+}
+
+type RegistrationFieldControlProps = {
+  id: RegistrationField
+  label: string
+  type?: 'email' | 'password' | 'text'
+  value: string
+  autoComplete: 'email' | 'new-password' | 'username'
+  error: RegistrationValidationCode | undefined
+  errorMessage: string | undefined
+  onChange: (value: string) => void
+}
+
+function RegistrationFieldControl({
+  id,
+  label,
+  type = 'text',
+  value,
+  autoComplete,
+  error,
+  errorMessage,
+  onChange,
+}: RegistrationFieldControlProps) {
+  const errorId = `${id}-error`
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type={type}
+        value={value}
+        autoComplete={autoComplete}
+        aria-invalid={error !== undefined}
+        aria-describedby={error === undefined ? undefined : errorId}
+        onChange={(event) => onChange(event.target.value)}
+        required
+      />
+      {errorMessage !== undefined && (
+        <p id={errorId} role="alert" className="text-sm text-danger-text">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/ui/src/routes/RegistrationPendingScreen.test.tsx
+++ b/ui/src/routes/RegistrationPendingScreen.test.tsx
@@ -1,0 +1,250 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import i18n from '../lib/i18n'
+import { AuthProvider } from '../lib/auth'
+import { RegistrationPendingScreen } from './RegistrationPendingScreen'
+
+type ResendResult =
+  | { status: number; problem?: unknown }
+  | {
+      status: 'network'
+    }
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function servePublicApi(resendResults: ResendResult[] = [{ status: 202 }]) {
+  let resendAttempt = 0
+
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input)
+
+    if (url.endsWith('/api/v1/server-info')) {
+      return json({
+        shardName: 'Moongate',
+        tagline: null,
+        contacts: { website: null, email: null, discord: null },
+        registrationEnabled: true,
+        assets: {},
+      })
+    }
+
+    if (url.endsWith('/api/v1/stats')) {
+      return json({
+        players: { online: 0, connections: 0 },
+        accounts: { total: 0, active: 0, characters: 0 },
+      })
+    }
+
+    if (url.endsWith('/api/v1/version')) {
+      return json({ shardName: 'Moongate', version: '1.0.0' })
+    }
+
+    if (url.endsWith('/api/v1/register/resend')) {
+      const result = resendResults[Math.min(resendAttempt, resendResults.length - 1)]
+      resendAttempt += 1
+
+      if (result.status === 'network') {
+        throw new TypeError('offline')
+      }
+
+      return result.status === 202
+        ? new Response(null, { status: 202 })
+        : json(result.problem ?? { detail: 'sensitive backend detail' }, result.status)
+    }
+
+    return json({})
+  })
+}
+
+function createTestClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function renderPending(state?: unknown) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/register/pending', state }]}>
+      <QueryClientProvider client={createTestClient()}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/register/pending" element={<RegistrationPendingScreen />} />
+          </Routes>
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+function resendCalls(fetchSpy: ReturnType<typeof servePublicApi>) {
+  return fetchSpy.mock.calls.filter(([input]) => String(input).endsWith('/api/v1/register/resend'))
+}
+
+describe('RegistrationPendingScreen', () => {
+  beforeEach(async () => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+    await i18n.changeLanguage('en')
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('prefills valid transient registration identity state without persisting it', async () => {
+    servePublicApi()
+    renderPending({ username: 'player.one', email: 'player@example.test' })
+
+    expect(await screen.findByLabelText(/account name/i)).toHaveValue('player.one')
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('player@example.test')
+    expect(screen.getByText(/look for a verification email/i)).toBeVisible()
+    expect(localStorage.length).toBe(0)
+    expect(sessionStorage.length).toBe(0)
+  })
+
+  it.each([undefined, { username: 123, email: null }])(
+    'uses blank fields for direct or malformed state',
+    async (state) => {
+      servePublicApi()
+      renderPending(state)
+
+      expect(await screen.findByLabelText(/account name/i)).toHaveValue('')
+      expect(screen.getByLabelText(/^email$/i)).toHaveValue('')
+    },
+  )
+
+  it('posts the normalized valid resend identity', async () => {
+    const fetchSpy = servePublicApi()
+    renderPending()
+
+    await userEvent.type(await screen.findByLabelText(/account name/i), '  player.one  ')
+    await userEvent.type(screen.getByLabelText(/^email$/i), '  player@example.test  ')
+    await userEvent.click(screen.getByRole('button', { name: /resend verification email/i }))
+
+    await screen.findByText(/your request has been received/i)
+    const calls = resendCalls(fetchSpy)
+    expect(calls).toHaveLength(1)
+    expect(JSON.parse(String((calls[0][1] as RequestInit).body))).toEqual({
+      username: 'player.one',
+      email: 'player@example.test',
+    })
+  })
+
+  it('shows the identical generic confirmation for distinct accepted identities', async () => {
+    const confirmations: string[] = []
+
+    for (const state of [
+      { username: 'player.one', email: 'player@example.test' },
+      { username: 'someone.else', email: 'other@example.test' },
+    ]) {
+      servePublicApi([{ status: 202 }])
+      const view = renderPending(state)
+
+      await userEvent.click(await screen.findByRole('button', { name: /resend verification email/i }))
+      confirmations.push((await screen.findByText(/your request has been received/i)).textContent ?? '')
+
+      view.unmount()
+      vi.restoreAllMocks()
+    }
+
+    expect(confirmations).toEqual([
+      'Your request has been received. Check your inbox for a verification email.',
+      'Your request has been received. Check your inbox for a verification email.',
+    ])
+  })
+
+  it('shows local field errors without requesting resend for invalid details', async () => {
+    const fetchSpy = servePublicApi()
+    renderPending()
+
+    await userEvent.type(await screen.findByLabelText(/account name/i), 'ab')
+    await userEvent.type(screen.getByLabelText(/^email$/i), 'invalid')
+    await userEvent.click(screen.getByRole('button', { name: /resend verification email/i }))
+
+    expect(await screen.findByText(/enter a valid account name/i)).toHaveAttribute('role', 'alert')
+    expect(screen.getByText(/enter a valid email address/i)).toHaveAttribute('role', 'alert')
+    expect(resendCalls(fetchSpy)).toHaveLength(0)
+  })
+
+  it.each([
+    [400, /check the account name and email and try again/i],
+    [429, /too many resend attempts/i],
+    [503, /verification email is temporarily unavailable/i],
+    ['network', /something went wrong/i],
+  ] as const)('maps resend failure %s to safe localized copy', async (result, message) => {
+    servePublicApi([{ status: result }])
+    renderPending({ username: 'player.one', email: 'player@example.test' })
+
+    await userEvent.click(await screen.findByRole('button', { name: /resend verification email/i }))
+
+    expect(await screen.findByText(message)).toHaveAttribute('aria-live', 'polite')
+    expect(screen.queryByText(/sensitive backend detail/i)).not.toBeInTheDocument()
+  })
+
+  it('disables only resend submission while the request is pending', async () => {
+    let resolveRequest: ((value: Response) => void) | undefined
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      if (String(input).endsWith('/api/v1/register/resend')) {
+        return new Promise<Response>((resolve) => {
+          resolveRequest = resolve
+        })
+      }
+
+      if (String(input).endsWith('/api/v1/server-info')) {
+        return json({
+          shardName: 'Moongate',
+          tagline: null,
+          contacts: { website: null, email: null, discord: null },
+          registrationEnabled: true,
+          assets: {},
+        })
+      }
+
+      if (String(input).endsWith('/api/v1/stats')) {
+        return json({
+          players: { online: 0, connections: 0 },
+          accounts: { total: 0, active: 0, characters: 0 },
+        })
+      }
+
+      if (String(input).endsWith('/api/v1/version')) {
+        return json({ shardName: 'Moongate', version: '1.0.0' })
+      }
+
+      return json({})
+    })
+    renderPending({ username: 'player.one', email: 'player@example.test' })
+
+    const username = await screen.findByLabelText(/account name/i)
+    const email = screen.getByLabelText(/^email$/i)
+    const submit = screen.getByRole('button', { name: /resend verification email/i })
+    await userEvent.click(submit)
+
+    await waitFor(() => expect(submit).toBeDisabled())
+    expect(username).not.toBeDisabled()
+    expect(email).not.toBeDisabled()
+    expect(screen.getByRole('link', { name: /back to sign in/i })).not.toHaveAttribute('aria-disabled', 'true')
+
+    resolveRequest?.(new Response(null, { status: 202 }))
+    await screen.findByText(/your request has been received/i)
+  })
+
+  it('does not write resend details to browser storage', async () => {
+    servePublicApi()
+    renderPending({ username: 'player.one', email: 'player@example.test' })
+
+    await userEvent.click(await screen.findByRole('button', { name: /resend verification email/i }))
+    await screen.findByText(/your request has been received/i)
+
+    expect(localStorage.length).toBe(0)
+    expect(sessionStorage.length).toBe(0)
+  })
+})

--- a/ui/src/routes/RegistrationPendingScreen.test.tsx
+++ b/ui/src/routes/RegistrationPendingScreen.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router'
 import i18n from '../lib/i18n'
 import { AuthProvider } from '../lib/auth'
 import { RegistrationPendingScreen } from './RegistrationPendingScreen'
@@ -83,6 +83,20 @@ function renderPending(state?: unknown) {
   )
 }
 
+function renderBrowserPending() {
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={createTestClient()}>
+        <AuthProvider>
+          <Routes>
+            <Route path="/register/pending" element={<RegistrationPendingScreen />} />
+          </Routes>
+        </AuthProvider>
+      </QueryClientProvider>
+    </BrowserRouter>,
+  )
+}
+
 function resendCalls(fetchSpy: ReturnType<typeof servePublicApi>) {
   return fetchSpy.mock.calls.filter(([input]) => String(input).endsWith('/api/v1/register/resend'))
 }
@@ -91,6 +105,7 @@ describe('RegistrationPendingScreen', () => {
   beforeEach(async () => {
     localStorage.clear()
     sessionStorage.clear()
+    window.history.replaceState(null, '', '/')
     vi.restoreAllMocks()
     await i18n.changeLanguage('en')
   })
@@ -108,6 +123,26 @@ describe('RegistrationPendingScreen', () => {
     expect(screen.getByText(/look for a verification email/i)).toBeVisible()
     expect(localStorage.length).toBe(0)
     expect(sessionStorage.length).toBe(0)
+  })
+
+  it('uses navigation state once and clears it before a subsequent browser reload', async () => {
+    servePublicApi()
+    window.history.replaceState(
+      { usr: { username: 'player.one', email: 'player@example.test' }, key: 'pending', idx: 0 },
+      '',
+      '/register/pending',
+    )
+
+    const firstMount = renderBrowserPending()
+
+    expect(await screen.findByLabelText(/account name/i)).toHaveValue('player.one')
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('player@example.test')
+
+    firstMount.unmount()
+    renderBrowserPending()
+
+    expect(await screen.findByLabelText(/account name/i)).toHaveValue('')
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('')
   })
 
   it.each([undefined, { username: 123, email: null }])(

--- a/ui/src/routes/RegistrationPendingScreen.test.tsx
+++ b/ui/src/routes/RegistrationPendingScreen.test.tsx
@@ -173,6 +173,18 @@ describe('RegistrationPendingScreen', () => {
     })
   })
 
+  it('keeps an empty polite resend status region mounted before submission', async () => {
+    servePublicApi()
+    renderPending()
+
+    await screen.findByLabelText(/account name/i)
+    const status = screen.getByRole('status')
+
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveAttribute('aria-atomic', 'true')
+    expect(status).toBeEmptyDOMElement()
+  })
+
   it('shows the identical generic confirmation for distinct accepted identities', async () => {
     const confirmations: string[] = []
 

--- a/ui/src/routes/RegistrationPendingScreen.tsx
+++ b/ui/src/routes/RegistrationPendingScreen.tsx
@@ -1,0 +1,156 @@
+import { useState, type FormEvent } from 'react'
+import { Link, useLocation } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { PublicAuthLayout } from '../components/PublicAuthLayout'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { ApiError } from '../lib/api'
+import {
+  useResendVerification,
+  validateResend,
+  type RegistrationField,
+  type RegistrationValidationErrors,
+} from '../lib/registration'
+
+type PendingState = { username?: unknown; email?: unknown }
+
+export function RegistrationPendingScreen() {
+  const { t } = useTranslation()
+  const location = useLocation()
+  const resendVerification = useResendVerification()
+  const state = (location.state ?? {}) as PendingState
+  const initialUsername = typeof state.username === 'string' ? state.username : ''
+  const initialEmail = typeof state.email === 'string' ? state.email : ''
+
+  const [username, setUsername] = useState(initialUsername)
+  const [email, setEmail] = useState(initialEmail)
+  const [fieldErrors, setFieldErrors] = useState<RegistrationValidationErrors>({})
+  const [formMessage, setFormMessage] = useState<string | null>(null)
+
+  function fieldMessage(field: RegistrationField): string {
+    return t(`register.errors.${field}`)
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setFormMessage(null)
+
+    const errors = validateResend({ username, email })
+    setFieldErrors(errors)
+    if (Object.keys(errors).length > 0) {
+      return
+    }
+
+    try {
+      await resendVerification.mutateAsync({ username: username.trim(), email: email.trim() })
+      setFormMessage(t('register.pending.confirmation'))
+    } catch (caught) {
+      setFormMessage(
+        caught instanceof ApiError
+          ? ({
+              400: t('register.pending.errors.invalidDetails'),
+              429: t('register.pending.errors.rateLimited'),
+              503: t('register.pending.errors.emailUnavailable'),
+            }[caught.status] ?? t('error.generic'))
+          : t('error.generic'),
+      )
+    }
+  }
+
+  return (
+    <PublicAuthLayout>
+      <section aria-labelledby="registration-pending-title" className="flex flex-col gap-4">
+        <h1 id="registration-pending-title" className="font-display text-[25px] font-bold tracking-wider text-gold">
+          {t('register.pending.title')}
+        </h1>
+        <p className="text-sm text-muted">{t('register.pending.guidance')}</p>
+
+        <form aria-labelledby="resend-title" onSubmit={submit} noValidate className="flex flex-col gap-4">
+          <h2 id="resend-title" className="font-display text-lg font-bold tracking-wide text-gold">
+            {t('register.pending.resendTitle')}
+          </h2>
+
+          <ResendFieldControl
+            id="username"
+            label={t('register.username')}
+            value={username}
+            autoComplete="username"
+            error={fieldErrors.username !== undefined}
+            errorMessage={fieldErrors.username === undefined ? undefined : fieldMessage('username')}
+            onChange={setUsername}
+          />
+          <ResendFieldControl
+            id="email"
+            label={t('register.email')}
+            type="email"
+            value={email}
+            autoComplete="email"
+            error={fieldErrors.email !== undefined}
+            errorMessage={fieldErrors.email === undefined ? undefined : fieldMessage('email')}
+            onChange={setEmail}
+          />
+
+          {formMessage !== null && (
+            <p aria-live="polite" aria-atomic="true" className="text-sm text-muted">
+              {formMessage}
+            </p>
+          )}
+
+          <Button type="submit" disabled={resendVerification.isPending} className="py-3 text-sm tracking-[0.14em]">
+            {t('register.pending.resendSubmit')}
+          </Button>
+        </form>
+
+        <Link to="/login" className="text-center text-sm text-gold hover:text-gold-hi">
+          {t('common.backToLogin')}
+        </Link>
+      </section>
+    </PublicAuthLayout>
+  )
+}
+
+type ResendFieldControlProps = {
+  id: 'username' | 'email'
+  label: string
+  type?: 'email' | 'text'
+  value: string
+  autoComplete: 'email' | 'username'
+  error: boolean
+  errorMessage: string | undefined
+  onChange: (value: string) => void
+}
+
+function ResendFieldControl({
+  id,
+  label,
+  type = 'text',
+  value,
+  autoComplete,
+  error,
+  errorMessage,
+  onChange,
+}: ResendFieldControlProps) {
+  const errorId = `${id}-error`
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type={type}
+        value={value}
+        autoComplete={autoComplete}
+        aria-invalid={error}
+        aria-describedby={error ? errorId : undefined}
+        onChange={(event) => onChange(event.target.value)}
+        required
+      />
+      {errorMessage !== undefined && (
+        <p id={errorId} role="alert" className="text-sm text-danger-text">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/ui/src/routes/RegistrationPendingScreen.tsx
+++ b/ui/src/routes/RegistrationPendingScreen.tsx
@@ -1,5 +1,5 @@
-import { useState, type FormEvent } from 'react'
-import { Link, useLocation } from 'react-router'
+import { useEffect, useState, type FormEvent } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { PublicAuthLayout } from '../components/PublicAuthLayout'
 import { Button } from '../components/ui/button'
@@ -18,6 +18,7 @@ type PendingState = { username?: unknown; email?: unknown }
 export function RegistrationPendingScreen() {
   const { t } = useTranslation()
   const location = useLocation()
+  const navigate = useNavigate()
   const resendVerification = useResendVerification()
   const state = (location.state ?? {}) as PendingState
   const initialUsername = typeof state.username === 'string' ? state.username : ''
@@ -27,6 +28,12 @@ export function RegistrationPendingScreen() {
   const [email, setEmail] = useState(initialEmail)
   const [fieldErrors, setFieldErrors] = useState<RegistrationValidationErrors>({})
   const [formMessage, setFormMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (location.state !== null) {
+      navigate(`${location.pathname}${location.search}${location.hash}`, { replace: true, state: null })
+    }
+  }, [location.hash, location.pathname, location.search, location.state, navigate])
 
   function fieldMessage(field: RegistrationField): string {
     return t(`register.errors.${field}`)

--- a/ui/src/routes/RegistrationPendingScreen.tsx
+++ b/ui/src/routes/RegistrationPendingScreen.tsx
@@ -98,11 +98,9 @@ export function RegistrationPendingScreen() {
             onChange={setEmail}
           />
 
-          {formMessage !== null && (
-            <p aria-live="polite" aria-atomic="true" className="text-sm text-muted">
-              {formMessage}
-            </p>
-          )}
+          <p role="status" aria-live="polite" aria-atomic="true" className="text-sm text-muted">
+            {formMessage ?? ''}
+          </p>
 
           <Button type="submit" disabled={resendVerification.isPending} className="py-3 text-sm tracking-[0.14em]">
             {t('register.pending.resendSubmit')}

--- a/ui/src/routes/SettingsScreen.test.tsx
+++ b/ui/src/routes/SettingsScreen.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import '../lib/i18n'
+import i18n from '../lib/i18n'
 import { SettingsScreen } from './SettingsScreen'
 
 function renderScreen() {
@@ -22,11 +22,20 @@ const settings = {
   tagline: 'Sosaria never sleeps.',
   contacts: { website: 'https://x.io', email: null, discord: null },
   registrationEnabled: true,
+  registrationReadiness: {
+    ready: true,
+    websiteValid: true,
+    emailChannelSelected: true,
+    emailChannelAvailable: true,
+  },
   assets: {},
 }
 
 describe('SettingsScreen', () => {
-  beforeEach(() => vi.restoreAllMocks())
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    await i18n.changeLanguage('en')
+  })
 
   it('shows the fetched settings', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
@@ -56,12 +65,132 @@ describe('SettingsScreen', () => {
     expect(await screen.findByRole('img', { name: /^logo$/i })).toBeInTheDocument()
   })
 
-  it('PUTs the current form state on Save', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+  it('shows every registration readiness prerequisite with text status', async () => {
+    const unavailable = {
+      ...settings,
+      contacts: { ...settings.contacts, website: null },
+      registrationEnabled: false,
+      registrationReadiness: {
+        ready: false,
+        websiteValid: false,
+        emailChannelSelected: true,
+        emailChannelAvailable: true,
+      },
+    }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(unavailable))
     renderScreen()
 
-    // The registration toggle is seeded on (from the fetched settings); flip it off and save.
-    const toggle = await screen.findByRole('switch', { name: /registration/i })
+    await screen.findByDisplayValue('The finest shard')
+    const readiness = screen.getByRole('region', { name: /registration readiness/i })
+    expect(within(readiness).getByText('Overall')).toBeInTheDocument()
+    expect(within(readiness).getByText('Not ready')).toBeInTheDocument()
+    expect(within(readiness).getByText('Website')).toBeInTheDocument()
+    expect(within(readiness).getByText('Invalid')).toBeInTheDocument()
+    expect(within(readiness).getByText('Verification channel')).toBeInTheDocument()
+    expect(within(readiness).getByText('Selected')).toBeInTheDocument()
+    expect(within(readiness).getByText('Email channel')).toBeInTheDocument()
+    expect(within(readiness).getByText('Available')).toBeInTheDocument()
+  })
+
+  it.each(['', 'http:/portal', 'https:/portal', 'http:portal', 'http:///portal', 'ftp://shard.example'])(
+    'prevents enabling registration with invalid draft Website %j',
+    async (website) => {
+      const unavailable = {
+        ...settings,
+        contacts: { ...settings.contacts, website },
+        registrationEnabled: false,
+        registrationReadiness: {
+          ready: false,
+          websiteValid: false,
+          emailChannelSelected: true,
+          emailChannelAvailable: true,
+        },
+      }
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(unavailable))
+      renderScreen()
+
+      await screen.findByDisplayValue('The finest shard')
+      expect(screen.getByRole('switch', { name: /registration/i })).toBeDisabled()
+    },
+  )
+
+  it('immediately permits enabling registration when the draft Website becomes valid', async () => {
+    const unavailable = {
+      ...settings,
+      contacts: { ...settings.contacts, website: 'http:/portal' },
+      registrationEnabled: false,
+      registrationReadiness: {
+        ready: false,
+        websiteValid: false,
+        emailChannelSelected: true,
+        emailChannelAvailable: true,
+      },
+    }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(unavailable))
+    renderScreen()
+
+    await screen.findByDisplayValue('http:/portal')
+    const toggle = screen.getByRole('switch', { name: /registration/i })
+    expect(toggle).toBeDisabled()
+
+    const website = screen.getByLabelText(/^website$/i)
+    await userEvent.clear(website)
+    await userEvent.type(website, 'https://shard.example/moongate')
+
+    expect(toggle).toBeEnabled()
+    const readiness = screen.getByRole('region', { name: /registration readiness/i })
+    expect(within(readiness).getByText('Ready')).toBeInTheDocument()
+    expect(within(readiness).getByText('Valid')).toBeInTheDocument()
+  })
+
+  it('PUTs a valid draft Website and registration enablement atomically', async () => {
+    const unavailable = {
+      ...settings,
+      contacts: { ...settings.contacts, website: null },
+      registrationEnabled: false,
+      registrationReadiness: {
+        ready: false,
+        websiteValid: false,
+        emailChannelSelected: true,
+        emailChannelAvailable: true,
+      },
+    }
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(unavailable))
+    renderScreen()
+
+    await screen.findByDisplayValue('The finest shard')
+    const website = screen.getByLabelText(/^website$/i)
+    await userEvent.type(website, 'https://shard.example/moongate')
+    await userEvent.click(screen.getByRole('switch', { name: /registration/i }))
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      const puts = fetchSpy.mock.calls.filter(([, init]) => (init as RequestInit)?.method === 'PUT')
+      expect(puts).toHaveLength(1)
+      expect(JSON.parse((puts[0][1] as RequestInit).body as string)).toMatchObject({
+        contacts: { website: 'https://shard.example/moongate' },
+        registrationEnabled: true,
+      })
+    })
+  })
+
+  it('allows unhealthy persisted registration to be switched off', async () => {
+    const unhealthy = {
+      ...settings,
+      contacts: { ...settings.contacts, website: null },
+      registrationReadiness: {
+        ready: false,
+        websiteValid: false,
+        emailChannelSelected: false,
+        emailChannelAvailable: false,
+      },
+    }
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(unhealthy))
+    renderScreen()
+
+    const toggle = screen.getByRole('switch', { name: /registration/i })
+    await waitFor(() => expect(toggle).toBeChecked())
+    expect(toggle).toBeEnabled()
     await userEvent.click(toggle)
     await userEvent.click(screen.getByRole('button', { name: /save/i }))
 
@@ -69,9 +198,19 @@ describe('SettingsScreen', () => {
       const put = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit)?.method === 'PUT')!
       expect(JSON.parse((put[1] as RequestInit).body as string)).toMatchObject({
         registrationEnabled: false,
-        description: 'The finest shard',
-        tagline: 'Sosaria never sleeps.',
       })
     })
+  })
+
+  it('guides channel configuration without exposing SMTP credentials', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(settings))
+    renderScreen()
+
+    await screen.findByDisplayValue('The finest shard')
+    const readiness = screen.getByRole('region', { name: /registration readiness/i })
+    expect(within(readiness).getByText(/moongate\.yaml/i)).toBeInTheDocument()
+    expect(within(readiness).getByText(/plugins\/configs\/smtp\.yaml|environment variables/i)).toBeInTheDocument()
+    expect(within(readiness).getByText(/restart the server/i)).toBeInTheDocument()
+    expect(within(readiness).queryByText(/host|username|password|sender/i)).not.toBeInTheDocument()
   })
 })

--- a/ui/src/routes/SettingsScreen.tsx
+++ b/ui/src/routes/SettingsScreen.tsx
@@ -12,6 +12,19 @@ import { useServerSettings, useUpdateSettings, type Contacts } from '../lib/sett
 const EMPTY_CONTACTS: Contacts = { website: null, email: null, discord: null }
 const ASSET_SLOTS = ['logo', 'favicon', 'banner'] as const
 
+function isValidWebsite(website: string | null | undefined): boolean {
+  if (website === null || website === undefined || !/^https?:\/\/[^/]/i.test(website)) {
+    return false
+  }
+
+  try {
+    const url = new URL(website)
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.host !== ''
+  } catch {
+    return false
+  }
+}
+
 export function SettingsScreen() {
   const { t } = useTranslation()
   const settings = useServerSettings()
@@ -53,6 +66,11 @@ export function SettingsScreen() {
   const setContact = (key: keyof Contacts) => (value: string) =>
     setContacts((current) => ({ ...current, [key]: value || null }))
 
+  const websiteValid = isValidWebsite(contacts.website)
+  const emailChannelSelected = settings.data?.registrationReadiness.emailChannelSelected ?? false
+  const emailChannelAvailable = settings.data?.registrationReadiness.emailChannelAvailable ?? false
+  const registrationReady = websiteValid && emailChannelSelected && emailChannelAvailable
+
   // The API keys the assets map in PascalCase ("Logo"), while the slot (and its upload path) is
   // lowercase — match case-insensitively so the preview finds the stored image.
   const assetUrl = (slot: string) =>
@@ -82,10 +100,44 @@ export function SettingsScreen() {
           <Switch
             checked={registration}
             onCheckedChange={setRegistration}
+            disabled={!registration && !registrationReady}
             aria-label={t('admin.settings.registration')}
           />
           {t('admin.settings.registration')}
         </Label>
+
+        <section aria-labelledby="registration-readiness-title" className="flex flex-col gap-3">
+          <h3 id="registration-readiness-title" className="font-display text-sm tracking-wide text-ink">
+            {t('admin.settings.readiness.title')}
+          </h3>
+          <dl className="grid gap-2 text-sm">
+            <ReadinessRow
+              label={t('admin.settings.readiness.overall')}
+              value={registrationReady}
+              positive={t('admin.settings.readiness.ready')}
+              negative={t('admin.settings.readiness.notReady')}
+            />
+            <ReadinessRow
+              label={t('admin.settings.readiness.website')}
+              value={websiteValid}
+              positive={t('admin.settings.readiness.valid')}
+              negative={t('admin.settings.readiness.invalid')}
+            />
+            <ReadinessRow
+              label={t('admin.settings.readiness.emailSelected')}
+              value={emailChannelSelected}
+              positive={t('admin.settings.readiness.selected')}
+              negative={t('admin.settings.readiness.notSelected')}
+            />
+            <ReadinessRow
+              label={t('admin.settings.readiness.emailAvailable')}
+              value={emailChannelAvailable}
+              positive={t('admin.settings.readiness.available')}
+              negative={t('admin.settings.readiness.unavailable')}
+            />
+          </dl>
+          <p className="text-xs leading-relaxed text-faint">{t('admin.settings.readiness.guidance')}</p>
+        </section>
       </Card>
 
       <Card className="flex flex-col gap-4 p-5">
@@ -115,5 +167,24 @@ export function SettingsScreen() {
         ))}
       </Card>
     </form>
+  )
+}
+
+function ReadinessRow({
+  label,
+  value,
+  positive,
+  negative,
+}: {
+  label: string
+  value: boolean
+  positive: string
+  negative: string
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <dt className="text-muted">{label}</dt>
+      <dd className={value ? 'text-success' : 'text-danger-text'}>{value ? positive : negative}</dd>
+    </div>
   )
 }

--- a/ui/src/routes/VerifyRegistrationScreen.test.tsx
+++ b/ui/src/routes/VerifyRegistrationScreen.test.tsx
@@ -1,5 +1,5 @@
 import { StrictMode, useEffect } from 'react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
@@ -93,11 +93,12 @@ function LocationProbe({ onChange }: { onChange: (location: ObservedLocation) =>
 function renderVerification(initialEntry = '/verify?token=secret-bearer-token') {
   const locations: ObservedLocation[] = []
   const observeLocation = (location: ObservedLocation) => locations.push(location)
+  const client = createTestClient()
 
   const view = render(
     <StrictMode>
       <MemoryRouter initialEntries={[initialEntry]}>
-        <QueryClientProvider client={createTestClient()}>
+        <QueryClientProvider client={client}>
           <AuthProvider>
             <LocationProbe onChange={observeLocation} />
             <Routes>
@@ -109,11 +110,18 @@ function renderVerification(initialEntry = '/verify?token=secret-bearer-token') 
     </StrictMode>,
   )
 
-  return { locations, view }
+  return { client, locations, view }
 }
 
 function verifyCalls(fetchSpy: ReturnType<typeof servePublicApi>) {
   return fetchSpy.mock.calls.filter(([input]) => String(input).endsWith('/api/v1/register/verify'))
+}
+
+function tokenBearingMutations(client: QueryClient, token: string) {
+  return client
+    .getMutationCache()
+    .getAll()
+    .filter((mutation) => (mutation.state.variables as { token?: unknown } | undefined)?.token === token)
 }
 
 describe('VerifyRegistrationScreen', () => {
@@ -133,7 +141,7 @@ describe('VerifyRegistrationScreen', () => {
     localStorage.setItem('sentinel', 'local-value')
     sessionStorage.setItem('sentinel', 'session-value')
     const fetchSpy = servePublicApi()
-    const { locations } = renderVerification(`/verify?token=${token}`)
+    const { client, locations } = renderVerification(`/verify?token=${token}`)
 
     expect(await screen.findByRole('heading', { name: /email verified/i })).toBeVisible()
     expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login')
@@ -150,16 +158,23 @@ describe('VerifyRegistrationScreen', () => {
     expect(sessionStorage.getItem('sentinel')).toBe('session-value')
     expect(localStorage.length).toBe(1)
     expect(sessionStorage.length).toBe(1)
+    expect(tokenBearingMutations(client, token)).toHaveLength(0)
   })
 
-  it('announces verification progress politely while the request is pending', async () => {
-    servePublicApi([{ status: 'pending' }])
-    renderVerification()
+  it('announces progress and removes a pending token from the mutation cache on unmount', async () => {
+    const token = 'pending-unmount-token'
+    const fetchSpy = servePublicApi([{ status: 'pending' }])
+    const { client, view } = renderVerification(`/verify?token=${token}`)
 
     const status = await screen.findByRole('status')
     expect(status).toHaveAttribute('aria-live', 'polite')
     expect(status).toHaveAttribute('aria-atomic', 'true')
     expect(screen.getByRole('heading', { name: /verifying your account/i })).toBeVisible()
+    await waitFor(() => expect(verifyCalls(fetchSpy)).toHaveLength(1))
+
+    view.unmount()
+
+    expect(tokenBearingMutations(client, token)).toHaveLength(0)
   })
 
   it('shows an expired-link state with a path to request another email for 410', async () => {
@@ -196,12 +211,14 @@ describe('VerifyRegistrationScreen', () => {
   ] as const)('retries a %s with only the in-memory token', async (_scenario, failure) => {
     const token = 'retry-only-memory-token'
     const fetchSpy = servePublicApi([failure, { status: 200 }])
-    renderVerification(`/verify?token=${token}`)
+    const { client } = renderVerification(`/verify?token=${token}`)
 
     expect(await screen.findByRole('heading', { name: /verification temporarily unavailable/i })).toBeVisible()
+    expect(tokenBearingMutations(client, token)).toHaveLength(0)
     await userEvent.click(screen.getByRole('button', { name: /try again/i }))
 
     expect(await screen.findByRole('heading', { name: /email verified/i })).toBeVisible()
+    expect(tokenBearingMutations(client, token)).toHaveLength(0)
     const calls = verifyCalls(fetchSpy)
     expect(calls).toHaveLength(2)
     expect(calls.map(([, init]) => JSON.parse(String((init as RequestInit).body)))).toEqual([{ token }, { token }])

--- a/ui/src/routes/VerifyRegistrationScreen.test.tsx
+++ b/ui/src/routes/VerifyRegistrationScreen.test.tsx
@@ -1,0 +1,212 @@
+import { StrictMode, useEffect } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import i18n from '../lib/i18n'
+import { AuthProvider } from '../lib/auth'
+import { VerifyRegistrationScreen } from './VerifyRegistrationScreen'
+
+type VerifyResult = { status: number; problem?: unknown } | { status: 'network' } | { status: 'pending' }
+
+type ObservedLocation = {
+  pathname: string
+  search: string
+  state: unknown
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function servePublicApi(verifyResults: VerifyResult[] = [{ status: 200 }]) {
+  let verifyAttempt = 0
+
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input)
+
+    if (url.endsWith('/api/v1/server-info')) {
+      return json({
+        shardName: 'Moongate',
+        tagline: null,
+        contacts: { website: null, email: null, discord: null },
+        registrationEnabled: true,
+        assets: {},
+      })
+    }
+
+    if (url.endsWith('/api/v1/stats')) {
+      return json({
+        players: { online: 0, connections: 0 },
+        accounts: { total: 0, active: 0, characters: 0 },
+      })
+    }
+
+    if (url.endsWith('/api/v1/version')) {
+      return json({ shardName: 'Moongate', version: '1.0.0' })
+    }
+
+    if (url.endsWith('/api/v1/register/verify')) {
+      const result = verifyResults[Math.min(verifyAttempt, verifyResults.length - 1)]
+      verifyAttempt += 1
+
+      if (result.status === 'network') {
+        throw new TypeError('offline')
+      }
+
+      if (result.status === 'pending') {
+        return new Promise<Response>(() => {})
+      }
+
+      return result.status === 200
+        ? new Response(null, { status: 200 })
+        : json(result.problem ?? { detail: 'sensitive backend detail' }, result.status)
+    }
+
+    return json({})
+  })
+}
+
+function createTestClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function LocationProbe({ onChange }: { onChange: (location: ObservedLocation) => void }) {
+  const location = useLocation()
+
+  useEffect(() => {
+    onChange({
+      pathname: location.pathname,
+      search: location.search,
+      state: location.state,
+    })
+  }, [location.pathname, location.search, location.state, onChange])
+
+  return null
+}
+
+function renderVerification(initialEntry = '/verify?token=secret-bearer-token') {
+  const locations: ObservedLocation[] = []
+  const observeLocation = (location: ObservedLocation) => locations.push(location)
+
+  const view = render(
+    <StrictMode>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <QueryClientProvider client={createTestClient()}>
+          <AuthProvider>
+            <LocationProbe onChange={observeLocation} />
+            <Routes>
+              <Route path="/verify" element={<VerifyRegistrationScreen />} />
+            </Routes>
+          </AuthProvider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    </StrictMode>,
+  )
+
+  return { locations, view }
+}
+
+function verifyCalls(fetchSpy: ReturnType<typeof servePublicApi>) {
+  return fetchSpy.mock.calls.filter(([input]) => String(input).endsWith('/api/v1/register/verify'))
+}
+
+describe('VerifyRegistrationScreen', () => {
+  beforeEach(async () => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+    await i18n.changeLanguage('en')
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('scrubs the bearer token, verifies once under Strict Mode, and leaves browser storage untouched', async () => {
+    const token = 'strict-mode-secret-token'
+    localStorage.setItem('sentinel', 'local-value')
+    sessionStorage.setItem('sentinel', 'session-value')
+    const fetchSpy = servePublicApi()
+    const { locations } = renderVerification(`/verify?token=${token}`)
+
+    expect(await screen.findByRole('heading', { name: /email verified/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login')
+
+    const calls = verifyCalls(fetchSpy)
+    expect(calls).toHaveLength(1)
+    expect(calls[0][1]).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(String((calls[0][1] as RequestInit).body))).toEqual({ token })
+
+    const finalLocation = locations[locations.length - 1]
+    expect(finalLocation).toEqual({ pathname: '/verify', search: '', state: null })
+    expect(document.documentElement.outerHTML).not.toContain(token)
+    expect(localStorage.getItem('sentinel')).toBe('local-value')
+    expect(sessionStorage.getItem('sentinel')).toBe('session-value')
+    expect(localStorage.length).toBe(1)
+    expect(sessionStorage.length).toBe(1)
+  })
+
+  it('announces verification progress politely while the request is pending', async () => {
+    servePublicApi([{ status: 'pending' }])
+    renderVerification()
+
+    const status = await screen.findByRole('status')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveAttribute('aria-atomic', 'true')
+    expect(screen.getByRole('heading', { name: /verifying your account/i })).toBeVisible()
+  })
+
+  it('shows an expired-link state with a path to request another email for 410', async () => {
+    servePublicApi([{ status: 410 }])
+    renderVerification()
+
+    expect(await screen.findByRole('heading', { name: /verification link expired/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /request another email/i })).toHaveAttribute('href', '/register/pending')
+    expect(screen.queryByText(/sensitive backend detail/i)).not.toBeInTheDocument()
+  })
+
+  it('shows safe invalid-link actions for 400', async () => {
+    servePublicApi([{ status: 400 }])
+    renderVerification()
+
+    expect(await screen.findByRole('heading', { name: /verification link invalid/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /request another email/i })).toHaveAttribute('href', '/register/pending')
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login')
+    expect(screen.queryByText(/sensitive backend detail/i)).not.toBeInTheDocument()
+  })
+
+  it('treats a missing token as invalid without making a verification request', async () => {
+    const fetchSpy = servePublicApi()
+    const { locations } = renderVerification('/verify')
+
+    expect(await screen.findByRole('heading', { name: /verification link invalid/i })).toBeVisible()
+    expect(verifyCalls(fetchSpy)).toHaveLength(0)
+    expect(locations[locations.length - 1]).toEqual({ pathname: '/verify', search: '', state: null })
+  })
+
+  it.each([
+    ['network failure', { status: 'network' }],
+    ['503 response', { status: 503 }],
+  ] as const)('retries a %s with only the in-memory token', async (_scenario, failure) => {
+    const token = 'retry-only-memory-token'
+    const fetchSpy = servePublicApi([failure, { status: 200 }])
+    renderVerification(`/verify?token=${token}`)
+
+    expect(await screen.findByRole('heading', { name: /verification temporarily unavailable/i })).toBeVisible()
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+    expect(await screen.findByRole('heading', { name: /email verified/i })).toBeVisible()
+    const calls = verifyCalls(fetchSpy)
+    expect(calls).toHaveLength(2)
+    expect(calls.map(([, init]) => JSON.parse(String((init as RequestInit).body)))).toEqual([{ token }, { token }])
+    expect(document.documentElement.outerHTML).not.toContain(token)
+    expect(localStorage.length).toBe(0)
+    expect(sessionStorage.length).toBe(0)
+  })
+})

--- a/ui/src/routes/VerifyRegistrationScreen.test.tsx
+++ b/ui/src/routes/VerifyRegistrationScreen.test.tsx
@@ -171,6 +171,7 @@ describe('VerifyRegistrationScreen', () => {
     expect(status).toHaveAttribute('aria-atomic', 'true')
     expect(screen.getByRole('heading', { name: /verifying your account/i })).toBeVisible()
     await waitFor(() => expect(verifyCalls(fetchSpy)).toHaveLength(1))
+    expect(tokenBearingMutations(client, token)).toHaveLength(0)
 
     view.unmount()
 

--- a/ui/src/routes/VerifyRegistrationScreen.tsx
+++ b/ui/src/routes/VerifyRegistrationScreen.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { PublicAuthLayout } from '../components/PublicAuthLayout'
+import { Button } from '../components/ui/button'
+import { ApiError } from '../lib/api'
+import { useVerifyRegistration } from '../lib/registration'
+
+type VerificationState = 'verifying' | 'verified' | 'expired' | 'invalid' | 'unavailable'
+
+export function VerifyRegistrationScreen() {
+  const { t } = useTranslation()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { mutateAsync, reset } = useVerifyRegistration()
+  const [token] = useState(() => new URLSearchParams(location.search).get('token') ?? '')
+  const [state, setState] = useState<VerificationState>(token === '' ? 'invalid' : 'verifying')
+  const started = useRef(false)
+
+  const verify = useCallback(async () => {
+    setState('verifying')
+
+    try {
+      await mutateAsync({ token })
+      reset()
+      setState('verified')
+    } catch (caught) {
+      reset()
+
+      if (caught instanceof ApiError && caught.status === 410) {
+        setState('expired')
+        return
+      }
+
+      if (caught instanceof ApiError && caught.status === 400) {
+        setState('invalid')
+        return
+      }
+
+      setState('unavailable')
+    }
+  }, [mutateAsync, reset, token])
+
+  useEffect(() => {
+    navigate('/verify', { replace: true })
+
+    if (started.current) {
+      return
+    }
+
+    started.current = true
+    if (token === '') {
+      setState('invalid')
+      return
+    }
+
+    void verify()
+  }, [navigate, token, verify])
+
+  return (
+    <PublicAuthLayout>
+      <section className="flex flex-col gap-4">
+        <div role="status" aria-live="polite" aria-atomic="true" className="flex flex-col gap-4">
+          {state === 'verifying' && (
+            <>
+              <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">
+                {t('register.verify.verifyingTitle')}
+              </h1>
+              <p className="text-sm text-muted">{t('register.verify.verifyingBody')}</p>
+            </>
+          )}
+
+          {state === 'verified' && (
+            <>
+              <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">
+                {t('register.verify.verifiedTitle')}
+              </h1>
+              <p className="text-sm text-muted">{t('register.verify.verifiedBody')}</p>
+              <Button asChild className="py-3 text-sm tracking-[0.14em]">
+                <Link to="/login">{t('register.verify.signIn')}</Link>
+              </Button>
+            </>
+          )}
+
+          {state === 'expired' && (
+            <>
+              <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">
+                {t('register.verify.expiredTitle')}
+              </h1>
+              <p className="text-sm text-muted">{t('register.verify.expiredBody')}</p>
+              <Button asChild className="py-3 text-sm tracking-[0.14em]">
+                <Link to="/register/pending">{t('register.verify.resend')}</Link>
+              </Button>
+            </>
+          )}
+
+          {state === 'invalid' && (
+            <>
+              <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">
+                {t('register.verify.invalidTitle')}
+              </h1>
+              <p className="text-sm text-muted">{t('register.verify.invalidBody')}</p>
+              <Button asChild className="py-3 text-sm tracking-[0.14em]">
+                <Link to="/register/pending">{t('register.verify.resend')}</Link>
+              </Button>
+              <Link to="/login" className="text-center text-sm text-gold hover:text-gold-hi">
+                {t('register.verify.signIn')}
+              </Link>
+            </>
+          )}
+
+          {state === 'unavailable' && (
+            <>
+              <h1 className="font-display text-[25px] font-bold tracking-wider text-gold">
+                {t('register.verify.unavailableTitle')}
+              </h1>
+              <p className="text-sm text-muted">{t('register.verify.unavailableBody')}</p>
+              <Button type="button" onClick={() => void verify()} className="py-3 text-sm tracking-[0.14em]">
+                {t('register.verify.retry')}
+              </Button>
+            </>
+          )}
+        </div>
+      </section>
+    </PublicAuthLayout>
+  )
+}


### PR DESCRIPTION
## Summary

- add public account registration with strict credential validation, expiring SHA-256 token storage, email verification, legacy recovery, and enumeration-safe resend
- enforce registration readiness from the configured Website and email notification channel, while exposing persisted and effective state to admins and public server info
- add localized register, pending/resend, and verification routes, including immediate bearer scrubbing and no in-flight TanStack cache retention
- keep admin-blocked accounts distinct from pending registrations and serialize account verification transitions under concurrent HTTP requests
- regenerate the OpenAPI/TypeScript contracts and document setup, rollout, status codes, and SMTP/readiness behavior

## Validation

- `dotnet test Moongate.slnx --no-restore` — 1,698 passed
- `npm run test:run` — 217 passed
- `dotnet build Moongate.slnx --no-restore` — 0 warnings, 0 errors
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings, 0 errors
- `npm run build` — passed (existing Vite chunk-size warning only)
- `npm run format:check` — passed
- `npm run openapi:sync` and `npm run openapi:types` — deterministic, no git drift
- final CodeGraph whole-branch review and scoped fix re-review — clean

Related to #107. The issue will be closed manually after this PR is merged into `develop`.