### PR TITLE
feat(network): handle ClientViewRange (0xC8)

### DIFF
--- a/docs/packets/families/world-state.md
+++ b/docs/packets/families/world-state.md
@@ -11,3 +11,5 @@ Light levels, game time, season, map change/patches, object removal.
 | [`0xBC`](../outgoing/0xbc-season-change.md) | Season Change | S → C | 3 bytes (fixed) | Sets the client's season and optionally plays the season-change sound. |
 | [`0xBF/0x08`](../outgoing/0xbf-map-change.md) | Map Change | S → C | 6 bytes (fixed) | Switches the client to the given map. |
 | [`0xBF/0x18`](../outgoing/0xbf-map-patches.md) | Map Patches | S → C | 41 bytes (fixed) | Declares the static/land map-diff block counts for the four classic facets. |
+| [`0xC8`](../incoming/0xc8-client-view-range.md) | Client View Range | C → S | 2 bytes (fixed) | The client announces the update range it wants, in tiles, whenever the option changes. |
+| [`0xC8`](../outgoing/0xc8-client-view-range-ack.md) | Client View Range Ack | S → C | 2 bytes (fixed) | Reports the view range the server actually granted, so a client that asked for more than the maximum learns what it got. |

--- a/docs/packets/includes/family-cards.md
+++ b/docs/packets/includes/family-cards.md
@@ -16,7 +16,7 @@
   </a>
   <a class="mg-card" href="families/world-state.md">
     <h3>World state</h3>
-    <div class="mg-card-ops">0x1D · 0x4E · 0x4F · 0x5B · 0xBC · 0xBF</div>
+    <div class="mg-card-ops">0x1D · 0x4E · 0x4F · 0x5B · 0xBC · 0xBF · 0xC8</div>
     <p>Light levels, game time, season, map change/patches, object removal.</p>
   </a>
   <a class="mg-card" href="families/items-containers.md">

--- a/docs/packets/includes/packet-table.md
+++ b/docs/packets/includes/packet-table.md
@@ -1,7 +1,7 @@
 <div class="mg-stats">
-  <div class="mg-stat"><div class="mg-stat-num">52</div><div class="mg-stat-label">implemented packets</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-grass">16</div><div class="mg-stat-label">incoming (client → server)</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-violet">36</div><div class="mg-stat-label">outgoing (server → client)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num">54</div><div class="mg-stat-label">implemented packets</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-grass">17</div><div class="mg-stat-label">incoming (client → server)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-violet">37</div><div class="mg-stat-label">outgoing (server → client)</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-stone">7.x</div><div class="mg-stat-label">client target</div></div>
 </div>
 
@@ -53,6 +53,8 @@
 | [`0xBF/0x08`](../outgoing/0xbf-map-change.md) | Map Change | S → C | 6 bytes (fixed) | Switches the client to the given map. |
 | [`0xBF/0x18`](../outgoing/0xbf-map-patches.md) | Map Patches | S → C | 41 bytes (fixed) | Declares the static/land map-diff block counts for the four classic facets. |
 | [`0xBF/0x19`](../outgoing/0xbf-stat-lock-info.md) | Stat Lock Info | S → C | 12 bytes (fixed) | The up/down/lock state of the three stats, packed two bits each into a single byte. |
+| [`0xC8`](../incoming/0xc8-client-view-range.md) | Client View Range | C → S | 2 bytes (fixed) | The client announces the update range it wants, in tiles, whenever the option changes. |
+| [`0xC8`](../outgoing/0xc8-client-view-range-ack.md) | Client View Range Ack | S → C | 2 bytes (fixed) | Reports the view range the server actually granted, so a client that asked for more than the maximum learns what it got. |
 | [`0xD6`](../incoming/0xd6-mega-cliloc-request.md) | Mega Cliloc Request | C → S | Variable | The client asks for the property lists of a batch of objects, identified by serial. |
 | [`0xD6`](../outgoing/0xd6-mega-cliloc.md) | Mega Cliloc | S → C | Variable | The property list ("tooltip") of one object — cliloc lines with UTF-16LE arguments, preceded by the content hash the client caches against. |
 | [`0xDC`](../outgoing/0xdc-opl-info.md) | Opl Info | S → C | 9 bytes (fixed) | Tells the client the current property-list revision of an object. |

--- a/docs/packets/incoming/0xc8-client-view-range.md
+++ b/docs/packets/incoming/0xc8-client-view-range.md
@@ -1,0 +1,14 @@
+# 0xC8 — Client View Range
+
+<span class="mg-dir mg-dir-in">Client → Server</span>
+
+Client view range (0xC8): the client announces the update range it wants, in tiles, whenever the option changes. The server clamps it and echoes the accepted value back with the same opcode. 2 bytes fixed.
+
+- **Class:** [`ClientViewRangePacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Incoming/ClientViewRangePacket.cs)
+- **Size:** 2 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Range` | `byte` |

--- a/docs/packets/outgoing/0xc8-client-view-range-ack.md
+++ b/docs/packets/outgoing/0xc8-client-view-range-ack.md
@@ -1,0 +1,14 @@
+# 0xC8 — Client View Range Ack
+
+<span class="mg-dir mg-dir-out">Server → Client</span>
+
+Client view range acknowledgement (0xC8): reports the view range the server actually granted, so a client that asked for more than the maximum learns what it got. 2 bytes fixed.
+
+- **Class:** [`ClientViewRangeAckPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Outgoing/ClientViewRangeAckPacket.cs)
+- **Size:** 2 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Range` | `byte` |

--- a/docs/packets/toc.yml
+++ b/docs/packets/toc.yml
@@ -50,6 +50,8 @@
       href: incoming/0xbd-client-version.md
     - name: "0xBF — General Information"
       href: incoming/0xbf-general-information.md
+    - name: "0xC8 — Client View Range"
+      href: incoming/0xc8-client-view-range.md
     - name: "0xD6 — Mega Cliloc Request"
       href: incoming/0xd6-mega-cliloc-request.md
     - name: "0xEF — Login Seed"
@@ -124,6 +126,8 @@
       href: outgoing/0xbf-map-patches.md
     - name: "0xBF/0x19 — Stat Lock Info"
       href: outgoing/0xbf-stat-lock-info.md
+    - name: "0xC8 — Client View Range Ack"
+      href: outgoing/0xc8-client-view-range-ack.md
     - name: "0xD6 — Mega Cliloc"
       href: outgoing/0xd6-mega-cliloc.md
     - name: "0xDC — Opl Info"

--- a/src/Moongate.Network/Packets/Incoming/ClientViewRangePacket.cs
+++ b/src/Moongate.Network/Packets/Incoming/ClientViewRangePacket.cs
@@ -1,0 +1,24 @@
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Incoming;
+
+/// <summary>
+/// Client view range (0xC8): the client announces the update range it wants, in tiles, whenever the
+/// option changes. The server clamps it and echoes the accepted value back with the same opcode.
+/// 2 bytes fixed.
+/// </summary>
+[PacketDocumentation(PacketFamilyType.WorldState, Length = 2)]
+public readonly record struct ClientViewRangePacket(byte Range) : IIncomingPacket<ClientViewRangePacket>
+{
+    public static byte PacketId => 0xC8;
+
+    public static ClientViewRangePacket Read(ref SpanReader reader)
+    {
+        reader.ReadByte(); // packet id
+
+        return new(reader.ReadByte());
+    }
+}

--- a/src/Moongate.Network/Packets/Outgoing/ClientViewRangeAckPacket.cs
+++ b/src/Moongate.Network/Packets/Outgoing/ClientViewRangeAckPacket.cs
@@ -1,0 +1,22 @@
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Outgoing;
+
+/// <summary>
+/// Client view range acknowledgement (0xC8): reports the view range the server actually granted, so a
+/// client that asked for more than the maximum learns what it got. 2 bytes fixed.
+/// </summary>
+[PacketDocumentation(PacketFamilyType.WorldState, Length = 2)]
+public readonly record struct ClientViewRangeAckPacket(byte Range) : IOutgoingPacket
+{
+    public const byte PacketId = 0xC8;
+
+    public void Write(ref SpanWriter writer)
+    {
+        writer.Write(PacketId);
+        writer.Write(Range);
+    }
+}

--- a/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
+++ b/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
@@ -16,6 +16,14 @@ public sealed class PlayerSession : ISeedTarget
 {
     private const int InitialWriteBufferSize = 1024;
 
+    /// <summary>Smallest view range a client may ask for, in tiles.</summary>
+    public const int MinViewRange = 5;
+
+    /// <summary>
+    /// Largest view range a client may ask for, in tiles, and the radius the server broadcasts to.
+    /// </summary>
+    public const int MaxViewRange = 18;
+
     private readonly ILogger _logger = Log.ForContext<PlayerSession>();
     private readonly SquidStdTcpClient _client;
     private readonly Lock _stateSync = new();
@@ -41,6 +49,13 @@ public sealed class PlayerSession : ISeedTarget
     public string? Language { get; private set; }
 
     /// <summary>
+    /// The update range this client asked for via 0xC8, in tiles, always within
+    /// <see cref="MinViewRange" />..<see cref="MaxViewRange" />. Starts at the maximum: the client
+    /// sees everything until it says otherwise.
+    /// </summary>
+    public int ViewRange { get; private set; } = MaxViewRange;
+
+    /// <summary>
     /// The last movement sequence number accepted from this client, or null before the first accepted move (or after a
     /// resync).
     /// </summary>
@@ -62,6 +77,14 @@ public sealed class PlayerSession : ISeedTarget
         Compression = new();
         client.AddMiddleware(Compression);
     }
+
+    /// <summary>
+    /// Holds a requested view range between <see cref="MinViewRange" /> and
+    /// <see cref="MaxViewRange" />. Static and pure so the rule can be tested without a live
+    /// session, which needs a socket.
+    /// </summary>
+    public static int ClampViewRange(int requested)
+        => Math.Clamp(requested, MinViewRange, MaxViewRange);
 
     /// <summary>Closes the underlying connection, dropping this session (fire-and-forget).</summary>
     public void Disconnect()
@@ -168,6 +191,15 @@ public sealed class PlayerSession : ISeedTarget
         lock (_stateSync)
         {
             State = state;
+        }
+    }
+
+    /// <summary>Records the view range reported via 0xC8, clamped to the range the server allows.</summary>
+    public void SetViewRange(int range)
+    {
+        lock (_stateSync)
+        {
+            ViewRange = ClampViewRange(range);
         }
     }
 

--- a/src/Moongate.Server/Handlers/ClientViewRangeHandler.cs
+++ b/src/Moongate.Server/Handlers/ClientViewRangeHandler.cs
@@ -1,0 +1,26 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Network;
+
+namespace Moongate.Server.Handlers;
+
+/// <summary>
+/// Handles client view range (0xC8): stores the update range the client asked for, clamped to what
+/// the server allows, and echoes the accepted value back. Valid in any session state — it is a
+/// client preference, not an action on the world.
+/// </summary>
+public sealed class ClientViewRangeHandler : IPacketHandler<ClientViewRangePacket>, IPacketHandlerRegistration
+{
+    public void Handle(ClientViewRangePacket packet, in PacketContext context)
+    {
+        context.Session.SetViewRange(packet.Range);
+
+        // Reads the range back off the session rather than reusing packet.Range, so the reply can
+        // never disagree with what was stored. The clamp keeps it inside 5..18, so the cast is safe.
+        context.Session.Send(new ClientViewRangeAckPacket((byte)context.Session.ViewRange));
+    }
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}

--- a/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
@@ -38,5 +38,6 @@ public class MoongatePacketHandlersPlugin : ISquidStdPlugin
         container.RegisterPacketHandler<DoubleClickHandler>();
         container.RegisterPacketHandler<MoveRequestHandler>();
         container.RegisterPacketHandler<SpeechHandler>();
+        container.RegisterPacketHandler<ClientViewRangeHandler>();
     }
 }

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -28,9 +28,6 @@ public sealed class MovementService : IMovementService
     private static readonly TimeSpan WalkInterval = TimeSpan.FromMilliseconds(400);
     private static readonly TimeSpan RunInterval = TimeSpan.FromMilliseconds(200);
 
-    // Classic UO client view range.
-    private const int ViewRange = 18;
-
     private readonly IMapTileService _mapTiles;
     private readonly IRegionService _regions;
     private readonly ISpatialIndexService _spatial;
@@ -200,6 +197,9 @@ public sealed class MovementService : IMovementService
         return true;
     }
 
+    private void Accept(PlayerSession session, MobileEntity mobile, byte sequence)
+        => session.Send(new MovementAckPacket(sequence, Notoriety.Resolve(mobile.Kills, mobile.Criminal)));
+
     private void Apply(MobileEntity mobile, MovementDecision decision)
     {
         var fromMapId = mobile.MapId;
@@ -222,14 +222,11 @@ public sealed class MovementService : IMovementService
         }
     }
 
-    private void Accept(PlayerSession session, MobileEntity mobile, byte sequence)
-        => session.Send(new MovementAckPacket(sequence, Notoriety.Resolve(mobile.Kills, mobile.Criminal)));
-
     private void Broadcast(MobileEntity mobile)
         => _world.SendToPlayersInRange(
             mobile.MapId,
             mobile.Position,
-            ViewRange,
+            PlayerSession.MaxViewRange,
             new UpdatePlayerPacket(
                 mobile.Id,
                 (ushort)mobile.Body,

--- a/tests/Moongate.Tests/Network/ClientViewRangePacketsTests.cs
+++ b/tests/Moongate.Tests/Network/ClientViewRangePacketsTests.cs
@@ -1,0 +1,27 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Tests.Network;
+
+public class ClientViewRangePacketsTests
+{
+    [Fact]
+    public void ClientViewRangeAckPacket_Write_EmitsOpcodeAndRange()
+    {
+        var writer = new SpanWriter(4);
+        new ClientViewRangeAckPacket(18).Write(ref writer);
+
+        Assert.Equal(new byte[] { 0xC8, 0x12 }, writer.Span.ToArray());
+    }
+
+    [Fact]
+    public void ClientViewRangePacket_Read_ParsesRangeByte()
+    {
+        var reader = new SpanReader(new byte[] { 0xC8, 0x0A });
+
+        var packet = ClientViewRangePacket.Read(ref reader);
+
+        Assert.Equal(10, packet.Range);
+    }
+}

--- a/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
+++ b/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
@@ -8,22 +8,23 @@ namespace Moongate.Tests.Network;
 public class PacketDocumentationTests
 {
     private static readonly List<Type> PacketTypes = typeof(IOutgoingPacket).Assembly
-        .GetTypes()
-        .Where(t => t is
-                    {
-                        IsValueType: true,
-                        Namespace: not null
-                    } &&
-                    t.Namespace.StartsWith(
-                        "Moongate.Network.Packets.",
-                        StringComparison.Ordinal
-                    )
-        )
-        .ToList();
+                                                                            .GetTypes()
+                                                                            .Where(
+                                                                                t => t is
+                                                                                    {
+                                                                                        IsValueType: true,
+                                                                                        Namespace: not null
+                                                                                    } &&
+                                                                                    t.Namespace.StartsWith(
+                                                                                        "Moongate.Network.Packets.",
+                                                                                        StringComparison.Ordinal
+                                                                                    )
+                                                                            )
+                                                                            .ToList();
 
     [Fact]
     public void AllPacketTypes_AreDiscovered()
-        => Assert.Equal(52, PacketTypes.Count);
+        => Assert.Equal(54, PacketTypes.Count);
 
     [Theory, MemberData(nameof(Packets))]
     public void DeclaredSize_MatchesThePacketLengthsTable(Type packetType)

--- a/tests/Moongate.Tests/Server/PlayerSessionTests.cs
+++ b/tests/Moongate.Tests/Server/PlayerSessionTests.cs
@@ -1,14 +1,33 @@
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Types;
 
 namespace Moongate.Tests.Server;
 
 public class PlayerSessionTests
 {
+    [Theory]
+    [InlineData(0, 5)]     // below the minimum, including the client's "unset" 0
+    [InlineData(4, 5)]
+    [InlineData(5, 5)]     // the minimum itself
+    [InlineData(12, 12)]   // inside the range, untouched
+    [InlineData(18, 18)]   // the maximum itself
+    [InlineData(19, 18)]
+    [InlineData(255, 18)]  // above the maximum, including a modified client's nonsense
+    public void ClampViewRange_HoldsTheRequestBetweenTheBounds(int requested, int expected)
+        => Assert.Equal(expected, PlayerSession.ClampViewRange(requested));
+
     [Fact]
     public void SessionStateType_Defaults_StartAtAwaitingSeed()
     {
         Assert.Equal((byte)0, (byte)SessionStateType.AwaitingSeed);
         Assert.Equal((byte)1, (byte)SessionStateType.Login);
         Assert.Equal((byte)2, (byte)SessionStateType.Authenticated);
+    }
+
+    [Fact]
+    public void ViewRangeBounds_AreTheClassicFiveToEighteen()
+    {
+        Assert.Equal(5, PlayerSession.MinViewRange);
+        Assert.Equal(18, PlayerSession.MaxViewRange);
     }
 }


### PR DESCRIPTION
Closes the 0xC8 gap from #121: the client's requested update range is clamped to 5-18, stored on the session and echoed back with the accepted value, so a client that asked for 30 learns it got 18.

- `ClientViewRangePacket` / `ClientViewRangeAckPacket`, both 2 bytes, both documented, both in the `WorldState` family.
- `PlayerSession` owns the value: `ViewRange` defaults to the maximum, and `SetViewRange` clamps through the pure static `ClampViewRange` — static because `PlayerSession` needs a live socket to construct, so an instance-level clamp could not be unit-tested at all. Same trick as `MovementService.Evaluate`.
- `MovementService` drops its private `18` for `PlayerSession.MaxViewRange`, so the broadcast radius and the maximum requestable range cannot drift apart. Same number, so behaviour is unchanged.
- The hardcoded packet-type count in `PacketDocumentationTests` goes 52 → 54.

Nothing consumes the stored value yet: broadcasts keep the fixed radius, and re-syncing the view when the range changes stays with the separate SendEverything work.

Full suite green (1741), docfx at 0 warnings, packet reference regenerated.

**Not yet smoke-tested against a real client** — that check needs a ClassicUO client driving the update-range option, and is the one step left.