### PR TITLE
fix(characters): dress new characters in the picked shirt and pants hues

### DIFF
--- a/src/Moongate.Server/Assets/starting_items.yaml
+++ b/src/Moongate.Server/Assets/starting_items.yaml
@@ -3,32 +3,45 @@ All:
         -   Item: dagger
         -   Item: my_story
 ByBody:
+    # "shirt" and "pants" are resolved at creation time to the hues picked on the creation screen;
+    # anything else (a literal, or nothing at all) keeps the item template's own hue.
     Human/Male:
         Equip:
             -   Item: long_pants
+                Hue: pants
             -   Item: shirt
+                Hue: shirt
             -   Item: shoes
     Human/Female:
         Equip:
             -   Item: skirt
+                Hue: pants
             -   Item: fancy_shirt
+                Hue: shirt
             -   Item: shoes
     Elf/Male:
         Equip:
             -   Item: long_pants
+                Hue: pants
             -   Item: shirt
+                Hue: shirt
             -   Item: shoes
     Elf/Female:
         Equip:
             -   Item: skirt
+                Hue: pants
             -   Item: fancy_shirt
+                Hue: shirt
             -   Item: shoes
+    # A gargoyle's robe stands in for both garments, so it takes the shirt hue.
     Gargoyle/Male:
         Equip:
             -   Item: robe
+                Hue: shirt
     Gargoyle/Female:
         Equip:
             -   Item: robe
+                Hue: shirt
 BySkill:
     Alchemy:
         Equip:

--- a/tests/Moongate.Tests/Data/StartingItemsDataTests.cs
+++ b/tests/Moongate.Tests/Data/StartingItemsDataTests.cs
@@ -20,6 +20,27 @@ public class StartingItemsDataTests
         Assert.NotEmpty(data.BySkill);
     }
 
+    // The hues picked on the creation screen only reach the character if the body kit asks for them:
+    // an entry with no Hue falls back to the template's own hue, which is 0 for every garment.
+    [Theory]
+    [InlineData("Human/Male", "shirt", "shirt")]
+    [InlineData("Human/Male", "long_pants", "pants")]
+    [InlineData("Human/Female", "fancy_shirt", "shirt")]
+    [InlineData("Human/Female", "skirt", "pants")]
+    [InlineData("Elf/Male", "shirt", "shirt")]
+    [InlineData("Elf/Male", "long_pants", "pants")]
+    [InlineData("Elf/Female", "fancy_shirt", "shirt")]
+    [InlineData("Elf/Female", "skirt", "pants")]
+    [InlineData("Gargoyle/Male", "robe", "shirt")]
+    [InlineData("Gargoyle/Female", "robe", "shirt")]
+    public void BodyKitGarments_WearThePlayerPickedHue(string body, string item, string hue)
+    {
+        var kit = LoadData().ByBody[body];
+        var entry = Assert.Single(kit.Equip.Where(equip => equip.Item == item));
+
+        Assert.Equal(hue, entry.Hue);
+    }
+
     [Fact]
     public async Task EveryReferencedItem_ResolvesToATemplate()
     {
@@ -33,12 +54,12 @@ public class StartingItemsDataTests
 
             var data = LoadData();
             var referenced = data.All
-                .Equip
-                .Concat(data.All.Pack)
-                .Concat(data.ByBody.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
-                .Concat(data.BySkill.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
-                .Select(entry => entry.Item)
-                .Distinct();
+                                 .Equip
+                                 .Concat(data.All.Pack)
+                                 .Concat(data.ByBody.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
+                                 .Concat(data.BySkill.Values.SelectMany(kit => kit.Equip.Concat(kit.Pack)))
+                                 .Select(entry => entry.Item)
+                                 .Distinct();
 
             foreach (var id in referenced)
             {


### PR DESCRIPTION
Fixes the character-creation bug reported in #116: the shirt and pants colours picked on the creation screen were ignored and the character entered the world in the default art colours (white shirt, grey pants).

## Root cause

The hues are read correctly off the 0xF8 packet (`CharacterCreationPacket.ShirtHue` / `PantsHue`) and `CharacterService.ResolveHue` already resolves the literals `shirt` and `pants` — but no garment in the shipped `Assets/starting_items.yaml` body kits declared them. With no `Hue` on the entry, `ItemFactoryService` falls back to the item template's own `Hue: 0`, which is the uncoloured art.

## Changes

- `Hue: pants` on `long_pants` / `skirt` and `Hue: shirt` on `shirt` / `fancy_shirt`, across the Human, Elf and Gargoyle body kits.
- The gargoyle robe takes the shirt hue, since it stands in for both garments.
- A theory over every body-kit garment locks the data, so a kit that drops the hue literal fails the data tests.

## Notes

- `StartingItemsLoader` only seeds `data/starting_items.yaml` when the file is missing, so **existing shards need the runtime copy deleted (or edited by hand)** to pick this up. Characters already created keep their colourless clothes.
- Full suite green: 1727 passed.