### PR TITLE
feat(items): pick up and drop items (0x07 / 0x08)

### DIFF
--- a/docs/packets/families/items-containers.md
+++ b/docs/packets/families/items-containers.md
@@ -4,9 +4,12 @@ World items, worn items, container gumps, contents and lift rejects.
 
 | Opcode | Name | Dir | Size | Description |
 |---|---|---|---|---|
+| [`0x07`](../incoming/0x07-pick-up-item.md) | Pick Up Item | C → S | 7 bytes (fixed) | The client asks to lift an item onto its cursor. |
+| [`0x08`](../incoming/0x08-drop-item.md) | Drop Item | C → S | 15 bytes (fixed) | Where the client wants to put the item it is holding. |
 | [`0x24`](../outgoing/0x24-draw-container.md) | Draw Container | S → C | 7 bytes (fixed) | Opens the container's gump on the client. |
 | [`0x25`](../outgoing/0x25-add-item-to-container.md) | Add Item To Container | S → C | 21 bytes (fixed) | Drops one item into an already-open container gump. |
 | [`0x27`](../outgoing/0x27-lift-reject.md) | Lift Reject | S → C | 2 bytes (fixed) | The lift the client asked for is refused, and why. |
+| [`0x29`](../outgoing/0x29-drop-item-approved.md) | Drop Item Approved | S → C | 1 bytes (fixed) | The drop the client asked for went through. |
 | [`0x2E`](../outgoing/0x2e-worn-item.md) | Worn Item | S → C | 15 bytes (fixed) | Draws a single item on a mobile that the client already knows about. |
 | [`0x3C`](../outgoing/0x3c-container-content.md) | Container Content | S → C | Variable | Every item inside a container, in one variable-length packet. |
 | [`0xF3`](../outgoing/0xf3-world-item.md) | World Item | S → C | 24 bytes (fixed) | Draws an item lying in the world. |

--- a/docs/packets/includes/family-cards.md
+++ b/docs/packets/includes/family-cards.md
@@ -21,7 +21,7 @@
   </a>
   <a class="mg-card" href="families/items-containers.md">
     <h3>Items &amp; containers</h3>
-    <div class="mg-card-ops">0x24 · 0x25 · 0x27 · 0x2E · 0x3C · 0xF3</div>
+    <div class="mg-card-ops">0x07 · 0x08 · 0x24 · 0x25 · 0x27 · 0x29 · 0x2E · 0x3C · 0xF3</div>
     <p>World items, worn items, container gumps, contents and lift rejects.</p>
   </a>
   <a class="mg-card" href="families/movement.md">

--- a/docs/packets/includes/packet-table.md
+++ b/docs/packets/includes/packet-table.md
@@ -1,7 +1,7 @@
 <div class="mg-stats">
-  <div class="mg-stat"><div class="mg-stat-num">54</div><div class="mg-stat-label">implemented packets</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-grass">17</div><div class="mg-stat-label">incoming (client → server)</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-violet">37</div><div class="mg-stat-label">outgoing (server → client)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num">57</div><div class="mg-stat-label">implemented packets</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-grass">19</div><div class="mg-stat-label">incoming (client → server)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-violet">38</div><div class="mg-stat-label">outgoing (server → client)</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-stone">7.x</div><div class="mg-stat-label">client target</div></div>
 </div>
 
@@ -9,6 +9,8 @@
 |---|---|---|---|---|
 | [`0x02`](../incoming/0x02-move-request.md) | Move Request | C → S | 7 bytes (fixed) | One step or turn, with anti-fastwalk key. |
 | [`0x06`](../incoming/0x06-double-click.md) | Double Click | C → S | 5 bytes (fixed) | The client double-clicked an entity, identified by its serial. |
+| [`0x07`](../incoming/0x07-pick-up-item.md) | Pick Up Item | C → S | 7 bytes (fixed) | The client asks to lift an item onto its cursor. |
+| [`0x08`](../incoming/0x08-drop-item.md) | Drop Item | C → S | 15 bytes (fixed) | Where the client wants to put the item it is holding. |
 | [`0x09`](../incoming/0x09-single-click.md) | Single Click | C → S | 5 bytes (fixed) | The client clicked an entity, identified by its serial. |
 | [`0x11`](../outgoing/0x11-status-bar-info.md) | Status Bar Info | S → C | Variable | The player's own status window. |
 | [`0x1B`](../outgoing/0x1b-login-confirm.md) | Login Confirm | S → C | 37 bytes (fixed) | The first packet of the enter-world burst. |
@@ -19,6 +21,7 @@
 | [`0x24`](../outgoing/0x24-draw-container.md) | Draw Container | S → C | 7 bytes (fixed) | Opens the container's gump on the client. |
 | [`0x25`](../outgoing/0x25-add-item-to-container.md) | Add Item To Container | S → C | 21 bytes (fixed) | Drops one item into an already-open container gump. |
 | [`0x27`](../outgoing/0x27-lift-reject.md) | Lift Reject | S → C | 2 bytes (fixed) | The lift the client asked for is refused, and why. |
+| [`0x29`](../outgoing/0x29-drop-item-approved.md) | Drop Item Approved | S → C | 1 bytes (fixed) | The drop the client asked for went through. |
 | [`0x2E`](../outgoing/0x2e-worn-item.md) | Worn Item | S → C | 15 bytes (fixed) | Draws a single item on a mobile that the client already knows about. |
 | [`0x3A`](../incoming/0x3a-skill-lock-change.md) | Skill Lock Change | C → S | Variable | The client sets the up/down/lock arrow on one skill. |
 | [`0x3A`](../outgoing/0x3a-skills.md) | Skills | S → C | Variable | Skill list (0x3A), in the absolute-with-caps form (type 0x02): the client's whole skill list in one go. |

--- a/docs/packets/incoming/0x07-pick-up-item.md
+++ b/docs/packets/incoming/0x07-pick-up-item.md
@@ -1,0 +1,15 @@
+# 0x07 — Pick Up Item
+
+<span class="mg-dir mg-dir-in">Client → Server</span>
+
+Pick up item (0x07): the client asks to lift an item onto its cursor. `Amount` is how much of a stack to take, and is clamped server-side to what the stack actually holds. 7 bytes fixed.
+
+- **Class:** [`PickUpItemPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Incoming/PickUpItemPacket.cs)
+- **Size:** 7 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Serial` | `Serial` |
+| `Amount` | `ushort` |

--- a/docs/packets/incoming/0x08-drop-item.md
+++ b/docs/packets/incoming/0x08-drop-item.md
@@ -1,0 +1,19 @@
+# 0x08 — Drop Item
+
+<span class="mg-dir mg-dir-in">Client → Server</span>
+
+Drop item (0x08): where the client wants to put the item it is holding. A `Container` of 0xFFFFFFFF means the ground at X/Y/Z; anything else is a container, and then X/Y are the position inside its gump. 15 bytes fixed.
+
+- **Class:** [`DropItemPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Incoming/DropItemPacket.cs)
+- **Size:** 15 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Serial` | `Serial` |
+| `X` | `ushort` |
+| `Y` | `ushort` |
+| `Z` | `sbyte` |
+| `GridIndex` | `byte` |
+| `Container` | `Serial` |

--- a/docs/packets/outgoing/0x29-drop-item-approved.md
+++ b/docs/packets/outgoing/0x29-drop-item-approved.md
@@ -1,0 +1,12 @@
+# 0x29 — Drop Item Approved
+
+<span class="mg-dir mg-dir-out">Server → Client</span>
+
+Drop item approved (0x29): the drop the client asked for went through. Opcode only, 1 byte — the client already knows what it dropped and where. A refused drop gets 0x27 instead.
+
+- **Class:** [`DropItemApprovedPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Outgoing/DropItemApprovedPacket.cs)
+- **Size:** 1 bytes (fixed)
+
+## Fields
+
+This packet carries no fields beyond its opcode.

--- a/docs/packets/toc.yml
+++ b/docs/packets/toc.yml
@@ -28,6 +28,10 @@
       href: incoming/0x02-move-request.md
     - name: "0x06 — Double Click"
       href: incoming/0x06-double-click.md
+    - name: "0x07 — Pick Up Item"
+      href: incoming/0x07-pick-up-item.md
+    - name: "0x08 — Drop Item"
+      href: incoming/0x08-drop-item.md
     - name: "0x09 — Single Click"
       href: incoming/0x09-single-click.md
     - name: "0x3A — Skill Lock Change"
@@ -78,6 +82,8 @@
       href: outgoing/0x25-add-item-to-container.md
     - name: "0x27 — Lift Reject"
       href: outgoing/0x27-lift-reject.md
+    - name: "0x29 — Drop Item Approved"
+      href: outgoing/0x29-drop-item-approved.md
     - name: "0x2E — Worn Item"
       href: outgoing/0x2e-worn-item.md
     - name: "0x3A — Skills"

--- a/docs/scripting/data/item-templates.md
+++ b/docs/scripting/data/item-templates.md
@@ -64,10 +64,10 @@ of templates.
 | `GoldValue` | `int` | optional, default `0` | Declared gold value. **Reserved** — not read by `ItemFactoryService` or copied onto the spawned item today. |
 | `Weight` | `double` | optional, default `0.0` | Item weight. Must be finite and non-negative. |
 | `ScriptId` | `string` | optional, default `""` | Free-form script identifier, copied onto the spawned item's `ScriptId`. **Reserved** — no loader in this codebase currently dispatches on it. |
-| `IsMovable` | `bool` | optional, default `false` | Declared and shape-validated but **not yet read** by `ItemFactoryService`. |
+| `IsMovable` | `bool` | optional, default `false` | Whether the item can be picked up. `false` refuses the lift with `CannotLift` (0x27). Not read by `ItemFactoryService` — it is enforced at drag time by `DragDropService`. |
 | `Rarity` | `ItemRarityType` enum | optional, default `Common` | One of `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`, `Artifact`. Must be a defined member. Copied onto the spawned item's `Rarity`. |
 | `Tags` | `List<string>` | optional, default `[]` | Free-form labels. Drives `item.create_by_tag` / `CreateByTag`, and is the pool loot entries' `ItemTag` matches against. Cannot be an explicit YAML null. |
-| `Stackable` | `bool?` | optional, default `null` | Declared on the DTO. **Reserved** — no consumer in this codebase. |
+| `Stackable` | `bool?` | optional, default `null` | Whether two piles of this item merge when one is dropped onto the other, up to 60000. Both templates must say `true`; `null` counts as not stackable. Enforced by `DragDropService`. |
 | `Dyeable` | `bool?` | optional, default `null` | Declared on the DTO. **Reserved** — no consumer in this codebase. |
 | `Visibility` | `string?` | optional, default `null` | Free-form string (shipped value seen: `GameMaster`). **Reserved** — distinct from the spawned entity's own `Visibility` (an `AccountLevelType`), which this key is not wired to. |
 | `LootType` | `string?` | optional, default `null` | Free-form string (shipped value seen: `Blessed`). **Reserved** — no consumer in this codebase. |
@@ -182,7 +182,7 @@ equips):
     GoldValue: 0                # declared, not consumed
     Weight: 16.0
     ScriptId: none              # copied onto the item; nothing dispatches on it yet
-    IsMovable: true              # declared, not consumed
+    IsMovable: true              # false would refuse the lift
     Rarity: Common               # must be a defined ItemRarityType member
     Tags:
         - modernuo

--- a/src/Moongate.Network/Packets/Incoming/DropItemPacket.cs
+++ b/src/Moongate.Network/Packets/Incoming/DropItemPacket.cs
@@ -1,0 +1,42 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Incoming;
+
+/// <summary>
+/// Drop item (0x08): where the client wants to put the item it is holding. A <c>Container</c> of
+/// 0xFFFFFFFF means the ground at X/Y/Z; anything else is a container, and then X/Y are the position
+/// inside its gump. 15 bytes fixed.
+/// </summary>
+[PacketDocumentation(PacketFamilyType.ItemsContainers, Length = 15)]
+public readonly record struct DropItemPacket(
+    Serial Serial,
+    ushort X,
+    ushort Y,
+    sbyte Z,
+    byte GridIndex,
+    Serial Container
+) : IIncomingPacket<DropItemPacket>
+{
+    /// <summary>The container serial modern clients send to mean "drop this on the ground".</summary>
+    public const uint GroundContainer = 0xFFFFFFFF;
+
+    public static byte PacketId => 0x08;
+
+    public static DropItemPacket Read(ref SpanReader reader)
+    {
+        reader.ReadByte(); // packet id
+
+        return new(
+            new Serial(reader.ReadUInt32()),
+            reader.ReadUInt16(),
+            reader.ReadUInt16(),
+            reader.ReadSByte(),
+            reader.ReadByte(), // grid index: a slot hint we do not use
+            new Serial(reader.ReadUInt32())
+        );
+    }
+}

--- a/src/Moongate.Network/Packets/Incoming/PickUpItemPacket.cs
+++ b/src/Moongate.Network/Packets/Incoming/PickUpItemPacket.cs
@@ -1,0 +1,24 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Incoming;
+
+/// <summary>
+/// Pick up item (0x07): the client asks to lift an item onto its cursor. <c>Amount</c> is how much of
+/// a stack to take, and is clamped server-side to what the stack actually holds. 7 bytes fixed.
+/// </summary>
+[PacketDocumentation(PacketFamilyType.ItemsContainers, Length = 7)]
+public readonly record struct PickUpItemPacket(Serial Serial, ushort Amount) : IIncomingPacket<PickUpItemPacket>
+{
+    public static byte PacketId => 0x07;
+
+    public static PickUpItemPacket Read(ref SpanReader reader)
+    {
+        reader.ReadByte(); // packet id
+
+        return new(new Serial(reader.ReadUInt32()), reader.ReadUInt16());
+    }
+}

--- a/src/Moongate.Network/Packets/Outgoing/DropItemApprovedPacket.cs
+++ b/src/Moongate.Network/Packets/Outgoing/DropItemApprovedPacket.cs
@@ -1,0 +1,19 @@
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Outgoing;
+
+/// <summary>
+/// Drop item approved (0x29): the drop the client asked for went through. Opcode only, 1 byte — the
+/// client already knows what it dropped and where. A refused drop gets 0x27 instead.
+/// </summary>
+[PacketDocumentation(PacketFamilyType.ItemsContainers, Length = 1)]
+public readonly record struct DropItemApprovedPacket : IOutgoingPacket
+{
+    public const byte PacketId = 0x29;
+
+    public void Write(ref SpanWriter writer)
+        => writer.Write(PacketId);
+}

--- a/src/Moongate.Server.Abstractions/Data/Internal/HeldItemOrigin.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/HeldItemOrigin.cs
@@ -1,0 +1,32 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// Where an item was before it was lifted, so a failed drop or a disconnect can put it back exactly
+/// there. Exactly one of the three origins is meaningful: a container slot, a worn layer, or a spot
+/// on a map. ModernUO calls the same idea BounceInfo.
+/// </summary>
+public sealed record HeldItemOrigin(
+    Serial ContainerId,
+    Point2D ContainerPosition,
+    Serial EquippedMobileId,
+    LayerType? EquippedLayer,
+    int MapId,
+    Point3D WorldPosition
+)
+{
+    /// <summary>Snapshots where <paramref name="item" /> currently is, before it is detached.</summary>
+    public static HeldItemOrigin From(ItemEntity item)
+        => new(
+            item.ParentContainerId,
+            item.ContainerPosition,
+            item.EquippedMobileId,
+            item.EquippedLayer,
+            item.MapId,
+            item.Position
+        );
+}

--- a/src/Moongate.Server.Abstractions/Data/Internal/LiftDecision.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/LiftDecision.cs
@@ -1,0 +1,9 @@
+using Moongate.Network.Types;
+
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// The outcome of the lift rules: accepted, or refused with the reason the client is told via 0x27.
+/// <see cref="Reason" /> is meaningless when <see cref="Accepted" /> is true.
+/// </summary>
+public readonly record struct LiftDecision(bool Accepted, LiftRejectReasonType Reason);

--- a/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
+++ b/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
@@ -2,6 +2,7 @@ using Moongate.Core.Primitives;
 using Moongate.Network.Interfaces;
 using Moongate.Network.Middlewares;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
 using Moongate.Server.Abstractions.Interfaces.Network;
 using Moongate.Server.Abstractions.Types;
 using Moongate.UO.Data.Version;
@@ -56,6 +57,16 @@ public sealed class PlayerSession : ISeedTarget
     public int ViewRange { get; private set; } = MaxViewRange;
 
     /// <summary>
+    /// The item this client is dragging on its cursor, or <see cref="Serial.Zero" /> when its hands
+    /// are empty. Deliberately not persisted: a held item is attached to nothing, and session state
+    /// cannot outlive the process, so a crash mid-drag cannot strand it.
+    /// </summary>
+    public Serial HeldItemId { get; private set; }
+
+    /// <summary>Where <see cref="HeldItemId" /> came from, so a failed drop can bounce it back.</summary>
+    public HeldItemOrigin? HeldItemOrigin { get; private set; }
+
+    /// <summary>
     /// The last movement sequence number accepted from this client, or null before the first accepted move (or after a
     /// resync).
     /// </summary>
@@ -86,6 +97,16 @@ public sealed class PlayerSession : ISeedTarget
     public static int ClampViewRange(int requested)
         => Math.Clamp(requested, MinViewRange, MaxViewRange);
 
+    /// <summary>Empties the client's hands, after a successful drop or a bounce.</summary>
+    public void ClearHold()
+    {
+        lock (_stateSync)
+        {
+            HeldItemId = Serial.Zero;
+            HeldItemOrigin = null;
+        }
+    }
+
     /// <summary>Closes the underlying connection, dropping this session (fire-and-forget).</summary>
     public void Disconnect()
         => _ = _client.CloseAsync();
@@ -96,6 +117,16 @@ public sealed class PlayerSession : ISeedTarget
     /// </summary>
     public void EnableCompression()
         => Compression.Enabled = true;
+
+    /// <summary>Records the item now on the client's cursor and where it was lifted from.</summary>
+    public void Hold(Serial itemId, HeldItemOrigin origin)
+    {
+        lock (_stateSync)
+        {
+            HeldItemId = itemId;
+            HeldItemOrigin = origin;
+        }
+    }
 
     public void MarkAuthenticated(string username)
     {

--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IDragDropService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IDragDropService.cs
@@ -1,0 +1,45 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
+
+namespace Moongate.Server.Abstractions.Interfaces.Items;
+
+/// <summary>
+/// The drag-and-drop rules: lifting an item onto a player's cursor, dropping it on the ground or into
+/// a container, and putting it back when either fails.
+/// </summary>
+public interface IDragDropService
+{
+    /// <summary>
+    /// Puts <paramref name="itemId" /> back where <paramref name="origin" /> says it came from,
+    /// falling back to <paramref name="actor" />'s backpack and then to the ground at their feet.
+    /// </summary>
+    void Bounce(MobileEntity actor, Serial itemId, HeldItemOrigin? origin);
+
+    /// <summary>
+    /// Drops the held item into <paramref name="containerId" /> (or on the ground when it is
+    /// <see cref="Serial.Zero" />) and reports whether it went through.
+    /// </summary>
+    LiftDecision Drop(
+        MobileEntity actor,
+        Serial heldItemId,
+        Serial containerId,
+        Point3D groundPosition,
+        Point2D containerPosition
+    );
+
+    /// <summary>
+    /// Validates and performs a lift. On success <paramref name="heldId" /> is the item now on the
+    /// cursor and <paramref name="origin" /> is where it was; on refusal both are empty and nothing
+    /// moved.
+    /// </summary>
+    LiftDecision Lift(
+        MobileEntity actor,
+        Serial itemId,
+        int amount,
+        Serial heldItemId,
+        out Serial heldId,
+        out HeldItemOrigin? origin
+    );
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IItemService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IItemService.cs
@@ -17,6 +17,13 @@ public interface IItemService
     /// <summary>Removes an item from the store; true when it existed.</summary>
     bool Delete(Serial itemId);
 
+    /// <summary>
+    /// Unhooks <paramref name="item" /> from wherever it is — a container, a worn layer, the ground —
+    /// leaving it attached to nothing and out of the spatial index. This is what a lift does: the item
+    /// belongs to no place until it is dropped.
+    /// </summary>
+    void Detach(ItemEntity item);
+
     /// <summary>Equips an item onto a mobile at a layer, detaching it from any previous location.</summary>
     void Equip(MobileEntity mobile, ItemEntity item, LayerType layer);
 
@@ -33,6 +40,12 @@ public interface IItemService
     IReadOnlyList<ItemEntity> GetEquipped(MobileEntity mobile);
 
     /// <summary>Removes an item from a container, clearing both sides.</summary>
+    /// <summary>
+    /// Detaches <paramref name="item" /> from wherever it is and places it on the ground at
+    /// <paramref name="position" /> on <paramref name="mapId" />, persisting it and indexing it.
+    /// </summary>
+    void MoveToWorld(ItemEntity item, int mapId, Point3D position);
+
     void RemoveFromContainer(ItemEntity container, ItemEntity item);
 
     /// <summary>Persists changes to an existing item.</summary>

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IWorldService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IWorldService.cs
@@ -26,6 +26,12 @@ public interface IWorldService
     void SendEnterWorld(PlayerSession session, MobileEntity mobile);
 
     /// <summary>
+    /// Sends <paramref name="packet" /> to the in-world session playing <paramref name="mobileId" />,
+    /// if any. Returns the number of recipients — 0 or 1.
+    /// </summary>
+    int SendToPlayer<TPacket>(Serial mobileId, TPacket packet) where TPacket : IOutgoingPacket;
+
+    /// <summary>
     /// Sends <paramref name="packet" /> to every in-world player session whose character is on
     /// <paramref name="mapId" /> within <paramref name="range" /> tiles of <paramref name="center" />,
     /// skipping the mobile identified by <paramref name="exclude" /> (typically the originator).

--- a/src/Moongate.Server/Handlers/DropItemHandler.cs
+++ b/src/Moongate.Server/Handlers/DropItemHandler.cs
@@ -1,0 +1,65 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Network.Types;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Network;
+
+namespace Moongate.Server.Handlers;
+
+/// <summary>
+/// Handles drop item (0x08): places the held item on the ground or into a container, answering 0x29
+/// on success. A refusal sends 0x27 and bounces the item back to where it was lifted from, otherwise
+/// it would stay attached to nothing.
+/// </summary>
+public sealed class DropItemHandler : IPacketHandler<DropItemPacket>, IPacketHandlerRegistration
+{
+    private readonly IDragDropService _dragDrop;
+
+    public DropItemHandler(IDragDropService dragDrop)
+    {
+        _dragDrop = dragDrop;
+    }
+
+    public void Handle(DropItemPacket packet, in PacketContext context)
+    {
+        var session = context.Session;
+
+        if (session.Character is not { } character)
+        {
+            session.Send(new LiftRejectPacket(LiftRejectReasonType.Inspecific));
+
+            return;
+        }
+
+        // The wire uses all-ones for "on the ground"; the service uses Serial.Zero.
+        var container = packet.Container.Value == DropItemPacket.GroundContainer
+            ? Serial.Zero
+            : packet.Container;
+
+        var decision = _dragDrop.Drop(
+            character,
+            session.HeldItemId,
+            container,
+            new Point3D(packet.X, packet.Y, packet.Z),
+            new Point2D(packet.X, packet.Y)
+        );
+
+        if (!decision.Accepted)
+        {
+            _dragDrop.Bounce(character, session.HeldItemId, session.HeldItemOrigin);
+            session.ClearHold();
+            session.Send(new LiftRejectPacket(decision.Reason));
+
+            return;
+        }
+
+        session.ClearHold();
+        session.Send(new DropItemApprovedPacket());
+    }
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}

--- a/src/Moongate.Server/Handlers/PickUpItemHandler.cs
+++ b/src/Moongate.Server/Handlers/PickUpItemHandler.cs
@@ -1,0 +1,53 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Network.Types;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Network;
+
+namespace Moongate.Server.Handlers;
+
+/// <summary>
+/// Handles pick up item (0x07): lifts the requested item onto the client's cursor, or refuses with
+/// 0x27 and a reason. An unanswered request leaves the client's cursor stuck, so every path replies.
+/// </summary>
+public sealed class PickUpItemHandler : IPacketHandler<PickUpItemPacket>, IPacketHandlerRegistration
+{
+    private readonly IDragDropService _dragDrop;
+
+    public PickUpItemHandler(IDragDropService dragDrop)
+    {
+        _dragDrop = dragDrop;
+    }
+
+    public void Handle(PickUpItemPacket packet, in PacketContext context)
+    {
+        if (context.Session.Character is not { } character)
+        {
+            context.Session.Send(new LiftRejectPacket(LiftRejectReasonType.Inspecific));
+
+            return;
+        }
+
+        var decision = _dragDrop.Lift(
+            character,
+            packet.Serial,
+            packet.Amount,
+            context.Session.HeldItemId,
+            out var heldId,
+            out var origin
+        );
+
+        if (!decision.Accepted)
+        {
+            context.Session.Send(new LiftRejectPacket(decision.Reason));
+
+            return;
+        }
+
+        context.Session.Hold(heldId, origin!);
+    }
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -29,6 +29,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<ContainerSubscriber>();
         container.RegisterEventSubscriber<SpatialSubscriber>();
         container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
+        container.RegisterEventSubscriber<HeldItemBounceSubscriber>();
 
         container.RegisterStdService<IEventSubscriberService, EventSubscriberService>();
     }

--- a/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
@@ -39,5 +39,7 @@ public class MoongatePacketHandlersPlugin : ISquidStdPlugin
         container.RegisterPacketHandler<MoveRequestHandler>();
         container.RegisterPacketHandler<SpeechHandler>();
         container.RegisterPacketHandler<ClientViewRangeHandler>();
+        container.RegisterPacketHandler<PickUpItemHandler>();
+        container.RegisterPacketHandler<DropItemHandler>();
     }
 }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -6,7 +6,6 @@ using Moongate.Http.Plugin;
 using Moongate.News.Plugin;
 using Moongate.Persistence;
 using Moongate.Scripting;
-using Moongate.Server;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Extensions;
@@ -15,6 +14,8 @@ using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Abstractions.Interfaces.Network;
+using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Abstractions.Interfaces.Server;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Autostart;
@@ -29,14 +30,12 @@ using Moongate.Server.Services.Game;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.Network;
-using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Services.Notifications;
-using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Services.Notifications.Channels;
 using Moongate.Server.Services.Plugins;
 using Moongate.Server.Services.Server;
-using Moongate.Smtp.Plugin;
 using Moongate.Server.Services.World;
+using Moongate.Smtp.Plugin;
 using Serilog;
 using SquidStd.Abstractions.Extensions.Config;
 using SquidStd.Abstractions.Extensions.Services;
@@ -122,7 +121,8 @@ await ConsoleApp.RunAsync(
         // different bootstrap phases: activation here, container registration in ConfigureServices below.
         var pluginCatalog = new PluginCatalog();
 
-        stdBootstrap.UsePlugins(builder =>
+        stdBootstrap.UsePlugins(
+            builder =>
             {
                 builder.FromDirectory("plugins");
 
@@ -132,7 +132,7 @@ await ConsoleApp.RunAsync(
                 {
                     var plugin = new TPlugin();
 
-                    pluginCatalog.Record(plugin, isExternal: false);
+                    pluginCatalog.Record(plugin, false);
                     builder.Add(plugin);
                 }
 
@@ -160,7 +160,8 @@ await ConsoleApp.RunAsync(
             }
         );
 
-        stdBootstrap.ConfigureServices(container =>
+        stdBootstrap.ConfigureServices(
+            container =>
             {
                 // Binds the SAME cached instance mutated above; the file cannot clobber it.
                 container.RegisterConfigSection<MoongateConfig>("moongate");
@@ -177,7 +178,7 @@ await ConsoleApp.RunAsync(
                 {
                     if (Activator.CreateInstance(type) is ISquidStdPlugin external)
                     {
-                        pluginCatalog.Record(external, isExternal: true);
+                        pluginCatalog.Record(external, true);
                     }
                 }
 
@@ -193,6 +194,7 @@ await ConsoleApp.RunAsync(
                 container.RegisterInstance(TimeProvider.System);
                 container.Register<IItemFactoryService, ItemFactoryService>(Reuse.Singleton);
                 container.Register<IItemService, ItemService>(Reuse.Singleton);
+                container.Register<IDragDropService, DragDropService>(Reuse.Singleton);
                 container.Register<ILootService, LootService>(Reuse.Singleton);
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
@@ -254,7 +256,8 @@ await ConsoleApp.RunAsync(
 
                 var eventBus = container.Resolve<IEventBus>();
 
-                eventBus.Subscribe<EngineStartedEvent>((_, _) =>
+                eventBus.Subscribe<EngineStartedEvent>(
+                    (_, _) =>
                     {
                         container.Resolve<TimerAutostartService>().InitDefaultTimers();
 

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -1,0 +1,60 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Server.Services.Items;
+
+/// <summary>
+/// Owns the drag-and-drop game rules. <see cref="Evaluate" /> is the pure decision core — public and
+/// static so the rules are unit-testable without a live session, mirroring
+/// <c>MovementService.Evaluate</c>. The rest of the service is orchestration: detach, hold, place,
+/// bounce, and the packets that follow.
+/// </summary>
+public sealed class DragDropService
+{
+    /// <summary>How close the player must be to lift something, in tiles. ModernUO uses the same 2.</summary>
+    public const int LiftRange = 2;
+
+    /// <summary>
+    /// Decides whether <paramref name="actor" /> may lift an item, in ModernUO's order: already
+    /// holding, then range, then whether the item can be moved at all, then whether the actor can
+    /// reach it. <paramref name="reachable" /> is computed by the caller, which needs the store to
+    /// walk the container chain; everything else here is a plain value.
+    /// </summary>
+    public static LiftDecision Evaluate(
+        MobileEntity actor,
+        int itemMapId,
+        Point3D itemWorldPosition,
+        ItemTemplate? template,
+        Serial heldItemId,
+        bool reachable
+    )
+    {
+        if (heldItemId != Serial.Zero)
+        {
+            return new(false, LiftRejectReasonType.AreHolding);
+        }
+
+        if (actor.MapId != itemMapId || !actor.Position.InRange(itemWorldPosition, LiftRange))
+        {
+            return new(false, LiftRejectReasonType.OutOfRange);
+        }
+
+        // A template that cannot be resolved is treated as unmovable: better a refused lift than an
+        // item whose rules are unknown.
+        if (template is null || !template.IsMovable)
+        {
+            return new(false, LiftRejectReasonType.CannotLift);
+        }
+
+        if (!reachable)
+        {
+            return new(false, LiftRejectReasonType.CannotLift);
+        }
+
+        return new(true, LiftRejectReasonType.Inspecific);
+    }
+}

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -143,6 +143,156 @@ public sealed class DragDropService
         return decision;
     }
 
+    public LiftDecision Drop(
+        MobileEntity actor,
+        Serial heldItemId,
+        Serial containerId,
+        Point3D groundPosition,
+        Point2D containerPosition
+    )
+    {
+        _loopAffinity?.AssertOnLoop("drag_drop.drop");
+
+        // The held serial is the authority. A drop naming anything else is a desynced or hostile
+        // client, and honouring it would let one move items it never lifted.
+        if (heldItemId == Serial.Zero || _items.GetById(heldItemId) is not { } item)
+        {
+            return new(false, LiftRejectReasonType.Inspecific);
+        }
+
+        return containerId == Serial.Zero
+            ? DropOnGround(actor, item, groundPosition)
+            : DropInContainer(actor, item, containerId, containerPosition);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="dropped" /> can merge into <paramref name="existing" />: the same thing,
+    /// the same colour, both declared stackable, and a total the client can represent.
+    /// </summary>
+    public static bool CanStack(
+        ItemEntity existing,
+        ItemEntity dropped,
+        ItemTemplate? existingTemplate,
+        ItemTemplate? droppedTemplate
+    )
+        => existing.Id != dropped.Id &&
+           existingTemplate?.Stackable == true &&
+           droppedTemplate?.Stackable == true &&
+           existing.TemplateId == dropped.TemplateId &&
+           existing.ItemId == dropped.ItemId &&
+           existing.Hue == dropped.Hue &&
+           existing.Amount + dropped.Amount <= MaxStackAmount;
+
+    private LiftDecision DropOnGround(MobileEntity actor, ItemEntity item, Point3D position)
+    {
+        if (!actor.Position.InRange(position, LiftRange))
+        {
+            return new(false, LiftRejectReasonType.OutOfRange);
+        }
+
+        PlaceOnGround(item, actor.MapId, position);
+
+        return new(true, LiftRejectReasonType.Inspecific);
+    }
+
+    private LiftDecision DropInContainer(
+        MobileEntity actor,
+        ItemEntity item,
+        Serial containerId,
+        Point2D position
+    )
+    {
+        // A container inside itself would take its whole contents out of reach for good.
+        if (containerId == item.Id || _items.GetById(containerId) is not { } container)
+        {
+            return new(false, LiftRejectReasonType.CannotLift);
+        }
+
+        if (IsDescendantOf(container, item.Id) || !Reachable(container, actor))
+        {
+            return new(false, LiftRejectReasonType.CannotLift);
+        }
+
+        var (containerMapId, containerWorldPosition) = WorldLocation(container, actor);
+
+        if (actor.MapId != containerMapId || !actor.Position.InRange(containerWorldPosition, LiftRange))
+        {
+            return new(false, LiftRejectReasonType.OutOfRange);
+        }
+
+        var stack = FindStack(container, item);
+
+        if (stack is not null)
+        {
+            stack.Amount += item.Amount;
+            _items.Save(stack);
+            _items.Delete(item.Id);
+
+            _world.SendToPlayer(actor.Id, ContainerPacket(stack, container.Id, stack.ContainerPosition));
+
+            return new(true, LiftRejectReasonType.Inspecific);
+        }
+
+        _items.AddToContainer(container, item, position);
+
+        _world.SendToPlayer(actor.Id, ContainerPacket(item, container.Id, position));
+
+        return new(true, LiftRejectReasonType.Inspecific);
+    }
+
+    private ItemEntity? FindStack(ItemEntity container, ItemEntity dropped)
+    {
+        var droppedTemplate = _templates.GetById(dropped.TemplateId);
+
+        foreach (var candidate in _items.GetContents(container.Id))
+        {
+            if (CanStack(candidate, dropped, _templates.GetById(candidate.TemplateId), droppedTemplate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>True when <paramref name="candidate" /> sits anywhere inside <paramref name="ancestorId" />.</summary>
+    private bool IsDescendantOf(ItemEntity candidate, Serial ancestorId)
+    {
+        var current = candidate;
+
+        for (var depth = 0; current.ParentContainerId != Serial.Zero && depth < 32; depth++)
+        {
+            if (current.ParentContainerId == ancestorId)
+            {
+                return true;
+            }
+
+            if (_items.GetById(current.ParentContainerId) is not { } parent)
+            {
+                return false;
+            }
+
+            current = parent;
+        }
+
+        return false;
+    }
+
+    private void PlaceOnGround(ItemEntity item, int mapId, Point3D position)
+    {
+        _items.MoveToWorld(item, mapId, position);
+
+        _world.SendToPlayersInRange(
+            mapId,
+            position,
+            PlayerSession.MaxViewRange,
+            new WorldItemPacket(item.Id, (ushort)item.ItemId, (ushort)item.Amount, position, item.Hue)
+        );
+    }
+
+    private static AddItemToContainerPacket ContainerPacket(ItemEntity item, Serial containerId, Point2D position)
+        => new(item.Id, (ushort)item.ItemId, (ushort)item.Amount, position, containerId, item.Hue);
+
     /// <summary>
     /// Walks up the container chain to the item that is actually somewhere — on the ground or on a
     /// mobile. The guard stops a corrupted cycle from hanging the loop thread.

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -18,7 +18,7 @@ namespace Moongate.Server.Services.Items;
 /// <c>MovementService.Evaluate</c>. The rest of the service is orchestration: detach, hold, place,
 /// bounce, and the packets that follow.
 /// </summary>
-public sealed class DragDropService
+public sealed class DragDropService : IDragDropService
 {
     /// <summary>How close the player must be to lift something, in tiles. ModernUO uses the same 2.</summary>
     public const int LiftRange = 2;
@@ -143,6 +143,32 @@ public sealed class DragDropService
         return decision;
     }
 
+    public void Bounce(MobileEntity actor, Serial itemId, HeldItemOrigin? origin)
+    {
+        _loopAffinity?.AssertOnLoop("drag_drop.bounce");
+
+        // Already gone — deleted, or merged into a stack by a drop that then failed elsewhere.
+        if (_items.GetById(itemId) is not { } item)
+        {
+            return;
+        }
+
+        if (origin is not null && BounceToOrigin(actor, item, origin))
+        {
+            return;
+        }
+
+        if (actor.BackpackId != Serial.Zero && _items.GetById(actor.BackpackId) is { } backpack)
+        {
+            _items.AddToContainer(backpack, item, BounceSlot);
+
+            return;
+        }
+
+        // No origin left and nowhere to carry it: it lands where the player stands.
+        PlaceOnGround(item, actor.MapId, actor.Position);
+    }
+
     public LiftDecision Drop(
         MobileEntity actor,
         Serial heldItemId,
@@ -182,6 +208,46 @@ public sealed class DragDropService
            existing.ItemId == dropped.ItemId &&
            existing.Hue == dropped.Hue &&
            existing.Amount + dropped.Amount <= MaxStackAmount;
+
+    /// <summary>
+    /// Puts the item back exactly where it was lifted from, or reports false so the caller can fall
+    /// back. ModernUO's Item.Bounce does the same, dropping to the player's feet when the recorded
+    /// parent has gone away.
+    /// </summary>
+    private bool BounceToOrigin(MobileEntity actor, ItemEntity item, HeldItemOrigin origin)
+    {
+        if (origin.ContainerId != Serial.Zero)
+        {
+            if (_items.GetById(origin.ContainerId) is not { } container)
+            {
+                return false;
+            }
+
+            _items.AddToContainer(container, item, origin.ContainerPosition);
+
+            return true;
+        }
+
+        if (origin.EquippedMobileId != Serial.Zero)
+        {
+            // Only ever back onto the actor's own layers, and only if the layer is still free —
+            // something else may have been equipped while this item was in the air.
+            if (origin.EquippedMobileId != actor.Id ||
+                origin.EquippedLayer is not { } layer ||
+                actor.EquippedItemIds.ContainsKey(layer))
+            {
+                return false;
+            }
+
+            _items.Equip(actor, item, layer);
+
+            return true;
+        }
+
+        PlaceOnGround(item, origin.MapId, origin.WorldPosition);
+
+        return true;
+    }
 
     private LiftDecision DropOnGround(MobileEntity actor, ItemEntity item, Point3D position)
     {

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -1,8 +1,13 @@
 using Moongate.Core.Geometry;
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Outgoing;
 using Moongate.Network.Types;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.UO.Data.Items;
 
 namespace Moongate.Server.Services.Items;
@@ -17,6 +22,32 @@ public sealed class DragDropService
 {
     /// <summary>How close the player must be to lift something, in tiles. ModernUO uses the same 2.</summary>
     public const int LiftRange = 2;
+
+    private const int MaxStackAmount = 60000;
+
+    /// <summary>Where a bounced item lands in the backpack — the base slot CharacterService uses.</summary>
+    private static readonly Point2D BounceSlot = new(44, 65);
+
+    private readonly IItemService _items;
+    private readonly IItemFactoryService _itemFactory;
+    private readonly IItemTemplateService _templates;
+    private readonly IWorldService _world;
+    private readonly ILoopAffinity? _loopAffinity;
+
+    public DragDropService(
+        IItemService items,
+        IItemFactoryService itemFactory,
+        IItemTemplateService templates,
+        IWorldService world,
+        ILoopAffinity? loopAffinity = null
+    )
+    {
+        _items = items;
+        _itemFactory = itemFactory;
+        _templates = templates;
+        _world = world;
+        _loopAffinity = loopAffinity;
+    }
 
     /// <summary>
     /// Decides whether <paramref name="actor" /> may lift an item, in ModernUO's order: already
@@ -56,5 +87,154 @@ public sealed class DragDropService
         }
 
         return new(true, LiftRejectReasonType.Inspecific);
+    }
+
+    public LiftDecision Lift(
+        MobileEntity actor,
+        Serial itemId,
+        int amount,
+        Serial heldItemId,
+        out Serial heldId,
+        out HeldItemOrigin? origin
+    )
+    {
+        _loopAffinity?.AssertOnLoop("drag_drop.lift");
+
+        heldId = Serial.Zero;
+        origin = null;
+
+        if (_items.GetById(itemId) is not { } item)
+        {
+            return new(false, LiftRejectReasonType.Inspecific);
+        }
+
+        var (mapId, position) = WorldLocation(item, actor);
+        var decision = Evaluate(
+            actor,
+            mapId,
+            position,
+            _templates.GetById(item.TemplateId),
+            heldItemId,
+            Reachable(item, actor)
+        );
+
+        if (!decision.Accepted)
+        {
+            return decision;
+        }
+
+        SplitStack(item, amount);
+
+        // Snapshot before detaching: Detach clears the very fields the origin is made of.
+        origin = HeldItemOrigin.From(item);
+        heldId = item.Id;
+
+        _items.Detach(item);
+
+        // Everyone who could see it there stops seeing it. ModernUO reaches the same end state by
+        // internalizing the item, which triggers the removal through the map-change path.
+        _world.SendToPlayersInRange(
+            mapId,
+            position,
+            PlayerSession.MaxViewRange,
+            new DeleteObjectPacket(item.Id)
+        );
+
+        return decision;
+    }
+
+    /// <summary>
+    /// Walks up the container chain to the item that is actually somewhere — on the ground or on a
+    /// mobile. The guard stops a corrupted cycle from hanging the loop thread.
+    /// </summary>
+    private ItemEntity Root(ItemEntity item)
+    {
+        var current = item;
+
+        for (var depth = 0; current.ParentContainerId != Serial.Zero && depth < 32; depth++)
+        {
+            if (_items.GetById(current.ParentContainerId) is not { } parent)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Where an item is in the world, for the range check: its own position when it lies on the
+    /// ground, its root's otherwise. An item worn by the actor is wherever the actor is; one worn by
+    /// somebody else keeps the stale coordinates of an equipped entity, which fails the range check —
+    /// the outcome we want anyway, since Reachable refuses it too.
+    /// </summary>
+    private (int MapId, Point3D Position) WorldLocation(ItemEntity item, MobileEntity actor)
+    {
+        var root = Root(item);
+
+        return root.EquippedMobileId == actor.Id
+            ? (actor.MapId, actor.Position)
+            : (root.MapId, root.Position);
+    }
+
+    /// <summary>
+    /// Whether the actor may touch this item at all. Their own worn items and anything inside their
+    /// own containers, yes; anything on another mobile, never; anything on the ground, yes — how far
+    /// away it may be is the range check's job, not this one's.
+    /// </summary>
+    private bool Reachable(ItemEntity item, MobileEntity actor)
+    {
+        var root = Root(item);
+
+        if (root.EquippedMobileId == actor.Id)
+        {
+            return true;
+        }
+
+        return root.EquippedMobileId == Serial.Zero;
+    }
+
+    /// <summary>
+    /// ModernUO's inversion (Mobile.LiftItemDupe): the ORIGINAL entity keeps travelling on the cursor
+    /// with the lifted amount, and the NEW entity is the remainder left behind. The serial the client
+    /// is dragging therefore never changes mid-drag.
+    /// </summary>
+    private void SplitStack(ItemEntity item, int amount)
+    {
+        var lifted = Math.Clamp(amount, 1, item.Amount);
+
+        if (lifted >= item.Amount)
+        {
+            return;
+        }
+
+        var created = _itemFactory.CreateFromTemplate(
+            item.TemplateId,
+            amount: item.Amount - lifted,
+            hue: item.Hue
+        );
+
+        // No template to build the remainder from: leave the stack whole rather than lose the rest.
+        if (created.Count == 0)
+        {
+            return;
+        }
+
+        var remainder = created[0];
+        _items.Create(remainder);
+
+        if (item.ParentContainerId != Serial.Zero && _items.GetById(item.ParentContainerId) is { } container)
+        {
+            _items.AddToContainer(container, remainder, item.ContainerPosition);
+        }
+        else
+        {
+            _items.MoveToWorld(remainder, item.MapId, item.Position);
+        }
+
+        item.Amount = lifted;
+        _items.Save(item);
     }
 }

--- a/src/Moongate.Server/Services/Items/ItemService.cs
+++ b/src/Moongate.Server/Services/Items/ItemService.cs
@@ -77,6 +77,20 @@ public sealed class ItemService : IItemService
         return _items.RemoveAsync(itemId).WaitSync();
     }
 
+    public void Detach(ItemEntity item)
+    {
+        _loopAffinity?.AssertOnLoop("item.detach");
+
+        DetachFromCurrentLocation(item);
+
+        // DetachFromCurrentLocation unwinds containers and layers but leaves the map coordinates
+        // alone, so a ground item would otherwise keep pointing at where it used to lie.
+        item.MapId = 0;
+        item.Position = Point3D.Zero;
+        _items.UpsertAsync(item).WaitSync();
+        _spatial?.Remove(item.Id);
+    }
+
     public void Equip(MobileEntity mobile, ItemEntity item, LayerType layer)
     {
         _loopAffinity?.AssertOnLoop("item.equip");
@@ -137,6 +151,18 @@ public sealed class ItemService : IItemService
 
     public IReadOnlyList<ItemEntity> GetEquipped(MobileEntity mobile)
         => Resolve(mobile.EquippedItemIds.Values);
+
+    public void MoveToWorld(ItemEntity item, int mapId, Point3D position)
+    {
+        _loopAffinity?.AssertOnLoop("item.move_to_world");
+
+        DetachFromCurrentLocation(item);
+
+        item.MapId = mapId;
+        item.Position = position;
+        _items.UpsertAsync(item).WaitSync();
+        _spatial?.AddOrUpdate(item);
+    }
 
     public void RemoveFromContainer(ItemEntity container, ItemEntity item)
     {

--- a/src/Moongate.Server/Services/World/WorldService.cs
+++ b/src/Moongate.Server/Services/World/WorldService.cs
@@ -192,6 +192,24 @@ public sealed class WorldService : IWorldService
         _eventBus.Publish(new PlayerEnteredWorldEvent(session.SessionId, session.AccountId, mobile));
     }
 
+    public int SendToPlayer<TPacket>(Serial mobileId, TPacket packet)
+        where TPacket : IOutgoingPacket
+    {
+        foreach (var session in _sessions.All)
+        {
+            if (session.State != SessionStateType.InWorld || session.Character?.Id != mobileId)
+            {
+                continue;
+            }
+
+            session.Send(packet);
+
+            return 1;
+        }
+
+        return 0;
+    }
+
     public int SendToPlayersInRange<TPacket>(int mapId, Point3D center, int range, TPacket packet, Serial? exclude = null)
         where TPacket : IOutgoingPacket
     {

--- a/src/Moongate.Server/Subscribers/HeldItemBounceSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/HeldItemBounceSubscriber.cs
@@ -1,0 +1,38 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Closes the drag-and-drop limbo: a player who disconnects while holding an item would otherwise
+/// leave it attached to nothing. SessionDestroyedEvent is loop-affine, so this may touch world state
+/// directly. The handler is public so tests can drive it without a dispatching event bus.
+/// </summary>
+public sealed class HeldItemBounceSubscriber : IEventSubscriberRegistration
+{
+    private readonly IDragDropService _dragDrop;
+
+    public HeldItemBounceSubscriber(IDragDropService dragDrop)
+    {
+        _dragDrop = dragDrop;
+    }
+
+    public Task OnSessionDestroyed(SessionDestroyedEvent message, CancellationToken cancellationToken)
+    {
+        var session = message.Session;
+
+        if (session.HeldItemId != Serial.Zero && session.Character is { } character)
+        {
+            _dragDrop.Bounce(character, session.HeldItemId, session.HeldItemOrigin);
+            session.ClearHold();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+}

--- a/tests/Moongate.Tests/Network/DragDropPacketsTests.cs
+++ b/tests/Moongate.Tests/Network/DragDropPacketsTests.cs
@@ -1,0 +1,64 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Tests.Network;
+
+public class DragDropPacketsTests
+{
+    [Fact]
+    public void DropItemApprovedPacket_Write_EmitsOnlyTheOpcode()
+    {
+        var writer = new SpanWriter(4);
+        new DropItemApprovedPacket().Write(ref writer);
+
+        Assert.Equal(new byte[] { 0x29 }, writer.Span.ToArray());
+    }
+
+    [Fact]
+    public void DropItemPacket_Read_ParsesTargetAndContainer()
+    {
+        // 0x08, serial 0x40000001, x 0x0064, y 0x00C8, z 0x05, grid 0x00, container 0x40000002
+        var reader = new SpanReader(
+            new byte[]
+            {
+                0x08, 0x40, 0x00, 0x00, 0x01, 0x00, 0x64, 0x00, 0xC8, 0x05, 0x00, 0x40, 0x00, 0x00, 0x02
+            }
+        );
+
+        var packet = DropItemPacket.Read(ref reader);
+
+        Assert.Equal((Serial)0x40000001, packet.Serial);
+        Assert.Equal(100, packet.X);
+        Assert.Equal(200, packet.Y);
+        Assert.Equal(5, packet.Z);
+        Assert.Equal((Serial)0x40000002, packet.Container);
+    }
+
+    [Fact]
+    public void DropItemPacket_Read_GroundDropCarriesTheAllOnesContainer()
+    {
+        var reader = new SpanReader(
+            new byte[]
+            {
+                0x08, 0x40, 0x00, 0x00, 0x01, 0x00, 0x64, 0x00, 0xC8, 0x05, 0x00, 0xFF, 0xFF, 0xFF, 0xFF
+            }
+        );
+
+        var packet = DropItemPacket.Read(ref reader);
+
+        Assert.Equal((Serial)0xFFFFFFFF, packet.Container);
+    }
+
+    [Fact]
+    public void PickUpItemPacket_Read_ParsesSerialAndAmount()
+    {
+        var reader = new SpanReader(new byte[] { 0x07, 0x40, 0x00, 0x00, 0x01, 0x00, 0x05 });
+
+        var packet = PickUpItemPacket.Read(ref reader);
+
+        Assert.Equal((Serial)0x40000001, packet.Serial);
+        Assert.Equal(5, packet.Amount);
+    }
+}

--- a/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
+++ b/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
@@ -24,7 +24,7 @@ public class PacketDocumentationTests
 
     [Fact]
     public void AllPacketTypes_AreDiscovered()
-        => Assert.Equal(54, PacketTypes.Count);
+        => Assert.Equal(57, PacketTypes.Count);
 
     [Theory, MemberData(nameof(Packets))]
     public void DeclaredSize_MatchesThePacketLengthsTable(Type packetType)

--- a/tests/Moongate.Tests/Server/HeldItemOriginTests.cs
+++ b/tests/Moongate.Tests/Server/HeldItemOriginTests.cs
@@ -1,0 +1,57 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Server;
+
+public class HeldItemOriginTests
+{
+    [Fact]
+    public void From_ContainedItem_RecordsTheContainerAndSlot()
+    {
+        var item = new ItemEntity
+        {
+            Id = (Serial)1,
+            ParentContainerId = (Serial)99,
+            ContainerPosition = new(44, 65)
+        };
+
+        var origin = HeldItemOrigin.From(item);
+
+        Assert.Equal((Serial)99, origin.ContainerId);
+        Assert.Equal(new Point2D(44, 65), origin.ContainerPosition);
+        Assert.Equal(Serial.Zero, origin.EquippedMobileId);
+    }
+
+    [Fact]
+    public void From_GroundItem_RecordsTheMapAndPosition()
+    {
+        var item = new ItemEntity { Id = (Serial)1, MapId = 1, Position = new(100, 200, 5) };
+
+        var origin = HeldItemOrigin.From(item);
+
+        Assert.Equal(Serial.Zero, origin.ContainerId);
+        Assert.Equal(Serial.Zero, origin.EquippedMobileId);
+        Assert.Equal(1, origin.MapId);
+        Assert.Equal(new Point3D(100, 200, 5), origin.WorldPosition);
+    }
+
+    [Fact]
+    public void From_WornItem_RecordsTheMobileAndLayer()
+    {
+        var item = new ItemEntity
+        {
+            Id = (Serial)1,
+            EquippedMobileId = (Serial)7,
+            EquippedLayer = LayerType.Shirt
+        };
+
+        var origin = HeldItemOrigin.From(item);
+
+        Assert.Equal((Serial)7, origin.EquippedMobileId);
+        Assert.Equal(LayerType.Shirt, origin.EquippedLayer);
+        Assert.Equal(Serial.Zero, origin.ContainerId);
+    }
+}

--- a/tests/Moongate.Tests/Server/ItemServiceTests.cs
+++ b/tests/Moongate.Tests/Server/ItemServiceTests.cs
@@ -331,6 +331,46 @@ public class ItemServiceTests
         return (new(persistence, null, spatial), spatial, persistence);
     }
 
+    [Fact]
+    public void Detach_FromAContainer_LeavesTheItemBelongingNowhere()
+    {
+        var persistence = new FakePersistenceService();
+        var service = new ItemService(persistence);
+
+        var backpack = new ItemEntity { ItemId = 3701 };
+        var item = new ItemEntity { ItemId = 3921, MapId = 1, Position = new(10, 20, 0) };
+        service.Create(backpack);
+        service.Create(item);
+        service.AddToContainer(backpack, item, new(50, 70));
+
+        service.Detach(item);
+
+        Assert.Equal(Serial.Zero, item.ParentContainerId);
+        Assert.Equal(0, item.MapId);
+        Assert.Equal(Point3D.Zero, item.Position);
+        Assert.DoesNotContain(item.Id, persistence.Store<ItemEntity>().GetById(backpack.Id)!.ContainedItemIds);
+    }
+
+    [Fact]
+    public void MoveToWorld_FromAContainer_DetachesAndPlacesOnTheGround()
+    {
+        var persistence = new FakePersistenceService();
+        var service = new ItemService(persistence);
+
+        var backpack = new ItemEntity { ItemId = 3701 };
+        var item = new ItemEntity { ItemId = 3921 };
+        service.Create(backpack);
+        service.Create(item);
+        service.AddToContainer(backpack, item, new(50, 70));
+
+        service.MoveToWorld(item, 1, new(100, 200, 5));
+
+        Assert.Equal(Serial.Zero, item.ParentContainerId);
+        Assert.Equal(1, item.MapId);
+        Assert.Equal(new Point3D(100, 200, 5), item.Position);
+        Assert.DoesNotContain(item.Id, persistence.Store<ItemEntity>().GetById(backpack.Id)!.ContainedItemIds);
+    }
+
     private static ItemEntity Item(string name = "Dagger", int itemId = 3921)
         => new() { Name = name, ItemId = itemId };
 }

--- a/tests/Moongate.Tests/Server/Items/DragDropDecisionTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropDecisionTests.cs
@@ -1,0 +1,144 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Tests.Server.Items;
+
+public class DragDropDecisionTests
+{
+    [Fact]
+    public void Evaluate_AlreadyHolding_RefusesBeforeAnythingElse()
+    {
+        // Out of range and unmovable too: already-holding still wins, as in ModernUO's Mobile.Lift.
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(500, 500, 0),
+            template: Template(movable: false),
+            heldItemId: (Serial)42,
+            reachable: false
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.AreHolding, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_InRangeMovableAndReachable_Accepts()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(101, 100, 0),
+            template: Template(),
+            heldItemId: Serial.Zero,
+            reachable: true
+        );
+
+        Assert.True(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_MissingTemplate_RefusesAsUnliftable()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(100, 100, 0),
+            template: null,
+            heldItemId: Serial.Zero,
+            reachable: true
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.CannotLift, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_OnAnotherMap_IsOutOfRange()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 2,
+            itemWorldPosition: new(100, 100, 0),
+            template: Template(),
+            heldItemId: Serial.Zero,
+            reachable: true
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.OutOfRange, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_ThreeTilesAway_IsOutOfRange()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(103, 100, 0),
+            template: Template(),
+            heldItemId: Serial.Zero,
+            reachable: true
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.OutOfRange, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_TwoTilesAway_IsInRange()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(102, 100, 0),
+            template: Template(),
+            heldItemId: Serial.Zero,
+            reachable: true
+        );
+
+        Assert.True(decision.Accepted);
+    }
+
+    [Fact]
+    public void Evaluate_UnmovableTemplate_RefusesAsUnliftable()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(100, 100, 0),
+            template: Template(movable: false),
+            heldItemId: Serial.Zero,
+            reachable: true
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.CannotLift, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_UnreachableItem_RefusesAsUnliftable()
+    {
+        var decision = DragDropService.Evaluate(
+            Actor(),
+            itemMapId: 1,
+            itemWorldPosition: new(100, 100, 0),
+            template: Template(),
+            heldItemId: Serial.Zero,
+            reachable: false
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.CannotLift, decision.Reason);
+    }
+
+    private static MobileEntity Actor()
+        => new() { Id = (Serial)7, MapId = 1, Position = new(100, 100, 0) };
+
+    private static ItemTemplate Template(bool movable = true)
+        => new() { Id = "dagger", Name = "Dagger", Category = "Weapon", ItemId = 3921, IsMovable = movable };
+}

--- a/tests/Moongate.Tests/Server/Items/DragDropServiceBounceTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropServiceBounceTests.cs
@@ -1,0 +1,47 @@
+using Moongate.Core.Primitives;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+public class DragDropServiceBounceTests
+{
+    [Fact]
+    public void Bounce_ToItsOrigin_PutsTheItemBackInTheSameContainerSlot()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 1, Serial.Zero, out var heldId, out var origin);
+
+        fixture.Service.Bounce(fixture.Actor, heldId, origin);
+
+        Assert.Equal(fixture.Backpack.Id, fixture.Gold.ParentContainerId);
+        Assert.Equal(origin!.ContainerPosition, fixture.Gold.ContainerPosition);
+    }
+
+    [Fact]
+    public void Bounce_WhenTheOriginContainerIsGone_FallsBackToTheBackpack()
+    {
+        var fixture = DragDropFixture.WithBagInBackpack();
+        var coin = fixture.PutGoldInTheBag(amount: 1);
+        fixture.Service.Lift(fixture.Actor, coin.Id, 1, Serial.Zero, out var heldId, out var origin);
+
+        fixture.DeleteTheBag();
+
+        fixture.Service.Bounce(fixture.Actor, heldId, origin);
+
+        Assert.Equal(fixture.Backpack.Id, coin.ParentContainerId);
+    }
+
+    [Fact]
+    public void Bounce_WithNoOriginAndNoBackpack_DropsItAtTheActorsFeet()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 1, Serial.Zero, out var heldId, out _);
+
+        fixture.RemoveTheBackpack();
+
+        fixture.Service.Bounce(fixture.Actor, heldId, origin: null);
+
+        Assert.Equal(fixture.Actor.MapId, fixture.Gold.MapId);
+        Assert.Equal(fixture.Actor.Position, fixture.Gold.Position);
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/DragDropServiceDropTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropServiceDropTests.cs
@@ -1,0 +1,90 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Types;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+public class DragDropServiceDropTests
+{
+    [Fact]
+    public void Drop_IntoAContainer_StoresItAtTheGivenSlot()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 1, Serial.Zero, out var heldId, out _);
+
+        var decision = fixture.Service.Drop(
+            fixture.Actor,
+            heldId,
+            fixture.Backpack.Id,
+            groundPosition: Point3D.Zero,
+            containerPosition: new(60, 80)
+        );
+
+        Assert.True(decision.Accepted);
+        Assert.Equal(fixture.Backpack.Id, fixture.Gold.ParentContainerId);
+        Assert.Equal(new Point2D(60, 80), fixture.Gold.ContainerPosition);
+    }
+
+    [Fact]
+    public void Drop_IntoTheHeldContainerItself_IsRefused()
+    {
+        var fixture = DragDropFixture.WithBagInBackpack();
+        fixture.Service.Lift(fixture.Actor, fixture.Bag.Id, 1, Serial.Zero, out var heldId, out _);
+
+        var decision = fixture.Service.Drop(fixture.Actor, heldId, heldId, Point3D.Zero, new(60, 80));
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.CannotLift, decision.Reason);
+    }
+
+    [Fact]
+    public void Drop_OfSomethingNotHeld_IsRefused()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+
+        var decision = fixture.Service.Drop(
+            fixture.Actor,
+            (Serial)0xDEAD,
+            Serial.Zero,
+            new(101, 100, 0),
+            Point2D.Zero
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.Inspecific, decision.Reason);
+    }
+
+    [Fact]
+    public void Drop_OnTheGround_PlacesTheItemAtThePosition()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 1, Serial.Zero, out var heldId, out _);
+
+        var decision = fixture.Service.Drop(
+            fixture.Actor,
+            heldId,
+            containerId: Serial.Zero,
+            groundPosition: new(101, 100, 0),
+            containerPosition: Point2D.Zero
+        );
+
+        Assert.True(decision.Accepted);
+        Assert.Equal(1, fixture.Gold.MapId);
+        Assert.Equal(new Point3D(101, 100, 0), fixture.Gold.Position);
+        Assert.Equal(Serial.Zero, fixture.Gold.ParentContainerId);
+    }
+
+    [Fact]
+    public void Drop_OntoACompatibleStack_MergesAndDeletesTheDroppedEntity()
+    {
+        // 100 gold in the backpack; lift 40, then drop the 40 back onto the 60.
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 100);
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 40, Serial.Zero, out var heldId, out _);
+
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(60, 80));
+
+        var stack = Assert.Single(fixture.BackpackContents());
+        Assert.Equal(100, stack.Amount);
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/DragDropServiceLiftTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropServiceLiftTests.cs
@@ -1,0 +1,88 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Types;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+public class DragDropServiceLiftTests
+{
+    [Fact]
+    public void Lift_Accepted_DetachesTheItemAndRecordsWhereItCameFrom()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 1, Serial.Zero, out var heldId, out var origin);
+
+        Assert.Equal(fixture.Gold.Id, heldId);
+        Assert.Equal(Serial.Zero, fixture.Gold.ParentContainerId);
+        Assert.NotNull(origin);
+        Assert.Equal(fixture.Backpack.Id, origin!.ContainerId);
+    }
+
+    [Fact]
+    public void Lift_AlreadyHolding_RefusesAndLeavesTheItemAlone()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+
+        var decision = fixture.Service.Lift(
+            fixture.Actor,
+            fixture.Gold.Id,
+            1,
+            heldItemId: (Serial)999,
+            out var heldId,
+            out _
+        );
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.AreHolding, decision.Reason);
+        Assert.Equal(Serial.Zero, heldId);
+        Assert.Equal(fixture.Backpack.Id, fixture.Gold.ParentContainerId);
+    }
+
+    [Fact]
+    public void Lift_PartialStack_KeepsTheOriginalOnTheCursorAndLeavesTheRemainder()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 100);
+
+        var decision = fixture.Service.Lift(
+            fixture.Actor,
+            fixture.Gold.Id,
+            amount: 5,
+            heldItemId: Serial.Zero,
+            out var heldId,
+            out _
+        );
+
+        Assert.True(decision.Accepted);
+
+        // ModernUO's inversion: the serial the client dragged stays the lifted portion.
+        Assert.Equal(fixture.Gold.Id, heldId);
+        Assert.Equal(5, fixture.Gold.Amount);
+
+        var remainder = Assert.Single(fixture.BackpackContents());
+        Assert.Equal(95, remainder.Amount);
+        Assert.Equal("gold", remainder.TemplateId);
+    }
+
+    [Fact]
+    public void Lift_UnknownSerial_RefusesAsInspecific()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+
+        var decision = fixture.Service.Lift(fixture.Actor, (Serial)0xDEAD, 1, Serial.Zero, out _, out _);
+
+        Assert.False(decision.Accepted);
+        Assert.Equal(LiftRejectReasonType.Inspecific, decision.Reason);
+    }
+
+    [Fact]
+    public void Lift_WholeStack_CreatesNoRemainder()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 100);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 100, Serial.Zero, out _, out _);
+
+        Assert.Empty(fixture.BackpackContents());
+        Assert.Equal(100, fixture.Gold.Amount);
+    }
+}

--- a/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
@@ -214,7 +214,7 @@ public class MovementServiceTests
         Assert.True(service.TryMoveNpc(mobile.Id, DirectionType.East));
 
         var stored = persistence.Store<MobileEntity>().GetById(mobile.Id)!;
-        Assert.Equal(new Point3D(2, 1, 0), stored.Position);
+        Assert.Equal(new(2, 1, 0), stored.Position);
         var moved = Assert.Single(bus.Published.OfType<MobileMovedEvent>());
         Assert.Equal(mobile.Id, moved.Mobile);
         Assert.Equal((0, new Point3D(1, 1, 0)), (moved.FromMapId, moved.FromPosition));
@@ -272,7 +272,7 @@ public class MovementServiceTests
         FakePersistenceService Persistence,
         SpatialIndexService Spatial,
         StubEventBus Bus
-    ) BuildMovementService()
+        ) BuildMovementService()
     {
         var (mapTiles, regions) = Build();
         var persistence = new FakePersistenceService();
@@ -280,28 +280,10 @@ public class MovementServiceTests
         var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), bus);
         var world = new StubWorldService();
 
-        return (new(mapTiles, regions, spatial, world, persistence, TimeProvider.System, bus, new StubLoopAffinity()), persistence, spatial, bus);
+        return (new(mapTiles, regions, spatial, world, persistence, TimeProvider.System, bus, new StubLoopAffinity()),
+                persistence, spatial, bus);
     }
 
     private static MobileEntity Mobile(int x = 1, int y = 1, int z = 0, DirectionType direction = DirectionType.East)
         => new() { Id = new(0x1), MapId = 0, Position = new(x, y, z), Direction = direction };
-
-    private sealed class StubWorldService : IWorldService
-    {
-        public int Broadcast<TPacket>(TPacket packet) where TPacket : IOutgoingPacket
-            => 0;
-
-        public void SendEnterWorld(PlayerSession session, MobileEntity mobile)
-        {
-        }
-
-        public int SendToPlayersInRange<TPacket>(
-            int mapId,
-            Point3D center,
-            int range,
-            TPacket packet,
-            Serial? exclude = null
-        ) where TPacket : IOutgoingPacket
-            => 0;
-    }
 }

--- a/tests/Moongate.Tests/Support/DragDropFixture.cs
+++ b/tests/Moongate.Tests/Support/DragDropFixture.cs
@@ -1,0 +1,106 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Hues;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// A live <see cref="DragDropService" /> over fake persistence, with the least world a drag needs: an
+/// actor standing at (100, 100, 0) on map 1 wearing a backpack, and templates for the three things the
+/// tests move around. <see cref="StubWorldService" /> swallows the visibility packets — this fixture
+/// is about where items end up, not what the client is told.
+/// </summary>
+public sealed class DragDropFixture
+{
+    public FakePersistenceService Persistence { get; }
+
+    public ItemService Items { get; }
+
+    public DragDropService Service { get; }
+
+    public MobileEntity Actor { get; }
+
+    public ItemEntity Backpack { get; }
+
+    public ItemEntity Gold { get; private set; } = null!;
+
+    public ItemEntity Bag { get; private set; } = null!;
+
+    private DragDropFixture()
+    {
+        Persistence = new();
+        Items = new(Persistence);
+
+        var templates = new ItemTemplateService();
+        templates.Register(
+            new() { Id = "backpack", Name = "Backpack", Category = "Container", ItemId = 3701, IsMovable = true }
+        );
+        templates.Register(
+            new()
+            {
+                Id = "gold", Name = "Gold", Category = "Currency", ItemId = 3821,
+                IsMovable = true, Stackable = true
+            }
+        );
+        templates.Register(
+            new() { Id = "bag", Name = "Bag", Category = "Container", ItemId = 3702, IsMovable = true }
+        );
+
+        Service = new(Items, new ItemFactoryService(templates, new Random(1)), templates, new StubWorldService());
+
+        Actor = new() { MapId = 1, Position = new(100, 100, 0) };
+        Persistence.Store<MobileEntity>().UpsertAsync(Actor).WaitSync();
+
+        Backpack = new() { TemplateId = "backpack", ItemId = 3701 };
+        Items.Create(Backpack);
+        Items.Equip(Actor, Backpack, LayerType.Backpack);
+    }
+
+    /// <summary>An actor carrying a single stack of <paramref name="amount" /> gold in the backpack.</summary>
+    public static DragDropFixture WithGoldInBackpack(int amount)
+    {
+        var fixture = new DragDropFixture();
+
+        fixture.Gold = new() { TemplateId = "gold", ItemId = 3821, Amount = amount, Hue = new Hue(0) };
+        fixture.Items.Create(fixture.Gold);
+        fixture.Items.AddToContainer(fixture.Backpack, fixture.Gold, new(50, 70));
+
+        return fixture;
+    }
+
+    /// <summary>An actor carrying an empty bag inside the backpack, for the nesting cases.</summary>
+    public static DragDropFixture WithBagInBackpack()
+    {
+        var fixture = new DragDropFixture();
+
+        fixture.Bag = new() { TemplateId = "bag", ItemId = 3702, Amount = 1 };
+        fixture.Items.Create(fixture.Bag);
+        fixture.Items.AddToContainer(fixture.Backpack, fixture.Bag, new(50, 70));
+
+        return fixture;
+    }
+
+    public IReadOnlyList<ItemEntity> BackpackContents()
+        => Items.GetContents(Backpack.Id);
+
+    /// <summary>Drops the bag out of the world, to exercise the bounce falling past a dead origin.</summary>
+    public void DeleteTheBag()
+        => Items.Delete(Bag.Id);
+
+    /// <summary>Takes the backpack off the actor, to exercise the bounce falling all the way to the feet.</summary>
+    public void RemoveTheBackpack()
+        => Items.Unequip(Actor, LayerType.Backpack);
+
+    /// <summary>Puts a stack of gold inside the bag, for the nested-origin bounce case.</summary>
+    public ItemEntity PutGoldInTheBag(int amount)
+    {
+        var gold = new ItemEntity { TemplateId = "gold", ItemId = 3821, Amount = amount, Hue = new Hue(0) };
+        Items.Create(gold);
+        Items.AddToContainer(Bag, gold, new(20, 30));
+
+        return gold;
+    }
+}

--- a/tests/Moongate.Tests/Support/StubItemService.cs
+++ b/tests/Moongate.Tests/Support/StubItemService.cs
@@ -28,6 +28,9 @@ public sealed class StubItemService : IItemService
     public bool Delete(Serial itemId)
         => throw new NotSupportedException();
 
+    public void Detach(ItemEntity item)
+        => throw new NotSupportedException();
+
     public void Equip(MobileEntity mobile, ItemEntity item, LayerType layer)
         => throw new NotSupportedException();
 
@@ -42,6 +45,9 @@ public sealed class StubItemService : IItemService
 
     public IReadOnlyList<ItemEntity> GetEquipped(MobileEntity mobile)
         => _equipped;
+
+    public void MoveToWorld(ItemEntity item, int mapId, Point3D position)
+        => throw new NotSupportedException();
 
     public void RemoveFromContainer(ItemEntity container, ItemEntity item)
         => throw new NotSupportedException();

--- a/tests/Moongate.Tests/Support/StubWorldService.cs
+++ b/tests/Moongate.Tests/Support/StubWorldService.cs
@@ -1,0 +1,32 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Interfaces;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Swallows every outgoing packet and reports no recipients. For tests that care about where entities
+/// end up rather than what the client is told.
+/// </summary>
+public sealed class StubWorldService : IWorldService
+{
+    public int Broadcast<TPacket>(TPacket packet) where TPacket : IOutgoingPacket
+        => 0;
+
+    public void SendEnterWorld(PlayerSession session, MobileEntity mobile) { }
+
+    public int SendToPlayer<TPacket>(Serial mobileId, TPacket packet) where TPacket : IOutgoingPacket
+        => 0;
+
+    public int SendToPlayersInRange<TPacket>(
+        int mapId,
+        Point3D center,
+        int range,
+        TPacket packet,
+        Serial? exclude = null
+    ) where TPacket : IOutgoingPacket
+        => 0;
+}


### PR DESCRIPTION
Implements the drag-and-drop exchange from #123: lift from the ground, a container or a paperdoll layer, drop onto the ground or into a container.

- `PickUpItemPacket` (0x07), `DropItemPacket` (0x08) and `DropItemApprovedPacket` (0x29). The 0x27 rejection packet already existed and had never been sent by anything — this is its first caller.
- `IDragDropService` owns the rules; the lift decision is a pure static, testable without a session, as with `MovementService.Evaluate`. Four checks: already-holding, 2-tile range, template movability, reachability.
- Partial stacks split on lift using ModernUO's inversion (`Mobile.LiftItemDupe`) — the original entity stays on the cursor and the remainder is the new one, so the dragged serial never changes mid-drag — and merge on drop, capped at 60000.
- The held item lives on `PlayerSession` with a bounce record. A failed drop or a disconnect puts it back where it came from, falling back to the backpack and then the player's feet.
- Three primitives were missing and are new: `IItemService.Detach`, `IItemService.MoveToWorld` and `IWorldService.SendToPlayer`. Nothing could place an item on the ground, unhook one into nowhere, or send a packet to a single player by mobile serial.
- First real use of `WorldItemPacket`, `DeleteObjectPacket` and `AddItemToContainerPacket` — ground items are now sent to other players for the first time.
- `ItemTemplate.IsMovable` and `Stackable` were declarative and are now enforced; the docs say so.
- The hardcoded packet-type count in `PacketDocumentationTests` goes 54 → 57.

Also extracts `MovementServiceTests`' private `StubWorldService` into `Support/`: two copies of the same stub would each need updating whenever `IWorldService` grows, which this change ran into immediately.

Out of scope: dropping onto another mobile, equipping by drag (0x13), line of sight, the 0x23 drag effect, weight limits.

Full suite green (1777), docfx at 0 warnings, packet reference regenerated, real boot clean.

**Not smoke-tested with a live client yet** — the two-client check (drop on the ground, second client sees it) needs real ClassicUO sessions.