### PR TITLE
feat(ai): add ai.step and ai.move_to for free NPC movement from brains

### DIFF
--- a/docs/scripting/guides/npc-brains.md
+++ b/docs/scripting/guides/npc-brains.md
@@ -179,7 +179,11 @@ reject the action, returning `false`.
 In particular, `ai.engage(target_id)` validates a perceived target and sets the
 owner's combat target and warmode; it does **not** attack or deal damage.
 `ai.say("...")` speaks only as the brain's owner (regular speech, range 15); it
-takes no serial, so a brain cannot choose an arbitrary speaker.
+takes no serial, so a brain cannot choose an arbitrary speaker. For free
+movement, `ai.step(direction)` steps one tile in a compass direction and
+`ai.move_to(x, y)` steps greedily toward a coordinate; both are single validated
+steps with no obstacle avoidance, so the brain composes multi-tile paths across
+ticks.
 
 The complete default `moongate.npcAi.advanced` limits are:
 

--- a/docs/scripting/reference/ai.md
+++ b/docs/scripting/reference/ai.md
@@ -76,3 +76,27 @@ ai.clear_target() -> boolean
 ```
 
 Clears the owner's combat target and disables warmode. Returns `true`.
+
+## ai.step
+
+```lua
+ai.step(direction) -> boolean
+```
+
+Steps one tile in a compass direction. `direction` is a case-insensitive
+string — a full name or its short alias: `north`/`n`, `northeast`/`ne`,
+`east`/`e`, `southeast`/`se`, `south`/`s`, `southwest`/`sw`, `west`/`w`,
+`northwest`/`nw`. Returns `false` on an unknown direction or a blocked step.
+The step is validated like any NPC move; there is no obstacle avoidance beyond
+that single-tile check, so the brain composes its own path.
+
+## ai.move_to
+
+```lua
+ai.move_to(x, y) -> boolean
+```
+
+Steps one tile toward `(x, y)` at the owner's current z, choosing the greedy
+eight-way direction. Returns `false` when the step is blocked; the owner
+"arrives" once `x, y` are reached. Like `ai.return_home`, this is greedy with no
+obstacle avoidance — it can stall against a wall.

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/IAiActionService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/IAiActionService.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Primitives;
+using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Data.AI;
 
 namespace Moongate.Server.Abstractions.Interfaces.AI;
@@ -17,6 +18,12 @@ public interface IAiActionService
 
     /// <summary>Steps one tile toward the home position; false when off the home map.</summary>
     bool ReturnHome();
+
+    /// <summary>Steps one tile in the given compass direction; false when the step is blocked.</summary>
+    bool Step(DirectionType direction);
+
+    /// <summary>Steps one tile toward (x, y) at the owner's current z; false when the step is blocked.</summary>
+    bool MoveTo(int x, int y);
 
     /// <summary>Steps one tile toward the perceived target; false when the target is not perceivable.</summary>
     bool MoveToward(Serial targetId);

--- a/src/Moongate.Server/Scripting/AiModule.cs
+++ b/src/Moongate.Server/Scripting/AiModule.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Primitives;
+using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using SquidStd.Scripting.Lua.Attributes.Scripts;
 
@@ -45,4 +46,54 @@ public sealed class AiModule
     [ScriptFunction("clear_target", "Clears combat posture on the current NPC.")]
     public bool ClearTarget()
         => _actions.ClearTarget();
+
+    [ScriptFunction("step", "Steps one tile in a compass direction (north/n, northeast/ne, …); false when blocked or unknown.")]
+    public bool Step(string direction)
+        => TryParseDirection(direction, out var parsed) && _actions.Step(parsed);
+
+    [ScriptFunction("move_to", "Steps one tile toward (x, y) at the current z; false when blocked.")]
+    public bool MoveTo(int x, int y)
+        => _actions.MoveTo(x, y);
+
+    private static bool TryParseDirection(string direction, out DirectionType parsed)
+    {
+        switch (direction?.Trim().ToLowerInvariant())
+        {
+            case "north":
+            case "n":
+                parsed = DirectionType.North;
+                return true;
+            case "northeast":
+            case "ne":
+                parsed = DirectionType.NorthEast;
+                return true;
+            case "east":
+            case "e":
+                parsed = DirectionType.East;
+                return true;
+            case "southeast":
+            case "se":
+                parsed = DirectionType.SouthEast;
+                return true;
+            case "south":
+            case "s":
+                parsed = DirectionType.South;
+                return true;
+            case "southwest":
+            case "sw":
+                parsed = DirectionType.SouthWest;
+                return true;
+            case "west":
+            case "w":
+                parsed = DirectionType.West;
+                return true;
+            case "northwest":
+            case "nw":
+                parsed = DirectionType.NorthWest;
+                return true;
+            default:
+                parsed = default;
+                return false;
+        }
+    }
 }

--- a/src/Moongate.Server/Services/AI/AiActionService.cs
+++ b/src/Moongate.Server/Services/AI/AiActionService.cs
@@ -80,6 +80,12 @@ public sealed class AiActionService : IAiActionService
     public bool ClearTarget()
         => Run((owner, _) => TryClearTarget(owner, out var reason) ? Ok() : Fail(reason));
 
+    public bool Step(DirectionType direction)
+        => Run((owner, _) => _movement.TryMoveNpc(owner.Id, direction) ? Ok() : Fail("movement service rejected the step"));
+
+    public bool MoveTo(int x, int y)
+        => Run((owner, _) => TryMoveToPosition(owner, new Point3D(x, y, owner.Position.Z), out var reason) ? Ok() : Fail(reason));
+
     private bool Run(Func<MobileEntity, BrainContext, (bool Ok, string Reason)> action)
     {
         _loopAffinity.AssertOnLoop("ai.action");

--- a/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
@@ -268,6 +268,51 @@ public class AiActionServiceTests
     }
 
     [Fact]
+    public void Step_MovesInGivenDirection()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.Step(DirectionType.NorthEast));
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveTo_StepsGreedilyTowardCoordinate()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.MoveTo(14, 8));
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveTo_AlreadyAtCoordinate_AcceptsWithoutMoving()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.MoveTo(10, 10));
+        }
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
     public void OrderedActions_ApplyInSequenceAndRevalidate()
     {
         var (service, persistence, chat, movement, metrics) = Build();

--- a/tests/Moongate.Tests/Server/Scripting/AiModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/AiModuleTests.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Primitives;
+using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Scripting;
@@ -40,6 +41,44 @@ public class AiModuleTests
         Assert.Equal(new Serial(0x4), Assert.Single(actions.MovedAway));
     }
 
+    [Theory]
+    [InlineData("north", DirectionType.North)]
+    [InlineData("N", DirectionType.North)]
+    [InlineData("ne", DirectionType.NorthEast)]
+    [InlineData("southwest", DirectionType.SouthWest)]
+    [InlineData(" NW ", DirectionType.NorthWest)]
+    public void Step_ParsesDirectionAndRoutesToService(string direction, DirectionType expected)
+    {
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
+
+        Assert.True(module.Step(direction));
+        Assert.Equal(expected, Assert.Single(actions.Stepped));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("up")]
+    [InlineData("nne")]
+    public void Step_UnknownDirection_ReturnsFalseWithoutCallingService(string direction)
+    {
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
+
+        Assert.False(module.Step(direction));
+        Assert.Empty(actions.Stepped);
+    }
+
+    [Fact]
+    public void MoveTo_RoutesCoordinatesToService()
+    {
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
+
+        Assert.True(module.MoveTo(42, 7));
+        Assert.Equal((42, 7), Assert.Single(actions.MovedTo));
+    }
+
     [Fact]
     public void ParameterlessActions_RouteToService()
     {
@@ -63,6 +102,8 @@ public class AiModuleTests
         public List<Serial> Engaged { get; } = [];
         public List<Serial> MovedToward { get; } = [];
         public List<Serial> MovedAway { get; } = [];
+        public List<DirectionType> Stepped { get; } = [];
+        public List<(int X, int Y)> MovedTo { get; } = [];
         public int Patrols { get; private set; }
         public int ReturnsHome { get; private set; }
         public int ClearsTarget { get; private set; }
@@ -109,6 +150,18 @@ public class AiModuleTests
         public bool ClearTarget()
         {
             ClearsTarget++;
+            return Result;
+        }
+
+        public bool Step(DirectionType direction)
+        {
+            Stepped.Add(direction);
+            return Result;
+        }
+
+        public bool MoveTo(int x, int y)
+        {
+            MovedTo.Add((x, y));
             return Result;
         }
 

--- a/tests/Moongate.Tests/Support/StubAiActionService.cs
+++ b/tests/Moongate.Tests/Support/StubAiActionService.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Primitives;
+using Moongate.Core.Types;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Interfaces.AI;
 
@@ -17,6 +18,12 @@ public sealed class StubAiActionService : IAiActionService
         => true;
 
     public bool ReturnHome()
+        => true;
+
+    public bool Step(DirectionType direction)
+        => true;
+
+    public bool MoveTo(int x, int y)
         => true;
 
     public bool MoveToward(Serial targetId)


### PR DESCRIPTION
Adds two thin `ai` movement actions over the existing `IMovementService.TryMoveNpc` primitive (issue #111), so brains can move NPCs freely instead of only relative to a target or home.

- **`ai.step(direction)`** — one validated tile step in a compass direction. `direction` is a case-insensitive string, full name or short alias: `north`/`n`, `northeast`/`ne`, `east`/`e`, `southeast`/`se`, `south`/`s`, `southwest`/`sw`, `west`/`w`, `northwest`/`nw`. Returns `false` on an unknown direction or a blocked step (the module parses the string; the service takes a typed `DirectionType`).
- **`ai.move_to(x, y)`** — one greedy eight-way step toward `(x, y)` at the owner's current z (reuses the existing toward-position logic). Returns `false` when blocked; "arrives" once `x, y` are reached. No obstacle avoidance, like `ai.return_home`.

Both are self-implicit on the current brain tick. Real pathfinding (`ai.walk_to`) is out of scope — there is no server-side pathfinder today.

## Verification

- `dotnet build Moongate.slnx` — 0 errors.
- `dotnet test Moongate.slnx` — 1703 passed, 0 failed (+12 new).
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings.

Docs: `ai.md` + the NPC brains guide updated. No network/packet or REST changes.