### PR TITLE
feat(ai): add durable long-term memory for NPC brains (memory.* module)

### DIFF
--- a/docs/scripting/guides/npc-brains.md
+++ b/docs/scripting/guides/npc-brains.md
@@ -112,6 +112,23 @@ created. It remains that bind-time origin through sleep/wake and a successful
 same-id reload. A brain-id change captures a new home, as does a server
 restart.
 
+### State vs memory
+
+`state` is **transient**: in-memory, per-mobile, lost on restart and cleared on a
+brain-id change or repeated failures. Use it for scratch within a tick or
+session. For facts an NPC must remember long-term, use the durable
+[`memory`](../reference/memory.md) module — persisted per NPC, scalar-valued and
+bounded, surviving restarts and brain changes:
+
+```lua
+function guard.on_speech_heard(ctx, state, event)
+  if event.speaker_is_player ~= true then return end
+  local seen = (memory.get("seen:" .. event.speaker_id) or 0) + 1
+  memory.set("seen:" .. event.speaker_id, seen)
+  if seen == 1 then ai.say("I haven't seen you before.") else ai.say("Welcome back.") end
+end
+```
+
 ## Hooks and event payloads
 
 `think(ctx, state, nil)` is required. All other hooks are optional; omit them

--- a/docs/scripting/index.md
+++ b/docs/scripting/index.md
@@ -23,6 +23,7 @@ the modules below and act on themselves through the imperative
 | `loot` | Roll loot tables into items. | [loot](reference/loot.md) |
 | `account` | Create and manage accounts by username. | [account](reference/account.md) |
 | `ai` | Act as the current NPC brain (valid only inside a brain hook). | [ai](reference/ai.md) |
+| `memory` | Durable per-NPC key/value memory (valid only inside a brain hook). | [memory](reference/memory.md) |
 | enums | `skill_name`, `gender_type`, `race_type`, `layer_type`, `account_level_type`. | [Enums](reference/enums.md) |
 
 ## Values and types

--- a/docs/scripting/reference/memory.md
+++ b/docs/scripting/reference/memory.md
@@ -1,0 +1,48 @@
+# memory
+
+`memory` is durable key/value storage for the current NPC brain. Every function
+acts on the mobile of the running tick — there is no serial argument — and
+values persist across server restarts and brain changes. Calling any `memory`
+function outside a brain hook raises a Lua error.
+
+Use it for facts the NPC should remember long-term. For per-tick scratch that
+does not need to survive a restart, use the `state` table instead (see the
+[NPC brains guide](../guides/npc-brains.md#state-vs-memory)).
+
+Values are scalars: `string`, `number`, or `boolean`. Bounds: at most 128 keys
+per NPC, keys up to 64 characters, string values up to 256 characters; a `set`
+past a bound returns `false`.
+
+## memory.set
+
+```lua
+memory.set(key, value) -> boolean
+```
+
+Stores `value` (a string, number, or boolean) under `key`. Returns `false` when
+the value is not a supported scalar, a bound is exceeded, or the NPC no longer
+exists.
+
+## memory.get
+
+```lua
+memory.get(key) -> value | nil
+```
+
+Returns the stored value with its original type, or `nil` when the key is unset.
+
+## memory.delete
+
+```lua
+memory.delete(key) -> boolean
+```
+
+Removes `key`. Returns `true` when it existed.
+
+## memory.all
+
+```lua
+memory.all() -> table
+```
+
+Returns a table of every stored `key = value` for the current NPC.

--- a/docs/scripting/toc.yml
+++ b/docs/scripting/toc.yml
@@ -18,6 +18,8 @@
       href: reference/log.md
     - name: ai
       href: reference/ai.md
+    - name: memory
+      href: reference/memory.md
     - name: game
       href: reference/game.md
     - name: events

--- a/src/Moongate.Core/Types/MemoryValueType.cs
+++ b/src/Moongate.Core/Types/MemoryValueType.cs
@@ -1,0 +1,8 @@
+namespace Moongate.Core.Types;
+
+public enum MemoryValueType
+{
+    String,
+    Number,
+    Boolean
+}

--- a/src/Moongate.Persistence/Entities/NpcMemoryEntity.cs
+++ b/src/Moongate.Persistence/Entities/NpcMemoryEntity.cs
@@ -1,0 +1,11 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Interfaces;
+
+namespace Moongate.Persistence.Entities;
+
+public sealed class NpcMemoryEntity : ISerialIdEntity
+{
+    public Serial Id { get; set; }
+
+    public Dictionary<string, NpcMemoryValue> Memory { get; set; } = new();
+}

--- a/src/Moongate.Persistence/Entities/NpcMemoryValue.cs
+++ b/src/Moongate.Persistence/Entities/NpcMemoryValue.cs
@@ -1,0 +1,21 @@
+using Moongate.Core.Types;
+
+namespace Moongate.Persistence.Entities;
+
+public sealed record NpcMemoryValue(MemoryValueType Type, string? Text, double Number, bool Flag)
+{
+    public static NpcMemoryValue FromString(string text) => new(MemoryValueType.String, text, 0, false);
+
+    public static NpcMemoryValue FromNumber(double number) => new(MemoryValueType.Number, null, number, false);
+
+    public static NpcMemoryValue FromBoolean(bool flag) => new(MemoryValueType.Boolean, null, 0, flag);
+
+    public object? ToScalar()
+        => Type switch
+        {
+            MemoryValueType.String => Text,
+            MemoryValueType.Number => Number,
+            MemoryValueType.Boolean => Flag,
+            _ => null
+        };
+}

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -70,6 +70,13 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
             (entity, id) => entity.Id = id,
             new DefaultSerialGenerator()
         );
+        container.RegisterPersistedEntity<NpcMemoryEntity, Serial>(
+            "npc_memory",
+            1,
+            entity => entity.Id,
+            (entity, id) => entity.Id = id,
+            new DefaultSerialGenerator()
+        );
         container.RegisterPersistenceSeeder(async (service, token) =>
             {
                 var accountStore = service.GetStore<AccountEntity, Serial>();

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcMemoryService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcMemoryService.cs
@@ -1,0 +1,27 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+
+namespace Moongate.Server.Abstractions.Interfaces.AI;
+
+/// <summary>Durable per-NPC key/value memory for the mobile of the active brain tick.</summary>
+public interface INpcMemoryService
+{
+    /// <summary>Sets the ambient brain context for the current tick; disposing restores the previous one.</summary>
+    IDisposable Begin(BrainContext context);
+
+    /// <summary>Stores a value under a key; false when the mobile is unknown or a bound is exceeded.</summary>
+    bool Set(string key, NpcMemoryValue value);
+
+    /// <summary>Returns the stored value for a key, or null when absent.</summary>
+    NpcMemoryValue? Get(string key);
+
+    /// <summary>Removes a key; true when it existed.</summary>
+    bool Delete(string key);
+
+    /// <summary>Returns every stored key/value for the active mobile.</summary>
+    IReadOnlyDictionary<string, NpcMemoryValue> All();
+
+    /// <summary>Permanently drops all memory for a mobile (used when it is deleted).</summary>
+    void Forget(Serial mobileId);
+}

--- a/src/Moongate.Server/Plugins/MoongateNpcAiPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateNpcAiPlugin.cs
@@ -29,11 +29,13 @@ public sealed class MoongateNpcAiPlugin : ISquidStdPlugin
         container.Register<INpcAiMetrics, NpcAiMetrics>(Reuse.Singleton);
         container.RegisterStdService<ISectorActivityService, SectorActivityService>();
         container.Register<IAiActionService, AiActionService>(Reuse.Singleton);
+        container.Register<INpcMemoryService, NpcMemoryService>(Reuse.Singleton);
         container.Register<NpcBrainContextFactory>(Reuse.Singleton);
         container.RegisterStdService<INpcBrainScheduler, NpcBrainScheduler>();
 
         container.RegisterEventSubscriber<SectorActivitySubscriber>();
         container.RegisterEventSubscriber<NpcBrainLifecycleSubscriber>();
         container.RegisterEventSubscriber<NpcBrainEventRouter>();
+        container.RegisterEventSubscriber<NpcMemoryLifecycleSubscriber>();
     }
 }

--- a/src/Moongate.Server/Plugins/MoongateScriptModulesPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateScriptModulesPlugin.cs
@@ -31,6 +31,7 @@ public class MoongateScriptModulesPlugin : ISquidStdPlugin
         container.RegisterScriptModule<LootModule>();
         container.RegisterScriptModule<ChatModule>();
         container.RegisterScriptModule<AiModule>();
+        container.RegisterScriptModule<MemoryModule>();
 
         container.RegisterScriptEnum<AccountLevelType>();
         container.RegisterScriptEnum<SkillName>();

--- a/src/Moongate.Server/Scripting/MemoryModule.cs
+++ b/src/Moongate.Server/Scripting/MemoryModule.cs
@@ -1,7 +1,6 @@
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Scripting.Views;
-using MoonSharp.Interpreter;
 using SquidStd.Scripting.Lua.Attributes.Scripts;
 
 namespace Moongate.Server.Scripting;
@@ -22,13 +21,15 @@ public sealed class MemoryModule
     }
 
     [ScriptFunction("set", "Stores a scalar (string/number/boolean) under a key; false when unsupported or rejected.")]
-    public bool Set(string key, DynValue value)
+    public bool Set(string key, object value)
     {
-        var stored = value.Type switch
+        var stored = value switch
         {
-            DataType.String => NpcMemoryValue.FromString(value.String),
-            DataType.Number => NpcMemoryValue.FromNumber(value.Number),
-            DataType.Boolean => NpcMemoryValue.FromBoolean(value.Boolean),
+            string text => NpcMemoryValue.FromString(text),
+            bool flag => NpcMemoryValue.FromBoolean(flag),
+            double number => NpcMemoryValue.FromNumber(number),
+            long number => NpcMemoryValue.FromNumber(number),
+            int number => NpcMemoryValue.FromNumber(number),
             _ => null
         };
 

--- a/src/Moongate.Server/Scripting/MemoryModule.cs
+++ b/src/Moongate.Server/Scripting/MemoryModule.cs
@@ -1,0 +1,49 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Scripting.Views;
+using MoonSharp.Interpreter;
+using SquidStd.Scripting.Lua.Attributes.Scripts;
+
+namespace Moongate.Server.Scripting;
+
+/// <summary>
+/// Durable key/value memory for the current NPC brain, persisted across restarts. Self-implicit on the
+/// mobile of the running tick; calling it outside a brain hook raises a Lua error. Values are scalars
+/// (string, number, boolean).
+/// </summary>
+[ScriptModule("memory", "Durable per-NPC memory: remember facts across restarts.")]
+public sealed class MemoryModule
+{
+    private readonly INpcMemoryService _memory;
+
+    public MemoryModule(INpcMemoryService memory)
+    {
+        _memory = memory;
+    }
+
+    [ScriptFunction("set", "Stores a scalar (string/number/boolean) under a key; false when unsupported or rejected.")]
+    public bool Set(string key, DynValue value)
+    {
+        var stored = value.Type switch
+        {
+            DataType.String => NpcMemoryValue.FromString(value.String),
+            DataType.Number => NpcMemoryValue.FromNumber(value.Number),
+            DataType.Boolean => NpcMemoryValue.FromBoolean(value.Boolean),
+            _ => null
+        };
+
+        return stored is not null && _memory.Set(key, stored);
+    }
+
+    [ScriptFunction("get", "Returns the stored value for a key, or nil.")]
+    public object? Get(string key)
+        => _memory.Get(key)?.ToScalar();
+
+    [ScriptFunction("delete", "Removes a key; true when it existed.")]
+    public bool Delete(string key)
+        => _memory.Delete(key);
+
+    [ScriptFunction("all", "Returns a table of every stored key/value for the current NPC.")]
+    public NpcMemoryLuaView All()
+        => new(_memory.All());
+}

--- a/src/Moongate.Server/Scripting/Views/NpcMemoryLuaView.cs
+++ b/src/Moongate.Server/Scripting/Views/NpcMemoryLuaView.cs
@@ -1,0 +1,11 @@
+using Moongate.Persistence.Entities;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+
+namespace Moongate.Server.Scripting.Views;
+
+/// <summary>Projects a mobile's stored memory into a Lua table of key → scalar value.</summary>
+public sealed record NpcMemoryLuaView(IReadOnlyDictionary<string, NpcMemoryValue> Memory) : ILuaTable
+{
+    public Dictionary<string, object?> ToDictionary()
+        => Memory.ToDictionary(pair => pair.Key, pair => pair.Value.ToScalar());
+}

--- a/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
@@ -27,6 +27,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private readonly IGameLoopContext _loop;
     private readonly INpcBrainRuntime _runtime;
     private readonly IAiActionService _aiActions;
+    private readonly INpcMemoryService _memory;
     private readonly ISectorActivityService _sectors;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
     private readonly NpcBrainContextFactory _contextFactory;
@@ -59,6 +60,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         IGameLoopContext loop,
         INpcBrainRuntime runtime,
         IAiActionService aiActions,
+        INpcMemoryService memory,
         ISectorActivityService sectors,
         IPersistenceService persistenceService,
         NpcBrainContextFactory contextFactory,
@@ -70,6 +72,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         _loop = loop;
         _runtime = runtime;
         _aiActions = aiActions;
+        _memory = memory;
         _sectors = sectors;
         _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
         _contextFactory = contextFactory;
@@ -552,6 +555,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         try
         {
             using (_aiActions.Begin(context))
+            using (_memory.Begin(context))
             {
                 return _runtime.Invoke(entry.MobileId, hook, context, brainEvent);
             }

--- a/src/Moongate.Server/Services/AI/NpcMemoryService.cs
+++ b/src/Moongate.Server/Services/AI/NpcMemoryService.cs
@@ -1,0 +1,136 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Services.AI;
+
+/// <summary>Durable per-NPC memory backed by the npc_memory store, resolved from an ambient brain context.</summary>
+public sealed class NpcMemoryService : INpcMemoryService
+{
+    private const int MaxKeys = 128;
+    private const int MaxKeyLength = 64;
+    private const int MaxValueLength = 256;
+
+    private static readonly IReadOnlyDictionary<string, NpcMemoryValue> Empty =
+        new Dictionary<string, NpcMemoryValue>();
+
+    private readonly IEntityStore<NpcMemoryEntity, Serial> _memory;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly ILoopAffinity _loopAffinity;
+
+    private BrainContext? _current;
+
+    public NpcMemoryService(IPersistenceService persistenceService, ILoopAffinity loopAffinity)
+    {
+        _memory = persistenceService.GetStore<NpcMemoryEntity, Serial>();
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _loopAffinity = loopAffinity;
+    }
+
+    public IDisposable Begin(BrainContext context)
+    {
+        _loopAffinity.AssertOnLoop("memory.begin");
+        var previous = _current;
+        _current = context;
+        return new ContextScope(this, previous);
+    }
+
+    public bool Set(string key, NpcMemoryValue value)
+    {
+        _loopAffinity.AssertOnLoop("memory.set");
+        var mobileId = Current();
+
+        if (string.IsNullOrEmpty(key) || key.Length > MaxKeyLength)
+        {
+            return false;
+        }
+
+        if (value.Type == MemoryValueType.String && (value.Text?.Length ?? 0) > MaxValueLength)
+        {
+            return false;
+        }
+
+        if (_mobiles.GetById(mobileId) is null)
+        {
+            return false;
+        }
+
+        var entity = _memory.GetById(mobileId) ?? new NpcMemoryEntity { Id = mobileId };
+
+        if (!entity.Memory.ContainsKey(key) && entity.Memory.Count >= MaxKeys)
+        {
+            return false;
+        }
+
+        entity.Memory[key] = value;
+        _memory.UpsertAsync(entity).WaitSync();
+
+        return true;
+    }
+
+    public NpcMemoryValue? Get(string key)
+    {
+        var mobileId = Current();
+
+        return _memory.GetById(mobileId) is { } entity && entity.Memory.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
+
+    public bool Delete(string key)
+    {
+        _loopAffinity.AssertOnLoop("memory.delete");
+        var mobileId = Current();
+
+        if (_memory.GetById(mobileId) is not { } entity || !entity.Memory.Remove(key))
+        {
+            return false;
+        }
+
+        _memory.UpsertAsync(entity).WaitSync();
+
+        return true;
+    }
+
+    public IReadOnlyDictionary<string, NpcMemoryValue> All()
+    {
+        var mobileId = Current();
+
+        return _memory.GetById(mobileId)?.Memory ?? Empty;
+    }
+
+    public void Forget(Serial mobileId)
+    {
+        _loopAffinity.AssertOnLoop("memory.forget");
+
+        if (_memory.GetById(mobileId) is not null)
+        {
+            _memory.RemoveAsync(mobileId).WaitSync();
+        }
+    }
+
+    private Serial Current()
+        => (_current ?? throw new InvalidOperationException("memory.* is only callable inside an NPC brain tick.")).Self.Id;
+
+    private sealed class ContextScope : IDisposable
+    {
+        private readonly NpcMemoryService _owner;
+        private readonly BrainContext? _previous;
+
+        public ContextScope(NpcMemoryService owner, BrainContext? previous)
+        {
+            _owner = owner;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            _owner._current = _previous;
+        }
+    }
+}

--- a/src/Moongate.Server/Subscribers/NpcMemoryLifecycleSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/NpcMemoryLifecycleSubscriber.cs
@@ -1,0 +1,29 @@
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>Drops an NPC's durable memory when the mobile is deleted, so no orphan rows remain.</summary>
+public sealed class NpcMemoryLifecycleSubscriber : IEventSubscriberRegistration
+{
+    private readonly INpcMemoryService _memory;
+
+    public NpcMemoryLifecycleSubscriber(INpcMemoryService memory)
+    {
+        _memory = memory;
+    }
+
+    public Task OnMobileDeleted(MobileDeletedEvent message, CancellationToken cancellationToken)
+    {
+        _memory.Forget(message.Mobile.Id);
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
+    }
+}

--- a/tests/Moongate.Tests/Persistence/Entities/NpcMemoryEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/NpcMemoryEntityTests.cs
@@ -1,0 +1,50 @@
+using MessagePack;
+using MessagePack.Resolvers;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Tests.Persistence.Entities;
+
+public class NpcMemoryEntityTests
+{
+    [Fact]
+    public void RoundTrip_CarriesEachScalarTypeAndKey()
+    {
+        var entity = new NpcMemoryEntity
+        {
+            Id = new(0x2A),
+            Memory =
+            {
+                ["name"] = NpcMemoryValue.FromString("Bob"),
+                ["count"] = NpcMemoryValue.FromNumber(3),
+                ["hostile"] = NpcMemoryValue.FromBoolean(true)
+            }
+        };
+
+        var loaded = RoundTrip(entity);
+
+        Assert.Equal(new Serial(0x2A), loaded.Id);
+        Assert.Equal(3, loaded.Memory.Count);
+
+        Assert.Equal(MemoryValueType.String, loaded.Memory["name"].Type);
+        Assert.Equal("Bob", loaded.Memory["name"].ToScalar());
+        Assert.Equal(3d, loaded.Memory["count"].ToScalar());
+        Assert.Equal(true, loaded.Memory["hostile"].ToScalar());
+    }
+
+    [Fact]
+    public void RoundTrip_EmptyMemory_IsPreserved()
+    {
+        var loaded = RoundTrip(new NpcMemoryEntity { Id = new(0x1) });
+
+        Assert.Empty(loaded.Memory);
+    }
+
+    // Mirrors the persistence layer, which registers MessagePack's contractless resolver.
+    private static NpcMemoryEntity RoundTrip(NpcMemoryEntity value)
+        => MessagePackSerializer.Deserialize<NpcMemoryEntity>(
+            MessagePackSerializer.Serialize(value, ContractlessStandardResolver.Options),
+            ContractlessStandardResolver.Options
+        );
+}

--- a/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
@@ -285,6 +285,7 @@ public sealed class NpcBrainIntegrationTests
                 Loop,
                 Runtime,
                 aiActions,
+                new StubNpcMemoryService(),
                 Activity,
                 Persistence,
                 contextFactory,

--- a/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
@@ -787,6 +787,8 @@ public class NpcBrainSchedulerTests
 
         public StubAiActionService AiActions { get; } = new();
 
+        public StubNpcMemoryService Memory { get; } = new();
+
         public StubSectorActivityService Sectors { get; } = new();
 
         public StubSessionManager Sessions { get; } = new();
@@ -832,6 +834,7 @@ public class NpcBrainSchedulerTests
                 Loop,
                 Runtime,
                 AiActions,
+                Memory,
                 Sectors,
                 Persistence,
                 contextFactory,

--- a/tests/Moongate.Tests/Server/AI/NpcMemoryLifecycleSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcMemoryLifecycleSubscriberTests.cs
@@ -1,0 +1,45 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Subscribers;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcMemoryLifecycleSubscriberTests
+{
+    [Fact]
+    public async Task OnMobileDeleted_ForgetsThatMobilesMemory()
+    {
+        var memory = new RecordingForget();
+        var subscriber = new NpcMemoryLifecycleSubscriber(memory);
+
+        await subscriber.OnMobileDeleted(new MobileDeletedEvent(new MobileEntity { Id = new(0x7) }), default);
+
+        Assert.Equal(new Serial(0x7), Assert.Single(memory.Forgotten));
+    }
+
+    private sealed class RecordingForget : INpcMemoryService
+    {
+        public List<Serial> Forgotten { get; } = [];
+
+        public IDisposable Begin(BrainContext context)
+            => throw new NotSupportedException();
+
+        public bool Set(string key, NpcMemoryValue value)
+            => throw new NotSupportedException();
+
+        public NpcMemoryValue? Get(string key)
+            => throw new NotSupportedException();
+
+        public bool Delete(string key)
+            => throw new NotSupportedException();
+
+        public IReadOnlyDictionary<string, NpcMemoryValue> All()
+            => throw new NotSupportedException();
+
+        public void Forget(Serial mobileId)
+            => Forgotten.Add(mobileId);
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/NpcMemoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcMemoryServiceTests.cs
@@ -1,0 +1,166 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Services.AI;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.AI;
+
+public class NpcMemoryServiceTests
+{
+    [Fact]
+    public void Set_Then_Get_RoundTripsScalarTypes()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+
+        using (service.Begin(Context(npc)))
+        {
+            Assert.True(service.Set("name", NpcMemoryValue.FromString("Bob")));
+            Assert.True(service.Set("count", NpcMemoryValue.FromNumber(3)));
+            Assert.True(service.Set("hostile", NpcMemoryValue.FromBoolean(true)));
+
+            Assert.Equal("Bob", service.Get("name")!.ToScalar());
+            Assert.Equal(3d, service.Get("count")!.ToScalar());
+            Assert.Equal(true, service.Get("hostile")!.ToScalar());
+            Assert.Null(service.Get("missing"));
+        }
+
+        var stored = persistence.Store<NpcMemoryEntity>().GetById(npc.Id)!;
+        Assert.Equal(3, stored.Memory.Count);
+    }
+
+    [Fact]
+    public void Set_SurvivesAFreshServiceOverTheSameStore()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+        using (service.Begin(Context(npc)))
+        {
+            service.Set("seen", NpcMemoryValue.FromNumber(1));
+        }
+
+        var reopened = new NpcMemoryService(persistence, new StubLoopAffinity());
+        using (reopened.Begin(Context(npc)))
+        {
+            Assert.Equal(1d, reopened.Get("seen")!.ToScalar());
+        }
+    }
+
+    [Fact]
+    public void Set_UnknownMobile_ReturnsFalse()
+    {
+        var (service, persistence) = Build();
+        var ghost = new MobileEntity { Id = new(0x99), Name = "ghost" };
+
+        using (service.Begin(Context(ghost)))
+        {
+            Assert.False(service.Set("k", NpcMemoryValue.FromString("v")));
+        }
+
+        Assert.Null(persistence.Store<NpcMemoryEntity>().GetById(new(0x99)));
+    }
+
+    [Fact]
+    public void Set_ExceedingBounds_ReturnsFalse()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+
+        using (service.Begin(Context(npc)))
+        {
+            Assert.False(service.Set(new string('k', 65), NpcMemoryValue.FromString("v")));
+            Assert.False(service.Set("k", NpcMemoryValue.FromString(new string('v', 257))));
+            for (var i = 0; i < 128; i++)
+            {
+                Assert.True(service.Set("k" + i, NpcMemoryValue.FromNumber(i)));
+            }
+
+            Assert.False(service.Set("k128", NpcMemoryValue.FromNumber(0)));
+            Assert.True(service.Set("k0", NpcMemoryValue.FromNumber(99)));
+        }
+    }
+
+    [Fact]
+    public void Delete_And_Forget()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+        using (service.Begin(Context(npc)))
+        {
+            service.Set("a", NpcMemoryValue.FromNumber(1));
+            Assert.True(service.Delete("a"));
+            Assert.False(service.Delete("a"));
+            Assert.Null(service.Get("a"));
+            service.Set("b", NpcMemoryValue.FromNumber(2));
+        }
+
+        service.Forget(npc.Id);
+        Assert.Null(persistence.Store<NpcMemoryEntity>().GetById(npc.Id));
+    }
+
+    [Fact]
+    public void Action_WithoutActiveContext_Throws()
+    {
+        var (service, _) = Build();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Get("k"));
+        Assert.Contains("brain tick", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Begin_RestoresPreviousContextOnDispose()
+    {
+        var (service, persistence) = Build();
+        var a = AddMobile(persistence, 0x1);
+        var b = AddMobile(persistence, 0x2);
+
+        using (service.Begin(Context(a)))
+        {
+            using (service.Begin(Context(b)))
+            {
+                service.Set("x", NpcMemoryValue.FromNumber(1));
+            }
+
+            service.Set("y", NpcMemoryValue.FromNumber(2));
+        }
+
+        Assert.Equal(1, persistence.Store<NpcMemoryEntity>().GetById(b.Id)!.Memory.Count);
+        Assert.Equal(1, persistence.Store<NpcMemoryEntity>().GetById(a.Id)!.Memory.Count);
+        Assert.Throws<InvalidOperationException>(() => service.Get("z"));
+    }
+
+    private static (NpcMemoryService Service, FakePersistenceService Persistence) Build()
+    {
+        var persistence = new FakePersistenceService();
+        return (new NpcMemoryService(persistence, new StubLoopAffinity()), persistence);
+    }
+
+    private static MobileEntity AddMobile(FakePersistenceService persistence, uint id)
+    {
+        var mobile = new MobileEntity { Id = new(id), Name = "npc-" + id };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).AsTask().Wait();
+        return mobile;
+    }
+
+    private static BrainContext Context(MobileEntity owner)
+        => new(
+            DateTimeOffset.UtcNow,
+            new BrainMobileSnapshot(
+                owner.Id,
+                owner.Name,
+                false,
+                owner.MapId,
+                owner.Position,
+                owner.Hits,
+                owner.HitsMax,
+                owner.Warmode,
+                owner.CombatantId,
+                owner.Criminal,
+                owner.Kills
+            ),
+            owner.MapId,
+            owner.Position,
+            []
+        );
+}

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -38,6 +38,7 @@ public sealed class MoongateNpcAiPluginTests
         Assert.IsType<NpcAiMetrics>(container.Resolve<INpcAiMetrics>());
         Assert.True(container.IsRegistered<ISectorActivityService>());
         Assert.True(container.IsRegistered<IAiActionService>());
+        Assert.True(container.IsRegistered<INpcMemoryService>());
         Assert.True(container.IsRegistered<NpcBrainContextFactory>());
         Assert.True(container.IsRegistered<INpcBrainScheduler>());
         var subscribers = container.GetServiceRegistrations()
@@ -45,7 +46,12 @@ public sealed class MoongateNpcAiPluginTests
             .Select(registration => registration.ImplementationType)
             .ToArray();
         Assert.Equal(
-            [typeof(SectorActivitySubscriber), typeof(NpcBrainLifecycleSubscriber), typeof(NpcBrainEventRouter)],
+            [
+                typeof(SectorActivitySubscriber),
+                typeof(NpcBrainLifecycleSubscriber),
+                typeof(NpcBrainEventRouter),
+                typeof(NpcMemoryLifecycleSubscriber)
+            ],
             subscribers
         );
     }
@@ -86,6 +92,7 @@ public sealed class MoongateNpcAiPluginTests
             Assert.IsType<LuaNpcBrainRuntime>(container.Resolve<INpcBrainRuntime>());
             Assert.IsType<SectorActivityService>(container.Resolve<ISectorActivityService>());
             Assert.IsType<AiActionService>(container.Resolve<IAiActionService>());
+            Assert.IsType<NpcMemoryService>(container.Resolve<INpcMemoryService>());
             Assert.IsType<NpcBrainScheduler>(container.Resolve<INpcBrainScheduler>());
         }
         finally

--- a/tests/Moongate.Tests/Server/Scripting/MemoryModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MemoryModuleTests.cs
@@ -3,7 +3,6 @@ using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Scripting;
-using MoonSharp.Interpreter;
 
 namespace Moongate.Tests.Server.Scripting;
 
@@ -15,9 +14,9 @@ public class MemoryModuleTests
         var svc = new RecordingMemoryService { Result = true };
         var module = new MemoryModule(svc);
 
-        Assert.True(module.Set("s", DynValue.NewString("hi")));
-        Assert.True(module.Set("n", DynValue.NewNumber(4)));
-        Assert.True(module.Set("b", DynValue.NewBoolean(true)));
+        Assert.True(module.Set("s", "hi"));
+        Assert.True(module.Set("n", 4d));
+        Assert.True(module.Set("b", true));
 
         Assert.Equal(NpcMemoryValue.FromString("hi"), svc.Stored["s"]);
         Assert.Equal(NpcMemoryValue.FromNumber(4), svc.Stored["n"]);
@@ -30,7 +29,7 @@ public class MemoryModuleTests
         var svc = new RecordingMemoryService { Result = true };
         var module = new MemoryModule(svc);
 
-        Assert.False(module.Set("t", DynValue.NewTable(new Table(new Script()))));
+        Assert.False(module.Set("t", new object()));
         Assert.Empty(svc.Stored);
     }
 

--- a/tests/Moongate.Tests/Server/Scripting/MemoryModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MemoryModuleTests.cs
@@ -1,0 +1,96 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Scripting;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Tests.Server.Scripting;
+
+public class MemoryModuleTests
+{
+    [Fact]
+    public void Set_ConvertsLuaScalarsToTypedValues()
+    {
+        var svc = new RecordingMemoryService { Result = true };
+        var module = new MemoryModule(svc);
+
+        Assert.True(module.Set("s", DynValue.NewString("hi")));
+        Assert.True(module.Set("n", DynValue.NewNumber(4)));
+        Assert.True(module.Set("b", DynValue.NewBoolean(true)));
+
+        Assert.Equal(NpcMemoryValue.FromString("hi"), svc.Stored["s"]);
+        Assert.Equal(NpcMemoryValue.FromNumber(4), svc.Stored["n"]);
+        Assert.Equal(NpcMemoryValue.FromBoolean(true), svc.Stored["b"]);
+    }
+
+    [Fact]
+    public void Set_UnsupportedType_ReturnsFalseWithoutCallingService()
+    {
+        var svc = new RecordingMemoryService { Result = true };
+        var module = new MemoryModule(svc);
+
+        Assert.False(module.Set("t", DynValue.NewTable(new Table(new Script()))));
+        Assert.Empty(svc.Stored);
+    }
+
+    [Fact]
+    public void Get_ReturnsUnderlyingScalarOrNull()
+    {
+        var svc = new RecordingMemoryService();
+        svc.Stored["n"] = NpcMemoryValue.FromNumber(7);
+        var module = new MemoryModule(svc);
+
+        Assert.Equal(7d, module.Get("n"));
+        Assert.Null(module.Get("missing"));
+    }
+
+    [Fact]
+    public void All_ProjectsScalarsByKey()
+    {
+        var svc = new RecordingMemoryService();
+        svc.Stored["s"] = NpcMemoryValue.FromString("x");
+        svc.Stored["b"] = NpcMemoryValue.FromBoolean(false);
+        var module = new MemoryModule(svc);
+
+        var dict = module.All().ToDictionary();
+
+        Assert.Equal("x", dict["s"]);
+        Assert.Equal(false, dict["b"]);
+    }
+
+    private sealed class RecordingMemoryService : INpcMemoryService
+    {
+        public bool Result { get; set; }
+
+        public Dictionary<string, NpcMemoryValue> Stored { get; } = new(StringComparer.Ordinal);
+
+        public IDisposable Begin(BrainContext context)
+            => new Noop();
+
+        public bool Set(string key, NpcMemoryValue value)
+        {
+            Stored[key] = value;
+            return Result;
+        }
+
+        public NpcMemoryValue? Get(string key)
+            => Stored.TryGetValue(key, out var value) ? value : null;
+
+        public bool Delete(string key)
+            => Stored.Remove(key);
+
+        public IReadOnlyDictionary<string, NpcMemoryValue> All()
+            => Stored;
+
+        public void Forget(Serial mobileId)
+            => Stored.Clear();
+
+        private sealed class Noop : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/Moongate.Tests/Support/StubNpcMemoryService.cs
+++ b/tests/Moongate.Tests/Support/StubNpcMemoryService.cs
@@ -1,0 +1,38 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Interfaces.AI;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>No-op NPC memory service for scheduler/integration tests that don't exercise memory.</summary>
+public sealed class StubNpcMemoryService : INpcMemoryService
+{
+    private static readonly IReadOnlyDictionary<string, NpcMemoryValue> Empty = new Dictionary<string, NpcMemoryValue>();
+
+    public IDisposable Begin(BrainContext context)
+        => new NoopScope();
+
+    public bool Set(string key, NpcMemoryValue value)
+        => true;
+
+    public NpcMemoryValue? Get(string key)
+        => null;
+
+    public bool Delete(string key)
+        => false;
+
+    public IReadOnlyDictionary<string, NpcMemoryValue> All()
+        => Empty;
+
+    public void Forget(Serial mobileId)
+    {
+    }
+
+    private sealed class NoopScope : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adds a durable, persisted per-NPC key/value memory (issue #113), distinct from the transient `state` blackboard, so an NPC can remember facts across restarts and brain changes.

## What it adds

- **`NpcMemoryEntity`** persisted store (`npc_memory`), keyed by mobile serial, holding `Dictionary<string, NpcMemoryValue>` (scalars: string/number/boolean, type-preserving).
- **`INpcMemoryService`** with a per-tick ambient context (like `IAiActionService`), resolving the current brain's mobile; on-loop writes; bounds (128 keys/NPC, key ≤ 64, string value ≤ 256 → `set` returns `false`).
- **`memory` Lua module**, self-implicit on the current brain: `memory.set(key, value)`, `memory.get(key)`, `memory.delete(key)`, `memory.all()`. Outside a brain tick it raises a Lua error.
- **Orphan cleanup**: a `MobileDeletedEvent` subscriber forgets an NPC's memory on deletion.
- Scheduler opens the memory ambient alongside the `ai` ambient.

```lua
function guard.on_speech_heard(ctx, state, event)
  if event.speaker_is_player ~= true then return end
  local seen = (memory.get("seen:" .. event.speaker_id) or 0) + 1
  memory.set("seen:" .. event.speaker_id, seen)
  if seen == 1 then ai.say("I haven't seen you before.") else ai.say("Welcome back.") end
end
```

## Notes

- A real-boot smoke caught that the Lua binder cannot marshal a scalar argument into a `DynValue` parameter; `memory.set` takes `object` and switches on the runtime type. Covered going forward by the module tests + smoke.
- `NpcMemoryValue` (a record) is verified to round-trip through the real MessagePack contractless resolver (`NpcMemoryEntityTests`), which the in-memory test fakes don't exercise.

## Verification

- `dotnet build Moongate.slnx` — 0 errors.
- `dotnet test Moongate.slnx` — 1717 passed, 0 failed.
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings.
- Real-boot smoke: `memory` registers on the real engine (in `definitions.lua`), the ambient guard fires, boot is clean.

Docs: `reference/memory.md` + a "State vs memory" note in the NPC brains guide. No network/packet or REST changes.