### PR TITLE
chore(mcp): drop the hardcoded cwd from the code-review-graph server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,6 @@
         "code-review-graph",
         "serve"
       ],
-      "cwd": "/home/squid/projects/personal/Moongate",
       "type": "stdio"
     }
   }


### PR DESCRIPTION
`.mcp.json` pinned `cwd` to `/home/squid/projects/personal/Moongate`, an absolute path that only resolves on the machine the file was written on — on a macOS checkout (`/Users/squid/...`) the directory does not exist.

Replacing it with the other absolute path would just move the breakage to the other machine. Removing it fixes both: with no `cwd`, the stdio server inherits the working directory of the client that launches it, which is the repo root wherever the repo is checked out.