### PR TITLE
style: second reformat pass with member reordering

### DIFF
--- a/Moongate.slnx
+++ b/Moongate.slnx
@@ -1,21 +1,21 @@
 <Solution>
     <Folder Name="/src/">
-        <Project Path="src/Moongate.Core/Moongate.Core.csproj" />
-        <Project Path="src/Moongate.Network/Moongate.Network.csproj" />
-        <Project Path="src/Moongate.Persistence/Moongate.Persistence.csproj" />
-        <Project Path="src/Moongate.Scripting/Moongate.Scripting.csproj" />
-        <Project Path="src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj" />
-        <Project Path="src/Moongate.Server/Moongate.Server.csproj" />
-        <Project Path="src/Moongate.Ultima/Moongate.Ultima.csproj" />
-        <Project Path="src/Moongate.UO.Data/Moongate.UO.Data.csproj" />
+        <Project Path="src/Moongate.Core/Moongate.Core.csproj"/>
+        <Project Path="src/Moongate.Network/Moongate.Network.csproj"/>
+        <Project Path="src/Moongate.Persistence/Moongate.Persistence.csproj"/>
+        <Project Path="src/Moongate.Scripting/Moongate.Scripting.csproj"/>
+        <Project Path="src/Moongate.Server.Abstractions/Moongate.Server.Abstractions.csproj"/>
+        <Project Path="src/Moongate.Server/Moongate.Server.csproj"/>
+        <Project Path="src/Moongate.Ultima/Moongate.Ultima.csproj"/>
+        <Project Path="src/Moongate.UO.Data/Moongate.UO.Data.csproj"/>
     </Folder>
     <Folder Name="/plugins/">
-        <Project Path="plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj" />
-        <Project Path="plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj" />
-        <Project Path="plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj" />
-        <Project Path="plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj" />
+        <Project Path="plugins/Moongate.Console.Admin.Plugin/Moongate.Console.Admin.Plugin.csproj"/>
+        <Project Path="plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj"/>
+        <Project Path="plugins/Moongate.News.Plugin/Moongate.News.Plugin.csproj"/>
+        <Project Path="plugins/Moongate.Smtp.Plugin/Moongate.Smtp.Plugin.csproj"/>
     </Folder>
     <Folder Name="/tests/">
-        <Project Path="tests/Moongate.Tests/Moongate.Tests.csproj" />
+        <Project Path="tests/Moongate.Tests/Moongate.Tests.csproj"/>
     </Folder>
 </Solution>

--- a/plugins/Moongate.Console.Admin.Plugin/Services/Console/ConsoleInput.cs
+++ b/plugins/Moongate.Console.Admin.Plugin/Services/Console/ConsoleInput.cs
@@ -19,8 +19,8 @@ public static class ConsoleInput
             return ConsoleInputKind.Help;
         }
 
-        if (trimmed.Equals("quit", StringComparison.OrdinalIgnoreCase)
-            || trimmed.Equals("exit", StringComparison.OrdinalIgnoreCase))
+        if (trimmed.Equals("quit", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("exit", StringComparison.OrdinalIgnoreCase))
         {
             return ConsoleInputKind.Quit;
         }

--- a/plugins/Moongate.Console.Admin.Plugin/Services/Console/ConsoleSession.cs
+++ b/plugins/Moongate.Console.Admin.Plugin/Services/Console/ConsoleSession.cs
@@ -42,6 +42,20 @@ public sealed class ConsoleSession
         _dispatcher = dispatcher;
     }
 
+    public void Close()
+    {
+        _closed = true;
+
+        try
+        {
+            _client.Close();
+        }
+        catch (Exception)
+        {
+            // socket already gone
+        }
+    }
+
     public async Task RunAsync(CancellationToken ct)
     {
         try
@@ -112,6 +126,23 @@ public sealed class ConsoleSession
         return null;
     }
 
+    private async Task<string?> ReadLineAsync(StreamReader reader, CancellationToken ct)
+    {
+        var raw = await reader.ReadLineAsync(ct);
+
+        if (raw is null)
+        {
+            return null;
+        }
+
+        if (raw.Length > MaxLineLength)
+        {
+            raw = raw[..MaxLineLength];
+        }
+
+        return TelnetInput.StripControls(raw);
+    }
+
     private async Task ReplLoopAsync(StreamReader reader, AccountLevelType level, CancellationToken ct)
     {
         while (!ct.IsCancellationRequested && !_closed)
@@ -148,6 +179,9 @@ public sealed class ConsoleSession
         }
     }
 
+    private void Write(string text)
+        => WriteRaw(text, false);
+
     private void WriteHelp(AccountLevelType level)
     {
         foreach (var command in _commands.ListCommands(CommandSourceType.Console))
@@ -162,28 +196,8 @@ public sealed class ConsoleSession
         WriteLine("  quit - close the session");
     }
 
-    private async Task<string?> ReadLineAsync(StreamReader reader, CancellationToken ct)
-    {
-        var raw = await reader.ReadLineAsync(ct);
-
-        if (raw is null)
-        {
-            return null;
-        }
-
-        if (raw.Length > MaxLineLength)
-        {
-            raw = raw[..MaxLineLength];
-        }
-
-        return TelnetInput.StripControls(raw);
-    }
-
-    private void Write(string text)
-        => WriteRaw(text, newline: false);
-
     private void WriteLine(string text)
-        => WriteRaw(text, newline: true);
+        => WriteRaw(text, true);
 
     private void WriteRaw(string text, bool newline)
     {
@@ -216,20 +230,6 @@ public sealed class ConsoleSession
             {
                 _closed = true;
             }
-        }
-    }
-
-    public void Close()
-    {
-        _closed = true;
-
-        try
-        {
-            _client.Close();
-        }
-        catch (Exception)
-        {
-            // socket already gone
         }
     }
 }

--- a/plugins/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
+++ b/plugins/Moongate.Console.Admin.Plugin/Services/Hosting/ConsoleServerService.cs
@@ -46,6 +46,12 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
     /// <summary>The port actually bound — the OS-assigned one when the configured port is 0. Zero when disabled.</summary>
     public int BoundPort { get; private set; }
 
+    public void Dispose()
+    {
+        _cts?.Dispose();
+        _listener?.Dispose();
+    }
+
     public ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
         if (!_config.Enabled)
@@ -57,7 +63,7 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
 
         try
         {
-            _listener = new TcpListener(IPAddress.Parse(_config.Address), _config.Port);
+            _listener = new(IPAddress.Parse(_config.Address), _config.Port);
             _listener.Start();
         }
         catch (Exception ex) when (ex is SocketException or FormatException)
@@ -80,6 +86,36 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
         _logger.Information("Admin console listening on {Address}:{Port}", _config.Address, BoundPort);
 
         return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_listener is null)
+        {
+            return;
+        }
+
+        _cts?.Cancel();
+        _listener.Stop();
+
+        foreach (var session in _sessions.Keys)
+        {
+            session.Close();
+        }
+
+        if (_acceptLoop is not null)
+        {
+            try
+            {
+                await _acceptLoop;
+            }
+            catch (Exception)
+            {
+                // accept loop unwinding on cancellation — nothing to report
+            }
+        }
+
+        _listener = null;
     }
 
     private async Task AcceptLoopAsync(CancellationToken ct)
@@ -116,12 +152,8 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
                 );
             }
         }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (ObjectDisposedException)
-        {
-        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
     }
 
     private static async Task RejectAsync(TcpClient client)
@@ -140,41 +172,5 @@ public sealed class ConsoleServerService : ISquidStdService, IDisposable
         {
             client.Close();
         }
-    }
-
-    public async ValueTask StopAsync(CancellationToken cancellationToken = default)
-    {
-        if (_listener is null)
-        {
-            return;
-        }
-
-        _cts?.Cancel();
-        _listener.Stop();
-
-        foreach (var session in _sessions.Keys)
-        {
-            session.Close();
-        }
-
-        if (_acceptLoop is not null)
-        {
-            try
-            {
-                await _acceptLoop;
-            }
-            catch (Exception)
-            {
-                // accept loop unwinding on cancellation — nothing to report
-            }
-        }
-
-        _listener = null;
-    }
-
-    public void Dispose()
-    {
-        _cts?.Dispose();
-        _listener?.Dispose();
     }
 }

--- a/plugins/Moongate.Http.Plugin/Data/Api/Plugins/PluginInfoResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Plugins/PluginInfoResponse.cs
@@ -7,6 +7,7 @@ namespace Moongate.Http.Plugin.Data.Api.Plugins;
 public record PluginInfoResponse(
     string Id,
     string Name,
+
     // Qualified: Moongate.Http.Plugin.Data.Api.Version is a sibling namespace of this one, so an
     // unqualified Version binds to it rather than to the type.
     System.Version Version,

--- a/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerInfoResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/ServerInfo/ServerInfoResponse.cs
@@ -1,6 +1,9 @@
 namespace Moongate.Http.Plugin.Data.Api.ServerInfo;
 
-/// <summary>The public server profile a website or launcher reads: identity, contacts, assets, and effective registration availability.</summary>
+/// <summary>
+/// The public server profile a website or launcher reads: identity, contacts, assets, and effective registration
+/// availability.
+/// </summary>
 public sealed record ServerInfoResponse(
     string ShardName,
     string? Description,

--- a/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Accounts/AccountEndpoints.cs
@@ -36,14 +36,14 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/accounts")
-            .WithTags("accounts")
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                          .WithTags("accounts")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapGet("/", List).WithName("ListAccounts").Produces<IReadOnlyList<AccountResponse>>();
         group.MapGet("/{username}", Get).WithName("GetAccount").Produces<AccountResponse>();
         group.MapPost("/", Create)
-            .WithName("CreateAccount")
-            .Produces<AccountResponse>(StatusCodes.Status201Created);
+             .WithName("CreateAccount")
+             .Produces<AccountResponse>(StatusCodes.Status201Created);
         group.MapPatch("/{username}", Update).WithName("UpdateAccount").Produces<AccountResponse>();
         group.MapDelete("/{username}", Delete).WithName("DeleteAccount").Produces(StatusCodes.Status204NoContent);
     }
@@ -113,9 +113,9 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         try
         {
             created = await _loop.InvokeAsync(
-                () => _accounts.Create(request.Username, request.Password, request.Email, level),
-                DeleteTimeout
-            );
+                          () => _accounts.Create(request.Username, request.Password, request.Email, level),
+                          DeleteTimeout
+                      );
         }
         catch (TimeoutException)
         {
@@ -200,8 +200,8 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
     /// <remarks>Answers 404 when no account carries that username.</remarks>
     private IResult Get(string username)
         => _accounts.GetByUsername(username) is { } account
-            ? Results.Ok(ToResponse(account))
-            : NotFound(username);
+               ? Results.Ok(ToResponse(account))
+               : NotFound(username);
 
     /// <summary>Lists every account on the shard.</summary>
     /// <remarks>Passwords are never returned, by any account route.</remarks>
@@ -229,7 +229,7 @@ public sealed class AccountEndpoints : IApiEndpointRegistration
         // The setters run together on the loop so a concurrent delete cannot land between them.
         try
         {
-            await _loop.InvokeAsync<bool>(
+            await _loop.InvokeAsync(
                 () =>
                 {
                     if (request.Level is not null)

--- a/plugins/Moongate.Http.Plugin/Endpoints/Admin/AdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Admin/AdminEndpoints.cs
@@ -24,10 +24,10 @@ public sealed class AdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/status", Status)
-            .WithName("GetAdminStatus")
-            .WithTags("admin")
-            .Produces<AdminStatusResponse>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                 .WithName("GetAdminStatus")
+                 .WithTags("admin")
+                 .Produces<AdminStatusResponse>()
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Reports the shard's name, build and how many sessions are connected.</summary>
     /// <remarks>A snapshot taken when the request is served, not a live figure.</remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Auth/AuthEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Auth/AuthEndpoints.cs
@@ -39,16 +39,16 @@ public sealed class AuthEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapPost("/api/v1/auth/login", Login)
-            .WithName("Login")
-            .WithTags("auth")
-            .Produces<ApiTokenResult>()
-            .AllowAnonymous();
+              .WithName("Login")
+              .WithTags("auth")
+              .Produces<ApiTokenResult>()
+              .AllowAnonymous();
 
         routes.MapPost("/api/v1/auth/renew", Renew)
-            .WithName("RenewToken")
-            .WithTags("auth")
-            .Produces<ApiTokenResult>()
-            .RequireAuthorization(HttpServerService.PlayerPolicy);
+              .WithName("RenewToken")
+              .WithTags("auth")
+              .Produces<ApiTokenResult>()
+              .RequireAuthorization(HttpServerService.PlayerPolicy);
     }
 
     /// <summary>Trades account credentials for a bearer token.</summary>
@@ -76,9 +76,7 @@ public sealed class AuthEndpoints : IApiEndpointRegistration
             return Results.Unauthorized();
         }
 
-        return Results.Ok(
-            _tokens.Issue(account.Id, account.Username, account.AccountLevel, _timeProvider.GetUtcNow())
-        );
+        return Results.Ok(_tokens.Issue(account.Id, account.Username, account.AccountLevel, _timeProvider.GetUtcNow()));
     }
 
     /// <summary>Exchanges a still-valid token for a fresh one, so an active session does not expire mid-use.</summary>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterAdminEndpoints.cs
@@ -21,10 +21,10 @@ public sealed class CharacterAdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/characters", List)
-            .WithName("ListCharacters")
-            .WithTags("characters")
-            .Produces<PagedResponse<CharacterResponse>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                 .WithName("ListCharacters")
+                 .WithTags("characters")
+                 .Produces<PagedResponse<CharacterResponse>>()
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Every player character on the shard, paged.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterEndpoints.cs
@@ -29,10 +29,10 @@ public sealed class CharacterEndpoints : IApiEndpointRegistration
         // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
         // has none — the route would document itself blank.
         => routes.MapGet("/api/v1/player/me/characters", GetMine)
-            .WithName("GetMyCharacters")
-            .WithTags("player")
-            .Produces<IReadOnlyList<CharacterResponse>>()
-            .RequireAuthorization(HttpServerService.PlayerPolicy);
+                 .WithName("GetMyCharacters")
+                 .WithTags("player")
+                 .Produces<IReadOnlyList<CharacterResponse>>()
+                 .RequireAuthorization(HttpServerService.PlayerPolicy);
 
     /// <summary>
     /// Reads the account id the token was issued with. JwtTokenService writes it into <c>sub</c>, but
@@ -84,7 +84,7 @@ public sealed class CharacterEndpoints : IApiEndpointRegistration
 
         return Results.Ok(
             _characters.GetPlayerCharacters(accountId)
-                .Select(mobile => CharacterResponse.From(mobile, null))
+                       .Select(mobile => CharacterResponse.From(mobile, null))
         );
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Console/ConsoleEndpoints.cs
@@ -1,11 +1,9 @@
-using System.Net.ServerSentEvents;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Moongate.Core.Types;
 using Moongate.Http.Plugin.Data.Api.Console;
-using Moongate.Http.Plugin.Data.Console;
 using Moongate.Http.Plugin.Interfaces.Console;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
 using Moongate.Http.Plugin.Services.Console;
@@ -34,35 +32,26 @@ public sealed class ConsoleEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/admin/console/stream", Stream)
-            .WithName("StreamConsole")
-            .WithTags("console")
+              .WithName("StreamConsole")
+              .WithTags("console")
 
-            // An event stream, not JSON: the frames have no schema a generated client could bind to,
-            // only a content type worth stating.
-            .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              // An event stream, not JSON: the frames have no schema a generated client could bind to,
+              // only a content type worth stating.
+              .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
+              .RequireAuthorization(HttpServerService.AdminPolicy);
 
         routes.MapPost("/api/v1/admin/console", Send)
-            .WithName("SendConsoleCommand")
-            .WithTags("console")
-            .Produces(StatusCodes.Status202Accepted)
-            .RequireAuthorization(HttpServerService.AdminPolicy);
-    }
-
-    /// <summary>Opens a per-connection SSE feed; its first event carries the connection id to POST with.</summary>
-    /// <remarks>Emits <c>ready</c> (data = the connection id), then a <c>line</c> per command reply and a
-    /// <c>done</c> when a command finishes. The connection is closed when the client disconnects.</remarks>
-    private IResult Stream(HttpContext context)
-    {
-        var (connectionId, reader) = _registry.Open();
-        context.RequestAborted.Register(() => _registry.Close(connectionId));
-
-        return TypedResults.ServerSentEvents(ConsoleSseStream.From(connectionId, reader, context.RequestAborted));
+              .WithName("SendConsoleCommand")
+              .WithTags("console")
+              .Produces(StatusCodes.Status202Accepted)
+              .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     /// <summary>Runs a console command; its reply lines stream to the given connection's SSE feed.</summary>
-    /// <remarks>Returns 202 immediately — the command is dispatched onto the game loop and its output
-    /// arrives asynchronously on <c>GET /api/v1/admin/console/stream</c>.</remarks>
+    /// <remarks>
+    /// Returns 202 immediately — the command is dispatched onto the game loop and its output
+    /// arrives asynchronously on <c>GET /api/v1/admin/console/stream</c>.
+    /// </remarks>
     private IResult Send(ConsoleCommandRequest request, ClaimsPrincipal user)
     {
         // Unknown or already-closed connection: nothing to stream to.
@@ -82,16 +71,30 @@ public sealed class ConsoleEndpoints : IApiEndpointRegistration
             level,
             null,
             request.Command,
-            line => writer.TryWrite(new ConsoleStreamEvent("line", line))
+            line => writer.TryWrite(new("line", line))
         );
 
-        _dispatcher.Post(() =>
+        _dispatcher.Post(
+            () =>
             {
                 _commands.Execute(invocation);
-                writer.TryWrite(new ConsoleStreamEvent("done", request.Command));
+                writer.TryWrite(new("done", request.Command));
             }
         );
 
         return TypedResults.Accepted((string?)null);
+    }
+
+    /// <summary>Opens a per-connection SSE feed; its first event carries the connection id to POST with.</summary>
+    /// <remarks>
+    /// Emits <c>ready</c> (data = the connection id), then a <c>line</c> per command reply and a
+    /// <c>done</c> when a command finishes. The connection is closed when the client disconnects.
+    /// </remarks>
+    private IResult Stream(HttpContext context)
+    {
+        var (connectionId, reader) = _registry.Open();
+        context.RequestAborted.Register(() => _registry.Close(connectionId));
+
+        return TypedResults.ServerSentEvents(ConsoleSseStream.From(connectionId, reader, context.RequestAborted));
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageAdminEndpoints.cs
@@ -23,12 +23,12 @@ public sealed class ItemImageAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/images/items")
-            .WithTags("images")
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                          .WithTags("images")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapPost("/", Start)
-            .WithName("StartItemImageExport")
-            .Produces<ItemImageExportStatus>(StatusCodes.Status202Accepted);
+             .WithName("StartItemImageExport")
+             .Produces<ItemImageExportStatus>(StatusCodes.Status202Accepted);
         group.MapGet("/", GetStatus).WithName("GetItemImageExportStatus").Produces<ItemImageExportStatus>();
     }
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Images/ItemImageEndpoints.cs
@@ -25,10 +25,10 @@ public sealed class ItemImageEndpoints : IApiEndpointRegistration
         // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
         // has none — the route would document itself blank.
         => routes.MapGet("/api/v1/images/items/{id}.png", Get)
-            .WithName("GetItemImage")
-            .WithTags("images")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
-            .AllowAnonymous();
+                 .WithName("GetItemImage")
+                 .WithTags("images")
+                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
+                 .AllowAnonymous();
 
     /// <summary>
     /// Hex, with or without the prefix. A bare "1234" is hex too: the route is documented as 0xITEM_ID,
@@ -110,10 +110,10 @@ public sealed class ItemImageEndpoints : IApiEndpointRegistration
         var path = await _images.GetOrCreateAsync(itemId, hueValue, cancellationToken);
 
         return path is null
-            ? Results.Problem(
-                $"No art for item 0x{itemId:x4}.",
-                statusCode: StatusCodes.Status404NotFound
-            )
-            : Results.File(path, "image/png");
+                   ? Results.Problem(
+                       $"No art for item 0x{itemId:x4}.",
+                       statusCode: StatusCodes.Status404NotFound
+                   )
+                   : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Items/ItemTemplateEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Items/ItemTemplateEndpoints.cs
@@ -23,16 +23,16 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/admin/items/templates", List)
-            .WithName("ListItemTemplates")
-            .WithTags("items")
-            .Produces<PagedResponse<ItemTemplateSummaryResponse>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("ListItemTemplates")
+              .WithTags("items")
+              .Produces<PagedResponse<ItemTemplateSummaryResponse>>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
 
         routes.MapGet("/api/v1/admin/items/templates/{id}", Get)
-            .WithName("GetItemTemplate")
-            .WithTags("items")
-            .Produces<ItemTemplateResponse>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("GetItemTemplate")
+              .WithTags("items")
+              .Produces<ItemTemplateResponse>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     private static List<ItemTemplate> Filter(IReadOnlyList<ItemTemplate> all, string? search)
@@ -44,11 +44,12 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
 
         return
         [
-            .. all.Where(template =>
-                Matches(template.Id, search) ||
-                Matches(template.Name, search) ||
-                Matches(template.Category, search) ||
-                template.Tags.Any(tag => Matches(tag, search))
+            .. all.Where(
+                template =>
+                    Matches(template.Id, search) ||
+                    Matches(template.Name, search) ||
+                    Matches(template.Category, search) ||
+                    template.Tags.Any(tag => Matches(tag, search))
             )
         ];
     }
@@ -60,8 +61,8 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
         var template = _templates.GetById(id);
 
         return template is null
-            ? Results.Problem($"No item template with id '{id}'.", statusCode: StatusCodes.Status404NotFound)
-            : Results.Ok(ItemTemplateResponse.From(template));
+                   ? Results.Problem($"No item template with id '{id}'.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.Ok(ItemTemplateResponse.From(template));
     }
 
     /// <summary>Every item template, paged.</summary>
@@ -82,9 +83,9 @@ public sealed class ItemTemplateEndpoints : IApiEndpointRegistration
         IReadOnlyList<ItemTemplateSummaryResponse> items =
         [
             .. matched.OrderBy(template => template.Id, StringComparer.OrdinalIgnoreCase)
-                .Skip(request.Skip)
-                .Take(request.PageSize)
-                .Select(ItemTemplateSummaryResponse.From)
+                      .Skip(request.Skip)
+                      .Take(request.PageSize)
+                      .Select(ItemTemplateSummaryResponse.From)
         ];
 
         return Results.Ok(PagedResponse<ItemTemplateSummaryResponse>.From(items, matched.Count, request));

--- a/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageAdminEndpoints.cs
@@ -23,12 +23,12 @@ public sealed class MapImageAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/images/maps")
-            .WithTags("images")
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                          .WithTags("images")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapPost("/", Start)
-            .WithName("StartMapImageExport")
-            .Produces<MapImageExportStatus>(StatusCodes.Status202Accepted);
+             .WithName("StartMapImageExport")
+             .Produces<MapImageExportStatus>(StatusCodes.Status202Accepted);
         group.MapGet("/", GetStatus).WithName("GetMapImageExportStatus").Produces<MapImageExportStatus>();
     }
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Maps/MapImageEndpoints.cs
@@ -27,23 +27,23 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
         // Method groups, not lambdas: Swashbuckle reads the /// off the handler's method, and a lambda has
         // none — the route would document itself blank.
         routes.MapGet("/api/v1/images/maps", List)
-            .WithName("ListMaps")
-            .WithTags("images")
-            .Produces<IReadOnlyList<MapFacetInfo>>()
-            .AllowAnonymous();
+              .WithName("ListMaps")
+              .WithTags("images")
+              .Produces<IReadOnlyList<MapFacetInfo>>()
+              .AllowAnonymous();
 
         // Before the tile route, so "full" is never read as a zoom.
         routes.MapGet("/api/v1/images/maps/{map}/full.png", GetFull)
-            .WithName("GetFullMapImage")
-            .WithTags("images")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
-            .AllowAnonymous();
+              .WithName("GetFullMapImage")
+              .WithTags("images")
+              .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
+              .AllowAnonymous();
 
         routes.MapGet("/api/v1/images/maps/{map}/{z}/{x}/{y}.png", GetTile)
-            .WithName("GetMapTile")
-            .WithTags("images")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
-            .AllowAnonymous();
+              .WithName("GetMapTile")
+              .WithTags("images")
+              .Produces<byte[]>(StatusCodes.Status200OK, "image/png")
+              .AllowAnonymous();
     }
 
     /// <summary>A whole facet as one PNG.</summary>
@@ -73,8 +73,8 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
         var path = await _maps.GetFullAsync(facet, renderStyle, cancellationToken);
 
         return path is null
-            ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)
-            : Results.File(path, "image/png");
+                   ? Results.Problem($"{facet} is not served by this shard.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.File(path, "image/png");
     }
 
     /// <summary>One map tile.</summary>
@@ -137,11 +137,11 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
         var path = await _maps.GetTileAsync(facet, renderStyle, zoom, x, y, cancellationToken);
 
         return path is null
-            ? Results.Problem(
-                $"No tile {x},{y} at zoom {zoom} for {facet}.",
-                statusCode: StatusCodes.Status404NotFound
-            )
-            : Results.File(path, "image/png");
+                   ? Results.Problem(
+                       $"No tile {x},{y} at zoom {zoom} for {facet}.",
+                       statusCode: StatusCodes.Status404NotFound
+                   )
+                   : Results.File(path, "image/png");
     }
 
     private static IResult InvalidFacet(string name)
@@ -170,23 +170,24 @@ public sealed class MapImageEndpoints : IApiEndpointRegistration
 
         return Results.Ok(
             _provider.Facets
-                .Select(facet => (Facet: facet, Map: _provider.Get(facet)))
-                .Where(entry => entry.Map is not null)
-                .Select(entry =>
-                    {
-                        var maxZoom = _maps.MaxZoomFor(entry.Facet);
+                     .Select(facet => (Facet: facet, Map: _provider.Get(facet)))
+                     .Where(entry => entry.Map is not null)
+                     .Select(
+                         entry =>
+                         {
+                             var maxZoom = _maps.MaxZoomFor(entry.Facet);
 
-                        return new MapFacetInfo(
-                            entry.Facet.ToString(),
-                            entry.Map!.Width,
-                            entry.Map.Height,
-                            maxZoom,
-                            MapTileGeometry.TileSize,
-                            MapTileGeometry.TilesAcross(entry.Map.Width, maxZoom, maxZoom),
-                            MapTileGeometry.TilesDown(entry.Map.Height, maxZoom, maxZoom)
-                        );
-                    }
-                )
+                             return new MapFacetInfo(
+                                 entry.Facet.ToString(),
+                                 entry.Map!.Width,
+                                 entry.Map.Height,
+                                 maxZoom,
+                                 MapTileGeometry.TileSize,
+                                 MapTileGeometry.TilesAcross(entry.Map.Width, maxZoom, maxZoom),
+                                 MapTileGeometry.TilesDown(entry.Map.Height, maxZoom, maxZoom)
+                             );
+                         }
+                     )
         );
     }
 

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/BodyImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/BodyImageEndpoints.cs
@@ -18,9 +18,9 @@ public sealed class BodyImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/bodies/{body}.png", Get)
-            .WithName("GetBodyImage")
-            .WithTags("mobiles")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+                 .WithName("GetBodyImage")
+                 .WithTags("mobiles")
+                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves a body's idle, front-facing frame as PNG.</summary>
     /// <remarks>
@@ -38,7 +38,7 @@ public sealed class BodyImageEndpoints : IApiEndpointRegistration
         var path = await _bodies.GetOrCreateAsync(bodyId, hue.GetValueOrDefault(), cancellationToken);
 
         return path is null
-            ? Results.Problem($"No animation for body {bodyId}.", statusCode: StatusCodes.Status404NotFound)
-            : Results.File(path, "image/png");
+                   ? Results.Problem($"No animation for body {bodyId}.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/HairImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/HairImageEndpoints.cs
@@ -20,9 +20,9 @@ public sealed class HairImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/hair/{style}.png", Get)
-            .WithName("GetHairImage")
-            .WithTags("mobiles")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+                 .WithName("GetHairImage")
+                 .WithTags("mobiles")
+                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves a hair (or facial-hair) style as PNG, rendered over a reference body.</summary>
     /// <remarks>
@@ -39,15 +39,15 @@ public sealed class HairImageEndpoints : IApiEndpointRegistration
 
         var referenceBody = body is > 0 ? body.Value : DefaultReferenceBody;
         var path = await _hair.GetOrCreateAsync(
-            styleId,
-            hue.GetValueOrDefault(),
-            referenceBody,
-            facial.GetValueOrDefault(),
-            cancellationToken
-        );
+                       styleId,
+                       hue.GetValueOrDefault(),
+                       referenceBody,
+                       facial.GetValueOrDefault(),
+                       cancellationToken
+                   );
 
         return path is null
-            ? Results.Problem($"Nothing decodes for style {styleId}.", statusCode: StatusCodes.Status404NotFound)
-            : Results.File(path, "image/png");
+                   ? Results.Problem($"Nothing decodes for style {styleId}.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileImageAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileImageAdminEndpoints.cs
@@ -33,25 +33,25 @@ public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var export = routes.MapGroup("/api/v1/admin/images/bodies")
-            .WithTags("mobiles")
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                           .WithTags("mobiles")
+                           .RequireAuthorization(HttpServerService.AdminPolicy);
 
         export.MapPost("/", Start)
-            .WithName("StartBodyImageExport")
-            .Produces<BodyImageExportStatus>(StatusCodes.Status202Accepted);
+              .WithName("StartBodyImageExport")
+              .Produces<BodyImageExportStatus>(StatusCodes.Status202Accepted);
         export.MapGet("/", GetStatus).WithName("GetBodyImageExportStatus").Produces<BodyImageExportStatus>();
 
         routes.MapGet("/api/v1/admin/bodies", ListBodies)
-            .WithName("ListBodies")
-            .WithTags("mobiles")
-            .Produces<PagedResponse<BodySummary>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("ListBodies")
+              .WithTags("mobiles")
+              .Produces<PagedResponse<BodySummary>>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
 
         routes.MapGet("/api/v1/admin/hair-styles", ListHairStyles)
-            .WithName("ListHairStyles")
-            .WithTags("mobiles")
-            .Produces<PagedResponse<HairStyleSummary>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("ListHairStyles")
+              .WithTags("mobiles")
+              .Produces<PagedResponse<HairStyleSummary>>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     /// <summary>Reports how far the body image export has got.</summary>
@@ -72,16 +72,16 @@ public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
         }
 
         var classified = _catalog.ClassifiedBodies
-            .Where(entry => entry.Type != MobType.Equipment)
-            .Where(entry => Matches(entry.Body, request.Search))
-            .OrderBy(entry => entry.Body)
-            .ToArray();
+                                 .Where(entry => entry.Type != MobType.Equipment)
+                                 .Where(entry => Matches(entry.Body, request.Search))
+                                 .OrderBy(entry => entry.Body)
+                                 .ToArray();
 
         IReadOnlyList<BodySummary> items =
         [
             .. classified.Skip(request.Skip)
-                .Take(request.PageSize)
-                .Select(entry => BodySummary.From(entry.Body, entry.Type))
+                         .Take(request.PageSize)
+                         .Select(entry => BodySummary.From(entry.Body, entry.Type))
         ];
 
         return Results.Ok(PagedResponse<BodySummary>.From(items, classified.Length, request));
@@ -98,10 +98,11 @@ public sealed class MobileImageAdminEndpoints : IApiEndpointRegistration
 
         var source = facial.GetValueOrDefault() ? HairStyleCatalog.Facial : HairStyleCatalog.Hair;
         var matched = source
-            .Where(entry => request.Search is null ||
-                            entry.Name.Contains(request.Search, StringComparison.OrdinalIgnoreCase)
-            )
-            .ToArray();
+                      .Where(
+                          entry => request.Search is null ||
+                                   entry.Name.Contains(request.Search, StringComparison.OrdinalIgnoreCase)
+                      )
+                      .ToArray();
 
         IReadOnlyList<HairStyleSummary> items =
         [

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateImageEndpoints.cs
@@ -18,9 +18,9 @@ public sealed class MobileTemplateImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/mobiles/templates/{id}.png", Get)
-            .WithName("GetMobileTemplateImage")
-            .WithTags("mobiles")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+                 .WithName("GetMobileTemplateImage")
+                 .WithTags("mobiles")
+                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves a mobile template's dressed figure as PNG: body, hair and worn equipment.</summary>
     /// <remarks>
@@ -32,7 +32,7 @@ public sealed class MobileTemplateImageEndpoints : IApiEndpointRegistration
         var path = await _figures.GetOrCreateAsync(id, cancellationToken);
 
         return path is null
-            ? Results.Problem($"No renderable figure for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
-            : Results.File(path, "image/png");
+                   ? Results.Problem($"No renderable figure for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/PaperdollEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/PaperdollEndpoints.cs
@@ -18,9 +18,9 @@ public sealed class PaperdollEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/images/mobiles/templates/{id}/paperdoll.png", Get)
-            .WithName("GetMobileTemplatePaperdoll")
-            .WithTags("mobiles")
-            .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+                 .WithName("GetMobileTemplatePaperdoll")
+                 .WithTags("mobiles")
+                 .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
     /// <summary>Serves the template's classic client paperdoll as PNG: background, body, hair, equipment.</summary>
     /// <remarks>
@@ -33,7 +33,7 @@ public sealed class PaperdollEndpoints : IApiEndpointRegistration
         var path = await _paperdolls.GetOrCreateAsync(id, background.GetValueOrDefault(true), cancellationToken);
 
         return path is null
-            ? Results.Problem($"No paperdoll for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
-            : Results.File(path, "image/png");
+                   ? Results.Problem($"No paperdoll for template '{id}'.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.File(path, "image/png");
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Players/OnlinePlayerAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Players/OnlinePlayerAdminEndpoints.cs
@@ -21,10 +21,10 @@ public sealed class OnlinePlayerAdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/players/online", List)
-            .WithName("ListOnlinePlayers")
-            .WithTags("players")
-            .Produces<IReadOnlyList<OnlinePlayerMapResponse>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                 .WithName("ListOnlinePlayers")
+                 .WithTags("players")
+                 .Produces<IReadOnlyList<OnlinePlayerMapResponse>>()
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Lists players who have entered the world with map-ready positions.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Players/PlayerEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Players/PlayerEndpoints.cs
@@ -16,10 +16,10 @@ public sealed class PlayerEndpoints : IApiEndpointRegistration
     // generated types have no shape to bind to.
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/player/me", Me)
-            .WithName("GetPlayerMe")
-            .WithTags("player")
-            .Produces<PlayerMeResponse>()
-            .RequireAuthorization(HttpServerService.PlayerPolicy);
+                 .WithName("GetPlayerMe")
+                 .WithTags("player")
+                 .Produces<PlayerMeResponse>()
+                 .RequireAuthorization(HttpServerService.PlayerPolicy);
 
     /// <summary>Reports the account the bearer token belongs to.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Endpoints/Plugins/PluginAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Plugins/PluginAdminEndpoints.cs
@@ -29,10 +29,10 @@ public sealed class PluginAdminEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/admin/plugins", Get)
-            .WithName("GetAdminPlugins")
-            .WithTags("admin")
-            .Produces<IReadOnlyList<PluginInfoResponse>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                 .WithName("GetAdminPlugins")
+                 .WithTags("admin")
+                 .Produces<IReadOnlyList<PluginInfoResponse>>()
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
 
     /// <summary>Lists the plugins this shard activated, each with the HTTP routes it declares.</summary>
     /// <remarks>
@@ -57,38 +57,14 @@ public sealed class PluginAdminEndpoints : IApiEndpointRegistration
         var plugins = _catalog.Plugins.Select(plugin => ToResponse(plugin, byAssembly)).ToList();
 
         var unattributed = byAssembly.Where(entry => !catalogued.Contains(entry.Key))
-            .SelectMany(entry => entry.Value)
-            .Select(ToResponse)
-            .ToList();
+                                     .SelectMany(entry => entry.Value)
+                                     .Select(ToResponse)
+                                     .ToList();
 
         plugins.Add(Host(unattributed));
 
         return Results.Ok(plugins);
     }
-
-    private static PluginInfoResponse ToResponse(
-        PluginDescriptor plugin,
-        IReadOnlyDictionary<string, IReadOnlyList<PluginRouteInfo>> byAssembly
-    )
-    {
-        var routes = byAssembly.TryGetValue(plugin.AssemblyName, out var declared)
-            ? declared.Select(ToResponse).ToList()
-            : [];
-
-        return new(
-            plugin.Id,
-            plugin.Name,
-            plugin.Version,
-            plugin.Author,
-            plugin.Description,
-            plugin.AssemblyName,
-            plugin.IsExternal,
-            routes
-        );
-    }
-
-    private static PluginRouteResponse ToResponse(PluginRouteInfo route)
-        => new(route.Method, route.Path, route.Policy);
 
     /// <summary>
     /// The catch-all entry. Its version is this plugin's own: there is no host assembly to read here,
@@ -108,4 +84,28 @@ public sealed class PluginAdminEndpoints : IApiEndpointRegistration
             false,
             routes
         );
+
+    private static PluginInfoResponse ToResponse(
+        PluginDescriptor plugin,
+        IReadOnlyDictionary<string, IReadOnlyList<PluginRouteInfo>> byAssembly
+    )
+    {
+        var routes = byAssembly.TryGetValue(plugin.AssemblyName, out var declared)
+                         ? declared.Select(ToResponse).ToList()
+                         : [];
+
+        return new(
+            plugin.Id,
+            plugin.Name,
+            plugin.Version,
+            plugin.Author,
+            plugin.Description,
+            plugin.AssemblyName,
+            plugin.IsExternal,
+            routes
+        );
+    }
+
+    private static PluginRouteResponse ToResponse(PluginRouteInfo route)
+        => new(route.Method, route.Path, route.Policy);
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Registration/RegistrationEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Registration/RegistrationEndpoints.cs
@@ -36,32 +36,42 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapPost("/api/v1/register", RegisterAccount)
-            .WithName("RegisterAccount")
-            .Produces(StatusCodes.Status202Accepted)
-            .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status403Forbidden)
-            .ProducesProblem(StatusCodes.Status409Conflict)
-            .ProducesProblem(StatusCodes.Status429TooManyRequests)
-            .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
-            .ProducesProblem(StatusCodes.Status500InternalServerError)
-            .WithTags("registration")
-            .AllowAnonymous();
+              .WithName("RegisterAccount")
+              .Produces(StatusCodes.Status202Accepted)
+              .ProducesValidationProblem()
+              .ProducesProblem(StatusCodes.Status403Forbidden)
+              .ProducesProblem(StatusCodes.Status409Conflict)
+              .ProducesProblem(StatusCodes.Status429TooManyRequests)
+              .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
+              .ProducesProblem(StatusCodes.Status500InternalServerError)
+              .WithTags("registration")
+              .AllowAnonymous();
         routes.MapPost("/api/v1/register/verify", Verify)
-            .WithName("VerifyRegistration")
-            .WithTags("registration")
-            .Produces(StatusCodes.Status200OK)
-            .ProducesProblem(StatusCodes.Status400BadRequest)
-            .ProducesProblem(StatusCodes.Status410Gone)
-            .AllowAnonymous();
+              .WithName("VerifyRegistration")
+              .WithTags("registration")
+              .Produces(StatusCodes.Status200OK)
+              .ProducesProblem(StatusCodes.Status400BadRequest)
+              .ProducesProblem(StatusCodes.Status410Gone)
+              .AllowAnonymous();
         routes.MapPost("/api/v1/register/resend", ResendVerification)
-            .WithName("ResendRegistrationVerification")
-            .WithTags("registration")
-            .Produces(StatusCodes.Status202Accepted)
-            .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status429TooManyRequests)
-            .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
-            .ProducesProblem(StatusCodes.Status500InternalServerError)
-            .AllowAnonymous();
+              .WithName("ResendRegistrationVerification")
+              .WithTags("registration")
+              .Produces(StatusCodes.Status202Accepted)
+              .ProducesValidationProblem()
+              .ProducesProblem(StatusCodes.Status429TooManyRequests)
+              .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
+              .ProducesProblem(StatusCodes.Status500InternalServerError)
+              .AllowAnonymous();
+    }
+
+    private static string BuildResendTargetKey(ResendVerificationRequest request)
+    {
+        var username = (request.Username ?? string.Empty).Trim();
+        var email = (request.Email ?? string.Empty).Trim().ToUpperInvariant();
+        var target = $"{username}\n{email}";
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(target));
+
+        return $"resend:target:{Convert.ToHexString(digest)}";
     }
 
     /// <summary>Registers a new account when web registration is open.</summary>
@@ -116,22 +126,6 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
         };
     }
 
-    /// <summary>Verifies an account's email with its token, activating the account.</summary>
-    /// <remarks>Answers 410 for an expired token and 400 for an unknown or already-used token.</remarks>
-    private IResult Verify(VerifyEmailRequest request)
-        => _accounts.VerifyEmail(request.Token) switch
-        {
-            AccountVerifyResultType.Verified => Results.Ok(),
-            AccountVerifyResultType.ExpiredToken => Results.Problem(
-                "Verification token expired.",
-                statusCode: StatusCodes.Status410Gone
-            ),
-            _ => Results.Problem(
-                "Invalid or already-used verification token.",
-                statusCode: StatusCodes.Status400BadRequest
-            )
-        };
-
     /// <summary>Resends the verification message for a matching pending public registration.</summary>
     /// <remarks>
     /// Answers 202 whether or not the supplied identity matches a pending account, so callers cannot
@@ -180,16 +174,22 @@ public sealed class RegistrationEndpoints : IApiEndpointRegistration
         };
     }
 
-    private static string BuildResendTargetKey(ResendVerificationRequest request)
-    {
-        var username = (request.Username ?? string.Empty).Trim();
-        var email = (request.Email ?? string.Empty).Trim().ToUpperInvariant();
-        var target = $"{username}\n{email}";
-        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(target));
-
-        return $"resend:target:{Convert.ToHexString(digest)}";
-    }
-
     private static IResult ValidationProblem(string field, string message)
         => Results.ValidationProblem(new Dictionary<string, string[]> { [field] = [message] });
+
+    /// <summary>Verifies an account's email with its token, activating the account.</summary>
+    /// <remarks>Answers 410 for an expired token and 400 for an unknown or already-used token.</remarks>
+    private IResult Verify(VerifyEmailRequest request)
+        => _accounts.VerifyEmail(request.Token) switch
+        {
+            AccountVerifyResultType.Verified => Results.Ok(),
+            AccountVerifyResultType.ExpiredToken => Results.Problem(
+                "Verification token expired.",
+                statusCode: StatusCodes.Status410Gone
+            ),
+            _ => Results.Problem(
+                "Invalid or already-used verification token.",
+                statusCode: StatusCodes.Status400BadRequest
+            )
+        };
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerInfoEndpoints.cs
@@ -36,18 +36,18 @@ public sealed class ServerInfoEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/server-info", Get)
-            .WithName("GetServerInfo")
-            .WithTags("server-info")
-            .Produces<ServerInfoResponse>()
-            .AllowAnonymous();
+              .WithName("GetServerInfo")
+              .WithTags("server-info")
+              .Produces<ServerInfoResponse>()
+              .AllowAnonymous();
         routes.MapGet("/api/v1/server-info/assets/{slot}", GetAsset)
-            .WithName("GetServerAsset")
-            .WithTags("server-info")
+              .WithName("GetServerAsset")
+              .WithTags("server-info")
 
-            // Binary, but no content type stated: the slot decides it. An operator's logo may be a PNG,
-            // an SVG or an ICO, and naming one here would document a promise the route does not make.
-            .Produces<byte[]>(StatusCodes.Status200OK)
-            .AllowAnonymous();
+              // Binary, but no content type stated: the slot decides it. An operator's logo may be a PNG,
+              // an SVG or an ICO, and naming one here would document a promise the route does not make.
+              .Produces<byte[]>()
+              .AllowAnonymous();
     }
 
     internal static ServerInfoResponse ToResponse(
@@ -80,7 +80,7 @@ public sealed class ServerInfoEndpoints : IApiEndpointRegistration
     /// <remarks>Answers 400 for an unknown slot and 404 when the slot has no asset.</remarks>
     private IResult GetAsset(string slot)
     {
-        if (!Enum.TryParse<ServerAssetSlotType>(slot, ignoreCase: true, out var parsed))
+        if (!Enum.TryParse<ServerAssetSlotType>(slot, true, out var parsed))
         {
             return Results.Problem($"'{slot}' is not an asset slot.", statusCode: StatusCodes.Status400BadRequest);
         }

--- a/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/ServerInfo/ServerSettingsAdminEndpoints.cs
@@ -10,7 +10,6 @@ using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Types;
 using Moongate.Persistence.Entities;
-using Moongate.Server.Abstractions.Data;
 using Moongate.Server.Abstractions.Interfaces.Server;
 using Moongate.Server.Abstractions.Types;
 
@@ -40,21 +39,21 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/v1/admin/server-settings")
-            .WithTags("server-settings")
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+                          .WithTags("server-settings")
+                          .RequireAuthorization(HttpServerService.AdminPolicy);
 
         group.MapGet("/", Get).WithName("GetServerSettings").Produces<ServerSettingsResponse>();
         group.MapPut("/", Update)
-            .WithName("UpdateServerSettings")
-            .Produces<ServerSettingsResponse>()
-            .ProducesValidationProblem();
+             .WithName("UpdateServerSettings")
+             .Produces<ServerSettingsResponse>()
+             .ProducesValidationProblem();
         group.MapPost("/assets/{slot}", UploadAsset)
-            .WithName("UploadServerAsset")
-            .DisableAntiforgery()
-            .Produces<ServerSettingsResponse>();
+             .WithName("UploadServerAsset")
+             .DisableAntiforgery()
+             .Produces<ServerSettingsResponse>();
         group.MapDelete("/assets/{slot}", DeleteAsset)
-            .WithName("DeleteServerAsset")
-            .Produces(StatusCodes.Status204NoContent);
+             .WithName("DeleteServerAsset")
+             .Produces(StatusCodes.Status204NoContent);
     }
 
     internal static ServerSettingsResponse ToResponse(
@@ -79,6 +78,23 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
         );
     }
 
+    /// <summary>Removes the image for a slot.</summary>
+    private IResult DeleteAsset(string slot)
+    {
+        if (!Enum.TryParse<ServerAssetSlotType>(slot, true, out var parsed))
+        {
+            return Results.Problem($"'{slot}' is not an asset slot.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (_settings.Get().Assets.TryGetValue(parsed.ToString(), out var meta))
+        {
+            _assets.Delete(meta.FileName);
+            _settings.ClearAsset(parsed);
+        }
+
+        return Results.NoContent();
+    }
+
     /// <summary>Returns the full server settings.</summary>
     private IResult Get()
         => Results.Ok(ToResponse(_settings.Get(), _registrationReadiness));
@@ -101,19 +117,19 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
         }
 
         _settings.Update(
-            new ServerSettingsUpdate
+            new()
             {
                 Description = request.Description,
                 Tagline = request.Tagline,
                 RegistrationEnabled = request.RegistrationEnabled,
                 Contacts = request.Contacts is null
-                    ? null
-                    : new ServerContacts
-                    {
-                        Website = request.Contacts.Website,
-                        Email = request.Contacts.Email,
-                        Discord = request.Contacts.Discord
-                    }
+                               ? null
+                               : new ServerContacts
+                               {
+                                   Website = request.Contacts.Website,
+                                   Email = request.Contacts.Email,
+                                   Discord = request.Contacts.Discord
+                               }
             }
         );
 
@@ -124,7 +140,7 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
     /// <remarks>Answers 400 for an unknown slot, 415 for a non-image type, and 413 when the file is too large.</remarks>
     private async Task<IResult> UploadAsset(string slot, IFormFile file)
     {
-        if (!Enum.TryParse<ServerAssetSlotType>(slot, ignoreCase: true, out var parsed))
+        if (!Enum.TryParse<ServerAssetSlotType>(slot, true, out var parsed))
         {
             return Results.Problem($"'{slot}' is not an asset slot.", statusCode: StatusCodes.Status400BadRequest);
         }
@@ -134,8 +150,14 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
         if (!validation.Ok)
         {
             return validation.Error == AssetValidationError.TooLarge
-                ? Results.Problem("Asset exceeds the maximum upload size.", statusCode: StatusCodes.Status413PayloadTooLarge)
-                : Results.Problem("Unsupported asset content-type.", statusCode: StatusCodes.Status415UnsupportedMediaType);
+                       ? Results.Problem(
+                           "Asset exceeds the maximum upload size.",
+                           statusCode: StatusCodes.Status413PayloadTooLarge
+                       )
+                       : Results.Problem(
+                           "Unsupported asset content-type.",
+                           statusCode: StatusCodes.Status415UnsupportedMediaType
+                       );
         }
 
         await using (var stream = file.OpenReadStream())
@@ -145,26 +167,9 @@ public sealed class ServerSettingsAdminEndpoints : IApiEndpointRegistration
 
         _settings.SetAsset(
             parsed,
-            new ServerAssetMeta { FileName = $"{parsed}.{validation.Extension}", ContentType = file.ContentType }
+            new() { FileName = $"{parsed}.{validation.Extension}", ContentType = file.ContentType }
         );
 
         return Results.Ok(ToResponse(_settings.Get(), _registrationReadiness));
-    }
-
-    /// <summary>Removes the image for a slot.</summary>
-    private IResult DeleteAsset(string slot)
-    {
-        if (!Enum.TryParse<ServerAssetSlotType>(slot, ignoreCase: true, out var parsed))
-        {
-            return Results.Problem($"'{slot}' is not an asset slot.", statusCode: StatusCodes.Status400BadRequest);
-        }
-
-        if (_settings.Get().Assets.TryGetValue(parsed.ToString(), out var meta))
-        {
-            _assets.Delete(meta.FileName);
-            _settings.ClearAsset(parsed);
-        }
-
-        return Results.NoContent();
     }
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Stats/StatsEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Stats/StatsEndpoints.cs
@@ -23,10 +23,10 @@ public sealed class StatsEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
         => routes.MapGet("/api/v1/stats", Get)
-            .WithName("GetServerStats")
-            .WithTags("stats")
-            .Produces<ServerStatsResponse>()
-            .AllowAnonymous();
+                 .WithName("GetServerStats")
+                 .WithTags("stats")
+                 .Produces<ServerStatsResponse>()
+                 .AllowAnonymous();
 
     internal static ServerStatsResponse ToResponse(ServerStatsSnapshot snapshot)
         => new(

--- a/plugins/Moongate.Http.Plugin/Endpoints/Version/VersionEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Version/VersionEndpoints.cs
@@ -26,10 +26,10 @@ public sealed class VersionEndpoints : IApiEndpointRegistration
         // A method group rather than a lambda: Swashbuckle reads the /// off the handler's method, and a
         // lambda has no method to read it from — the route would document itself as blank.
         => routes.MapGet("/api/v1/version", Version)
-            .WithName("GetVersion")
-            .WithTags("version")
-            .Produces<VersionResponse>()
-            .AllowAnonymous();
+                 .WithName("GetVersion")
+                 .WithTags("version")
+                 .Produces<VersionResponse>()
+                 .AllowAnonymous();
 
     /// <summary>Reports the shard's name and build.</summary>
     /// <remarks>

--- a/plugins/Moongate.Http.Plugin/Interfaces/Assets/IServerAssetFileStore.cs
+++ b/plugins/Moongate.Http.Plugin/Interfaces/Assets/IServerAssetFileStore.cs
@@ -5,12 +5,12 @@ namespace Moongate.Http.Plugin.Interfaces.Assets;
 /// <summary>Stores and serves the shard's visual-asset files under one directory, one file per slot.</summary>
 public interface IServerAssetFileStore
 {
+    /// <summary>Deletes the stored file by name, if present.</summary>
+    void Delete(string fileName);
+
     /// <summary>Writes the content atomically to <c>{slot}.{extension}</c>, replacing any existing file.</summary>
     Task SaveAsync(ServerAssetSlotType slot, string extension, Stream content);
 
     /// <summary>Opens the stored file by its recorded name, or null when it is missing.</summary>
     (Stream stream, string fileName)? TryOpen(string fileName);
-
-    /// <summary>Deletes the stored file by name, if present.</summary>
-    void Delete(string fileName);
 }

--- a/plugins/Moongate.Http.Plugin/Interfaces/Console/IConsoleStreamRegistry.cs
+++ b/plugins/Moongate.Http.Plugin/Interfaces/Console/IConsoleStreamRegistry.cs
@@ -6,12 +6,12 @@ namespace Moongate.Http.Plugin.Interfaces.Console;
 /// <summary>Holds the open console SSE connections, keyed by an unguessable connection id.</summary>
 public interface IConsoleStreamRegistry
 {
+    /// <summary>Completes and removes a connection; safe to call more than once.</summary>
+    void Close(string connectionId);
+
     /// <summary>Opens a new connection: returns its id and the reader the SSE endpoint streams from.</summary>
     (string ConnectionId, ChannelReader<ConsoleStreamEvent> Reader) Open();
 
     /// <summary>Gets the writer for an open connection; false if the id is unknown or closed.</summary>
     bool TryGetWriter(string connectionId, out ChannelWriter<ConsoleStreamEvent> writer);
-
-    /// <summary>Completes and removes a connection; safe to call more than once.</summary>
-    void Close(string connectionId);
 }

--- a/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -40,7 +40,7 @@
             what lets the web app run on the game's own container. Scalar reads the document either way.
         -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.16.16"/>
         <PackageReference Include="SquidStd.Abstractions" Version="0.41.0"/>
         <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.41.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">

--- a/plugins/Moongate.Http.Plugin/Services/Assets/ServerAssetFileStore.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Assets/ServerAssetFileStore.cs
@@ -13,6 +13,16 @@ public sealed class ServerAssetFileStore : IServerAssetFileStore
         Directory.CreateDirectory(_directory);
     }
 
+    public void Delete(string fileName)
+    {
+        var path = Path.Combine(_directory, fileName);
+
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
     public async Task SaveAsync(ServerAssetSlotType slot, string extension, Stream content)
     {
         var fileName = $"{slot}.{extension}";
@@ -24,7 +34,7 @@ public sealed class ServerAssetFileStore : IServerAssetFileStore
             await content.CopyToAsync(file);
         }
 
-        File.Move(tempPath, finalPath, overwrite: true);
+        File.Move(tempPath, finalPath, true);
     }
 
     public (Stream stream, string fileName)? TryOpen(string fileName)
@@ -32,17 +42,7 @@ public sealed class ServerAssetFileStore : IServerAssetFileStore
         var path = Path.Combine(_directory, fileName);
 
         return File.Exists(path)
-            ? (File.OpenRead(path), fileName)
-            : null;
-    }
-
-    public void Delete(string fileName)
-    {
-        var path = Path.Combine(_directory, fileName);
-
-        if (File.Exists(path))
-        {
-            File.Delete(path);
-        }
+                   ? (File.OpenRead(path), fileName)
+                   : null;
     }
 }

--- a/plugins/Moongate.Http.Plugin/Services/Console/ConsoleSseStream.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Console/ConsoleSseStream.cs
@@ -18,11 +18,11 @@ public static class ConsoleSseStream
         [EnumeratorCancellation] CancellationToken cancellationToken
     )
     {
-        yield return new SseItem<string>(connectionId, "ready");
+        yield return new(connectionId, "ready");
 
         await foreach (var evt in reader.ReadAllAsync(cancellationToken))
         {
-            yield return new SseItem<string>(evt.Text, evt.Event);
+            yield return new(evt.Text, evt.Event);
         }
     }
 }

--- a/plugins/Moongate.Http.Plugin/Services/Console/ConsoleStreamRegistry.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Console/ConsoleStreamRegistry.cs
@@ -14,6 +14,14 @@ public sealed class ConsoleStreamRegistry : IConsoleStreamRegistry
 {
     private readonly ConcurrentDictionary<string, Channel<ConsoleStreamEvent>> _channels = new();
 
+    public void Close(string connectionId)
+    {
+        if (_channels.TryRemove(connectionId, out var channel))
+        {
+            channel.Writer.TryComplete();
+        }
+    }
+
     public (string ConnectionId, ChannelReader<ConsoleStreamEvent> Reader) Open()
     {
         var connectionId = Guid.NewGuid().ToString("N");
@@ -35,13 +43,5 @@ public sealed class ConsoleStreamRegistry : IConsoleStreamRegistry
         writer = Channel.CreateUnbounded<ConsoleStreamEvent>().Writer;
 
         return false;
-    }
-
-    public void Close(string connectionId)
-    {
-        if (_channels.TryRemove(connectionId, out var channel))
-        {
-            channel.Writer.TryComplete();
-        }
     }
 }

--- a/plugins/Moongate.Http.Plugin/Services/Hosting/HttpServerService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Hosting/HttpServerService.cs
@@ -86,7 +86,8 @@ public sealed class HttpServerService : ISquidStdService
 
         builder.Services.AddProblemDetails();
         builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen(options =>
+        builder.Services.AddSwaggerGen(
+            options =>
             {
                 // Every DTO here is a record of non-nullable properties, but by default Swashbuckle marks
                 // nothing required — so a generated client has to treat every field as possibly absent and
@@ -107,37 +108,39 @@ public sealed class HttpServerService : ISquidStdService
         // camelCase over the wire while the DTOs stay PascalCase in C#. ASP.NET already defaults to this,
         // but the wire format is a contract clients are written against: stated here it cannot be changed
         // by a default shifting under us.
-        builder.Services.ConfigureHttpJsonOptions(options =>
-            options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        builder.Services.ConfigureHttpJsonOptions(
+            options =>
+                options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         );
 
         builder.Services
-            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options =>
-                {
-                    options.TokenValidationParameters = new()
-                    {
-                        ValidateIssuer = true,
-                        ValidIssuer = _config.Jwt.Issuer,
-                        ValidateAudience = true,
-                        ValidAudience = _config.Jwt.Issuer,
-                        ValidateIssuerSigningKey = true,
-                        IssuerSigningKey = signingKey,
-                        ValidateLifetime = true
-                    };
-                }
-            );
+               .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+               .AddJwtBearer(
+                   options =>
+                   {
+                       options.TokenValidationParameters = new()
+                       {
+                           ValidateIssuer = true,
+                           ValidIssuer = _config.Jwt.Issuer,
+                           ValidateAudience = true,
+                           ValidAudience = _config.Jwt.Issuer,
+                           ValidateIssuerSigningKey = true,
+                           IssuerSigningKey = signingKey,
+                           ValidateLifetime = true
+                       };
+                   }
+               );
 
         builder.Services
-            .AddAuthorizationBuilder()
-            .AddPolicy(
-                AdminPolicy,
-                policy => policy.RequireRole(
-                    nameof(AccountLevelType.Administrator),
-                    nameof(AccountLevelType.GrandMaster)
-                )
-            )
-            .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
+               .AddAuthorizationBuilder()
+               .AddPolicy(
+                   AdminPolicy,
+                   policy => policy.RequireRole(
+                       nameof(AccountLevelType.Administrator),
+                       nameof(AccountLevelType.GrandMaster)
+                   )
+               )
+               .AddPolicy(PlayerPolicy, policy => policy.RequireAuthenticatedUser());
 
         _app = builder.Build();
 
@@ -162,9 +165,12 @@ public sealed class HttpServerService : ISquidStdService
                     // carries the pointers to them and must not be, or a deploy would keep handing out the
                     // previous bundle's names.
                     OnPrepareResponse = context => context.Context.Response.Headers.CacheControl =
-                        context.File.Name.Equals("index.html", StringComparison.OrdinalIgnoreCase)
-                            ? "no-cache"
-                            : "public, max-age=31536000, immutable"
+                                                       context.File.Name.Equals(
+                                                           "index.html",
+                                                           StringComparison.OrdinalIgnoreCase
+                                                       )
+                                                           ? "no-cache"
+                                                           : "public, max-age=31536000, immutable"
                 }
             );
 
@@ -175,7 +181,8 @@ public sealed class HttpServerService : ISquidStdService
         _app.UseAuthorization();
 
         _app.UseSwagger();
-        _app.MapScalarApiReference(options =>
+        _app.MapScalarApiReference(
+            options =>
             {
                 options.WithOpenApiRoutePattern(SwaggerRoutePattern);
                 options.AddDocument(DocumentName);
@@ -203,10 +210,12 @@ public sealed class HttpServerService : ISquidStdService
         {
             var indexPath = Path.Combine(uiDist, "index.html");
 
-            _app.MapFallback(async context =>
+            _app.MapFallback(
+                async context =>
                 {
                     var path = context.Request.Path;
-                    var reserved = ReservedPrefixes.Any(prefix => path.StartsWithSegments(
+                    var reserved = ReservedPrefixes.Any(
+                        prefix => path.StartsWithSegments(
                             prefix,
                             StringComparison.OrdinalIgnoreCase
                         )
@@ -267,12 +276,12 @@ public sealed class HttpServerService : ISquidStdService
     /// </summary>
     private IEnumerable<string> EndpointXmlDocumentationPaths()
         => _container.GetServiceRegistrations()
-            .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
-            .Select(registration => registration.ImplementationType?.Assembly)
-            .Where(assembly => assembly is not null)
-            .Select(assembly => Path.Combine(AppContext.BaseDirectory, $"{assembly!.GetName().Name}.xml"))
-            .Distinct()
-            .Where(File.Exists);
+                     .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+                     .Select(registration => registration.ImplementationType?.Assembly)
+                     .Where(assembly => assembly is not null)
+                     .Select(assembly => Path.Combine(AppContext.BaseDirectory, $"{assembly!.GetName().Name}.xml"))
+                     .Distinct()
+                     .Where(File.Exists);
 
     /// <summary>
     /// Mints a signing key for a server that has not configured one, and writes it to moongate.yaml.
@@ -302,6 +311,18 @@ public sealed class HttpServerService : ISquidStdService
     }
 
     /// <summary>
+    /// Asks Kestrel what it actually bound. With a configured port of 0 the OS picks one, and this is the
+    /// only way to learn it.
+    /// </summary>
+    private static int ResolveBoundPort(WebApplication app)
+    {
+        var addresses = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+        var address = addresses?.Addresses.FirstOrDefault();
+
+        return address is null ? 0 : new Uri(address).Port;
+    }
+
+    /// <summary>
     /// The first candidate that exists, or null. Configuration wins, then the environment variable — which is
     /// what lets a developer point a published server at a working tree without copying anything — then the
     /// conventional locations.
@@ -327,19 +348,7 @@ public sealed class HttpServerService : ISquidStdService
         // index.html rather than the directory: a directory that exists but holds no entry point would pass
         // the check and then serve nothing.
         return Candidates()
-            .Select(Path.GetFullPath)
-            .FirstOrDefault(candidate => File.Exists(Path.Combine(candidate, "index.html")));
-    }
-
-    /// <summary>
-    /// Asks Kestrel what it actually bound. With a configured port of 0 the OS picks one, and this is the
-    /// only way to learn it.
-    /// </summary>
-    private static int ResolveBoundPort(WebApplication app)
-    {
-        var addresses = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
-        var address = addresses?.Addresses.FirstOrDefault();
-
-        return address is null ? 0 : new Uri(address).Port;
+               .Select(Path.GetFullPath)
+               .FirstOrDefault(candidate => File.Exists(Path.Combine(candidate, "index.html")));
     }
 }

--- a/plugins/Moongate.Http.Plugin/Services/Images/ItemImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Images/ItemImageService.cs
@@ -34,23 +34,23 @@ public sealed class ItemImageService : IItemImageService
 
     public async Task<IReadOnlyList<uint>> GetArtItemIdsAsync(CancellationToken cancellationToken = default)
         => await _gate.ReadAsync(
-            () =>
-            {
-                var ids = new List<uint>();
-                var max = Art.GetMaxItemId();
+               () =>
+               {
+                   var ids = new List<uint>();
+                   var max = Art.GetMaxItemId();
 
-                for (var id = 0; id <= max; id++)
-                {
-                    if (Art.IsValidStatic(id))
-                    {
-                        ids.Add((uint)id);
-                    }
-                }
+                   for (var id = 0; id <= max; id++)
+                   {
+                       if (Art.IsValidStatic(id))
+                       {
+                           ids.Add((uint)id);
+                       }
+                   }
 
-                return (IReadOnlyList<uint>)ids;
-            },
-            cancellationToken
-        );
+                   return (IReadOnlyList<uint>)ids;
+               },
+               cancellationToken
+           );
 
     public async Task<string?> GetOrCreateAsync(
         uint itemId,
@@ -70,9 +70,9 @@ public sealed class ItemImageService : IItemImageService
         // Re-checked inside the gate, because another request may have produced it while this one waited.
         // The decode is all that needs the gate — the write is ordinary file I/O and is done outside it.
         var png = await _gate.ReadAsync(
-            () => File.Exists(path) ? null : _catalog.GetItemImage(itemId, hue),
-            cancellationToken
-        );
+                      () => File.Exists(path) ? null : _catalog.GetItemImage(itemId, hue),
+                      cancellationToken
+                  );
 
         // Null means two different things here: another request won the race, or the item has no art.
         // The file is what tells them apart — returning null blindly would turn a cache race into a 404.

--- a/plugins/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Maps/MapImageService.cs
@@ -66,19 +66,19 @@ public sealed class MapImageService : IMapImageService
         // A facet-sized bitmap, unavoidably: the output is that image. The gate makes concurrent first
         // requests queue rather than each allocating their own, and the re-check means only the first pays.
         using var image = await _gate.ReadAsync(
-            () =>
-            {
-                if (File.Exists(path))
-                {
-                    return null;
-                }
+                              () =>
+                              {
+                                  if (File.Exists(path))
+                                  {
+                                      return null;
+                                  }
 
-                using var bitmap = RenderBlocks(map, style, 0, 0, Blocks(map.Width), Blocks(map.Height));
+                                  using var bitmap = RenderBlocks(map, style, 0, 0, Blocks(map.Width), Blocks(map.Height));
 
-                return bitmap.ToImage();
-            },
-            cancellationToken
-        );
+                                  return bitmap.ToImage();
+                              },
+                              cancellationToken
+                          );
 
         if (image is null)
         {
@@ -126,8 +126,8 @@ public sealed class MapImageService : IMapImageService
         }
 
         using var tile = zoom == maxZoom
-            ? await RenderNativeAsync(map, style, x, y, cancellationToken)
-            : await ComposeAsync(facet, style, zoom, x, y, cancellationToken);
+                             ? await RenderNativeAsync(map, style, x, y, cancellationToken)
+                             : await ComposeAsync(facet, style, zoom, x, y, cancellationToken);
 
         await WriteAtomicallyAsync(path, tile, cancellationToken);
 
@@ -195,8 +195,8 @@ public sealed class MapImageService : IMapImageService
         int height
     )
         => style == MapRenderStyleType.Relief
-            ? map.GetImageWithAltitude(x, y, width, height, true, MapAltitudeModeType.NormalWithAltitude)
-            : map.GetImage(x, y, width, height, true);
+               ? map.GetImageWithAltitude(x, y, width, height, true, MapAltitudeModeType.NormalWithAltitude)
+               : map.GetImage(x, y, width, height, true);
 
     /// <summary>
     /// One GetImage of exactly 32 blocks, clipped at the facet's edge. The remainder of an edge tile is
@@ -216,14 +216,14 @@ public sealed class MapImageService : IMapImageService
         var height = Math.Min(MapTileGeometry.BlocksPerTile, Blocks(map.Height) - blockY);
 
         var rendered = await _gate.ReadAsync(
-            () =>
-            {
-                using var bitmap = RenderBlocks(map, style, blockX, blockY, width, height);
+                           () =>
+                           {
+                               using var bitmap = RenderBlocks(map, style, blockX, blockY, width, height);
 
-                return bitmap.ToImage();
-            },
-            cancellationToken
-        );
+                               return bitmap.ToImage();
+                           },
+                           cancellationToken
+                       );
 
         if (rendered.Width == MapTileGeometry.TileSize && rendered.Height == MapTileGeometry.TileSize)
         {
@@ -241,9 +241,9 @@ public sealed class MapImageService : IMapImageService
 
     private string StyleDirectory(MapType facet, MapRenderStyleType style)
         => Directory.CreateDirectory(
-                Path.Combine(_cachePath, facet.ToString().ToLowerInvariant(), style.ToString().ToLowerInvariant())
-            )
-            .FullName;
+                        Path.Combine(_cachePath, facet.ToString().ToLowerInvariant(), style.ToString().ToLowerInvariant())
+                    )
+                    .FullName;
 
     private string TilePath(MapType facet, MapRenderStyleType style, int zoom, int x, int y)
     {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageExportJob.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageExportJob.cs
@@ -70,9 +70,9 @@ public sealed class BodyImageExportJob : IBodyImageExportJob
         try
         {
             var bodies = _catalog.ClassifiedBodies
-                .Where(entry => entry.Type != MobType.Equipment)
-                .Select(entry => entry.Body)
-                .ToArray();
+                                 .Where(entry => entry.Type != MobType.Equipment)
+                                 .Select(entry => entry.Body)
+                                 .ToArray();
 
             lock (_sync)
             {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/BodyImageService.cs
@@ -35,9 +35,9 @@ public sealed class BodyImageService : IBodyImageService
         }
 
         var frame = await _gate.ReadAsync(
-            () => File.Exists(path) ? null : _catalog.GetFrame(body, 0, 1, 0, hue),
-            cancellationToken
-        );
+                        () => File.Exists(path) ? null : _catalog.GetFrame(body, 0, 1, 0, hue),
+                        cancellationToken
+                    );
 
         if (frame is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/HairImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/HairImageService.cs
@@ -37,21 +37,21 @@ public sealed class HairImageService : IHairImageService
         }
 
         var figure = await _gate.ReadAsync(
-            () => File.Exists(path)
-                ? null
-                : _renderer.Render(
-                    new(
-                        referenceBody,
-                        0,
-                        facial ? 0 : style,
-                        facial ? 0 : hue,
-                        facial ? style : 0,
-                        facial ? hue : 0,
-                        []
-                    )
-                ),
-            cancellationToken
-        );
+                         () => File.Exists(path)
+                                   ? null
+                                   : _renderer.Render(
+                                       new(
+                                           referenceBody,
+                                           0,
+                                           facial ? 0 : style,
+                                           facial ? 0 : hue,
+                                           facial ? style : 0,
+                                           facial ? hue : 0,
+                                           []
+                                       )
+                                   ),
+                         cancellationToken
+                     );
 
         if (figure is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileTemplateImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileTemplateImageService.cs
@@ -60,9 +60,9 @@ public sealed class MobileTemplateImageService : IMobileTemplateImageService
         );
 
         var figure = await _gate.ReadAsync(
-            () => File.Exists(path) ? null : _renderer.Render(request),
-            cancellationToken
-        );
+                         () => File.Exists(path) ? null : _renderer.Render(request),
+                         cancellationToken
+                     );
 
         if (figure is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/PaperdollImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/PaperdollImageService.cs
@@ -68,9 +68,9 @@ public sealed class PaperdollImageService : IPaperdollImageService
         );
 
         var doll = await _gate.ReadAsync(
-            () => File.Exists(path) ? null : _renderer.Render(request),
-            cancellationToken
-        );
+                       () => File.Exists(path) ? null : _renderer.Render(request),
+                       cancellationToken
+                   );
 
         if (doll is null)
         {

--- a/plugins/Moongate.Http.Plugin/Services/Plugins/EndpointPluginRouteInspector.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Plugins/EndpointPluginRouteInspector.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Moongate.Http.Plugin.Data.Plugins;
 using Moongate.Http.Plugin.Interfaces.Plugins;
@@ -28,8 +27,8 @@ public sealed class EndpointPluginRouteInspector : IPluginRouteInspector
 
         foreach (var endpoint in endpoints.Endpoints.OfType<RouteEndpoint>())
         {
-            var assembly = endpoint.Metadata.GetMetadata<MethodInfo>()?.DeclaringType?.Assembly.GetName().Name
-                           ?? string.Empty;
+            var assembly = endpoint.Metadata.GetMetadata<MethodInfo>()?.DeclaringType?.Assembly.GetName().Name ??
+                           string.Empty;
 
             if (!grouped.TryGetValue(assembly, out var routes))
             {
@@ -72,8 +71,8 @@ public sealed class EndpointPluginRouteInspector : IPluginRouteInspector
         }
 
         return endpoint.Metadata
-            .GetOrderedMetadata<IAuthorizeData>()
-            .Select(data => data.Policy ?? data.Roles)
-            .FirstOrDefault(value => !string.IsNullOrEmpty(value));
+                       .GetOrderedMetadata<IAuthorizeData>()
+                       .Select(data => data.Policy ?? data.Roles)
+                       .FirstOrDefault(value => !string.IsNullOrEmpty(value));
     }
 }

--- a/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationRateLimiter.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationRateLimiter.cs
@@ -17,20 +17,20 @@ public sealed class RegistrationRateLimiter : IRegistrationRateLimiter
         _window = window;
     }
 
+    private sealed record Window(DateTimeOffset Start, int Count);
+
     public bool TryAcquire(string clientKey)
     {
         var now = _time.GetUtcNow();
 
         var updated = _windows.AddOrUpdate(
             clientKey,
-            _ => new Window(now, 1),
+            _ => new(now, 1),
             (_, current) => now - current.Start >= _window
-                ? new Window(now, 1)
-                : current with { Count = current.Count + 1 }
+                                ? new(now, 1)
+                                : current with { Count = current.Count + 1 }
         );
 
         return updated.Count <= _permitPerWindow;
     }
-
-    private sealed record Window(DateTimeOffset Start, int Count);
 }

--- a/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationReadinessService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Registration/RegistrationReadinessService.cs
@@ -23,20 +23,22 @@ public sealed class RegistrationReadinessService : IRegistrationReadinessService
     /// <inheritdoc />
     public RegistrationReadiness Evaluate(string? website)
     {
-        var websiteValid = Uri.TryCreate(website, UriKind.Absolute, out var uri)
-            && !string.IsNullOrEmpty(uri.Host)
-            && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
+        var websiteValid = Uri.TryCreate(website, UriKind.Absolute, out var uri) &&
+                           !string.IsNullOrEmpty(uri.Host) &&
+                           (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
         var emailChannelSelected = string.Equals(
             _notificationConfig.AccountVerificationChannel,
             "email",
             StringComparison.OrdinalIgnoreCase
         );
-        var emailChannelAvailable = _notificationChannels.Any(channel => string.Equals(
-            channel.Id,
-            "email",
-            StringComparison.OrdinalIgnoreCase
-        ));
+        var emailChannelAvailable = _notificationChannels.Any(
+            channel => string.Equals(
+                channel.Id,
+                "email",
+                StringComparison.OrdinalIgnoreCase
+            )
+        );
 
         return new(websiteValid, emailChannelSelected, emailChannelAvailable);
     }

--- a/plugins/Moongate.News.Plugin/Endpoints/NewsAdminEndpoints.cs
+++ b/plugins/Moongate.News.Plugin/Endpoints/NewsAdminEndpoints.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Moongate.Core.Primitives;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.News.Plugin.Data.Api;
@@ -23,30 +22,30 @@ public sealed class NewsAdminEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapPost("/api/v1/admin/news", Create)
-            .WithName("CreateNews")
-            .WithTags("news")
-            .Produces<NewsResponse>(StatusCodes.Status201Created)
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("CreateNews")
+              .WithTags("news")
+              .Produces<NewsResponse>(StatusCodes.Status201Created)
+              .RequireAuthorization(HttpServerService.AdminPolicy);
         routes.MapGet("/api/v1/admin/news", ListAll)
-            .WithName("ListAllNews")
-            .WithTags("news")
-            .Produces<IReadOnlyList<NewsResponse>>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("ListAllNews")
+              .WithTags("news")
+              .Produces<IReadOnlyList<NewsResponse>>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
         routes.MapGet("/api/v1/admin/news/{id}", GetOne)
-            .WithName("GetNewsAdmin")
-            .WithTags("news")
-            .Produces<NewsResponse>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("GetNewsAdmin")
+              .WithTags("news")
+              .Produces<NewsResponse>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
         routes.MapPut("/api/v1/admin/news/{id}", Update)
-            .WithName("UpdateNews")
-            .WithTags("news")
-            .Produces<NewsResponse>()
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("UpdateNews")
+              .WithTags("news")
+              .Produces<NewsResponse>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
         routes.MapDelete("/api/v1/admin/news/{id}", Delete)
-            .WithName("DeleteNews")
-            .WithTags("news")
-            .Produces(StatusCodes.Status204NoContent)
-            .RequireAuthorization(HttpServerService.AdminPolicy);
+              .WithName("DeleteNews")
+              .WithTags("news")
+              .Produces(StatusCodes.Status204NoContent)
+              .RequireAuthorization(HttpServerService.AdminPolicy);
     }
 
     /// <summary>Creates a news entry, authored by the calling staff member.</summary>
@@ -58,23 +57,23 @@ public sealed class NewsAdminEndpoints : IApiEndpointRegistration
         return TypedResults.Created($"/api/v1/news/{news.Id.Value}", NewsResponse.From(news));
     }
 
+    /// <summary>Deletes a news entry.</summary>
+    private async Task<IResult> Delete(uint id)
+        => await _news.DeleteAsync(new(id)) ? TypedResults.NoContent() : TypedResults.NotFound();
+
+    /// <summary>Returns one news entry in any state.</summary>
+    private IResult GetOne(uint id)
+        => _news.Get(new(id)) is { } news ? TypedResults.Ok(NewsResponse.From(news)) : TypedResults.NotFound();
+
     /// <summary>Lists every news entry, drafts included, newest first.</summary>
     private IResult ListAll()
         => TypedResults.Ok(_news.GetAll().Select(NewsResponse.From).ToList());
 
-    /// <summary>Returns one news entry in any state.</summary>
-    private IResult GetOne(uint id)
-        => _news.Get(new Serial(id)) is { } news ? TypedResults.Ok(NewsResponse.From(news)) : TypedResults.NotFound();
-
     /// <summary>Updates a news entry's title, body and published state.</summary>
     private async Task<IResult> Update(uint id, UpdateNewsRequest request)
     {
-        var news = await _news.UpdateAsync(new Serial(id), request.Title, request.Body, request.IsPublished);
+        var news = await _news.UpdateAsync(new(id), request.Title, request.Body, request.IsPublished);
 
         return news is { } updated ? TypedResults.Ok(NewsResponse.From(updated)) : TypedResults.NotFound();
     }
-
-    /// <summary>Deletes a news entry.</summary>
-    private async Task<IResult> Delete(uint id)
-        => await _news.DeleteAsync(new Serial(id)) ? TypedResults.NoContent() : TypedResults.NotFound();
 }

--- a/plugins/Moongate.News.Plugin/Endpoints/NewsEndpoints.cs
+++ b/plugins/Moongate.News.Plugin/Endpoints/NewsEndpoints.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Moongate.Core.Primitives;
 using Moongate.Http.Plugin.Interfaces.Endpoints;
 using Moongate.News.Plugin.Data.Api;
 using Moongate.News.Plugin.Interfaces;
@@ -21,22 +20,22 @@ public sealed class NewsEndpoints : IApiEndpointRegistration
     public void Register(IEndpointRouteBuilder routes)
     {
         routes.MapGet("/api/v1/news", List)
-            .WithName("ListNews")
-            .WithTags("news")
-            .Produces<IReadOnlyList<NewsResponse>>();
+              .WithName("ListNews")
+              .WithTags("news")
+              .Produces<IReadOnlyList<NewsResponse>>();
         routes.MapGet("/api/v1/news/{id}", GetOne)
-            .WithName("GetNews")
-            .WithTags("news")
-            .Produces<NewsResponse>();
+              .WithName("GetNews")
+              .WithTags("news")
+              .Produces<NewsResponse>();
     }
+
+    /// <summary>Returns one published news entry; 404 if it is missing or a draft.</summary>
+    private IResult GetOne(uint id)
+        => _news.Get(new(id)) is { IsPublished: true } news
+               ? TypedResults.Ok(NewsResponse.From(news))
+               : TypedResults.NotFound();
 
     /// <summary>Lists published news, newest first.</summary>
     private IResult List()
         => TypedResults.Ok(_news.GetPublished().Select(NewsResponse.From).ToList());
-
-    /// <summary>Returns one published news entry; 404 if it is missing or a draft.</summary>
-    private IResult GetOne(uint id)
-        => _news.Get(new Serial(id)) is { IsPublished: true } news
-            ? TypedResults.Ok(NewsResponse.From(news))
-            : TypedResults.NotFound();
 }

--- a/plugins/Moongate.News.Plugin/Interfaces/INewsService.cs
+++ b/plugins/Moongate.News.Plugin/Interfaces/INewsService.cs
@@ -8,16 +8,18 @@ public interface INewsService
 {
     /// <summary>Creates a news entry; the store assigns its id. Timestamps are set to now.</summary>
     ValueTask<NewsEntity> CreateAsync(
-        string title, string body, string author, bool isPublished, CancellationToken ct = default
-    );
-
-    /// <summary>Updates an entry's title/body/published state and its <c>UpdatedAt</c>; null if not found.</summary>
-    ValueTask<NewsEntity?> UpdateAsync(
-        Serial id, string title, string body, bool isPublished, CancellationToken ct = default
+        string title,
+        string body,
+        string author,
+        bool isPublished,
+        CancellationToken ct = default
     );
 
     /// <summary>Deletes an entry; false if it did not exist.</summary>
     ValueTask<bool> DeleteAsync(Serial id, CancellationToken ct = default);
+
+    /// <summary>One entry by id, or null.</summary>
+    NewsEntity? Get(Serial id);
 
     /// <summary>Every entry, drafts included, newest first.</summary>
     IReadOnlyList<NewsEntity> GetAll();
@@ -25,6 +27,12 @@ public interface INewsService
     /// <summary>Published entries only, newest first.</summary>
     IReadOnlyList<NewsEntity> GetPublished();
 
-    /// <summary>One entry by id, or null.</summary>
-    NewsEntity? Get(Serial id);
+    /// <summary>Updates an entry's title/body/published state and its <c>UpdatedAt</c>; null if not found.</summary>
+    ValueTask<NewsEntity?> UpdateAsync(
+        Serial id,
+        string title,
+        string body,
+        bool isPublished,
+        CancellationToken ct = default
+    );
 }

--- a/plugins/Moongate.News.Plugin/Services/NewsService.cs
+++ b/plugins/Moongate.News.Plugin/Services/NewsService.cs
@@ -16,7 +16,11 @@ public sealed class NewsService : INewsService
     }
 
     public async ValueTask<NewsEntity> CreateAsync(
-        string title, string body, string author, bool isPublished, CancellationToken ct = default
+        string title,
+        string body,
+        string author,
+        bool isPublished,
+        CancellationToken ct = default
     )
     {
         var now = DateTime.UtcNow;
@@ -34,8 +38,24 @@ public sealed class NewsService : INewsService
         return news;
     }
 
+    public async ValueTask<bool> DeleteAsync(Serial id, CancellationToken ct = default)
+        => await _store.RemoveAsync(id, ct);
+
+    public NewsEntity? Get(Serial id)
+        => _store.GetById(id);
+
+    public IReadOnlyList<NewsEntity> GetAll()
+        => _store.GetAll().OrderByDescending(news => news.PublishedAt).ToList();
+
+    public IReadOnlyList<NewsEntity> GetPublished()
+        => _store.GetAll().Where(news => news.IsPublished).OrderByDescending(news => news.PublishedAt).ToList();
+
     public async ValueTask<NewsEntity?> UpdateAsync(
-        Serial id, string title, string body, bool isPublished, CancellationToken ct = default
+        Serial id,
+        string title,
+        string body,
+        bool isPublished,
+        CancellationToken ct = default
     )
     {
         if (_store.GetById(id) is not { } news)
@@ -51,16 +71,4 @@ public sealed class NewsService : INewsService
 
         return news;
     }
-
-    public async ValueTask<bool> DeleteAsync(Serial id, CancellationToken ct = default)
-        => await _store.RemoveAsync(id, ct);
-
-    public IReadOnlyList<NewsEntity> GetAll()
-        => _store.GetAll().OrderByDescending(news => news.PublishedAt).ToList();
-
-    public IReadOnlyList<NewsEntity> GetPublished()
-        => _store.GetAll().Where(news => news.IsPublished).OrderByDescending(news => news.PublishedAt).ToList();
-
-    public NewsEntity? Get(Serial id)
-        => _store.GetById(id);
 }

--- a/plugins/Moongate.Smtp.Plugin/Data/Exceptions/SmtpInsecureConnectionException.cs
+++ b/plugins/Moongate.Smtp.Plugin/Data/Exceptions/SmtpInsecureConnectionException.cs
@@ -7,7 +7,5 @@ namespace Moongate.Smtp.Plugin.Data.Exceptions;
 /// </summary>
 public sealed class SmtpInsecureConnectionException : Exception
 {
-    public SmtpInsecureConnectionException(string message) : base(message)
-    {
-    }
+    public SmtpInsecureConnectionException(string message) : base(message) { }
 }

--- a/src/Moongate.Core/Geometry/Point2D.cs
+++ b/src/Moongate.Core/Geometry/Point2D.cs
@@ -50,12 +50,6 @@ public readonly struct Point2D : IEquatable<Point2D>, IComparable<Point2D>, ISpa
     public bool InRange(Point2D other, int range)
         => DistanceTo(other) <= range;
 
-    public static bool operator ==(Point2D left, Point2D right)
-        => left.Equals(right);
-
-    public static bool operator !=(Point2D left, Point2D right)
-        => !left.Equals(right);
-
     public static Point2D Parse(string s, IFormatProvider? provider)
         => Parse(s.AsSpan(), provider);
 
@@ -103,4 +97,10 @@ public readonly struct Point2D : IEquatable<Point2D>, IComparable<Point2D>, ISpa
 
         return true;
     }
+
+    public static bool operator ==(Point2D left, Point2D right)
+        => left.Equals(right);
+
+    public static bool operator !=(Point2D left, Point2D right)
+        => !left.Equals(right);
 }

--- a/src/Moongate.Core/Geometry/Point3D.cs
+++ b/src/Moongate.Core/Geometry/Point3D.cs
@@ -68,15 +68,6 @@ public readonly struct Point3D : IEquatable<Point3D>, IComparable<Point3D>, ISpa
     public bool InRange(Point3D other, int range)
         => DistanceTo(other) <= range;
 
-    public static bool operator ==(Point3D left, Point3D right)
-        => left.Equals(right);
-
-    public static implicit operator Point2D(Point3D p)
-        => new(p.X, p.Y);
-
-    public static bool operator !=(Point3D left, Point3D right)
-        => !left.Equals(right);
-
     public static Point3D Parse(string s, IFormatProvider? provider)
         => Parse(s.AsSpan(), provider);
 
@@ -136,4 +127,13 @@ public readonly struct Point3D : IEquatable<Point3D>, IComparable<Point3D>, ISpa
 
         return true;
     }
+
+    public static bool operator ==(Point3D left, Point3D right)
+        => left.Equals(right);
+
+    public static implicit operator Point2D(Point3D p)
+        => new(p.X, p.Y);
+
+    public static bool operator !=(Point3D left, Point3D right)
+        => !left.Equals(right);
 }

--- a/src/Moongate.Core/Geometry/Rectangle2D.cs
+++ b/src/Moongate.Core/Geometry/Rectangle2D.cs
@@ -49,12 +49,12 @@ public readonly struct Rectangle2D : IEquatable<Rectangle2D>
     public override int GetHashCode()
         => HashCode.Combine(X, Y, Width, Height);
 
+    public override string ToString()
+        => $"({X}, {Y})+({Width}, {Height})";
+
     public static bool operator ==(Rectangle2D left, Rectangle2D right)
         => left.Equals(right);
 
     public static bool operator !=(Rectangle2D left, Rectangle2D right)
         => !left.Equals(right);
-
-    public override string ToString()
-        => $"({X}, {Y})+({Width}, {Height})";
 }

--- a/src/Moongate.Core/Geometry/Rectangle3D.cs
+++ b/src/Moongate.Core/Geometry/Rectangle3D.cs
@@ -47,12 +47,12 @@ public readonly struct Rectangle3D : IEquatable<Rectangle3D>
     public override int GetHashCode()
         => HashCode.Combine(Start, End);
 
+    public override string ToString()
+        => $"{Start}+({Width}, {Height}, {Depth})";
+
     public static bool operator ==(Rectangle3D left, Rectangle3D right)
         => left.Equals(right);
 
     public static bool operator !=(Rectangle3D left, Rectangle3D right)
         => !left.Equals(right);
-
-    public override string ToString()
-        => $"{Start}+({Width}, {Height}, {Depth})";
 }

--- a/src/Moongate.Core/Interfaces/IGameLoopContext.cs
+++ b/src/Moongate.Core/Interfaces/IGameLoopContext.cs
@@ -19,6 +19,13 @@ public interface IGameLoopContext
     /// <summary>Cancels a scheduled timer by id. Returns true when a timer was removed.</summary>
     bool Cancel(string timerId);
 
+    /// <summary>
+    /// Runs <paramref name="work" /> on the game-loop thread and returns its result. Throws
+    /// <see cref="TimeoutException" /> if the loop does not run it within <paramref name="timeout" />
+    /// (default 5 seconds).
+    /// </summary>
+    Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null);
+
     /// <summary>Runs <paramref name="action" /> on the game-loop thread on the next frame.</summary>
     void Post(Action action);
 
@@ -34,11 +41,4 @@ public interface IGameLoopContext
     /// </summary>
     /// <returns>The timer id, usable with <see cref="Cancel" />.</returns>
     string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null);
-
-    /// <summary>
-    /// Runs <paramref name="work" /> on the game-loop thread and returns its result. Throws
-    /// <see cref="TimeoutException" /> if the loop does not run it within <paramref name="timeout" />
-    /// (default 5 seconds).
-    /// </summary>
-    Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null);
 }

--- a/src/Moongate.Core/Primitives/Serial.cs
+++ b/src/Moongate.Core/Primitives/Serial.cs
@@ -59,6 +59,9 @@ public readonly struct Serial : IEquatable<Serial>, IComparable<Serial>
     public override int GetHashCode()
         => Value.GetHashCode();
 
+    public override string ToString()
+        => $"0x{Value:X8}";
+
     public static bool operator ==(Serial left, Serial right)
         => left.Value == right.Value;
 
@@ -82,7 +85,4 @@ public readonly struct Serial : IEquatable<Serial>, IComparable<Serial>
 
     public static bool operator <=(Serial left, Serial right)
         => left.Value <= right.Value;
-
-    public override string ToString()
-        => $"0x{Value:X8}";
 }

--- a/src/Moongate.Network/Exceptions/UoFramingException.cs
+++ b/src/Moongate.Network/Exceptions/UoFramingException.cs
@@ -7,7 +7,5 @@ namespace Moongate.Network.Exceptions;
 /// </summary>
 public sealed class UoFramingException : Exception
 {
-    public UoFramingException(string message) : base(message)
-    {
-    }
+    public UoFramingException(string message) : base(message) { }
 }

--- a/src/Moongate.Persistence/Entities/NpcMemoryValue.cs
+++ b/src/Moongate.Persistence/Entities/NpcMemoryValue.cs
@@ -4,18 +4,21 @@ namespace Moongate.Persistence.Entities;
 
 public sealed record NpcMemoryValue(MemoryValueType Type, string? Text, double Number, bool Flag)
 {
-    public static NpcMemoryValue FromString(string text) => new(MemoryValueType.String, text, 0, false);
+    public static NpcMemoryValue FromBoolean(bool flag)
+        => new(MemoryValueType.Boolean, null, 0, flag);
 
-    public static NpcMemoryValue FromNumber(double number) => new(MemoryValueType.Number, null, number, false);
+    public static NpcMemoryValue FromNumber(double number)
+        => new(MemoryValueType.Number, null, number, false);
 
-    public static NpcMemoryValue FromBoolean(bool flag) => new(MemoryValueType.Boolean, null, 0, flag);
+    public static NpcMemoryValue FromString(string text)
+        => new(MemoryValueType.String, text, 0, false);
 
     public object? ToScalar()
         => Type switch
         {
-            MemoryValueType.String => Text,
-            MemoryValueType.Number => Number,
+            MemoryValueType.String  => Text,
+            MemoryValueType.Number  => Number,
             MemoryValueType.Boolean => Flag,
-            _ => null
+            _                       => null
         };
 }

--- a/src/Moongate.Persistence/MoongatePersistencePlugin.cs
+++ b/src/Moongate.Persistence/MoongatePersistencePlugin.cs
@@ -77,7 +77,8 @@ public class MoongatePersistencePlugin : ISquidStdPlugin
             (entity, id) => entity.Id = id,
             new DefaultSerialGenerator()
         );
-        container.RegisterPersistenceSeeder(async (service, token) =>
+        container.RegisterPersistenceSeeder(
+            async (service, token) =>
             {
                 var accountStore = service.GetStore<AccountEntity, Serial>();
 

--- a/src/Moongate.Scripting/AI/BrainAssetSeeder.cs
+++ b/src/Moongate.Scripting/AI/BrainAssetSeeder.cs
@@ -12,10 +12,10 @@ public static class BrainAssetSeeder
 
         var assembly = typeof(BrainAssetSeeder).Assembly;
         var resources = assembly
-            .GetManifestResourceNames()
-            .Where(name => name.StartsWith(ResourcePrefix, StringComparison.Ordinal))
-            .Where(name => name.EndsWith(".lua", StringComparison.Ordinal))
-            .Order(StringComparer.Ordinal);
+                        .GetManifestResourceNames()
+                        .Where(name => name.StartsWith(ResourcePrefix, StringComparison.Ordinal))
+                        .Where(name => name.EndsWith(".lua", StringComparison.Ordinal))
+                        .Order(StringComparer.Ordinal);
 
         foreach (var resourceName in resources)
         {
@@ -37,20 +37,22 @@ public static class BrainAssetSeeder
 
         try
         {
-            using (var source = assembly.GetManifestResourceStream(resourceName)
-                ?? throw new InvalidOperationException($"Embedded brain resource was not found: {resourceName}"))
-            using (var temporary = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            using (var source = assembly.GetManifestResourceStream(resourceName) ??
+                                throw new InvalidOperationException(
+                                    $"Embedded brain resource was not found: {resourceName}"
+                                ))
             {
-                source.CopyTo(temporary);
+                using (var temporary = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    source.CopyTo(temporary);
+                }
             }
 
             try
             {
                 File.Move(temporaryPath, destination);
             }
-            catch (IOException) when (File.Exists(destination))
-            {
-            }
+            catch (IOException) when (File.Exists(destination)) { }
         }
         finally
         {

--- a/src/Moongate.Scripting/AI/LuaBrainValueConverter.cs
+++ b/src/Moongate.Scripting/AI/LuaBrainValueConverter.cs
@@ -55,27 +55,33 @@ internal sealed class LuaBrainValueConverter
                 break;
             case NpcBrainEventType.SpeechHeard:
                 SetSpeechFields(table, brainEvent);
+
                 break;
             case NpcBrainEventType.MobileEnteredRange:
             case NpcBrainEventType.MobileLeftRange:
                 SetMobileFields(table, brainEvent);
                 SetPosition(table, "from_position", brainEvent.FromPosition);
                 SetPosition(table, "to_position", brainEvent.ToPosition);
+
                 break;
             case NpcBrainEventType.MobileMoved:
                 SetMobileFields(table, brainEvent);
                 SetPosition(table, "from_position", brainEvent.FromPosition);
                 SetPosition(table, "to_position", brainEvent.ToPosition);
+
                 break;
             case NpcBrainEventType.Attacked:
                 SetSubjectSerial(table, "attacker_id", brainEvent.Mobile);
+
                 break;
             case NpcBrainEventType.Damage:
                 SetSubjectSerial(table, "attacker_id", brainEvent.Mobile);
                 table.Set("amount", DynValue.NewNumber(brainEvent.Amount));
+
                 break;
             case NpcBrainEventType.Death:
                 SetSubjectSerial(table, "killer_id", brainEvent.Mobile);
+
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(brainEvent), brainEvent.Type, null);
@@ -83,6 +89,57 @@ internal sealed class LuaBrainValueConverter
 
         return table;
     }
+
+    private void SetMobileFields(Table table, NpcBrainEvent brainEvent)
+    {
+        var mobile = brainEvent.Mobile;
+        SetSubjectSerial(table, "mobile_id", mobile);
+
+        if (mobile is null)
+        {
+            table.Set("mobile_name", DynValue.Nil);
+            table.Set("mobile_is_player", DynValue.Nil);
+
+            return;
+        }
+
+        table.Set("mobile_name", DynValue.NewString(mobile.Name));
+        table.Set("mobile_is_player", DynValue.NewBoolean(mobile.IsPlayer));
+    }
+
+    private void SetOptionalSerial(Table table, string name, Serial serial)
+        => table.Set(name, serial == Serial.Zero ? DynValue.Nil : DynValue.NewNumber(serial.Value));
+
+    private void SetPosition(Table table, string name, Point3D? position)
+        => table.Set(name, position.HasValue ? DynValue.NewTable(ToPosition(position.Value)) : DynValue.Nil);
+
+    private void SetSpeechFields(Table table, NpcBrainEvent brainEvent)
+    {
+        var speaker = brainEvent.Mobile;
+        SetSubjectSerial(table, "speaker_id", speaker);
+
+        if (speaker is null)
+        {
+            table.Set("speaker_name", DynValue.Nil);
+            table.Set("speaker_is_player", DynValue.Nil);
+        }
+        else
+        {
+            table.Set("speaker_name", DynValue.NewString(speaker.Name));
+            table.Set("speaker_is_player", DynValue.NewBoolean(speaker.IsPlayer));
+        }
+
+        table.Set(
+            "speech_type",
+            brainEvent.SpeechType.HasValue
+                ? DynValue.NewString(brainEvent.SpeechType.Value.ToString().ToLowerInvariant())
+                : DynValue.Nil
+        );
+        table.Set("text", brainEvent.Text is null ? DynValue.Nil : DynValue.NewString(brainEvent.Text));
+    }
+
+    private static void SetSubjectSerial(Table table, string name, BrainMobileSnapshot? mobile)
+        => table.Set(name, mobile is null ? DynValue.Nil : DynValue.NewNumber(mobile.Id.Value));
 
     private Table ToMobileSnapshot(BrainMobileSnapshot mobile)
     {
@@ -115,54 +172,4 @@ internal sealed class LuaBrainValueConverter
 
         return table;
     }
-
-    private void SetMobileFields(Table table, NpcBrainEvent brainEvent)
-    {
-        var mobile = brainEvent.Mobile;
-        SetSubjectSerial(table, "mobile_id", mobile);
-
-        if (mobile is null)
-        {
-            table.Set("mobile_name", DynValue.Nil);
-            table.Set("mobile_is_player", DynValue.Nil);
-            return;
-        }
-
-        table.Set("mobile_name", DynValue.NewString(mobile.Name));
-        table.Set("mobile_is_player", DynValue.NewBoolean(mobile.IsPlayer));
-    }
-
-    private void SetPosition(Table table, string name, Point3D? position)
-        => table.Set(name, position.HasValue ? DynValue.NewTable(ToPosition(position.Value)) : DynValue.Nil);
-
-    private void SetOptionalSerial(Table table, string name, Serial serial)
-        => table.Set(name, serial == Serial.Zero ? DynValue.Nil : DynValue.NewNumber(serial.Value));
-
-    private void SetSpeechFields(Table table, NpcBrainEvent brainEvent)
-    {
-        var speaker = brainEvent.Mobile;
-        SetSubjectSerial(table, "speaker_id", speaker);
-
-        if (speaker is null)
-        {
-            table.Set("speaker_name", DynValue.Nil);
-            table.Set("speaker_is_player", DynValue.Nil);
-        }
-        else
-        {
-            table.Set("speaker_name", DynValue.NewString(speaker.Name));
-            table.Set("speaker_is_player", DynValue.NewBoolean(speaker.IsPlayer));
-        }
-
-        table.Set(
-            "speech_type",
-            brainEvent.SpeechType.HasValue
-                ? DynValue.NewString(brainEvent.SpeechType.Value.ToString().ToLowerInvariant())
-                : DynValue.Nil
-        );
-        table.Set("text", brainEvent.Text is null ? DynValue.Nil : DynValue.NewString(brainEvent.Text));
-    }
-
-    private static void SetSubjectSerial(Table table, string name, BrainMobileSnapshot? mobile)
-        => table.Set(name, mobile is null ? DynValue.Nil : DynValue.NewNumber(mobile.Id.Value));
 }

--- a/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
+++ b/src/Moongate.Scripting/AI/LuaNpcBrainRuntime.cs
@@ -21,6 +21,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private const int MaximumBrainFileBytes = 256 * 1024;
     private const int MaximumPerceptionRange = 64;
     private const int ReloadDebounceMilliseconds = 250;
+
     private static readonly string[] OptionalHookNames =
     [
         "on_activate",
@@ -33,16 +34,20 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         "on_damage",
         "on_death"
     ];
+
     private static readonly Regex ValidBrainIdPattern = new(
         "^[a-z0-9][a-z0-9_-]*$",
         RegexOptions.CultureInvariant
     );
+
     private readonly NpcAiAdvancedConfig _advanced;
     private readonly Dictionary<Serial, BrainBinding> _bindings = [];
     private readonly string _brainsDirectory;
+
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _debounces = new(
         OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal
     );
+
     private readonly Dictionary<string, LuaBrainDefinition> _definitions = new(StringComparer.Ordinal);
     private readonly IEventBus _eventBus;
     private readonly IGameLoopContext _gameLoop;
@@ -85,6 +90,63 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         _watcherFactory = watcherFactory ?? CreateFileSystemWatcher;
     }
 
+    private sealed class BrainBinding
+    {
+        public string BrainId { get; }
+
+        public Table State { get; set; }
+
+        public BrainBinding(string brainId, Table state)
+        {
+            BrainId = brainId;
+            State = state;
+        }
+    }
+
+    private sealed class WatcherRegistration : IDisposable
+    {
+        private readonly FileSystemEventHandler _fileChanged;
+        private readonly RenamedEventHandler _fileRenamed;
+
+        public int Generation { get; }
+
+        public FileSystemWatcher Watcher { get; }
+
+        public WatcherRegistration(
+            FileSystemWatcher watcher,
+            int generation,
+            Action<FileSystemWatcher, int, object, string> queueReload
+        )
+        {
+            _fileChanged = (sender, eventArgs) =>
+                               queueReload(watcher, generation, sender, eventArgs.FullPath);
+            _fileRenamed = (sender, eventArgs) =>
+                               queueReload(watcher, generation, sender, eventArgs.FullPath);
+            Generation = generation;
+            Watcher = watcher;
+        }
+
+        public void Dispose()
+        {
+            Watcher.EnableRaisingEvents = false;
+            Watcher.Changed -= _fileChanged;
+            Watcher.Created -= _fileChanged;
+            Watcher.Renamed -= _fileRenamed;
+            Watcher.Dispose();
+        }
+
+        public void Start()
+        {
+            Watcher.Changed += _fileChanged;
+            Watcher.Created += _fileChanged;
+            Watcher.Renamed += _fileRenamed;
+            Watcher.EnableRaisingEvents = true;
+        }
+    }
+
+    public void Dispose()
+        => StopWatching();
+
     public NpcBrainInvocationResult Invoke(
         Serial mobileId,
         NpcBrainHookType hook,
@@ -102,9 +164,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
 
         if (!IsSupportedHook(hook))
         {
-            return FailInvocation(
-                $"Unsupported brain hook value: {(int)hook}."
-            );
+            return FailInvocation($"Unsupported brain hook value: {(int)hook}.");
         }
 
         var hookValue = definition.Strategy.Get(hookName);
@@ -161,6 +221,35 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         }
     }
 
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        BrainAssetSeeder.SeedMissing(_brainsDirectory);
+
+        if (_watcherRegistration is not null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var watcher = _watcherFactory(_brainsDirectory);
+        watcher.Filter = "*.lua";
+        watcher.IncludeSubdirectories = false;
+        watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size;
+        var watcherGeneration = Interlocked.Increment(ref _watcherGeneration);
+        var registration = new WatcherRegistration(watcher, watcherGeneration, QueueReload);
+        _watcherRegistration = registration;
+        Volatile.Write(ref _watching, 1);
+        registration.Start();
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        StopWatching();
+
+        return ValueTask.CompletedTask;
+    }
+
     public bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error)
     {
         if (!_definitions.TryGetValue(brainId, out var definition))
@@ -168,6 +257,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             if (!TryLoadDefinition(brainId, out definition, out error))
             {
                 descriptor = null;
+
                 return false;
             }
 
@@ -207,6 +297,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         {
             descriptor = null;
             _metrics.RecordReload(false);
+
             return false;
         }
 
@@ -219,57 +310,8 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         return true;
     }
 
-    public ValueTask StartAsync(CancellationToken cancellationToken = default)
-    {
-        BrainAssetSeeder.SeedMissing(_brainsDirectory);
-
-        if (_watcherRegistration is not null)
-        {
-            return ValueTask.CompletedTask;
-        }
-
-        var watcher = _watcherFactory(_brainsDirectory);
-        watcher.Filter = "*.lua";
-        watcher.IncludeSubdirectories = false;
-        watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size;
-        var watcherGeneration = Interlocked.Increment(ref _watcherGeneration);
-        var registration = new WatcherRegistration(watcher, watcherGeneration, QueueReload);
-        _watcherRegistration = registration;
-        Volatile.Write(ref _watching, 1);
-        registration.Start();
-
-        return ValueTask.CompletedTask;
-    }
-
-    public ValueTask StopAsync(CancellationToken cancellationToken = default)
-    {
-        StopWatching();
-
-        return ValueTask.CompletedTask;
-    }
-
     public void Unbind(Serial mobileId)
         => _bindings.Remove(mobileId);
-
-    private void StopWatching()
-    {
-        Volatile.Write(ref _watching, 0);
-        Interlocked.Increment(ref _watcherGeneration);
-
-        var registration = _watcherRegistration;
-        _watcherRegistration = null;
-        registration?.Dispose();
-
-        foreach (var debounce in _debounces)
-        {
-            CancelDebounce(debounce.Value);
-        }
-
-        _debounces.Clear();
-    }
-
-    private static bool IsCallable(DynValue value)
-        => value.Type is DataType.Function or DataType.ClrFunction;
 
     private static void CancelDebounce(CancellationTokenSource cancellation)
     {
@@ -286,75 +328,6 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
     private static FileSystemWatcher CreateFileSystemWatcher(string path)
         => new(path);
 
-    private static string GetHookName(NpcBrainHookType hook)
-        => hook switch
-        {
-            NpcBrainHookType.Activate => "on_activate",
-            NpcBrainHookType.Deactivate => "on_deactivate",
-            NpcBrainHookType.SpeechHeard => "on_speech_heard",
-            NpcBrainHookType.MobileEnteredRange => "on_mobile_entered_range",
-            NpcBrainHookType.MobileLeftRange => "on_mobile_left_range",
-            NpcBrainHookType.MobileMoved => "on_mobile_moved",
-            NpcBrainHookType.Attacked => "on_attacked",
-            NpcBrainHookType.Damage => "on_damage",
-            NpcBrainHookType.Death => "on_death",
-            NpcBrainHookType.Think => "think",
-            _ => $"unknown({(int)hook})"
-        };
-
-    private static string GetInterpreterError(InterpreterException exception)
-        => string.IsNullOrWhiteSpace(exception.DecoratedMessage) ? exception.Message : exception.DecoratedMessage;
-
-    private static bool IsSupportedHook(NpcBrainHookType hook)
-        => hook is
-            NpcBrainHookType.Activate or
-            NpcBrainHookType.Deactivate or
-            NpcBrainHookType.SpeechHeard or
-            NpcBrainHookType.MobileEnteredRange or
-            NpcBrainHookType.MobileLeftRange or
-            NpcBrainHookType.MobileMoved or
-            NpcBrainHookType.Attacked or
-            NpcBrainHookType.Damage or
-            NpcBrainHookType.Death or
-            NpcBrainHookType.Think;
-
-    private static bool TryReadInteger(Table table, string name, out int value)
-    {
-        value = 0;
-        var field = table.Get(name);
-
-        if (field.Type != DataType.Number ||
-            !double.IsFinite(field.Number) ||
-            field.Number != Math.Truncate(field.Number) ||
-            field.Number is < int.MinValue or > int.MaxValue)
-        {
-            return false;
-        }
-
-        value = (int)field.Number;
-
-        return true;
-    }
-
-    private static int? ReadNextTick(DynValue value)
-    {
-        if (value.Type != DataType.Number ||
-            !double.IsFinite(value.Number) ||
-            value.Number is < int.MinValue or > int.MaxValue)
-        {
-            return null;
-        }
-
-        return (int)value.Number;
-    }
-
-    private NpcBrainInvocationResult FailInvocation(string error, bool budgetExceeded = false)
-    {
-        _metrics.RecordHookFailure(budgetExceeded);
-
-        return NpcBrainInvocationResult.Failed(error, budgetExceeded);
-    }
-
     private async Task DebounceReloadAsync(
         string path,
         CancellationTokenSource cancellation,
@@ -365,12 +338,12 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         try
         {
             await Task
-                .Delay(
-                    TimeSpan.FromMilliseconds(ReloadDebounceMilliseconds),
-                    _timeProvider,
-                    cancellation.Token
-                )
-                .ConfigureAwait(false);
+                  .Delay(
+                      TimeSpan.FromMilliseconds(ReloadDebounceMilliseconds),
+                      _timeProvider,
+                      cancellation.Token
+                  )
+                  .ConfigureAwait(false);
 
             if (!RemoveDebounce(path, cancellation) ||
                 !IsCurrentWatcher(watcher, watcherGeneration))
@@ -390,15 +363,42 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
                 }
             );
         }
-        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
-        {
-        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { }
         finally
         {
             RemoveDebounce(path, cancellation);
             cancellation.Dispose();
         }
     }
+
+    private NpcBrainInvocationResult FailInvocation(string error, bool budgetExceeded = false)
+    {
+        _metrics.RecordHookFailure(budgetExceeded);
+
+        return NpcBrainInvocationResult.Failed(error, budgetExceeded);
+    }
+
+    private static string GetHookName(NpcBrainHookType hook)
+        => hook switch
+        {
+            NpcBrainHookType.Activate           => "on_activate",
+            NpcBrainHookType.Deactivate         => "on_deactivate",
+            NpcBrainHookType.SpeechHeard        => "on_speech_heard",
+            NpcBrainHookType.MobileEnteredRange => "on_mobile_entered_range",
+            NpcBrainHookType.MobileLeftRange    => "on_mobile_left_range",
+            NpcBrainHookType.MobileMoved        => "on_mobile_moved",
+            NpcBrainHookType.Attacked           => "on_attacked",
+            NpcBrainHookType.Damage             => "on_damage",
+            NpcBrainHookType.Death              => "on_death",
+            NpcBrainHookType.Think              => "think",
+            _                                   => $"unknown({(int)hook})"
+        };
+
+    private static string GetInterpreterError(InterpreterException exception)
+        => string.IsNullOrWhiteSpace(exception.DecoratedMessage) ? exception.Message : exception.DecoratedMessage;
+
+    private static bool IsCallable(DynValue value)
+        => value.Type is DataType.Function or DataType.ClrFunction;
 
     private bool IsCurrentWatcher(FileSystemWatcher watcher, int watcherGeneration)
     {
@@ -410,6 +410,19 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
                current.Generation == watcherGeneration &&
                ReferenceEquals(current.Watcher, watcher);
     }
+
+    private static bool IsSupportedHook(NpcBrainHookType hook)
+        => hook is
+               NpcBrainHookType.Activate or
+               NpcBrainHookType.Deactivate or
+               NpcBrainHookType.SpeechHeard or
+               NpcBrainHookType.MobileEnteredRange or
+               NpcBrainHookType.MobileLeftRange or
+               NpcBrainHookType.MobileMoved or
+               NpcBrainHookType.Attacked or
+               NpcBrainHookType.Damage or
+               NpcBrainHookType.Death or
+               NpcBrainHookType.Think;
 
     private void QueueReload(
         FileSystemWatcher watcher,
@@ -432,6 +445,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             (_, previous) =>
             {
                 CancelDebounce(previous);
+
                 return cancellation;
             }
         );
@@ -441,16 +455,44 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             CancelDebounce(cancellation);
             RemoveDebounce(normalizedPath, cancellation);
             cancellation.Dispose();
+
             return;
         }
 
         _ = DebounceReloadAsync(normalizedPath, cancellation, watcher, watcherGeneration);
     }
 
+    private static int? ReadNextTick(DynValue value)
+    {
+        if (value.Type != DataType.Number ||
+            !double.IsFinite(value.Number) ||
+            value.Number is < int.MinValue or > int.MaxValue)
+        {
+            return null;
+        }
+
+        return (int)value.Number;
+    }
+
     private bool RemoveDebounce(string path, CancellationTokenSource cancellation)
-        => ((ICollection<KeyValuePair<string, CancellationTokenSource>>)_debounces).Remove(
-            new(path, cancellation)
-        );
+        => ((ICollection<KeyValuePair<string, CancellationTokenSource>>)_debounces).Remove(new(path, cancellation));
+
+    private void StopWatching()
+    {
+        Volatile.Write(ref _watching, 0);
+        Interlocked.Increment(ref _watcherGeneration);
+
+        var registration = _watcherRegistration;
+        _watcherRegistration = null;
+        registration?.Dispose();
+
+        foreach (var debounce in _debounces)
+        {
+            CancelDebounce(debounce.Value);
+        }
+
+        _debounces.Clear();
+    }
 
     private bool TryLoadDefinition(
         string brainId,
@@ -463,6 +505,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         if (string.IsNullOrWhiteSpace(brainId) || !ValidBrainIdPattern.IsMatch(brainId))
         {
             error = $"Brain ID '{brainId}' is invalid.";
+
             return false;
         }
 
@@ -471,6 +514,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         if (!File.Exists(path))
         {
             error = $"Brain file was not found: {path}";
+
             return false;
         }
 
@@ -483,12 +527,14 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
                 (fileInfo.Attributes & FileAttributes.ReparsePoint) != 0)
             {
                 error = "Brain directories and files may not be symbolic links or reparse points.";
+
                 return false;
             }
 
             if (fileInfo.Length > MaximumBrainFileBytes)
             {
                 error = "Brain files may not exceed 256 KiB.";
+
                 return false;
             }
 
@@ -501,12 +547,14 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             if (coroutine.State == CoroutineState.ForceSuspended)
             {
                 error = "Instruction budget exceeded while loading brain definition.";
+
                 return false;
             }
 
             if (coroutine.State != CoroutineState.Dead)
             {
                 error = "Brain definition chunks may not yield.";
+
                 return false;
             }
 
@@ -520,13 +568,33 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         catch (InterpreterException exception)
         {
             error = GetInterpreterError(exception);
+
             return false;
         }
         catch (Exception exception)
         {
             error = exception.Message;
+
             return false;
         }
+    }
+
+    private static bool TryReadInteger(Table table, string name, out int value)
+    {
+        value = 0;
+        var field = table.Get(name);
+
+        if (field.Type != DataType.Number ||
+            !double.IsFinite(field.Number) ||
+            field.Number != Math.Truncate(field.Number) ||
+            field.Number is < int.MinValue or > int.MaxValue)
+        {
+            return false;
+        }
+
+        value = (int)field.Number;
+
+        return true;
     }
 
     private bool TryValidateDefinition(
@@ -541,6 +609,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         if (value.Type != DataType.Table)
         {
             error = "Brain definition must return a table.";
+
             return false;
         }
 
@@ -550,6 +619,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         if (id.Type != DataType.String || !string.Equals(id.String, brainId, StringComparison.Ordinal))
         {
             error = $"Brain definition id must exactly match '{brainId}'.";
+
             return false;
         }
 
@@ -558,8 +628,9 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             defaultTickMilliseconds > _advanced.MaxTickMilliseconds)
         {
             error =
-                $"Brain default_tick_ms must be between {_advanced.MinTickMilliseconds} and "
-                + $"{_advanced.MaxTickMilliseconds}.";
+                $"Brain default_tick_ms must be between {_advanced.MinTickMilliseconds} and " +
+                $"{_advanced.MaxTickMilliseconds}.";
+
             return false;
         }
 
@@ -567,6 +638,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             perceptionRange is < 0 or > MaximumPerceptionRange)
         {
             error = $"Brain perception_range must be between 0 and {MaximumPerceptionRange}.";
+
             return false;
         }
 
@@ -574,12 +646,14 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             hearingRange is < 0 or > MaximumPerceptionRange)
         {
             error = $"Brain hearing_range must be between 0 and {MaximumPerceptionRange}.";
+
             return false;
         }
 
         if (!IsCallable(strategy.Get("think")))
         {
             error = "Brain think must be callable.";
+
             return false;
         }
 
@@ -590,6 +664,7 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
             if (hook.Type is not DataType.Nil and not DataType.Void && !IsCallable(hook))
             {
                 error = $"Brain {hookName} must be callable or nil.";
+
                 return false;
             }
         }
@@ -601,64 +676,5 @@ public sealed class LuaNpcBrainRuntime : INpcBrainRuntime, ISquidStdService, IDi
         error = null;
 
         return true;
-    }
-
-    private sealed class BrainBinding
-    {
-        public string BrainId { get; }
-
-        public Table State { get; set; }
-
-        public BrainBinding(string brainId, Table state)
-        {
-            BrainId = brainId;
-            State = state;
-        }
-    }
-
-    private sealed class WatcherRegistration : IDisposable
-    {
-        private readonly FileSystemEventHandler _fileChanged;
-        private readonly RenamedEventHandler _fileRenamed;
-
-        public int Generation { get; }
-
-        public FileSystemWatcher Watcher { get; }
-
-        public WatcherRegistration(
-            FileSystemWatcher watcher,
-            int generation,
-            Action<FileSystemWatcher, int, object, string> queueReload
-        )
-        {
-            _fileChanged = (sender, eventArgs) =>
-                queueReload(watcher, generation, sender, eventArgs.FullPath);
-            _fileRenamed = (sender, eventArgs) =>
-                queueReload(watcher, generation, sender, eventArgs.FullPath);
-            Generation = generation;
-            Watcher = watcher;
-        }
-
-        public void Start()
-        {
-            Watcher.Changed += _fileChanged;
-            Watcher.Created += _fileChanged;
-            Watcher.Renamed += _fileRenamed;
-            Watcher.EnableRaisingEvents = true;
-        }
-
-        public void Dispose()
-        {
-            Watcher.EnableRaisingEvents = false;
-            Watcher.Changed -= _fileChanged;
-            Watcher.Created -= _fileChanged;
-            Watcher.Renamed -= _fileRenamed;
-            Watcher.Dispose();
-        }
-    }
-
-    public void Dispose()
-    {
-        StopWatching();
     }
 }

--- a/src/Moongate.Scripting/Assets/Brains/guard.lua
+++ b/src/Moongate.Scripting/Assets/Brains/guard.lua
@@ -33,7 +33,7 @@ function guard.on_speech_heard(ctx, state, event)
 end
 
 function guard.think()
-    -- idle: no action
+-- idle: no action
 end
 
 return guard

--- a/src/Moongate.Scripting/LoopAffineInvokeMarshaller.cs
+++ b/src/Moongate.Scripting/LoopAffineInvokeMarshaller.cs
@@ -34,7 +34,8 @@ public sealed class LoopAffineInvokeMarshaller : ILuaInvokeMarshaller
             return call();
         }
 
-        _dispatcher.Post(() =>
+        _dispatcher.Post(
+            () =>
             {
                 var result = call();
 

--- a/src/Moongate.Scripting/MoongateScriptingPlugin.cs
+++ b/src/Moongate.Scripting/MoongateScriptingPlugin.cs
@@ -1,7 +1,7 @@
 using DryIoc;
 using Moongate.Scripting.AI;
-using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Scripting.Modules;
+using Moongate.Server.Abstractions.Interfaces.AI;
 using SquidStd.Abstractions.Extensions.Services;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Directories;

--- a/src/Moongate.Server.Abstractions/Data/AI/NpcAiMetricsSnapshot.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/NpcAiMetricsSnapshot.cs
@@ -23,6 +23,6 @@ public sealed record NpcAiMetricsSnapshot(
     long ReloadFallbacks
 )
 {
-    public TimeSpan AverageHookDuration =>
-        HookInvocations == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(TotalHookDurationTicks / HookInvocations);
+    public TimeSpan AverageHookDuration
+        => HookInvocations == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(TotalHookDurationTicks / HookInvocations);
 }

--- a/src/Moongate.Server.Abstractions/Data/AI/NpcBrainInvocationResult.cs
+++ b/src/Moongate.Server.Abstractions/Data/AI/NpcBrainInvocationResult.cs
@@ -7,8 +7,9 @@ public sealed record NpcBrainInvocationResult(
     bool InstructionBudgetExceeded
 )
 {
-    public static NpcBrainInvocationResult Succeeded(int? nextTickMs) => new(true, nextTickMs, null, false);
-
     public static NpcBrainInvocationResult Failed(string error, bool budgetExceeded = false)
         => new(false, null, error, budgetExceeded);
+
+    public static NpcBrainInvocationResult Succeeded(int? nextTickMs)
+        => new(true, nextTickMs, null, false);
 }

--- a/src/Moongate.Server.Abstractions/Data/Stats/ServerStatsSnapshot.cs
+++ b/src/Moongate.Server.Abstractions/Data/Stats/ServerStatsSnapshot.cs
@@ -24,5 +24,17 @@ public sealed record ServerStatsSnapshot(
     /// distinguishable from a genuinely empty shard.
     /// </summary>
     public static ServerStatsSnapshot Empty { get; } =
-        new(DateTimeOffset.MinValue, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        new(
+            DateTimeOffset.MinValue,
+            TimeSpan.Zero,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        );
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/IAiActionService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/IAiActionService.cs
@@ -10,17 +10,14 @@ public interface IAiActionService
     /// <summary>Sets the ambient brain context for the current tick; disposing restores the previous one.</summary>
     IDisposable Begin(BrainContext context);
 
-    /// <summary>Speaks as the active mobile; false when the text is blank or over the length limit.</summary>
-    bool Say(string text);
+    /// <summary>Clears combatant and warmode on the active mobile.</summary>
+    bool ClearTarget();
 
-    /// <summary>Steps randomly within the home leash, or toward home when outside it; false when off the home map.</summary>
-    bool Patrol();
+    /// <summary>Sets combatant and warmode on the perceived target; false when the target is not perceivable.</summary>
+    bool Engage(Serial targetId);
 
-    /// <summary>Steps one tile toward the home position; false when off the home map.</summary>
-    bool ReturnHome();
-
-    /// <summary>Steps one tile in the given compass direction; false when the step is blocked.</summary>
-    bool Step(DirectionType direction);
+    /// <summary>Steps one tile away from the perceived target; false when the target is not perceivable.</summary>
+    bool MoveAway(Serial targetId);
 
     /// <summary>Steps one tile toward (x, y) at the owner's current z; false when the step is blocked.</summary>
     bool MoveTo(int x, int y);
@@ -28,12 +25,15 @@ public interface IAiActionService
     /// <summary>Steps one tile toward the perceived target; false when the target is not perceivable.</summary>
     bool MoveToward(Serial targetId);
 
-    /// <summary>Steps one tile away from the perceived target; false when the target is not perceivable.</summary>
-    bool MoveAway(Serial targetId);
+    /// <summary>Steps randomly within the home leash, or toward home when outside it; false when off the home map.</summary>
+    bool Patrol();
 
-    /// <summary>Sets combatant and warmode on the perceived target; false when the target is not perceivable.</summary>
-    bool Engage(Serial targetId);
+    /// <summary>Steps one tile toward the home position; false when off the home map.</summary>
+    bool ReturnHome();
 
-    /// <summary>Clears combatant and warmode on the active mobile.</summary>
-    bool ClearTarget();
+    /// <summary>Speaks as the active mobile; false when the text is blank or over the length limit.</summary>
+    bool Say(string text);
+
+    /// <summary>Steps one tile in the given compass direction; false when the step is blocked.</summary>
+    bool Step(DirectionType direction);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcAiMetrics.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcAiMetrics.cs
@@ -9,33 +9,33 @@ public interface INpcAiMetrics
     /// <summary>Gets an immutable snapshot of the current measurements.</summary>
     NpcAiMetricsSnapshot Current { get; }
 
-    /// <summary>Sets the current counts of active and grace-period sectors.</summary>
-    void SetActiveSectorCounts(int active, int grace);
-
-    /// <summary>Sets the current count of sleeping sectors.</summary>
-    void SetSleepingSectorCount(int sleeping);
-
-    /// <summary>Sets the current counts of active, sleeping and fault-backoff brains.</summary>
-    void SetBrainCounts(int active, int sleeping, int faultBackoff);
+    /// <summary>Records a brain deferred by scheduler limits.</summary>
+    void RecordBrainDeferred();
 
     /// <summary>Records execution of a brain during a scheduler iteration.</summary>
     void RecordBrainExecuted();
 
-    /// <summary>Records a brain deferred by scheduler limits.</summary>
-    void RecordBrainDeferred();
-
-    /// <summary>Records the duration of one brain hook invocation.</summary>
-    void RecordHookInvocation(TimeSpan duration);
+    /// <summary>Records how a queued brain event was handled.</summary>
+    void RecordEvent(NpcBrainEventDispositionType disposition);
 
     /// <summary>Records a failed brain hook invocation.</summary>
     void RecordHookFailure(bool instructionBudgetExceeded);
 
-    /// <summary>Records how a queued brain event was handled.</summary>
-    void RecordEvent(NpcBrainEventDispositionType disposition);
+    /// <summary>Records the duration of one brain hook invocation.</summary>
+    void RecordHookInvocation(TimeSpan duration);
 
     /// <summary>Records whether a brain intent was accepted for execution.</summary>
     void RecordIntent(bool accepted);
 
     /// <summary>Records whether a brain reload succeeded or used its fallback.</summary>
     void RecordReload(bool succeeded);
+
+    /// <summary>Sets the current counts of active and grace-period sectors.</summary>
+    void SetActiveSectorCounts(int active, int grace);
+
+    /// <summary>Sets the current counts of active, sleeping and fault-backoff brains.</summary>
+    void SetBrainCounts(int active, int sleeping, int faultBackoff);
+
+    /// <summary>Sets the current count of sleeping sectors.</summary>
+    void SetSleepingSectorCount(int sleeping);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainRuntime.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainRuntime.cs
@@ -7,12 +7,6 @@ namespace Moongate.Server.Abstractions.Interfaces.AI;
 /// <summary>Provides runtime binding and hook invocation for NPC brain implementations.</summary>
 public interface INpcBrainRuntime
 {
-    /// <summary>Attempts to bind a mobile to a brain and returns its descriptor on success.</summary>
-    bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error);
-
-    /// <summary>Attempts to obtain the descriptor bound to a mobile.</summary>
-    bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor);
-
     /// <summary>Invokes a brain hook with the supplied world context and optional event.</summary>
     NpcBrainInvocationResult Invoke(
         Serial mobileId,
@@ -21,11 +15,17 @@ public interface INpcBrainRuntime
         NpcBrainEvent? brainEvent = null
     );
 
-    /// <summary>Attempts to reload a brain definition and returns its descriptor on success.</summary>
-    bool TryReload(string brainId, out BrainDescriptor? descriptor, out string? error);
-
     /// <summary>Resets the runtime state held for a mobile.</summary>
     void Reset(Serial mobileId);
+
+    /// <summary>Attempts to bind a mobile to a brain and returns its descriptor on success.</summary>
+    bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error);
+
+    /// <summary>Attempts to obtain the descriptor bound to a mobile.</summary>
+    bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor);
+
+    /// <summary>Attempts to reload a brain definition and returns its descriptor on success.</summary>
+    bool TryReload(string brainId, out BrainDescriptor? descriptor, out string? error);
 
     /// <summary>Removes a mobile's brain binding and runtime state.</summary>
     void Unbind(Serial mobileId);

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainScheduler.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcBrainScheduler.cs
@@ -14,30 +14,30 @@ public interface INpcBrainScheduler
     /// <summary>Gets the greatest perception range of all scheduled brains.</summary>
     int MaxPerceptionRange { get; }
 
-    /// <summary>Binds a mobile to its configured brain.</summary>
-    void Bind(MobileEntity mobile);
-
-    /// <summary>Removes a mobile and its brain from scheduling.</summary>
-    void Unbind(Serial mobileId);
-
     /// <summary>Activates a mobile's scheduled brain.</summary>
     void Activate(Serial mobileId);
+
+    /// <summary>Binds a mobile to its configured brain.</summary>
+    void Bind(MobileEntity mobile);
 
     /// <summary>Begins deactivating a mobile's scheduled brain.</summary>
     void Deactivate(Serial mobileId);
 
-    /// <summary>Refreshes every scheduled brain using the supplied descriptor.</summary>
-    void RefreshDescriptor(string brainId, BrainDescriptor descriptor);
+    /// <summary>Queues a brain event for delivery on the mobile's next wake.</summary>
+    void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent);
 
     /// <summary>Returns whether a mobile's brain is active.</summary>
     bool IsActive(Serial mobileId);
 
-    /// <summary>Attempts to obtain the descriptor scheduled for a mobile.</summary>
-    bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor);
-
-    /// <summary>Queues a brain event for delivery on the mobile's next wake.</summary>
-    void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent);
+    /// <summary>Refreshes every scheduled brain using the supplied descriptor.</summary>
+    void RefreshDescriptor(string brainId, BrainDescriptor descriptor);
 
     /// <summary>Executes due brain work for the current scheduler iteration.</summary>
     void Tick();
+
+    /// <summary>Attempts to obtain the descriptor scheduled for a mobile.</summary>
+    bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor);
+
+    /// <summary>Removes a mobile and its brain from scheduling.</summary>
+    void Unbind(Serial mobileId);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/AI/INpcMemoryService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/AI/INpcMemoryService.cs
@@ -7,21 +7,21 @@ namespace Moongate.Server.Abstractions.Interfaces.AI;
 /// <summary>Durable per-NPC key/value memory for the mobile of the active brain tick.</summary>
 public interface INpcMemoryService
 {
+    /// <summary>Returns every stored key/value for the active mobile.</summary>
+    IReadOnlyDictionary<string, NpcMemoryValue> All();
+
     /// <summary>Sets the ambient brain context for the current tick; disposing restores the previous one.</summary>
     IDisposable Begin(BrainContext context);
-
-    /// <summary>Stores a value under a key; false when the mobile is unknown or a bound is exceeded.</summary>
-    bool Set(string key, NpcMemoryValue value);
-
-    /// <summary>Returns the stored value for a key, or null when absent.</summary>
-    NpcMemoryValue? Get(string key);
 
     /// <summary>Removes a key; true when it existed.</summary>
     bool Delete(string key);
 
-    /// <summary>Returns every stored key/value for the active mobile.</summary>
-    IReadOnlyDictionary<string, NpcMemoryValue> All();
-
     /// <summary>Permanently drops all memory for a mobile (used when it is deleted).</summary>
     void Forget(Serial mobileId);
+
+    /// <summary>Returns the stored value for a key, or null when absent.</summary>
+    NpcMemoryValue? Get(string key);
+
+    /// <summary>Stores a value under a key; false when the mobile is unknown or a bound is exceeded.</summary>
+    bool Set(string key, NpcMemoryValue value);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Accounts/IAccountService.cs
@@ -25,29 +25,6 @@ public interface IAccountService
     AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level);
 
     /// <summary>
-    /// Creates a pending Player account for web self-registration: inactive, carrying a single-use
-    /// verification token stored as a hash with a 24-hour expiry, with the required, validated email
-    /// stored. Publishes
-    /// <see cref="Moongate.Server.Abstractions.Data.Events.AccountRegistrationRequestedEvent" />. The
-    /// account cannot log in until verified.
-    /// </summary>
-    AccountRegisterResult RegisterPending(string username, string password, string email);
-
-    /// <summary>
-    /// Reissues a verification token for a pending account whose normalized username and email match.
-    /// Valid requests that do not match a pending account return <see cref="AccountResendResultType.Ignored" />
-    /// so callers do not disclose account state.
-    /// </summary>
-    AccountResendResultType ResendVerification(string username, string email)
-        => AccountResendResultType.Ignored;
-
-    /// <summary>
-    /// Activates the account holding an unexpired <paramref name="token" /> and clears its token state.
-    /// Consumed, expired, or unknown tokens cannot activate an account.
-    /// </summary>
-    AccountVerifyResultType VerifyEmail(string token);
-
-    /// <summary>
     /// Deletes the account along with every character it owns and everything those characters carry.
     /// Refused outright while any of them is being played.
     /// </summary>
@@ -76,6 +53,23 @@ public interface IAccountService
     IReadOnlyList<string> GetUsernames();
 
     /// <summary>
+    /// Creates a pending Player account for web self-registration: inactive, carrying a single-use
+    /// verification token stored as a hash with a 24-hour expiry, with the required, validated email
+    /// stored. Publishes
+    /// <see cref="Moongate.Server.Abstractions.Data.Events.AccountRegistrationRequestedEvent" />. The
+    /// account cannot log in until verified.
+    /// </summary>
+    AccountRegisterResult RegisterPending(string username, string password, string email);
+
+    /// <summary>
+    /// Reissues a verification token for a pending account whose normalized username and email match.
+    /// Valid requests that do not match a pending account return <see cref="AccountResendResultType.Ignored" />
+    /// so callers do not disclose account state.
+    /// </summary>
+    AccountResendResultType ResendVerification(string username, string email)
+        => AccountResendResultType.Ignored;
+
+    /// <summary>
     /// Activates or deactivates the account. A deactivated account is refused at login but keeps its
     /// characters. False on unknown username.
     /// </summary>
@@ -89,4 +83,10 @@ public interface IAccountService
     /// username or blank password.
     /// </summary>
     bool SetPassword(string username, string password);
+
+    /// <summary>
+    /// Activates the account holding an unexpired <paramref name="token" /> and clears its token state.
+    /// Consumed, expired, or unknown tokens cannot activate an account.
+    /// </summary>
+    AccountVerifyResultType VerifyEmail(string token);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/Events/ILoopAffineEvent.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Events/ILoopAffineEvent.cs
@@ -7,6 +7,4 @@ namespace Moongate.Server.Abstractions.Interfaces.Events;
 /// game-loop thread. The event bus decorator routes such an event onto the loop when it is
 /// published off it, and guards its handlers against running — or going async — off the loop.
 /// </summary>
-public interface ILoopAffineEvent : IEvent
-{
-}
+public interface ILoopAffineEvent : IEvent { }

--- a/src/Moongate.Server.Abstractions/Interfaces/Server/IServerSettingsService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Server/IServerSettingsService.cs
@@ -10,15 +10,15 @@ namespace Moongate.Server.Abstractions.Interfaces.Server;
 /// </summary>
 public interface IServerSettingsService
 {
+    /// <summary>Removes the asset metadata for a slot, if any.</summary>
+    void ClearAsset(ServerAssetSlotType slot);
+
     /// <summary>Returns the settings, creating the singleton with safe defaults on first access.</summary>
     ServerSettingsEntity Get();
-
-    /// <summary>Applies a partial update; a null field on <paramref name="update" /> is left unchanged.</summary>
-    void Update(ServerSettingsUpdate update);
 
     /// <summary>Records the file metadata for a slot, replacing any previous asset in it.</summary>
     void SetAsset(ServerAssetSlotType slot, ServerAssetMeta meta);
 
-    /// <summary>Removes the asset metadata for a slot, if any.</summary>
-    void ClearAsset(ServerAssetSlotType slot);
+    /// <summary>Applies a partial update; a null field on <paramref name="update" /> is left unchanged.</summary>
+    void Update(ServerSettingsUpdate update);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/World/ISectorActivityService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/ISectorActivityService.cs
@@ -13,15 +13,15 @@ public interface ISectorActivityService
     /// <summary>Returns whether a sector is reference-positive or still within its idle grace period.</summary>
     bool IsActive(int mapId, int sectorX, int sectorY);
 
-    /// <summary>Tracks a player at its current map and spatial-index sector.</summary>
-    void TrackPlayer(MobileEntity player);
-
     /// <summary>Moves an already tracked player to a spatial-index sector; unknown serials are ignored.</summary>
     void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY);
 
-    /// <summary>Stops tracking a player; unknown serials are ignored.</summary>
-    void UntrackPlayer(Serial playerId);
-
     /// <summary>Expires zero-reference sectors whose idle grace period has elapsed.</summary>
     void Tick();
+
+    /// <summary>Tracks a player at its current map and spatial-index sector.</summary>
+    void TrackPlayer(MobileEntity player);
+
+    /// <summary>Stops tracking a player; unknown serials are ignored.</summary>
+    void UntrackPlayer(Serial playerId);
 }

--- a/src/Moongate.Server/Data/Exceptions/UODirectoryNotValidException.cs
+++ b/src/Moongate.Server/Data/Exceptions/UODirectoryNotValidException.cs
@@ -2,17 +2,11 @@ namespace Moongate.Server.Data.Exceptions;
 
 public class UODirectoryNotValidException : Exception
 {
-    public UODirectoryNotValidException()
-    {
-    }
+    public UODirectoryNotValidException() { }
 
     public UODirectoryNotValidException(string message)
-        : base(message)
-    {
-    }
+        : base(message) { }
 
     public UODirectoryNotValidException(string message, Exception inner)
-        : base(message, inner)
-    {
-    }
+        : base(message, inner) { }
 }

--- a/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
+++ b/src/Moongate.Server/Data/Internal/AI/NpcBrainMailbox.cs
@@ -21,25 +21,8 @@ public sealed class NpcBrainMailbox
         _metrics = metrics;
     }
 
-    public bool Enqueue(NpcBrainHookType hook, NpcBrainEvent brainEvent)
-    {
-        if (TryCoalesce(hook, brainEvent))
-        {
-            _metrics.RecordEvent(NpcBrainEventDispositionType.Coalesced);
-            return false;
-        }
-
-        if (_entries.Count == _capacity && !MakeRoom(hook))
-        {
-            _metrics.RecordEvent(NpcBrainEventDispositionType.Dropped);
-            return false;
-        }
-
-        var schedulingChanged = _entries.Count == 0;
-        _entries.Add((hook, brainEvent, _nextSequence++));
-
-        return schedulingChanged;
-    }
+    public void Clear()
+        => _entries.Clear();
 
     public IReadOnlyList<(NpcBrainHookType Hook, NpcBrainEvent Event)> Dequeue(int maximumCount)
     {
@@ -63,55 +46,26 @@ public sealed class NpcBrainMailbox
         return delivered;
     }
 
-    public void Clear()
+    public bool Enqueue(NpcBrainHookType hook, NpcBrainEvent brainEvent)
     {
-        _entries.Clear();
-    }
-
-    private bool TryCoalesce(NpcBrainHookType hook, NpcBrainEvent brainEvent)
-    {
-        if (brainEvent.Mobile is not { Id: var mobileId } || mobileId == Serial.Zero)
+        if (TryCoalesce(hook, brainEvent))
         {
+            _metrics.RecordEvent(NpcBrainEventDispositionType.Coalesced);
+
             return false;
         }
 
-        if (hook == NpcBrainHookType.MobileMoved)
+        if (_entries.Count == _capacity && !MakeRoom(hook))
         {
-            for (var index = 0; index < _entries.Count; index++)
-            {
-                var entry = _entries[index];
+            _metrics.RecordEvent(NpcBrainEventDispositionType.Dropped);
 
-                if (entry.Hook != hook || entry.Event.Mobile?.Id != mobileId)
-                {
-                    continue;
-                }
-
-                _entries[index] = (hook, brainEvent, entry.Sequence);
-                return true;
-            }
+            return false;
         }
 
-        if (hook is NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange)
-        {
-            for (var index = _entries.Count - 1; index >= 0; index--)
-            {
-                var entry = _entries[index];
+        var schedulingChanged = _entries.Count == 0;
+        _entries.Add((hook, brainEvent, _nextSequence++));
 
-                if (
-                    entry.Event.Mobile?.Id != mobileId ||
-                    entry.Hook is not (
-                        NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange
-                    )
-                )
-                {
-                    continue;
-                }
-
-                return entry.Hook == hook;
-            }
-        }
-
-        return false;
+        return schedulingChanged;
     }
 
     private bool MakeRoom(NpcBrainHookType incomingHook)
@@ -134,9 +88,56 @@ public sealed class NpcBrainMailbox
         => hook switch
         {
             NpcBrainHookType.Activate or NpcBrainHookType.Deactivate or NpcBrainHookType.Death => 4,
-            NpcBrainHookType.Attacked or NpcBrainHookType.Damage => 3,
-            NpcBrainHookType.SpeechHeard => 2,
-            NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange => 1,
-            _ => 0
+            NpcBrainHookType.Attacked or NpcBrainHookType.Damage                               => 3,
+            NpcBrainHookType.SpeechHeard                                                       => 2,
+            NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange            => 1,
+            _                                                                                  => 0
         };
+
+    private bool TryCoalesce(NpcBrainHookType hook, NpcBrainEvent brainEvent)
+    {
+        if (brainEvent.Mobile is not { Id: var mobileId } || mobileId == Serial.Zero)
+        {
+            return false;
+        }
+
+        if (hook == NpcBrainHookType.MobileMoved)
+        {
+            for (var index = 0; index < _entries.Count; index++)
+            {
+                var entry = _entries[index];
+
+                if (entry.Hook != hook || entry.Event.Mobile?.Id != mobileId)
+                {
+                    continue;
+                }
+
+                _entries[index] = (hook, brainEvent, entry.Sequence);
+
+                return true;
+            }
+        }
+
+        if (hook is NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange)
+        {
+            for (var index = _entries.Count - 1; index >= 0; index--)
+            {
+                var entry = _entries[index];
+
+                if (
+                    entry.Event.Mobile?.Id != mobileId ||
+                    entry.Hook is not (
+                        NpcBrainHookType.MobileEnteredRange or NpcBrainHookType.MobileLeftRange
+                        )
+                )
+                {
+                    continue;
+                }
+
+                return entry.Hook == hook;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Moongate.Server/Extensions/DataLoaderServiceRegistrationExtensions.cs
+++ b/src/Moongate.Server/Extensions/DataLoaderServiceRegistrationExtensions.cs
@@ -26,10 +26,10 @@ public static class DataLoaderServiceRegistrationExtensions
                 var recorded = resolver.Resolve<List<DataLoaderRegistration>>(IfUnresolved.ReturnDefault);
 
                 return recorded is null
-                    ? []
-                    : recorded.OrderBy(registration => registration.Priority)
-                        .Select(registration => registration.Resolve(resolver))
-                        .ToList();
+                           ? []
+                           : recorded.OrderBy(registration => registration.Priority)
+                                     .Select(registration => registration.Resolve(resolver))
+                                     .ToList();
             },
             Reuse.Singleton
         );

--- a/src/Moongate.Server/Handlers/DeleteCharacterHandler.cs
+++ b/src/Moongate.Server/Handlers/DeleteCharacterHandler.cs
@@ -34,8 +34,8 @@ public sealed class DeleteCharacterHandler : IPacketHandler<DeleteCharacterPacke
         }
 
         var characters = _characterService.GetPlayerCharacters(context.Session.AccountId)
-            .Select(character => character.Name)
-            .ToList();
+                                          .Select(character => character.Name)
+                                          .ToList();
 
         context.Session.Send(new CharacterListUpdatePacket(characters, CharacterSlots));
     }

--- a/src/Moongate.Server/Handlers/SpeechHandler.cs
+++ b/src/Moongate.Server/Handlers/SpeechHandler.cs
@@ -11,7 +11,8 @@ namespace Moongate.Server.Handlers;
 /// <summary>
 /// Handles player speech (0xAD): rate-limits, classifies the raw text (say/emote/whisper/yell/
 /// command) via <see cref="ChatService" />'s pure core, and either dispatches the "." prefix to
-/// <see cref="ICommandService.Execute(Moongate.Server.Abstractions.Data.Session.PlayerSession, Moongate.Persistence.Entities.MobileEntity, string)" />
+/// <see
+///     cref="ICommandService.Execute(Moongate.Server.Abstractions.Data.Session.PlayerSession, Moongate.Persistence.Entities.MobileEntity, string)" />
 /// or hands the classified message to
 /// <see cref="IChatService.Say" />. Packets with the classic-client "encoded" (keyword-menu) flag
 /// are dropped, as is any text that is empty or longer than 128 characters after trimming.

--- a/src/Moongate.Server/Internal/EmbeddedResourceDirectorySeeder.cs
+++ b/src/Moongate.Server/Internal/EmbeddedResourceDirectorySeeder.cs
@@ -18,12 +18,13 @@ internal static class EmbeddedResourceDirectorySeeder
         var temporaryDirectory = Path.Combine(parentDirectory, $".{directoryName}-{Guid.NewGuid():N}.tmp");
         var temporaryPrefix = temporaryDirectory + Path.DirectorySeparatorChar;
         var resources = ResourceUtils.GetEmbeddedResourceNames(assembly, embeddedDirectory)
-            .Where(resourceName => resourceName.StartsWith(
-                    embeddedNamespace + ".",
-                    StringComparison.Ordinal
-                )
-            )
-            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase);
+                                     .Where(
+                                         resourceName => resourceName.StartsWith(
+                                             embeddedNamespace + ".",
+                                             StringComparison.Ordinal
+                                         )
+                                     )
+                                     .OrderBy(name => name, StringComparer.OrdinalIgnoreCase);
 
         Directory.CreateDirectory(parentDirectory);
 

--- a/src/Moongate.Server/Loaders/ItemTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/ItemTemplatesLoader.cs
@@ -53,8 +53,8 @@ public sealed class ItemTemplatesLoader : IDataLoader
         }
 
         var files = Directory.GetFiles(itemsDirectory, "*.yaml", SearchOption.AllDirectories)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                             .ToArray();
 
         if (files.Length == 0)
         {

--- a/src/Moongate.Server/Loaders/LootTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/LootTemplatesLoader.cs
@@ -46,8 +46,8 @@ public sealed class LootTemplatesLoader : IDataLoader
         }
 
         var files = Directory.GetFiles(lootDirectory, "*.yaml", SearchOption.AllDirectories)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                             .ToArray();
 
         if (files.Length == 0)
         {

--- a/src/Moongate.Server/Loaders/MobileTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/MobileTemplatesLoader.cs
@@ -46,8 +46,8 @@ public sealed class MobileTemplatesLoader : IDataLoader
         }
 
         var files = Directory.GetFiles(mobilesDirectory, "*.yaml", SearchOption.AllDirectories)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                             .ToArray();
 
         if (files.Length == 0)
         {

--- a/src/Moongate.Server/Loaders/NotificationTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/NotificationTemplatesLoader.cs
@@ -52,12 +52,12 @@ public sealed class NotificationTemplatesLoader : IDataLoader
         var failed = 0;
 
         foreach (var channelDirectory in Directory.GetDirectories(templatesDirectory)
-                     .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+                                                  .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
         {
             var channelId = Path.GetFileName(channelDirectory);
 
             foreach (var file in Directory.GetFiles(channelDirectory, Extension, SearchOption.TopDirectoryOnly)
-                         .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+                                          .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
             {
                 var templateId = Path.GetFileNameWithoutExtension(file);
 

--- a/src/Moongate.Server/Scripting/AiModule.cs
+++ b/src/Moongate.Server/Scripting/AiModule.cs
@@ -19,9 +19,25 @@ public sealed class AiModule
         _actions = actions;
     }
 
-    [ScriptFunction("say", "Speaks as the current NPC; false when the text is blank or too long.")]
-    public bool Say(string text)
-        => _actions.Say(text);
+    [ScriptFunction("clear_target", "Clears combat posture on the current NPC.")]
+    public bool ClearTarget()
+        => _actions.ClearTarget();
+
+    [ScriptFunction("engage", "Sets combat posture on the perceived target; false when not perceivable.")]
+    public bool Engage(uint target)
+        => _actions.Engage((Serial)target);
+
+    [ScriptFunction("move_away", "Steps away from the perceived target; false when not perceivable.")]
+    public bool MoveAway(uint target)
+        => _actions.MoveAway((Serial)target);
+
+    [ScriptFunction("move_to", "Steps one tile toward (x, y) at the current z; false when blocked.")]
+    public bool MoveTo(int x, int y)
+        => _actions.MoveTo(x, y);
+
+    [ScriptFunction("move_toward", "Steps toward the perceived target; false when not perceivable.")]
+    public bool MoveToward(uint target)
+        => _actions.MoveToward((Serial)target);
 
     [ScriptFunction("patrol", "Wanders within the home leash, else steps toward home; false off the home map.")]
     public bool Patrol()
@@ -31,29 +47,16 @@ public sealed class AiModule
     public bool ReturnHome()
         => _actions.ReturnHome();
 
-    [ScriptFunction("move_toward", "Steps toward the perceived target; false when not perceivable.")]
-    public bool MoveToward(uint target)
-        => _actions.MoveToward((Serial)target);
+    [ScriptFunction("say", "Speaks as the current NPC; false when the text is blank or too long.")]
+    public bool Say(string text)
+        => _actions.Say(text);
 
-    [ScriptFunction("move_away", "Steps away from the perceived target; false when not perceivable.")]
-    public bool MoveAway(uint target)
-        => _actions.MoveAway((Serial)target);
-
-    [ScriptFunction("engage", "Sets combat posture on the perceived target; false when not perceivable.")]
-    public bool Engage(uint target)
-        => _actions.Engage((Serial)target);
-
-    [ScriptFunction("clear_target", "Clears combat posture on the current NPC.")]
-    public bool ClearTarget()
-        => _actions.ClearTarget();
-
-    [ScriptFunction("step", "Steps one tile in a compass direction (north/n, northeast/ne, …); false when blocked or unknown.")]
+    [ScriptFunction(
+        "step",
+        "Steps one tile in a compass direction (north/n, northeast/ne, …); false when blocked or unknown."
+    )]
     public bool Step(string direction)
         => TryParseDirection(direction, out var parsed) && _actions.Step(parsed);
-
-    [ScriptFunction("move_to", "Steps one tile toward (x, y) at the current z; false when blocked.")]
-    public bool MoveTo(int x, int y)
-        => _actions.MoveTo(x, y);
 
     private static bool TryParseDirection(string direction, out DirectionType parsed)
     {
@@ -62,37 +65,46 @@ public sealed class AiModule
             case "north":
             case "n":
                 parsed = DirectionType.North;
+
                 return true;
             case "northeast":
             case "ne":
                 parsed = DirectionType.NorthEast;
+
                 return true;
             case "east":
             case "e":
                 parsed = DirectionType.East;
+
                 return true;
             case "southeast":
             case "se":
                 parsed = DirectionType.SouthEast;
+
                 return true;
             case "south":
             case "s":
                 parsed = DirectionType.South;
+
                 return true;
             case "southwest":
             case "sw":
                 parsed = DirectionType.SouthWest;
+
                 return true;
             case "west":
             case "w":
                 parsed = DirectionType.West;
+
                 return true;
             case "northwest":
             case "nw":
                 parsed = DirectionType.NorthWest;
+
                 return true;
             default:
                 parsed = default;
+
                 return false;
         }
     }

--- a/src/Moongate.Server/Scripting/ItemModule.cs
+++ b/src/Moongate.Server/Scripting/ItemModule.cs
@@ -53,27 +53,19 @@ public sealed class ItemModule
 
     [ScriptFunction("create", "Creates an item from a template; returns its serial or nil.")]
     public uint? Create(string templateId, int amount, uint hue)
-    {
-        return Persist(_factory.CreateFromTemplate(templateId, amount: amount, hue: ToHue(hue)));
-    }
+        => Persist(_factory.CreateFromTemplate(templateId, amount: amount, hue: ToHue(hue)));
 
     [ScriptFunction("create_by_category", "Creates a random item in the category; returns its serial or nil.")]
     public uint? CreateByCategory(string category, int amount, uint hue)
-    {
-        return Persist(_factory.CreateByCategory(category, amount: amount, hue: ToHue(hue)));
-    }
+        => Persist(_factory.CreateByCategory(category, amount: amount, hue: ToHue(hue)));
 
     [ScriptFunction("create_by_tag", "Creates a random item carrying the tag; returns its serial or nil.")]
     public uint? CreateByTag(string tag, int amount, uint hue)
-    {
-        return Persist(_factory.CreateByTag(tag, amount: amount, hue: ToHue(hue)));
-    }
+        => Persist(_factory.CreateByTag(tag, amount: amount, hue: ToHue(hue)));
 
     [ScriptFunction("delete", "Deletes the item; true when it existed.")]
     public bool Delete(uint serial)
-    {
-        return _items.Delete((Serial)serial);
-    }
+        => _items.Delete((Serial)serial);
 
     [ScriptFunction("equip", "Equips the item on a mobile at a layer; false on unknown mobile/item/layer.")]
     public bool Equip(uint mobile, uint serial, object layer)

--- a/src/Moongate.Server/Scripting/MemoryModule.cs
+++ b/src/Moongate.Server/Scripting/MemoryModule.cs
@@ -20,31 +20,31 @@ public sealed class MemoryModule
         _memory = memory;
     }
 
-    [ScriptFunction("set", "Stores a scalar (string/number/boolean) under a key; false when unsupported or rejected.")]
-    public bool Set(string key, object value)
-    {
-        var stored = value switch
-        {
-            string text => NpcMemoryValue.FromString(text),
-            bool flag => NpcMemoryValue.FromBoolean(flag),
-            double number => NpcMemoryValue.FromNumber(number),
-            long number => NpcMemoryValue.FromNumber(number),
-            int number => NpcMemoryValue.FromNumber(number),
-            _ => null
-        };
-
-        return stored is not null && _memory.Set(key, stored);
-    }
-
-    [ScriptFunction("get", "Returns the stored value for a key, or nil.")]
-    public object? Get(string key)
-        => _memory.Get(key)?.ToScalar();
+    [ScriptFunction("all", "Returns a table of every stored key/value for the current NPC.")]
+    public NpcMemoryLuaView All()
+        => new(_memory.All());
 
     [ScriptFunction("delete", "Removes a key; true when it existed.")]
     public bool Delete(string key)
         => _memory.Delete(key);
 
-    [ScriptFunction("all", "Returns a table of every stored key/value for the current NPC.")]
-    public NpcMemoryLuaView All()
-        => new(_memory.All());
+    [ScriptFunction("get", "Returns the stored value for a key, or nil.")]
+    public object? Get(string key)
+        => _memory.Get(key)?.ToScalar();
+
+    [ScriptFunction("set", "Stores a scalar (string/number/boolean) under a key; false when unsupported or rejected.")]
+    public bool Set(string key, object value)
+    {
+        var stored = value switch
+        {
+            string text   => NpcMemoryValue.FromString(text),
+            bool flag     => NpcMemoryValue.FromBoolean(flag),
+            double number => NpcMemoryValue.FromNumber(number),
+            long number   => NpcMemoryValue.FromNumber(number),
+            int number    => NpcMemoryValue.FromNumber(number),
+            _             => null
+        };
+
+        return stored is not null && _memory.Set(key, stored);
+    }
 }

--- a/src/Moongate.Server/Services/AI/AiActionService.cs
+++ b/src/Moongate.Server/Services/AI/AiActionService.cs
@@ -51,16 +51,44 @@ public sealed class AiActionService : IAiActionService
         _metrics = metrics;
     }
 
+    private sealed class ContextScope : IDisposable
+    {
+        private readonly AiActionService _owner;
+        private readonly BrainContext? _previous;
+
+        public ContextScope(AiActionService owner, BrainContext? previous)
+        {
+            _owner = owner;
+            _previous = previous;
+        }
+
+        public void Dispose()
+            => _owner._current = _previous;
+    }
+
     public IDisposable Begin(BrainContext context)
     {
         _loopAffinity.AssertOnLoop("ai.begin");
         var previous = _current;
         _current = context;
+
         return new ContextScope(this, previous);
     }
 
-    public bool Say(string text)
-        => Run((owner, _) => TrySay(owner, text, out var reason) ? Ok() : Fail(reason));
+    public bool ClearTarget()
+        => Run((owner, _) => TryClearTarget(owner, out var reason) ? Ok() : Fail(reason));
+
+    public bool Engage(Serial targetId)
+        => Run((owner, context) => TryEngage(owner, context, targetId, out var reason) ? Ok() : Fail(reason));
+
+    public bool MoveAway(Serial targetId)
+        => Run((owner, context) => TryMove(owner, context, targetId, true, out var reason) ? Ok() : Fail(reason));
+
+    public bool MoveTo(int x, int y)
+        => Run((owner, _) => TryMoveToPosition(owner, new(x, y, owner.Position.Z), out var reason) ? Ok() : Fail(reason));
+
+    public bool MoveToward(Serial targetId)
+        => Run((owner, context) => TryMove(owner, context, targetId, false, out var reason) ? Ok() : Fail(reason));
 
     public bool Patrol()
         => Run((owner, context) => TryPatrol(owner, context, out var reason) ? Ok() : Fail(reason));
@@ -68,30 +96,37 @@ public sealed class AiActionService : IAiActionService
     public bool ReturnHome()
         => Run((owner, context) => TryReturnHome(owner, context, out var reason) ? Ok() : Fail(reason));
 
-    public bool MoveToward(Serial targetId)
-        => Run((owner, context) => TryMove(owner, context, targetId, false, out var reason) ? Ok() : Fail(reason));
-
-    public bool MoveAway(Serial targetId)
-        => Run((owner, context) => TryMove(owner, context, targetId, true, out var reason) ? Ok() : Fail(reason));
-
-    public bool Engage(Serial targetId)
-        => Run((owner, context) => TryEngage(owner, context, targetId, out var reason) ? Ok() : Fail(reason));
-
-    public bool ClearTarget()
-        => Run((owner, _) => TryClearTarget(owner, out var reason) ? Ok() : Fail(reason));
+    public bool Say(string text)
+        => Run((owner, _) => TrySay(owner, text, out var reason) ? Ok() : Fail(reason));
 
     public bool Step(DirectionType direction)
         => Run((owner, _) => _movement.TryMoveNpc(owner.Id, direction) ? Ok() : Fail("movement service rejected the step"));
 
-    public bool MoveTo(int x, int y)
-        => Run((owner, _) => TryMoveToPosition(owner, new Point3D(x, y, owner.Position.Z), out var reason) ? Ok() : Fail(reason));
+    private static DirectionType DirectionToward(Point3D from, Point3D to)
+        => (Math.Sign(to.X - from.X), Math.Sign(to.Y - from.Y)) switch
+        {
+            (0, -1)  => DirectionType.North,
+            (1, -1)  => DirectionType.NorthEast,
+            (1, 0)   => DirectionType.East,
+            (1, 1)   => DirectionType.SouthEast,
+            (0, 1)   => DirectionType.South,
+            (-1, 1)  => DirectionType.SouthWest,
+            (-1, 0)  => DirectionType.West,
+            (-1, -1) => DirectionType.NorthWest,
+            _        => DirectionType.North
+        };
+
+    private static (bool Ok, string Reason) Fail(string reason)
+        => (false, reason);
+
+    private static (bool Ok, string Reason) Ok()
+        => (true, "");
 
     private bool Run(Func<MobileEntity, BrainContext, (bool Ok, string Reason)> action)
     {
         _loopAffinity.AssertOnLoop("ai.action");
 
-        var context = _current
-            ?? throw new InvalidOperationException("ai.* is only callable inside an NPC brain tick.");
+        var context = _current ?? throw new InvalidOperationException("ai.* is only callable inside an NPC brain tick.");
 
         var owner = _mobiles.GetById(context.Self.Id);
 
@@ -99,6 +134,7 @@ public sealed class AiActionService : IAiActionService
         {
             _metrics.RecordIntent(false);
             _logger.Debug("Rejected NPC brain action {MobileId}: owner is missing", context.Self.Id);
+
             return false;
         }
 
@@ -114,28 +150,17 @@ public sealed class AiActionService : IAiActionService
         return ok;
     }
 
-    private static (bool Ok, string Reason) Ok()
-        => (true, "");
-
-    private static (bool Ok, string Reason) Fail(string reason)
-        => (false, reason);
-
-    private bool TrySay(MobileEntity owner, string? text, out string reason)
+    private bool TryClearTarget(MobileEntity owner, out string reason)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        if (owner.CombatantId != Serial.Zero || owner.Warmode)
         {
-            reason = "speech text is blank";
-            return false;
+            owner.CombatantId = Serial.Zero;
+            owner.Warmode = false;
+            _mobiles.UpsertAsync(owner).WaitSync();
         }
 
-        if (text.Length > SpeechMaximumLength)
-        {
-            reason = "speech text exceeds the maximum length";
-            return false;
-        }
-
-        _chat.Say(owner, ChatMessageType.Regular, text, Hue.Default, SpeechRange);
         reason = "";
+
         return true;
     }
 
@@ -154,19 +179,60 @@ public sealed class AiActionService : IAiActionService
         }
 
         reason = "";
+
         return true;
     }
 
-    private bool TryClearTarget(MobileEntity owner, out string reason)
+    private bool TryGetPerceivedTarget(
+        MobileEntity owner,
+        BrainContext context,
+        Serial targetId,
+        [NotNullWhen(true)] out MobileEntity? target,
+        out string reason
+    )
     {
-        if (owner.CombatantId != Serial.Zero || owner.Warmode)
+        target = null;
+
+        if (targetId == Serial.Zero)
         {
-            owner.CombatantId = Serial.Zero;
-            owner.Warmode = false;
-            _mobiles.UpsertAsync(owner).WaitSync();
+            reason = "target is missing";
+
+            return false;
         }
 
+        if (targetId == owner.Id)
+        {
+            reason = "owner cannot target itself";
+
+            return false;
+        }
+
+        if (context.Nearby is null || !context.Nearby.Any(snapshot => snapshot.Id == targetId))
+        {
+            reason = "target is outside current perception";
+
+            return false;
+        }
+
+        var resolvedTarget = _mobiles.GetById(targetId);
+
+        if (resolvedTarget is null)
+        {
+            reason = "target is missing";
+
+            return false;
+        }
+
+        if (resolvedTarget.MapId != owner.MapId)
+        {
+            reason = "target is on another map";
+
+            return false;
+        }
+
+        target = resolvedTarget;
         reason = "";
+
         return true;
     }
 
@@ -188,6 +254,7 @@ public sealed class AiActionService : IAiActionService
         if (owner.Position == target.Position)
         {
             reason = "";
+
             return true;
         }
 
@@ -199,22 +266,34 @@ public sealed class AiActionService : IAiActionService
         if (!_movement.TryMoveNpc(owner.Id, direction))
         {
             reason = "movement service rejected the move";
+
             return false;
         }
 
         reason = "";
+
         return true;
     }
 
-    private bool TryReturnHome(MobileEntity owner, BrainContext context, out string reason)
+    private bool TryMoveToPosition(MobileEntity owner, Point3D target, out string reason)
     {
-        if (owner.MapId != context.HomeMapId)
+        if (owner.Position == target)
         {
-            reason = "owner is not on the home map";
+            reason = "";
+
+            return true;
+        }
+
+        if (!_movement.TryMoveNpc(owner.Id, DirectionToward(owner.Position, target)))
+        {
+            reason = "movement service rejected the move";
+
             return false;
         }
 
-        return TryMoveToPosition(owner, context.HomePosition, out reason);
+        reason = "";
+
+        return true;
     }
 
     private bool TryPatrol(MobileEntity owner, BrainContext context, out string reason)
@@ -222,6 +301,7 @@ public sealed class AiActionService : IAiActionService
         if (owner.MapId != context.HomeMapId)
         {
             reason = "owner is not on the home map";
+
             return false;
         }
 
@@ -233,106 +313,46 @@ public sealed class AiActionService : IAiActionService
         if (!_movement.TryMoveNpc(owner.Id, (DirectionType)_random.Next(0, 8)))
         {
             reason = "movement service rejected the patrol move";
+
             return false;
         }
 
         reason = "";
+
         return true;
     }
 
-    private bool TryMoveToPosition(MobileEntity owner, Point3D target, out string reason)
+    private bool TryReturnHome(MobileEntity owner, BrainContext context, out string reason)
     {
-        if (owner.Position == target)
+        if (owner.MapId != context.HomeMapId)
         {
-            reason = "";
-            return true;
-        }
+            reason = "owner is not on the home map";
 
-        if (!_movement.TryMoveNpc(owner.Id, DirectionToward(owner.Position, target)))
-        {
-            reason = "movement service rejected the move";
             return false;
         }
 
+        return TryMoveToPosition(owner, context.HomePosition, out reason);
+    }
+
+    private bool TrySay(MobileEntity owner, string? text, out string reason)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            reason = "speech text is blank";
+
+            return false;
+        }
+
+        if (text.Length > SpeechMaximumLength)
+        {
+            reason = "speech text exceeds the maximum length";
+
+            return false;
+        }
+
+        _chat.Say(owner, ChatMessageType.Regular, text, Hue.Default, SpeechRange);
         reason = "";
+
         return true;
-    }
-
-    private bool TryGetPerceivedTarget(
-        MobileEntity owner,
-        BrainContext context,
-        Serial targetId,
-        [NotNullWhen(true)] out MobileEntity? target,
-        out string reason
-    )
-    {
-        target = null;
-
-        if (targetId == Serial.Zero)
-        {
-            reason = "target is missing";
-            return false;
-        }
-
-        if (targetId == owner.Id)
-        {
-            reason = "owner cannot target itself";
-            return false;
-        }
-
-        if (context.Nearby is null || !context.Nearby.Any(snapshot => snapshot.Id == targetId))
-        {
-            reason = "target is outside current perception";
-            return false;
-        }
-
-        var resolvedTarget = _mobiles.GetById(targetId);
-
-        if (resolvedTarget is null)
-        {
-            reason = "target is missing";
-            return false;
-        }
-
-        if (resolvedTarget.MapId != owner.MapId)
-        {
-            reason = "target is on another map";
-            return false;
-        }
-
-        target = resolvedTarget;
-        reason = "";
-        return true;
-    }
-
-    private static DirectionType DirectionToward(Point3D from, Point3D to)
-        => (Math.Sign(to.X - from.X), Math.Sign(to.Y - from.Y)) switch
-        {
-            (0, -1) => DirectionType.North,
-            (1, -1) => DirectionType.NorthEast,
-            (1, 0) => DirectionType.East,
-            (1, 1) => DirectionType.SouthEast,
-            (0, 1) => DirectionType.South,
-            (-1, 1) => DirectionType.SouthWest,
-            (-1, 0) => DirectionType.West,
-            (-1, -1) => DirectionType.NorthWest,
-            _ => DirectionType.North
-        };
-
-    private sealed class ContextScope : IDisposable
-    {
-        private readonly AiActionService _owner;
-        private readonly BrainContext? _previous;
-
-        public ContextScope(AiActionService owner, BrainContext? previous)
-        {
-            _owner = owner;
-            _previous = previous;
-        }
-
-        public void Dispose()
-        {
-            _owner._current = _previous;
-        }
     }
 }

--- a/src/Moongate.Server/Services/AI/NpcAiMetrics.cs
+++ b/src/Moongate.Server/Services/AI/NpcAiMetrics.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Abstractions.Types;
@@ -28,62 +27,55 @@ public sealed class NpcAiMetrics : INpcAiMetrics
     private long _reloadSuccesses;
     private long _reloadFallbacks;
 
-    public NpcAiMetricsSnapshot Current => new(
-        Interlocked.Read(ref _activeSectors),
-        Interlocked.Read(ref _graceSectors),
-        Interlocked.Read(ref _sleepingSectors),
-        Interlocked.Read(ref _activeBrains),
-        Interlocked.Read(ref _sleepingBrains),
-        Interlocked.Read(ref _faultBackoffBrains),
-        Interlocked.Read(ref _brainsExecuted),
-        Interlocked.Read(ref _brainsDeferred),
-        Interlocked.Read(ref _hookInvocations),
-        Interlocked.Read(ref _totalHookDurationTicks),
-        Interlocked.Read(ref _maxHookDurationTicks),
-        Interlocked.Read(ref _hookFailures),
-        Interlocked.Read(ref _instructionBudgetBreaches),
-        Interlocked.Read(ref _eventsDelivered),
-        Interlocked.Read(ref _eventsCoalesced),
-        Interlocked.Read(ref _eventsDropped),
-        Interlocked.Read(ref _intentsAccepted),
-        Interlocked.Read(ref _intentsRejected),
-        Interlocked.Read(ref _reloadSuccesses),
-        Interlocked.Read(ref _reloadFallbacks)
-    );
-
-    public void SetActiveSectorCounts(int active, int grace)
-    {
-        Interlocked.Exchange(ref _activeSectors, active);
-        Interlocked.Exchange(ref _graceSectors, grace);
-    }
-
-    public void SetSleepingSectorCount(int sleeping)
-    {
-        Interlocked.Exchange(ref _sleepingSectors, sleeping);
-    }
-
-    public void SetBrainCounts(int active, int sleeping, int faultBackoff)
-    {
-        Interlocked.Exchange(ref _activeBrains, active);
-        Interlocked.Exchange(ref _sleepingBrains, sleeping);
-        Interlocked.Exchange(ref _faultBackoffBrains, faultBackoff);
-    }
-
-    public void RecordBrainExecuted()
-    {
-        Interlocked.Increment(ref _brainsExecuted);
-    }
+    public NpcAiMetricsSnapshot Current
+        => new(
+            Interlocked.Read(ref _activeSectors),
+            Interlocked.Read(ref _graceSectors),
+            Interlocked.Read(ref _sleepingSectors),
+            Interlocked.Read(ref _activeBrains),
+            Interlocked.Read(ref _sleepingBrains),
+            Interlocked.Read(ref _faultBackoffBrains),
+            Interlocked.Read(ref _brainsExecuted),
+            Interlocked.Read(ref _brainsDeferred),
+            Interlocked.Read(ref _hookInvocations),
+            Interlocked.Read(ref _totalHookDurationTicks),
+            Interlocked.Read(ref _maxHookDurationTicks),
+            Interlocked.Read(ref _hookFailures),
+            Interlocked.Read(ref _instructionBudgetBreaches),
+            Interlocked.Read(ref _eventsDelivered),
+            Interlocked.Read(ref _eventsCoalesced),
+            Interlocked.Read(ref _eventsDropped),
+            Interlocked.Read(ref _intentsAccepted),
+            Interlocked.Read(ref _intentsRejected),
+            Interlocked.Read(ref _reloadSuccesses),
+            Interlocked.Read(ref _reloadFallbacks)
+        );
 
     public void RecordBrainDeferred()
-    {
-        Interlocked.Increment(ref _brainsDeferred);
-    }
+        => Interlocked.Increment(ref _brainsDeferred);
 
-    public void RecordHookInvocation(TimeSpan duration)
+    public void RecordBrainExecuted()
+        => Interlocked.Increment(ref _brainsExecuted);
+
+    public void RecordEvent(NpcBrainEventDispositionType disposition)
     {
-        Interlocked.Increment(ref _hookInvocations);
-        Interlocked.Add(ref _totalHookDurationTicks, duration.Ticks);
-        UpdateMaximumHookDuration(duration.Ticks);
+        switch (disposition)
+        {
+            case NpcBrainEventDispositionType.Delivered:
+                Interlocked.Increment(ref _eventsDelivered);
+
+                break;
+            case NpcBrainEventDispositionType.Coalesced:
+                Interlocked.Increment(ref _eventsCoalesced);
+
+                break;
+            case NpcBrainEventDispositionType.Dropped:
+                Interlocked.Increment(ref _eventsDropped);
+
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(disposition), disposition, null);
+        }
     }
 
     public void RecordHookFailure(bool instructionBudgetExceeded)
@@ -96,22 +88,11 @@ public sealed class NpcAiMetrics : INpcAiMetrics
         }
     }
 
-    public void RecordEvent(NpcBrainEventDispositionType disposition)
+    public void RecordHookInvocation(TimeSpan duration)
     {
-        switch (disposition)
-        {
-            case NpcBrainEventDispositionType.Delivered:
-                Interlocked.Increment(ref _eventsDelivered);
-                break;
-            case NpcBrainEventDispositionType.Coalesced:
-                Interlocked.Increment(ref _eventsCoalesced);
-                break;
-            case NpcBrainEventDispositionType.Dropped:
-                Interlocked.Increment(ref _eventsDropped);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(disposition), disposition, null);
-        }
+        Interlocked.Increment(ref _hookInvocations);
+        Interlocked.Add(ref _totalHookDurationTicks, duration.Ticks);
+        UpdateMaximumHookDuration(duration.Ticks);
     }
 
     public void RecordIntent(bool accepted)
@@ -119,6 +100,7 @@ public sealed class NpcAiMetrics : INpcAiMetrics
         if (accepted)
         {
             Interlocked.Increment(ref _intentsAccepted);
+
             return;
         }
 
@@ -130,11 +112,28 @@ public sealed class NpcAiMetrics : INpcAiMetrics
         if (succeeded)
         {
             Interlocked.Increment(ref _reloadSuccesses);
+
             return;
         }
 
         Interlocked.Increment(ref _reloadFallbacks);
     }
+
+    public void SetActiveSectorCounts(int active, int grace)
+    {
+        Interlocked.Exchange(ref _activeSectors, active);
+        Interlocked.Exchange(ref _graceSectors, grace);
+    }
+
+    public void SetBrainCounts(int active, int sleeping, int faultBackoff)
+    {
+        Interlocked.Exchange(ref _activeBrains, active);
+        Interlocked.Exchange(ref _sleepingBrains, sleeping);
+        Interlocked.Exchange(ref _faultBackoffBrains, faultBackoff);
+    }
+
+    public void SetSleepingSectorCount(int sleeping)
+        => Interlocked.Exchange(ref _sleepingSectors, sleeping);
 
     private void UpdateMaximumHookDuration(long durationTicks)
     {

--- a/src/Moongate.Server/Services/AI/NpcBrainContextFactory.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainContextFactory.cs
@@ -31,11 +31,11 @@ public sealed class NpcBrainContextFactory
     )
     {
         var nearby = _spatial
-            .GetMobilesInRange(owner.MapId, owner.Position, descriptor.PerceptionRange)
-            .Where(mobile => mobile.Id != owner.Id)
-            .Select(ToSnapshot)
-            .OrderBy(snapshot => snapshot.Id)
-            .ToArray();
+                     .GetMobilesInRange(owner.MapId, owner.Position, descriptor.PerceptionRange)
+                     .Where(mobile => mobile.Id != owner.Id)
+                     .Select(ToSnapshot)
+                     .OrderBy(snapshot => snapshot.Id)
+                     .ToArray();
 
         return new(
             _timeProvider.GetUtcNow(),

--- a/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
+++ b/src/Moongate.Server/Services/AI/NpcBrainScheduler.cs
@@ -36,6 +36,7 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private readonly INpcAiMetrics _metrics;
     private readonly Dictionary<Serial, SchedulerEntry> _entries = [];
     private readonly PriorityQueue<(Serial MobileId, long Version), (long DueTicks, long Sequence)> _queue = new();
+
     private readonly Dictionary<
         (string BrainId, Serial MobileId, NpcBrainHookType Hook, string Error),
         DateTimeOffset
@@ -44,17 +45,19 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
     private string? _timerId;
     private long _nextQueueSequence;
 
-    public int MaxHearingRange => _entries.Values
-        .Where(HasCurrentDescriptor)
-        .Select(entry => entry.Descriptor!.HearingRange)
-        .DefaultIfEmpty()
-        .Max();
+    public int MaxHearingRange
+        => _entries.Values
+                   .Where(HasCurrentDescriptor)
+                   .Select(entry => entry.Descriptor!.HearingRange)
+                   .DefaultIfEmpty()
+                   .Max();
 
-    public int MaxPerceptionRange => _entries.Values
-        .Where(HasCurrentDescriptor)
-        .Select(entry => entry.Descriptor!.PerceptionRange)
-        .DefaultIfEmpty()
-        .Max();
+    public int MaxPerceptionRange
+        => _entries.Values
+                   .Where(HasCurrentDescriptor)
+                   .Select(entry => entry.Descriptor!.PerceptionRange)
+                   .DefaultIfEmpty()
+                   .Max();
 
     public NpcBrainScheduler(
         IGameLoopContext loop,
@@ -80,756 +83,6 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
         _advanced = config.NpcAi.Advanced;
         _metrics = metrics;
     }
-
-    public void Bind(MobileEntity mobile)
-    {
-        if (string.IsNullOrWhiteSpace(mobile.BrainScriptId))
-        {
-            Unbind(mobile.Id);
-            return;
-        }
-
-        if (_entries.TryGetValue(mobile.Id, out var existing))
-        {
-            if (string.Equals(existing.BrainId, mobile.BrainScriptId, StringComparison.Ordinal))
-            {
-                if (_runtime.TryGetDescriptor(mobile.Id, out var currentDescriptor) &&
-                    !TryCacheDescriptor(existing, currentDescriptor))
-                {
-                    existing.Descriptor = null;
-                }
-
-                return;
-            }
-
-            RebindChangedBrain(existing, mobile);
-            return;
-        }
-
-        var now = _timeProvider.GetUtcNow();
-        var isActive = IsSectorActive(mobile);
-        var entry = new SchedulerEntry(
-            mobile.Id,
-            mobile.BrainScriptId,
-            isActive ? NpcBrainStateType.Active : NpcBrainStateType.Sleeping,
-            mobile.MapId,
-            mobile.Position,
-            now,
-            new NpcBrainMailbox(_advanced.MaxMailboxEvents, _metrics)
-        );
-        _entries[mobile.Id] = entry;
-
-        if (isActive)
-        {
-            entry.Mailbox.Enqueue(
-                NpcBrainHookType.Activate,
-                new NpcBrainEvent(NpcBrainEventType.Activate)
-            );
-        }
-
-        var isBound = _runtime.TryBind(
-            mobile.Id,
-            mobile.BrainScriptId,
-            out var descriptor,
-            out var error
-        ) && TryCacheDescriptor(entry, descriptor);
-
-        if (!isBound && isActive)
-        {
-            RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
-        }
-
-        if (entry.State != NpcBrainStateType.Sleeping)
-        {
-            Requeue(entry, GetDueAt(entry, now));
-        }
-    }
-
-    public void Unbind(Serial mobileId)
-    {
-        ClearFaultLogs(mobileId);
-
-        if (!_entries.Remove(mobileId))
-        {
-            return;
-        }
-
-        _runtime.Unbind(mobileId);
-        CompactQueueIfNeeded();
-    }
-
-    public void Activate(Serial mobileId)
-    {
-        if (!_entries.TryGetValue(mobileId, out var entry))
-        {
-            return;
-        }
-
-        if (entry.State == NpcBrainStateType.Deactivating)
-        {
-            entry.State = NpcBrainStateType.Active;
-            entry.Mailbox.Clear();
-            Requeue(entry, entry.NextThinkAt, true);
-            return;
-        }
-
-        if (entry.State != NpcBrainStateType.Sleeping)
-        {
-            return;
-        }
-
-        var now = _timeProvider.GetUtcNow();
-        entry.State = NpcBrainStateType.Active;
-        entry.NextThinkAt = now;
-        entry.FaultUntil = null;
-        entry.ConsecutiveFailures = 0;
-        entry.Mailbox.Enqueue(
-            NpcBrainHookType.Activate,
-            new NpcBrainEvent(NpcBrainEventType.Activate)
-        );
-        Requeue(entry, now);
-    }
-
-    public void Deactivate(Serial mobileId)
-    {
-        if (!_entries.TryGetValue(mobileId, out var entry) ||
-            entry.State is NpcBrainStateType.Sleeping or NpcBrainStateType.Deactivating)
-        {
-            return;
-        }
-
-        var now = _timeProvider.GetUtcNow();
-        entry.State = NpcBrainStateType.Deactivating;
-        entry.FaultUntil = null;
-        entry.Mailbox.Clear();
-        entry.Mailbox.Enqueue(
-            NpcBrainHookType.Deactivate,
-            new NpcBrainEvent(NpcBrainEventType.Deactivate)
-        );
-        Requeue(entry, now);
-    }
-
-    public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
-    {
-        if (!string.Equals(descriptor.BrainId, brainId, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        foreach (var entry in _entries.Values.Where(
-                     entry => string.Equals(entry.BrainId, brainId, StringComparison.Ordinal)
-                 ))
-        {
-            TryCacheDescriptor(entry, descriptor);
-        }
-    }
-
-    public bool IsActive(Serial mobileId)
-        => _entries.TryGetValue(mobileId, out var entry) &&
-           entry.State == NpcBrainStateType.Active;
-
-    public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
-    {
-        if (_entries.TryGetValue(mobileId, out var entry) && HasCurrentDescriptor(entry))
-        {
-            descriptor = entry.Descriptor;
-            return true;
-        }
-
-        descriptor = null;
-        return false;
-    }
-
-    public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
-    {
-        if (!_entries.TryGetValue(mobileId, out var entry) ||
-            entry.State is NpcBrainStateType.Sleeping or NpcBrainStateType.Deactivating)
-        {
-            return;
-        }
-
-        var schedulingChanged = entry.Mailbox.Enqueue(hook, brainEvent);
-
-        if (entry.State == NpcBrainStateType.Active && schedulingChanged)
-        {
-            Requeue(entry, _timeProvider.GetUtcNow());
-        }
-    }
-
-    public void Tick()
-    {
-        var now = _timeProvider.GetUtcNow();
-        PruneFaultLogs(now);
-        var executed = 0;
-        var woken = new HashSet<Serial>();
-        var postponed = new List<(
-            (Serial MobileId, long Version) Element,
-            (long DueTicks, long Sequence) Priority
-        )>();
-
-        while (executed < _advanced.MaxBrainsPerLoop &&
-               _queue.TryPeek(out _, out var priority) &&
-               priority.DueTicks <= DueTicks(now))
-        {
-            _queue.TryDequeue(out var element, out priority);
-            var (mobileId, version) = element;
-
-            if (!_entries.TryGetValue(mobileId, out var entry) ||
-                entry.QueueVersion != version)
-            {
-                continue;
-            }
-
-            if (entry.State == NpcBrainStateType.Sleeping)
-            {
-                entry.ScheduledDueTicks = null;
-                continue;
-            }
-
-            if (woken.Contains(mobileId))
-            {
-                postponed.Add((element, priority));
-                continue;
-            }
-
-            entry.ScheduledDueTicks = null;
-            var dueAt = GetDueAt(entry, now);
-
-            if (dueAt > now)
-            {
-                Requeue(entry, dueAt);
-                continue;
-            }
-
-            woken.Add(mobileId);
-            executed++;
-            _metrics.RecordBrainExecuted();
-            ProcessEntry(entry, now);
-
-            if (entry.State != NpcBrainStateType.Sleeping)
-            {
-                Requeue(entry, GetDueAt(entry, now));
-            }
-        }
-
-        foreach (var queued in postponed)
-        {
-            _queue.Enqueue(queued.Element, queued.Priority);
-        }
-
-        CompactQueueIfNeeded();
-
-        if (executed == _advanced.MaxBrainsPerLoop)
-        {
-            RecordDeferred(now, woken);
-        }
-
-        UpdateGauges();
-    }
-
-    public ValueTask StartAsync(CancellationToken cancellationToken = default)
-    {
-        if (_timerId is null)
-        {
-            _timerId = _loop.ScheduleRepeating(
-                TimerName,
-                TimeSpan.FromMilliseconds(_advanced.MinTickMilliseconds),
-                Tick
-            );
-        }
-
-        return ValueTask.CompletedTask;
-    }
-
-    public ValueTask StopAsync(CancellationToken cancellationToken = default)
-    {
-        if (_timerId is not null)
-        {
-            _loop.Cancel(_timerId);
-            _timerId = null;
-        }
-
-        return ValueTask.CompletedTask;
-    }
-
-    private void RebindChangedBrain(SchedulerEntry entry, MobileEntity mobile)
-    {
-        var now = _timeProvider.GetUtcNow();
-        ClearFaultLogs(mobile.Id);
-        CancelSchedule(entry);
-        _runtime.Reset(mobile.Id);
-        entry.BrainId = mobile.BrainScriptId;
-        entry.Descriptor = null;
-        entry.State = IsSectorActive(mobile) ? NpcBrainStateType.Active : NpcBrainStateType.Sleeping;
-        entry.HomeMapId = mobile.MapId;
-        entry.HomePosition = mobile.Position;
-        entry.NextThinkAt = now;
-        entry.FaultUntil = null;
-        entry.ConsecutiveFailures = 0;
-        entry.Mailbox.Clear();
-
-        if (entry.State == NpcBrainStateType.Active)
-        {
-            entry.Mailbox.Enqueue(
-                NpcBrainHookType.Activate,
-                new NpcBrainEvent(NpcBrainEventType.Activate)
-            );
-        }
-
-        var isBound = _runtime.TryBind(
-            mobile.Id,
-            mobile.BrainScriptId,
-            out var descriptor,
-            out var error
-        ) && TryCacheDescriptor(entry, descriptor);
-
-        if (!isBound && entry.State == NpcBrainStateType.Active)
-        {
-            RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
-        }
-
-        if (entry.State != NpcBrainStateType.Sleeping)
-        {
-            Requeue(entry, GetDueAt(entry, now));
-        }
-    }
-
-    private void ProcessEntry(SchedulerEntry entry, DateTimeOffset now)
-    {
-        if (entry.State == NpcBrainStateType.FaultBackoff)
-        {
-            if (entry.FaultUntil is { } faultUntil && faultUntil > now)
-            {
-                return;
-            }
-
-            entry.State = NpcBrainStateType.Active;
-            entry.FaultUntil = null;
-        }
-
-        var owner = _mobiles.GetById(entry.MobileId);
-
-        if (owner is null)
-        {
-            if (entry.State == NpcBrainStateType.Deactivating)
-            {
-                CompleteSleep(entry);
-                return;
-            }
-
-            RegisterFailure(entry, NpcBrainHookType.Think, "Brain owner is missing.", now);
-            return;
-        }
-
-        if (!EnsureBinding(entry, now))
-        {
-            if (entry.State == NpcBrainStateType.Deactivating)
-            {
-                CompleteSleep(entry);
-            }
-
-            return;
-        }
-
-        var context = _contextFactory.Create(
-            owner,
-            entry.HomeMapId,
-            entry.HomePosition,
-            entry.Descriptor!
-        );
-
-        if (entry.State == NpcBrainStateType.Deactivating)
-        {
-            ProcessDeactivation(entry, context, now);
-            return;
-        }
-
-        for (var delivered = 0;
-             delivered < _advanced.MaxEventsPerBrainWake && entry.Mailbox.HasEvents;
-             delivered++)
-        {
-            var queued = entry.Mailbox.Dequeue(1)[0];
-            var result = Invoke(entry, queued.Hook, context, queued.Event);
-
-            if (!result.Success)
-            {
-                RegisterFailure(
-                    entry,
-                    queued.Hook,
-                    result.Error ?? "Brain hook failed.",
-                    now
-                );
-                return;
-            }
-
-            ApplySuccess(entry, result, false, now);
-        }
-
-        if (entry.NextThinkAt > now)
-        {
-            return;
-        }
-
-        var thinkResult = Invoke(entry, NpcBrainHookType.Think, context, null);
-
-        if (!thinkResult.Success)
-        {
-            RegisterFailure(
-                entry,
-                NpcBrainHookType.Think,
-                thinkResult.Error ?? "Brain think failed.",
-                now
-            );
-            return;
-        }
-
-        ApplySuccess(entry, thinkResult, true, now);
-    }
-
-    private bool EnsureBinding(SchedulerEntry entry, DateTimeOffset now)
-    {
-        if (_runtime.TryGetDescriptor(entry.MobileId, out var descriptor) &&
-            TryCacheDescriptor(entry, descriptor))
-        {
-            return true;
-        }
-
-        if (_runtime.TryBind(entry.MobileId, entry.BrainId, out descriptor, out var error) &&
-            TryCacheDescriptor(entry, descriptor))
-        {
-            entry.ConsecutiveFailures = 0;
-            return true;
-        }
-
-        if (entry.State != NpcBrainStateType.Deactivating)
-        {
-            RegisterFailure(
-                entry,
-                NpcBrainHookType.Think,
-                error ?? "Brain binding failed.",
-                now
-            );
-        }
-        else
-        {
-            LogFailure(entry, NpcBrainHookType.Deactivate, error ?? "Brain binding failed.", now);
-        }
-
-        return false;
-    }
-
-    private void ProcessDeactivation(SchedulerEntry entry, BrainContext context, DateTimeOffset now)
-    {
-        if (entry.Mailbox.HasEvents)
-        {
-            var queued = entry.Mailbox.Dequeue(1)[0];
-            var result = Invoke(entry, queued.Hook, context, queued.Event);
-
-            if (result.Success)
-            {
-                ApplySuccess(entry, result, false, now);
-            }
-            else
-            {
-                LogFailure(
-                    entry,
-                    queued.Hook,
-                    result.Error ?? "Brain deactivation failed.",
-                    now
-                );
-            }
-        }
-
-        CompleteSleep(entry);
-    }
-
-    private NpcBrainInvocationResult Invoke(
-        SchedulerEntry entry,
-        NpcBrainHookType hook,
-        BrainContext context,
-        NpcBrainEvent? brainEvent
-    )
-    {
-        var started = _timeProvider.GetTimestamp();
-
-        try
-        {
-            using (_aiActions.Begin(context))
-            using (_memory.Begin(context))
-            {
-                return _runtime.Invoke(entry.MobileId, hook, context, brainEvent);
-            }
-        }
-        catch (Exception exception)
-        {
-            _metrics.RecordHookFailure(false);
-            return NpcBrainInvocationResult.Failed(exception.Message);
-        }
-        finally
-        {
-            _metrics.RecordHookInvocation(_timeProvider.GetElapsedTime(started));
-        }
-    }
-
-    private void ApplySuccess(
-        SchedulerEntry entry,
-        NpcBrainInvocationResult result,
-        bool wasThink,
-        DateTimeOffset now
-    )
-    {
-        entry.ConsecutiveFailures = 0;
-        entry.FaultUntil = null;
-
-        if (result.NextTickMs is { } nextTick)
-        {
-            entry.NextThinkAt = now + TimeSpan.FromMilliseconds(
-                Math.Clamp(
-                    nextTick,
-                    _advanced.MinTickMilliseconds,
-                    _advanced.MaxTickMilliseconds
-                )
-            );
-        }
-        else if (wasThink)
-        {
-            entry.NextThinkAt = now + TimeSpan.FromMilliseconds(
-                Math.Clamp(
-                    entry.Descriptor!.DefaultTickMilliseconds,
-                    _advanced.MinTickMilliseconds,
-                    _advanced.MaxTickMilliseconds
-                )
-            );
-        }
-    }
-
-    private void RegisterFailure(
-        SchedulerEntry entry,
-        NpcBrainHookType hook,
-        string error,
-        DateTimeOffset now
-    )
-    {
-        entry.ConsecutiveFailures++;
-
-        if (entry.ConsecutiveFailures == 4)
-        {
-            _runtime.Reset(entry.MobileId);
-        }
-
-        entry.State = NpcBrainStateType.FaultBackoff;
-        entry.FaultUntil = now + FailureBackoff(entry.ConsecutiveFailures);
-        LogFailure(entry, hook, error, now);
-    }
-
-    private void LogFailure(
-        SchedulerEntry entry,
-        NpcBrainHookType hook,
-        string error,
-        DateTimeOffset now
-    )
-    {
-        PruneFaultLogs(now);
-        var key = (entry.BrainId, entry.MobileId, hook, error);
-
-        if (_faultLogs.TryGetValue(key, out var loggedAt) &&
-            now - loggedAt < TimeSpan.FromSeconds(FaultLogIntervalSeconds))
-        {
-            return;
-        }
-
-        _faultLogs[key] = now;
-        _logger.Warning(
-            "NPC brain scheduler fault for brain {BrainId}, mobile {MobileId}, hook {Hook}: {Error}",
-            entry.BrainId,
-            entry.MobileId.Value,
-            hook,
-            error
-        );
-    }
-
-    private void ClearFaultLogs(Serial mobileId)
-    {
-        foreach (var key in _faultLogs.Keys.Where(key => key.MobileId == mobileId).ToArray())
-        {
-            _faultLogs.Remove(key);
-        }
-    }
-
-    private void CompleteSleep(SchedulerEntry entry)
-    {
-        CancelSchedule(entry);
-        entry.State = NpcBrainStateType.Sleeping;
-        entry.FaultUntil = null;
-        entry.ConsecutiveFailures = 0;
-        entry.Mailbox.Clear();
-    }
-
-    private void Requeue(
-        SchedulerEntry entry,
-        DateTimeOffset dueAt,
-        bool replaceExisting = false
-    )
-    {
-        var dueTicks = DueTicks(dueAt);
-
-        if (!replaceExisting &&
-            entry.ScheduledDueTicks is { } scheduledDueTicks &&
-            scheduledDueTicks <= dueTicks)
-        {
-            return;
-        }
-
-        entry.QueueVersion++;
-        entry.ScheduledDueTicks = dueTicks;
-        _queue.Enqueue(
-            (entry.MobileId, entry.QueueVersion),
-            (dueTicks, _nextQueueSequence++)
-        );
-        CompactQueueIfNeeded();
-    }
-
-    private void CancelSchedule(SchedulerEntry entry)
-    {
-        if (entry.ScheduledDueTicks is null)
-        {
-            return;
-        }
-
-        entry.QueueVersion++;
-        entry.ScheduledDueTicks = null;
-    }
-
-    private void CompactQueueIfNeeded()
-    {
-        var scheduledCount = _entries.Values.Count(entry => entry.ScheduledDueTicks is not null);
-        var maximumQueueCount = (scheduledCount * QueueCompactionFactor) + QueueCompactionSlack;
-
-        if (_queue.Count <= maximumQueueCount)
-        {
-            return;
-        }
-
-        var current = _queue.UnorderedItems
-            .Where(item =>
-                _entries.TryGetValue(item.Element.MobileId, out var entry) &&
-                entry.QueueVersion == item.Element.Version &&
-                entry.ScheduledDueTicks == item.Priority.DueTicks
-            )
-            .ToArray();
-        _queue.Clear();
-
-        foreach (var item in current)
-        {
-            _queue.Enqueue(item.Element, item.Priority);
-        }
-    }
-
-    private DateTimeOffset GetDueAt(SchedulerEntry entry, DateTimeOffset now)
-        => entry.State switch
-        {
-            NpcBrainStateType.Deactivating => now,
-            NpcBrainStateType.FaultBackoff => entry.FaultUntil ?? now,
-            NpcBrainStateType.Active when entry.Mailbox.HasEvents => now,
-            _ => entry.NextThinkAt
-        };
-
-    private void RecordDeferred(DateTimeOffset now, IReadOnlySet<Serial> woken)
-    {
-        var dueMobileIds = _queue.UnorderedItems
-            .Where(item => item.Priority.DueTicks <= DueTicks(now))
-            .Select(item => item.Element)
-            .Where(element =>
-                _entries.TryGetValue(element.MobileId, out var entry) &&
-                entry.QueueVersion == element.Version &&
-                entry.ScheduledDueTicks is not null &&
-                entry.State != NpcBrainStateType.Sleeping &&
-                GetDueAt(entry, now) <= now
-            )
-            .Select(element => element.MobileId)
-            .Where(mobileId => !woken.Contains(mobileId))
-            .Distinct()
-            .ToArray();
-
-        foreach (var _ in dueMobileIds)
-        {
-            _metrics.RecordBrainDeferred();
-        }
-    }
-
-    private void UpdateGauges()
-    {
-        _metrics.SetBrainCounts(
-            _entries.Values.Count(entry => entry.State == NpcBrainStateType.Active),
-            _entries.Values.Count(entry => entry.State == NpcBrainStateType.Sleeping),
-            _entries.Values.Count(entry => entry.State == NpcBrainStateType.FaultBackoff)
-        );
-
-        var sleepingSectors = _entries.Values
-            .Where(entry => entry.State == NpcBrainStateType.Sleeping)
-            .Select(entry => _mobiles.GetById(entry.MobileId))
-            .Where(mobile => mobile is not null)
-            .Select(mobile => (
-                mobile!.MapId,
-                SectorX: mobile.Position.X >> SectorShift,
-                SectorY: mobile.Position.Y >> SectorShift
-            ))
-            .Distinct()
-            .Count();
-        _metrics.SetSleepingSectorCount(sleepingSectors);
-    }
-
-    private bool IsSectorActive(MobileEntity mobile)
-        => _sectors.IsActive(
-            mobile.MapId,
-            mobile.Position.X >> SectorShift,
-            mobile.Position.Y >> SectorShift
-        );
-
-    private void PruneFaultLogs(DateTimeOffset now)
-    {
-        var interval = TimeSpan.FromSeconds(FaultLogIntervalSeconds);
-
-        foreach (var key in _faultLogs
-                     .Where(entry => now - entry.Value >= interval)
-                     .Select(entry => entry.Key)
-                     .ToArray())
-        {
-            _faultLogs.Remove(key);
-        }
-    }
-
-    private static bool HasCurrentDescriptor(SchedulerEntry entry)
-        => entry.Descriptor is { } descriptor &&
-           string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal);
-
-    private static bool TryCacheDescriptor(SchedulerEntry entry, BrainDescriptor? descriptor)
-    {
-        if (
-            descriptor is null ||
-            !string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal)
-        )
-        {
-            return false;
-        }
-
-        entry.Descriptor = descriptor;
-        return true;
-    }
-
-    private static long DueTicks(DateTimeOffset dueAt)
-        => dueAt.UtcDateTime.Ticks;
-
-    private static TimeSpan FailureBackoff(int consecutiveFailures)
-        => TimeSpan.FromSeconds(
-            consecutiveFailures switch
-            {
-                1 => 1,
-                2 => 5,
-                3 => 30,
-                _ => 60
-            }
-        );
 
     private sealed class SchedulerEntry
     {
@@ -875,5 +128,781 @@ public sealed class NpcBrainScheduler : INpcBrainScheduler, ISquidStdService
             NextThinkAt = nextThinkAt;
             Mailbox = mailbox;
         }
+    }
+
+    public void Activate(Serial mobileId)
+    {
+        if (!_entries.TryGetValue(mobileId, out var entry))
+        {
+            return;
+        }
+
+        if (entry.State == NpcBrainStateType.Deactivating)
+        {
+            entry.State = NpcBrainStateType.Active;
+            entry.Mailbox.Clear();
+            Requeue(entry, entry.NextThinkAt, true);
+
+            return;
+        }
+
+        if (entry.State != NpcBrainStateType.Sleeping)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        entry.State = NpcBrainStateType.Active;
+        entry.NextThinkAt = now;
+        entry.FaultUntil = null;
+        entry.ConsecutiveFailures = 0;
+        entry.Mailbox.Enqueue(
+            NpcBrainHookType.Activate,
+            new(NpcBrainEventType.Activate)
+        );
+        Requeue(entry, now);
+    }
+
+    public void Bind(MobileEntity mobile)
+    {
+        if (string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+        {
+            Unbind(mobile.Id);
+
+            return;
+        }
+
+        if (_entries.TryGetValue(mobile.Id, out var existing))
+        {
+            if (string.Equals(existing.BrainId, mobile.BrainScriptId, StringComparison.Ordinal))
+            {
+                if (_runtime.TryGetDescriptor(mobile.Id, out var currentDescriptor) &&
+                    !TryCacheDescriptor(existing, currentDescriptor))
+                {
+                    existing.Descriptor = null;
+                }
+
+                return;
+            }
+
+            RebindChangedBrain(existing, mobile);
+
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var isActive = IsSectorActive(mobile);
+        var entry = new SchedulerEntry(
+            mobile.Id,
+            mobile.BrainScriptId,
+            isActive ? NpcBrainStateType.Active : NpcBrainStateType.Sleeping,
+            mobile.MapId,
+            mobile.Position,
+            now,
+            new(_advanced.MaxMailboxEvents, _metrics)
+        );
+        _entries[mobile.Id] = entry;
+
+        if (isActive)
+        {
+            entry.Mailbox.Enqueue(
+                NpcBrainHookType.Activate,
+                new(NpcBrainEventType.Activate)
+            );
+        }
+
+        var isBound = _runtime.TryBind(
+                          mobile.Id,
+                          mobile.BrainScriptId,
+                          out var descriptor,
+                          out var error
+                      ) &&
+                      TryCacheDescriptor(entry, descriptor);
+
+        if (!isBound && isActive)
+        {
+            RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
+        }
+
+        if (entry.State != NpcBrainStateType.Sleeping)
+        {
+            Requeue(entry, GetDueAt(entry, now));
+        }
+    }
+
+    public void Deactivate(Serial mobileId)
+    {
+        if (!_entries.TryGetValue(mobileId, out var entry) ||
+            entry.State is NpcBrainStateType.Sleeping or NpcBrainStateType.Deactivating)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        entry.State = NpcBrainStateType.Deactivating;
+        entry.FaultUntil = null;
+        entry.Mailbox.Clear();
+        entry.Mailbox.Enqueue(
+            NpcBrainHookType.Deactivate,
+            new(NpcBrainEventType.Deactivate)
+        );
+        Requeue(entry, now);
+    }
+
+    public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
+    {
+        if (!_entries.TryGetValue(mobileId, out var entry) ||
+            entry.State is NpcBrainStateType.Sleeping or NpcBrainStateType.Deactivating)
+        {
+            return;
+        }
+
+        var schedulingChanged = entry.Mailbox.Enqueue(hook, brainEvent);
+
+        if (entry.State == NpcBrainStateType.Active && schedulingChanged)
+        {
+            Requeue(entry, _timeProvider.GetUtcNow());
+        }
+    }
+
+    public bool IsActive(Serial mobileId)
+        => _entries.TryGetValue(mobileId, out var entry) &&
+           entry.State == NpcBrainStateType.Active;
+
+    public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
+    {
+        if (!string.Equals(descriptor.BrainId, brainId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        foreach (var entry in _entries.Values.Where(
+                     entry => string.Equals(entry.BrainId, brainId, StringComparison.Ordinal)
+                 ))
+        {
+            TryCacheDescriptor(entry, descriptor);
+        }
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is null)
+        {
+            _timerId = _loop.ScheduleRepeating(
+                TimerName,
+                TimeSpan.FromMilliseconds(_advanced.MinTickMilliseconds),
+                Tick
+            );
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is not null)
+        {
+            _loop.Cancel(_timerId);
+            _timerId = null;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public void Tick()
+    {
+        var now = _timeProvider.GetUtcNow();
+        PruneFaultLogs(now);
+        var executed = 0;
+        var woken = new HashSet<Serial>();
+        var postponed = new List<(
+            (Serial MobileId, long Version) Element,
+            (long DueTicks, long Sequence) Priority
+            )>();
+
+        while (executed < _advanced.MaxBrainsPerLoop &&
+               _queue.TryPeek(out _, out var priority) &&
+               priority.DueTicks <= DueTicks(now))
+        {
+            _queue.TryDequeue(out var element, out priority);
+            var (mobileId, version) = element;
+
+            if (!_entries.TryGetValue(mobileId, out var entry) ||
+                entry.QueueVersion != version)
+            {
+                continue;
+            }
+
+            if (entry.State == NpcBrainStateType.Sleeping)
+            {
+                entry.ScheduledDueTicks = null;
+
+                continue;
+            }
+
+            if (woken.Contains(mobileId))
+            {
+                postponed.Add((element, priority));
+
+                continue;
+            }
+
+            entry.ScheduledDueTicks = null;
+            var dueAt = GetDueAt(entry, now);
+
+            if (dueAt > now)
+            {
+                Requeue(entry, dueAt);
+
+                continue;
+            }
+
+            woken.Add(mobileId);
+            executed++;
+            _metrics.RecordBrainExecuted();
+            ProcessEntry(entry, now);
+
+            if (entry.State != NpcBrainStateType.Sleeping)
+            {
+                Requeue(entry, GetDueAt(entry, now));
+            }
+        }
+
+        foreach (var queued in postponed)
+        {
+            _queue.Enqueue(queued.Element, queued.Priority);
+        }
+
+        CompactQueueIfNeeded();
+
+        if (executed == _advanced.MaxBrainsPerLoop)
+        {
+            RecordDeferred(now, woken);
+        }
+
+        UpdateGauges();
+    }
+
+    public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+    {
+        if (_entries.TryGetValue(mobileId, out var entry) && HasCurrentDescriptor(entry))
+        {
+            descriptor = entry.Descriptor;
+
+            return true;
+        }
+
+        descriptor = null;
+
+        return false;
+    }
+
+    public void Unbind(Serial mobileId)
+    {
+        ClearFaultLogs(mobileId);
+
+        if (!_entries.Remove(mobileId))
+        {
+            return;
+        }
+
+        _runtime.Unbind(mobileId);
+        CompactQueueIfNeeded();
+    }
+
+    private void ApplySuccess(
+        SchedulerEntry entry,
+        NpcBrainInvocationResult result,
+        bool wasThink,
+        DateTimeOffset now
+    )
+    {
+        entry.ConsecutiveFailures = 0;
+        entry.FaultUntil = null;
+
+        if (result.NextTickMs is { } nextTick)
+        {
+            entry.NextThinkAt = now +
+                                TimeSpan.FromMilliseconds(
+                                    Math.Clamp(
+                                        nextTick,
+                                        _advanced.MinTickMilliseconds,
+                                        _advanced.MaxTickMilliseconds
+                                    )
+                                );
+        }
+        else if (wasThink)
+        {
+            entry.NextThinkAt = now +
+                                TimeSpan.FromMilliseconds(
+                                    Math.Clamp(
+                                        entry.Descriptor!.DefaultTickMilliseconds,
+                                        _advanced.MinTickMilliseconds,
+                                        _advanced.MaxTickMilliseconds
+                                    )
+                                );
+        }
+    }
+
+    private void CancelSchedule(SchedulerEntry entry)
+    {
+        if (entry.ScheduledDueTicks is null)
+        {
+            return;
+        }
+
+        entry.QueueVersion++;
+        entry.ScheduledDueTicks = null;
+    }
+
+    private void ClearFaultLogs(Serial mobileId)
+    {
+        foreach (var key in _faultLogs.Keys.Where(key => key.MobileId == mobileId).ToArray())
+        {
+            _faultLogs.Remove(key);
+        }
+    }
+
+    private void CompactQueueIfNeeded()
+    {
+        var scheduledCount = _entries.Values.Count(entry => entry.ScheduledDueTicks is not null);
+        var maximumQueueCount = scheduledCount * QueueCompactionFactor + QueueCompactionSlack;
+
+        if (_queue.Count <= maximumQueueCount)
+        {
+            return;
+        }
+
+        var current = _queue.UnorderedItems
+                            .Where(
+                                item =>
+                                    _entries.TryGetValue(item.Element.MobileId, out var entry) &&
+                                    entry.QueueVersion == item.Element.Version &&
+                                    entry.ScheduledDueTicks == item.Priority.DueTicks
+                            )
+                            .ToArray();
+        _queue.Clear();
+
+        foreach (var item in current)
+        {
+            _queue.Enqueue(item.Element, item.Priority);
+        }
+    }
+
+    private void CompleteSleep(SchedulerEntry entry)
+    {
+        CancelSchedule(entry);
+        entry.State = NpcBrainStateType.Sleeping;
+        entry.FaultUntil = null;
+        entry.ConsecutiveFailures = 0;
+        entry.Mailbox.Clear();
+    }
+
+    private static long DueTicks(DateTimeOffset dueAt)
+        => dueAt.UtcDateTime.Ticks;
+
+    private bool EnsureBinding(SchedulerEntry entry, DateTimeOffset now)
+    {
+        if (_runtime.TryGetDescriptor(entry.MobileId, out var descriptor) &&
+            TryCacheDescriptor(entry, descriptor))
+        {
+            return true;
+        }
+
+        if (_runtime.TryBind(entry.MobileId, entry.BrainId, out descriptor, out var error) &&
+            TryCacheDescriptor(entry, descriptor))
+        {
+            entry.ConsecutiveFailures = 0;
+
+            return true;
+        }
+
+        if (entry.State != NpcBrainStateType.Deactivating)
+        {
+            RegisterFailure(
+                entry,
+                NpcBrainHookType.Think,
+                error ?? "Brain binding failed.",
+                now
+            );
+        }
+        else
+        {
+            LogFailure(entry, NpcBrainHookType.Deactivate, error ?? "Brain binding failed.", now);
+        }
+
+        return false;
+    }
+
+    private static TimeSpan FailureBackoff(int consecutiveFailures)
+        => TimeSpan.FromSeconds(
+            consecutiveFailures switch
+            {
+                1 => 1,
+                2 => 5,
+                3 => 30,
+                _ => 60
+            }
+        );
+
+    private DateTimeOffset GetDueAt(SchedulerEntry entry, DateTimeOffset now)
+        => entry.State switch
+        {
+            NpcBrainStateType.Deactivating                        => now,
+            NpcBrainStateType.FaultBackoff                        => entry.FaultUntil ?? now,
+            NpcBrainStateType.Active when entry.Mailbox.HasEvents => now,
+            _                                                     => entry.NextThinkAt
+        };
+
+    private static bool HasCurrentDescriptor(SchedulerEntry entry)
+        => entry.Descriptor is { } descriptor &&
+           string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal);
+
+    private NpcBrainInvocationResult Invoke(
+        SchedulerEntry entry,
+        NpcBrainHookType hook,
+        BrainContext context,
+        NpcBrainEvent? brainEvent
+    )
+    {
+        var started = _timeProvider.GetTimestamp();
+
+        try
+        {
+            using (_aiActions.Begin(context))
+            {
+                using (_memory.Begin(context))
+                {
+                    return _runtime.Invoke(entry.MobileId, hook, context, brainEvent);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            _metrics.RecordHookFailure(false);
+
+            return NpcBrainInvocationResult.Failed(exception.Message);
+        }
+        finally
+        {
+            _metrics.RecordHookInvocation(_timeProvider.GetElapsedTime(started));
+        }
+    }
+
+    private bool IsSectorActive(MobileEntity mobile)
+        => _sectors.IsActive(
+            mobile.MapId,
+            mobile.Position.X >> SectorShift,
+            mobile.Position.Y >> SectorShift
+        );
+
+    private void LogFailure(
+        SchedulerEntry entry,
+        NpcBrainHookType hook,
+        string error,
+        DateTimeOffset now
+    )
+    {
+        PruneFaultLogs(now);
+        var key = (entry.BrainId, entry.MobileId, hook, error);
+
+        if (_faultLogs.TryGetValue(key, out var loggedAt) &&
+            now - loggedAt < TimeSpan.FromSeconds(FaultLogIntervalSeconds))
+        {
+            return;
+        }
+
+        _faultLogs[key] = now;
+        _logger.Warning(
+            "NPC brain scheduler fault for brain {BrainId}, mobile {MobileId}, hook {Hook}: {Error}",
+            entry.BrainId,
+            entry.MobileId.Value,
+            hook,
+            error
+        );
+    }
+
+    private void ProcessDeactivation(SchedulerEntry entry, BrainContext context, DateTimeOffset now)
+    {
+        if (entry.Mailbox.HasEvents)
+        {
+            var queued = entry.Mailbox.Dequeue(1)[0];
+            var result = Invoke(entry, queued.Hook, context, queued.Event);
+
+            if (result.Success)
+            {
+                ApplySuccess(entry, result, false, now);
+            }
+            else
+            {
+                LogFailure(
+                    entry,
+                    queued.Hook,
+                    result.Error ?? "Brain deactivation failed.",
+                    now
+                );
+            }
+        }
+
+        CompleteSleep(entry);
+    }
+
+    private void ProcessEntry(SchedulerEntry entry, DateTimeOffset now)
+    {
+        if (entry.State == NpcBrainStateType.FaultBackoff)
+        {
+            if (entry.FaultUntil is { } faultUntil && faultUntil > now)
+            {
+                return;
+            }
+
+            entry.State = NpcBrainStateType.Active;
+            entry.FaultUntil = null;
+        }
+
+        var owner = _mobiles.GetById(entry.MobileId);
+
+        if (owner is null)
+        {
+            if (entry.State == NpcBrainStateType.Deactivating)
+            {
+                CompleteSleep(entry);
+
+                return;
+            }
+
+            RegisterFailure(entry, NpcBrainHookType.Think, "Brain owner is missing.", now);
+
+            return;
+        }
+
+        if (!EnsureBinding(entry, now))
+        {
+            if (entry.State == NpcBrainStateType.Deactivating)
+            {
+                CompleteSleep(entry);
+            }
+
+            return;
+        }
+
+        var context = _contextFactory.Create(
+            owner,
+            entry.HomeMapId,
+            entry.HomePosition,
+            entry.Descriptor!
+        );
+
+        if (entry.State == NpcBrainStateType.Deactivating)
+        {
+            ProcessDeactivation(entry, context, now);
+
+            return;
+        }
+
+        for (var delivered = 0;
+             delivered < _advanced.MaxEventsPerBrainWake && entry.Mailbox.HasEvents;
+             delivered++)
+        {
+            var queued = entry.Mailbox.Dequeue(1)[0];
+            var result = Invoke(entry, queued.Hook, context, queued.Event);
+
+            if (!result.Success)
+            {
+                RegisterFailure(
+                    entry,
+                    queued.Hook,
+                    result.Error ?? "Brain hook failed.",
+                    now
+                );
+
+                return;
+            }
+
+            ApplySuccess(entry, result, false, now);
+        }
+
+        if (entry.NextThinkAt > now)
+        {
+            return;
+        }
+
+        var thinkResult = Invoke(entry, NpcBrainHookType.Think, context, null);
+
+        if (!thinkResult.Success)
+        {
+            RegisterFailure(
+                entry,
+                NpcBrainHookType.Think,
+                thinkResult.Error ?? "Brain think failed.",
+                now
+            );
+
+            return;
+        }
+
+        ApplySuccess(entry, thinkResult, true, now);
+    }
+
+    private void PruneFaultLogs(DateTimeOffset now)
+    {
+        var interval = TimeSpan.FromSeconds(FaultLogIntervalSeconds);
+
+        foreach (var key in _faultLogs
+                            .Where(entry => now - entry.Value >= interval)
+                            .Select(entry => entry.Key)
+                            .ToArray())
+        {
+            _faultLogs.Remove(key);
+        }
+    }
+
+    private void RebindChangedBrain(SchedulerEntry entry, MobileEntity mobile)
+    {
+        var now = _timeProvider.GetUtcNow();
+        ClearFaultLogs(mobile.Id);
+        CancelSchedule(entry);
+        _runtime.Reset(mobile.Id);
+        entry.BrainId = mobile.BrainScriptId;
+        entry.Descriptor = null;
+        entry.State = IsSectorActive(mobile) ? NpcBrainStateType.Active : NpcBrainStateType.Sleeping;
+        entry.HomeMapId = mobile.MapId;
+        entry.HomePosition = mobile.Position;
+        entry.NextThinkAt = now;
+        entry.FaultUntil = null;
+        entry.ConsecutiveFailures = 0;
+        entry.Mailbox.Clear();
+
+        if (entry.State == NpcBrainStateType.Active)
+        {
+            entry.Mailbox.Enqueue(
+                NpcBrainHookType.Activate,
+                new(NpcBrainEventType.Activate)
+            );
+        }
+
+        var isBound = _runtime.TryBind(
+                          mobile.Id,
+                          mobile.BrainScriptId,
+                          out var descriptor,
+                          out var error
+                      ) &&
+                      TryCacheDescriptor(entry, descriptor);
+
+        if (!isBound && entry.State == NpcBrainStateType.Active)
+        {
+            RegisterFailure(entry, NpcBrainHookType.Activate, error ?? "Brain binding failed.", now);
+        }
+
+        if (entry.State != NpcBrainStateType.Sleeping)
+        {
+            Requeue(entry, GetDueAt(entry, now));
+        }
+    }
+
+    private void RecordDeferred(DateTimeOffset now, IReadOnlySet<Serial> woken)
+    {
+        var dueMobileIds = _queue.UnorderedItems
+                                 .Where(item => item.Priority.DueTicks <= DueTicks(now))
+                                 .Select(item => item.Element)
+                                 .Where(
+                                     element =>
+                                         _entries.TryGetValue(element.MobileId, out var entry) &&
+                                         entry.QueueVersion == element.Version &&
+                                         entry.ScheduledDueTicks is not null &&
+                                         entry.State != NpcBrainStateType.Sleeping &&
+                                         GetDueAt(entry, now) <= now
+                                 )
+                                 .Select(element => element.MobileId)
+                                 .Where(mobileId => !woken.Contains(mobileId))
+                                 .Distinct()
+                                 .ToArray();
+
+        foreach (var _ in dueMobileIds)
+        {
+            _metrics.RecordBrainDeferred();
+        }
+    }
+
+    private void RegisterFailure(
+        SchedulerEntry entry,
+        NpcBrainHookType hook,
+        string error,
+        DateTimeOffset now
+    )
+    {
+        entry.ConsecutiveFailures++;
+
+        if (entry.ConsecutiveFailures == 4)
+        {
+            _runtime.Reset(entry.MobileId);
+        }
+
+        entry.State = NpcBrainStateType.FaultBackoff;
+        entry.FaultUntil = now + FailureBackoff(entry.ConsecutiveFailures);
+        LogFailure(entry, hook, error, now);
+    }
+
+    private void Requeue(
+        SchedulerEntry entry,
+        DateTimeOffset dueAt,
+        bool replaceExisting = false
+    )
+    {
+        var dueTicks = DueTicks(dueAt);
+
+        if (!replaceExisting &&
+            entry.ScheduledDueTicks is { } scheduledDueTicks &&
+            scheduledDueTicks <= dueTicks)
+        {
+            return;
+        }
+
+        entry.QueueVersion++;
+        entry.ScheduledDueTicks = dueTicks;
+        _queue.Enqueue(
+            (entry.MobileId, entry.QueueVersion),
+            (dueTicks, _nextQueueSequence++)
+        );
+        CompactQueueIfNeeded();
+    }
+
+    private static bool TryCacheDescriptor(SchedulerEntry entry, BrainDescriptor? descriptor)
+    {
+        if (
+            descriptor is null ||
+            !string.Equals(descriptor.BrainId, entry.BrainId, StringComparison.Ordinal)
+        )
+        {
+            return false;
+        }
+
+        entry.Descriptor = descriptor;
+
+        return true;
+    }
+
+    private void UpdateGauges()
+    {
+        _metrics.SetBrainCounts(
+            _entries.Values.Count(entry => entry.State == NpcBrainStateType.Active),
+            _entries.Values.Count(entry => entry.State == NpcBrainStateType.Sleeping),
+            _entries.Values.Count(entry => entry.State == NpcBrainStateType.FaultBackoff)
+        );
+
+        var sleepingSectors = _entries.Values
+                                      .Where(entry => entry.State == NpcBrainStateType.Sleeping)
+                                      .Select(entry => _mobiles.GetById(entry.MobileId))
+                                      .Where(mobile => mobile is not null)
+                                      .Select(
+                                          mobile => (
+                                                        mobile!.MapId,
+                                                        SectorX: mobile.Position.X >> SectorShift,
+                                                        SectorY: mobile.Position.Y >> SectorShift
+                                                    )
+                                      )
+                                      .Distinct()
+                                      .Count();
+        _metrics.SetSleepingSectorCount(sleepingSectors);
     }
 }

--- a/src/Moongate.Server/Services/AI/NpcMemoryService.cs
+++ b/src/Moongate.Server/Services/AI/NpcMemoryService.cs
@@ -32,12 +32,69 @@ public sealed class NpcMemoryService : INpcMemoryService
         _loopAffinity = loopAffinity;
     }
 
+    private sealed class ContextScope : IDisposable
+    {
+        private readonly NpcMemoryService _owner;
+        private readonly BrainContext? _previous;
+
+        public ContextScope(NpcMemoryService owner, BrainContext? previous)
+        {
+            _owner = owner;
+            _previous = previous;
+        }
+
+        public void Dispose()
+            => _owner._current = _previous;
+    }
+
+    public IReadOnlyDictionary<string, NpcMemoryValue> All()
+    {
+        var mobileId = Current();
+
+        return _memory.GetById(mobileId)?.Memory ?? Empty;
+    }
+
     public IDisposable Begin(BrainContext context)
     {
         _loopAffinity.AssertOnLoop("memory.begin");
         var previous = _current;
         _current = context;
+
         return new ContextScope(this, previous);
+    }
+
+    public bool Delete(string key)
+    {
+        _loopAffinity.AssertOnLoop("memory.delete");
+        var mobileId = Current();
+
+        if (_memory.GetById(mobileId) is not { } entity || !entity.Memory.Remove(key))
+        {
+            return false;
+        }
+
+        _memory.UpsertAsync(entity).WaitSync();
+
+        return true;
+    }
+
+    public void Forget(Serial mobileId)
+    {
+        _loopAffinity.AssertOnLoop("memory.forget");
+
+        if (_memory.GetById(mobileId) is not null)
+        {
+            _memory.RemoveAsync(mobileId).WaitSync();
+        }
+    }
+
+    public NpcMemoryValue? Get(string key)
+    {
+        var mobileId = Current();
+
+        return _memory.GetById(mobileId) is { } entity && entity.Memory.TryGetValue(key, out var value)
+                   ? value
+                   : null;
     }
 
     public bool Set(string key, NpcMemoryValue value)
@@ -73,64 +130,6 @@ public sealed class NpcMemoryService : INpcMemoryService
         return true;
     }
 
-    public NpcMemoryValue? Get(string key)
-    {
-        var mobileId = Current();
-
-        return _memory.GetById(mobileId) is { } entity && entity.Memory.TryGetValue(key, out var value)
-            ? value
-            : null;
-    }
-
-    public bool Delete(string key)
-    {
-        _loopAffinity.AssertOnLoop("memory.delete");
-        var mobileId = Current();
-
-        if (_memory.GetById(mobileId) is not { } entity || !entity.Memory.Remove(key))
-        {
-            return false;
-        }
-
-        _memory.UpsertAsync(entity).WaitSync();
-
-        return true;
-    }
-
-    public IReadOnlyDictionary<string, NpcMemoryValue> All()
-    {
-        var mobileId = Current();
-
-        return _memory.GetById(mobileId)?.Memory ?? Empty;
-    }
-
-    public void Forget(Serial mobileId)
-    {
-        _loopAffinity.AssertOnLoop("memory.forget");
-
-        if (_memory.GetById(mobileId) is not null)
-        {
-            _memory.RemoveAsync(mobileId).WaitSync();
-        }
-    }
-
     private Serial Current()
         => (_current ?? throw new InvalidOperationException("memory.* is only callable inside an NPC brain tick.")).Self.Id;
-
-    private sealed class ContextScope : IDisposable
-    {
-        private readonly NpcMemoryService _owner;
-        private readonly BrainContext? _previous;
-
-        public ContextScope(NpcMemoryService owner, BrainContext? previous)
-        {
-            _owner = owner;
-            _previous = previous;
-        }
-
-        public void Dispose()
-        {
-            _owner._current = _previous;
-        }
-    }
 }

--- a/src/Moongate.Server/Services/AI/SectorActivityService.cs
+++ b/src/Moongate.Server/Services/AI/SectorActivityService.cs
@@ -47,41 +47,21 @@ public sealed class SectorActivityService : ISectorActivityService, ISquidStdSer
         _metrics = metrics;
     }
 
-    public SectorActivitySnapshot Current => new(
-        _sectors.Count(pair => pair.Value.ReferenceCount > 0),
-        _sectors.Count(pair => pair.Value.ReferenceCount == 0)
-    );
+    public SectorActivitySnapshot Current
+        => new(
+            _sectors.Count(pair => pair.Value.ReferenceCount > 0),
+            _sectors.Count(pair => pair.Value.ReferenceCount == 0)
+        );
+
+    private sealed class SectorState
+    {
+        public int ReferenceCount { get; set; }
+
+        public DateTimeOffset? DeactivateAt { get; set; }
+    }
 
     public bool IsActive(int mapId, int sectorX, int sectorY)
         => _sectors.ContainsKey((mapId, sectorX, sectorY));
-
-    public void TrackPlayer(MobileEntity player)
-    {
-        var location = (
-            MapId: player.MapId,
-            SectorX: player.Position.X >> SectorShift,
-            SectorY: player.Position.Y >> SectorShift
-        );
-
-        if (_players.TryGetValue(player.Id, out var previous))
-        {
-            if (previous == location)
-            {
-                return;
-            }
-
-            MovePlayer(player.Id, location.MapId, location.Item2, location.Item3);
-
-            return;
-        }
-
-        _players[player.Id] = location;
-
-        foreach (var sector in Coverage(location))
-        {
-            Acquire(sector);
-        }
-    }
 
     public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
     {
@@ -113,36 +93,6 @@ public sealed class SectorActivityService : ISectorActivityService, ISquidStdSer
         _players[playerId] = next;
     }
 
-    public void UntrackPlayer(Serial playerId)
-    {
-        if (!_players.Remove(playerId, out var location))
-        {
-            return;
-        }
-
-        foreach (var sector in Coverage(location))
-        {
-            Release(sector);
-        }
-    }
-
-    public void Tick()
-    {
-        var now = _timeProvider.GetUtcNow();
-        var expired = _sectors
-            .Where(pair => pair.Value.ReferenceCount == 0 && pair.Value.DeactivateAt is { } deactivateAt && deactivateAt <= now)
-            .Select(pair => pair.Key)
-            .ToArray();
-
-        foreach (var sector in expired)
-        {
-            _sectors.Remove(sector);
-            _eventBus.Publish(new SectorDeactivatedEvent(sector.MapId, sector.SectorX, sector.SectorY));
-        }
-
-        UpdateMetrics();
-    }
-
     public ValueTask StartAsync(CancellationToken cancellationToken = default)
     {
         if (_timerId is null)
@@ -162,6 +112,68 @@ public sealed class SectorActivityService : ISectorActivityService, ISquidStdSer
         }
 
         return ValueTask.CompletedTask;
+    }
+
+    public void Tick()
+    {
+        var now = _timeProvider.GetUtcNow();
+        var expired = _sectors
+                      .Where(
+                          pair => pair.Value.ReferenceCount == 0 &&
+                                  pair.Value.DeactivateAt is { } deactivateAt &&
+                                  deactivateAt <= now
+                      )
+                      .Select(pair => pair.Key)
+                      .ToArray();
+
+        foreach (var sector in expired)
+        {
+            _sectors.Remove(sector);
+            _eventBus.Publish(new SectorDeactivatedEvent(sector.MapId, sector.SectorX, sector.SectorY));
+        }
+
+        UpdateMetrics();
+    }
+
+    public void TrackPlayer(MobileEntity player)
+    {
+        var location = (
+                           player.MapId,
+                           SectorX: player.Position.X >> SectorShift,
+                           SectorY: player.Position.Y >> SectorShift
+                       );
+
+        if (_players.TryGetValue(player.Id, out var previous))
+        {
+            if (previous == location)
+            {
+                return;
+            }
+
+            MovePlayer(player.Id, location.MapId, location.Item2, location.Item3);
+
+            return;
+        }
+
+        _players[player.Id] = location;
+
+        foreach (var sector in Coverage(location))
+        {
+            Acquire(sector);
+        }
+    }
+
+    public void UntrackPlayer(Serial playerId)
+    {
+        if (!_players.Remove(playerId, out var location))
+        {
+            return;
+        }
+
+        foreach (var sector in Coverage(location))
+        {
+            Release(sector);
+        }
     }
 
     private void Acquire((int MapId, int SectorX, int SectorY) sector)
@@ -184,6 +196,17 @@ public sealed class SectorActivityService : ISectorActivityService, ISquidStdSer
         UpdateMetrics();
     }
 
+    private IEnumerable<(int MapId, int SectorX, int SectorY)> Coverage((int MapId, int SectorX, int SectorY) center)
+    {
+        for (var sectorX = center.SectorX - 1; sectorX <= center.SectorX + 1; sectorX++)
+        {
+            for (var sectorY = center.SectorY - 1; sectorY <= center.SectorY + 1; sectorY++)
+            {
+                yield return (center.MapId, sectorX, sectorY);
+            }
+        }
+    }
+
     private void Release((int MapId, int SectorX, int SectorY) sector)
     {
         var state = _sectors[sector];
@@ -197,29 +220,9 @@ public sealed class SectorActivityService : ISectorActivityService, ISquidStdSer
         UpdateMetrics();
     }
 
-    private IEnumerable<(int MapId, int SectorX, int SectorY)> Coverage((int MapId, int SectorX, int SectorY) center)
-    {
-        for (var sectorX = center.SectorX - 1; sectorX <= center.SectorX + 1; sectorX++)
-        {
-            for (var sectorY = center.SectorY - 1; sectorY <= center.SectorY + 1; sectorY++)
-            {
-                yield return (center.MapId, sectorX, sectorY);
-            }
-        }
-    }
-
     private void UpdateMetrics()
-    {
-        _metrics.SetActiveSectorCounts(
+        => _metrics.SetActiveSectorCounts(
             _sectors.Count(pair => pair.Value.ReferenceCount > 0),
             _sectors.Count(pair => pair.Value.ReferenceCount == 0)
         );
-    }
-
-    private sealed class SectorState
-    {
-        public int ReferenceCount { get; set; }
-
-        public DateTimeOffset? DeactivateAt { get; set; }
-    }
 }

--- a/src/Moongate.Server/Services/Accounts/AccountService.cs
+++ b/src/Moongate.Server/Services/Accounts/AccountService.cs
@@ -47,8 +47,8 @@ public class AccountService : IAccountService
     public AccountAuthResult Authenticate(string username, string password)
     {
         var account = _accountStore
-            .Query()
-            .FirstOrDefault(s => s.Username == username && HashUtils.VerifyPassword(password, s.PasswordHash));
+                      .Query()
+                      .FirstOrDefault(s => s.Username == username && HashUtils.VerifyPassword(password, s.PasswordHash));
 
         if (account == null)
         {
@@ -96,190 +96,6 @@ public class AccountService : IAccountService
             _logger.Information("Account created: {Username} at level {Level}", username, level);
 
             return AccountCreateResultType.Created;
-        }
-    }
-
-    public AccountRegisterResult RegisterPending(string username, string password, string email)
-    {
-        var normalizedUsername = PublicRegistrationValidator.NormalizeUsername(username);
-        var normalizedEmail = PublicRegistrationValidator.NormalizeEmail(email);
-
-        if (string.IsNullOrEmpty(normalizedUsername))
-        {
-            return new() { Result = AccountRegisterResultType.UsernameEmpty };
-        }
-
-        if (string.IsNullOrEmpty(password))
-        {
-            return new() { Result = AccountRegisterResultType.PasswordEmpty };
-        }
-
-        if (string.IsNullOrEmpty(normalizedEmail))
-        {
-            return new() { Result = AccountRegisterResultType.EmailEmpty };
-        }
-
-        if (!PublicRegistrationValidator.IsUsernameValid(normalizedUsername))
-        {
-            return new() { Result = AccountRegisterResultType.UsernameInvalid };
-        }
-
-        if (!PublicRegistrationValidator.IsPasswordValid(password))
-        {
-            return new() { Result = AccountRegisterResultType.PasswordInvalid };
-        }
-
-        if (!PublicRegistrationValidator.IsEmailValid(normalizedEmail))
-        {
-            return new() { Result = AccountRegisterResultType.EmailInvalid };
-        }
-
-        lock (_registrationTransitionLock)
-        {
-            if (GetByUsername(normalizedUsername) is not null)
-            {
-                return new() { Result = AccountRegisterResultType.UsernameTaken };
-            }
-
-            if (_accountStore.Query().Any(account => string.Equals(
-                    account.Email,
-                    normalizedEmail,
-                    StringComparison.OrdinalIgnoreCase
-                )))
-            {
-                return new() { Result = AccountRegisterResultType.EmailTaken };
-            }
-
-            var token = RandomNumberGenerator.GetHexString(64);
-
-            var account = new AccountEntity
-            {
-                Username = normalizedUsername,
-                Email = normalizedEmail,
-                PasswordHash = HashUtils.HashPassword(password),
-                IsActive = false,
-                ActivationToken = string.Empty,
-                ActivationTokenHash = HashActivationToken(token),
-                ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime),
-                IsPublicRegistrationPending = true,
-                AccountLevel = AccountLevelType.Player
-            };
-
-            _accountStore.UpsertAsync(account).WaitSync();
-
-            _logger.Information(
-                "Web registration pending for {Username}; awaiting email verification",
-                normalizedUsername
-            );
-            _eventBus.Publish(
-                new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token)
-            );
-
-            return new() { Result = AccountRegisterResultType.Created, Token = token };
-        }
-    }
-
-    public AccountResendResultType ResendVerification(string username, string email)
-    {
-        var normalizedUsername = PublicRegistrationValidator.NormalizeUsername(username);
-        var normalizedEmail = PublicRegistrationValidator.NormalizeEmail(email);
-
-        if (!PublicRegistrationValidator.IsUsernameValid(normalizedUsername))
-        {
-            return AccountResendResultType.UsernameInvalid;
-        }
-
-        if (!PublicRegistrationValidator.IsEmailValid(normalizedEmail))
-        {
-            return AccountResendResultType.EmailInvalid;
-        }
-
-        lock (_registrationTransitionLock)
-        {
-            var account = _accountStore.Query().FirstOrDefault(candidate =>
-                !candidate.IsActive
-                && candidate.AccountLevel == AccountLevelType.Player
-                && (candidate.IsPublicRegistrationPending || !string.IsNullOrEmpty(candidate.ActivationToken))
-                && candidate.Username == normalizedUsername
-                && string.Equals(candidate.Email, normalizedEmail, StringComparison.OrdinalIgnoreCase)
-            );
-
-            if (account is null)
-            {
-                return AccountResendResultType.Ignored;
-            }
-
-            var token = RandomNumberGenerator.GetHexString(64);
-            ClearActivationTokenState(account);
-            account.ActivationTokenHash = HashActivationToken(token);
-            account.ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime);
-            account.IsPublicRegistrationPending = true;
-            _accountStore.UpsertAsync(account).WaitSync();
-
-            _eventBus.Publish(
-                new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token)
-            );
-
-            return AccountResendResultType.Sent;
-        }
-    }
-
-    public AccountVerifyResultType VerifyEmail(string token)
-    {
-        if (string.IsNullOrWhiteSpace(token))
-        {
-            return AccountVerifyResultType.InvalidToken;
-        }
-
-        var tokenHash = HashActivationToken(token);
-
-        lock (_registrationTransitionLock)
-        {
-            var account = _accountStore.Query().FirstOrDefault(candidate =>
-                !candidate.IsActive
-                && candidate.AccountLevel == AccountLevelType.Player
-                && candidate.IsPublicRegistrationPending
-                && candidate.ActivationTokenHash == tokenHash
-            );
-
-            if (account is not null)
-            {
-                if (account.ActivationTokenExpiresAtUtc is null
-                    || account.ActivationTokenExpiresAtUtc <= _timeProvider.GetUtcNow())
-                {
-                    ClearActivationTokenState(account);
-                    _accountStore.UpsertAsync(account).WaitSync();
-
-                    return AccountVerifyResultType.ExpiredToken;
-                }
-
-                account.IsActive = true;
-                ClearActivationTokenState(account);
-                account.IsPublicRegistrationPending = false;
-                _accountStore.UpsertAsync(account).WaitSync();
-
-                _logger.Information("Account {Username} verified and activated", account.Username);
-
-                return AccountVerifyResultType.Verified;
-            }
-
-            account = _accountStore.Query().FirstOrDefault(candidate =>
-                !candidate.IsActive
-                && candidate.AccountLevel == AccountLevelType.Player
-                && !string.IsNullOrEmpty(candidate.ActivationToken)
-                && candidate.ActivationToken == token
-            );
-
-            if (account is null)
-            {
-                return AccountVerifyResultType.InvalidToken;
-            }
-
-            ClearActivationTokenState(account);
-            account.IsPublicRegistrationPending = true;
-            _accountStore.UpsertAsync(account).WaitSync();
-
-            return AccountVerifyResultType.ExpiredToken;
         }
     }
 
@@ -334,6 +150,137 @@ public class AccountService : IAccountService
     public IReadOnlyList<string> GetUsernames()
         => _accountStore.Query().Select(account => account.Username).ToList();
 
+    public AccountRegisterResult RegisterPending(string username, string password, string email)
+    {
+        var normalizedUsername = PublicRegistrationValidator.NormalizeUsername(username);
+        var normalizedEmail = PublicRegistrationValidator.NormalizeEmail(email);
+
+        if (string.IsNullOrEmpty(normalizedUsername))
+        {
+            return new() { Result = AccountRegisterResultType.UsernameEmpty };
+        }
+
+        if (string.IsNullOrEmpty(password))
+        {
+            return new() { Result = AccountRegisterResultType.PasswordEmpty };
+        }
+
+        if (string.IsNullOrEmpty(normalizedEmail))
+        {
+            return new() { Result = AccountRegisterResultType.EmailEmpty };
+        }
+
+        if (!PublicRegistrationValidator.IsUsernameValid(normalizedUsername))
+        {
+            return new() { Result = AccountRegisterResultType.UsernameInvalid };
+        }
+
+        if (!PublicRegistrationValidator.IsPasswordValid(password))
+        {
+            return new() { Result = AccountRegisterResultType.PasswordInvalid };
+        }
+
+        if (!PublicRegistrationValidator.IsEmailValid(normalizedEmail))
+        {
+            return new() { Result = AccountRegisterResultType.EmailInvalid };
+        }
+
+        lock (_registrationTransitionLock)
+        {
+            if (GetByUsername(normalizedUsername) is not null)
+            {
+                return new() { Result = AccountRegisterResultType.UsernameTaken };
+            }
+
+            if (_accountStore.Query()
+                             .Any(
+                                 account => string.Equals(
+                                     account.Email,
+                                     normalizedEmail,
+                                     StringComparison.OrdinalIgnoreCase
+                                 )
+                             ))
+            {
+                return new() { Result = AccountRegisterResultType.EmailTaken };
+            }
+
+            var token = RandomNumberGenerator.GetHexString(64);
+
+            var account = new AccountEntity
+            {
+                Username = normalizedUsername,
+                Email = normalizedEmail,
+                PasswordHash = HashUtils.HashPassword(password),
+                IsActive = false,
+                ActivationToken = string.Empty,
+                ActivationTokenHash = HashActivationToken(token),
+                ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime),
+                IsPublicRegistrationPending = true,
+                AccountLevel = AccountLevelType.Player
+            };
+
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _logger.Information(
+                "Web registration pending for {Username}; awaiting email verification",
+                normalizedUsername
+            );
+            _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token));
+
+            return new() { Result = AccountRegisterResultType.Created, Token = token };
+        }
+    }
+
+    public AccountResendResultType ResendVerification(string username, string email)
+    {
+        var normalizedUsername = PublicRegistrationValidator.NormalizeUsername(username);
+        var normalizedEmail = PublicRegistrationValidator.NormalizeEmail(email);
+
+        if (!PublicRegistrationValidator.IsUsernameValid(normalizedUsername))
+        {
+            return AccountResendResultType.UsernameInvalid;
+        }
+
+        if (!PublicRegistrationValidator.IsEmailValid(normalizedEmail))
+        {
+            return AccountResendResultType.EmailInvalid;
+        }
+
+        lock (_registrationTransitionLock)
+        {
+            var account = _accountStore.Query()
+                                       .FirstOrDefault(
+                                           candidate =>
+                                               !candidate.IsActive &&
+                                               candidate.AccountLevel == AccountLevelType.Player &&
+                                               (candidate.IsPublicRegistrationPending ||
+                                                !string.IsNullOrEmpty(candidate.ActivationToken)) &&
+                                               candidate.Username == normalizedUsername &&
+                                               string.Equals(
+                                                   candidate.Email,
+                                                   normalizedEmail,
+                                                   StringComparison.OrdinalIgnoreCase
+                                               )
+                                       );
+
+            if (account is null)
+            {
+                return AccountResendResultType.Ignored;
+            }
+
+            var token = RandomNumberGenerator.GetHexString(64);
+            ClearActivationTokenState(account);
+            account.ActivationTokenHash = HashActivationToken(token);
+            account.ActivationTokenExpiresAtUtc = _timeProvider.GetUtcNow().Add(VerificationLifetime);
+            account.IsPublicRegistrationPending = true;
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            _eventBus.Publish(new AccountRegistrationRequestedEvent(account.Id, normalizedUsername, normalizedEmail, token));
+
+            return AccountResendResultType.Sent;
+        }
+    }
+
     public bool SetActive(string username, bool isActive)
     {
         lock (_registrationTransitionLock)
@@ -363,6 +310,7 @@ public class AccountService : IAccountService
             }
 
             account.AccountLevel = level;
+
             if (level != AccountLevelType.Player)
             {
                 ClearPublicRegistrationState(account);
@@ -391,8 +339,68 @@ public class AccountService : IAccountService
         return true;
     }
 
-    private static string HashActivationToken(string token)
-        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+    public AccountVerifyResultType VerifyEmail(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return AccountVerifyResultType.InvalidToken;
+        }
+
+        var tokenHash = HashActivationToken(token);
+
+        lock (_registrationTransitionLock)
+        {
+            var account = _accountStore.Query()
+                                       .FirstOrDefault(
+                                           candidate =>
+                                               !candidate.IsActive &&
+                                               candidate.AccountLevel == AccountLevelType.Player &&
+                                               candidate.IsPublicRegistrationPending &&
+                                               candidate.ActivationTokenHash == tokenHash
+                                       );
+
+            if (account is not null)
+            {
+                if (account.ActivationTokenExpiresAtUtc is null ||
+                    account.ActivationTokenExpiresAtUtc <= _timeProvider.GetUtcNow())
+                {
+                    ClearActivationTokenState(account);
+                    _accountStore.UpsertAsync(account).WaitSync();
+
+                    return AccountVerifyResultType.ExpiredToken;
+                }
+
+                account.IsActive = true;
+                ClearActivationTokenState(account);
+                account.IsPublicRegistrationPending = false;
+                _accountStore.UpsertAsync(account).WaitSync();
+
+                _logger.Information("Account {Username} verified and activated", account.Username);
+
+                return AccountVerifyResultType.Verified;
+            }
+
+            account = _accountStore.Query()
+                                   .FirstOrDefault(
+                                       candidate =>
+                                           !candidate.IsActive &&
+                                           candidate.AccountLevel == AccountLevelType.Player &&
+                                           !string.IsNullOrEmpty(candidate.ActivationToken) &&
+                                           candidate.ActivationToken == token
+                                   );
+
+            if (account is null)
+            {
+                return AccountVerifyResultType.InvalidToken;
+            }
+
+            ClearActivationTokenState(account);
+            account.IsPublicRegistrationPending = true;
+            _accountStore.UpsertAsync(account).WaitSync();
+
+            return AccountVerifyResultType.ExpiredToken;
+        }
+    }
 
     private static void ClearActivationTokenState(AccountEntity account)
     {
@@ -406,4 +414,7 @@ public class AccountService : IAccountService
         ClearActivationTokenState(account);
         account.IsPublicRegistrationPending = false;
     }
+
+    private static string HashActivationToken(string token)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
 }

--- a/src/Moongate.Server/Services/Accounts/CharacterService.cs
+++ b/src/Moongate.Server/Services/Accounts/CharacterService.cs
@@ -234,13 +234,13 @@ public class CharacterService : ICharacterService
     private void GiveStartingItems(MobileEntity mobile, ItemEntity backpack, CharacterCreationPacket packet)
     {
         var topSkillNames = packet.Skills
-            .Where(skill => skill.Value > 0)
-            .OrderByDescending(skill => skill.Value)
-            .Take(3)
-            .Select(skill => _skills.GetById(skill.SkillId)?.Name)
-            .Where(name => name is not null)
-            .Select(name => name!)
-            .ToList();
+                                  .Where(skill => skill.Value > 0)
+                                  .OrderByDescending(skill => skill.Value)
+                                  .Take(3)
+                                  .Select(skill => _skills.GetById(skill.SkillId)?.Name)
+                                  .Where(name => name is not null)
+                                  .Select(name => name!)
+                                  .ToList();
 
         var kit = _startingItems.Resolve(packet.Race, packet.Gender, topSkillNames);
 

--- a/src/Moongate.Server/Services/Accounts/PublicRegistrationValidator.cs
+++ b/src/Moongate.Server/Services/Accounts/PublicRegistrationValidator.cs
@@ -5,21 +5,20 @@ namespace Moongate.Server.Services.Accounts;
 
 internal static partial class PublicRegistrationValidator
 {
-    public static string NormalizeUsername(string? username)
-        => username?.Trim() ?? string.Empty;
+    public static bool IsEmailValid(string email)
+        => MailAddress.TryCreate(email, out _);
 
-    public static string NormalizeEmail(string? email)
-        => email?.Trim() ?? string.Empty;
+    public static bool IsPasswordValid(string? password)
+        => password is { Length: >= 8 and <= 30 } && password.All(character => character is >= ' ' and <= '~');
 
     public static bool IsUsernameValid(string username)
         => UsernameRegex().IsMatch(username);
 
-    public static bool IsPasswordValid(string? password)
-        => password is { Length: >= 8 and <= 30 }
-           && password.All(character => character is >= ' ' and <= '~');
+    public static string NormalizeEmail(string? email)
+        => email?.Trim() ?? string.Empty;
 
-    public static bool IsEmailValid(string email)
-        => MailAddress.TryCreate(email, out _);
+    public static string NormalizeUsername(string? username)
+        => username?.Trim() ?? string.Empty;
 
     [GeneratedRegex("^[A-Za-z0-9._-]{3,30}$", RegexOptions.CultureInvariant)]
     private static partial Regex UsernameRegex();

--- a/src/Moongate.Server/Services/Commands/CommandService.cs
+++ b/src/Moongate.Server/Services/Commands/CommandService.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using DryIoc;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
@@ -31,7 +30,9 @@ public sealed class CommandService : ICommandService
     private readonly IAccountService _accounts;
 
     public CommandService(
-        IReadOnlyList<CommandRegistration> registrations, IResolverContext resolver, IAccountService accounts
+        IReadOnlyList<CommandRegistration> registrations,
+        IResolverContext resolver,
+        IAccountService accounts
     )
     {
         _registry = BuildRegistry(registrations);
@@ -65,7 +66,7 @@ public sealed class CommandService : ICommandService
         var actorLevel = _accounts.GetById(session.AccountId)?.AccountLevel ?? AccountLevelType.Player;
 
         Execute(
-            new CommandInvocation(
+            new(
                 CommandSourceType.InGame,
                 actorLevel,
                 actor,
@@ -79,10 +80,10 @@ public sealed class CommandService : ICommandService
     {
         var (name, arguments) = Parse(invocation.CommandLine);
 
-        if (name.Length == 0
-            || !_registry.TryGetValue(name, out var registration)
-            || !registration.Sources.HasFlag(invocation.Source)
-            || !IsAuthorized(invocation.ActorLevel, registration.MinLevel))
+        if (name.Length == 0 ||
+            !_registry.TryGetValue(name, out var registration) ||
+            !registration.Sources.HasFlag(invocation.Source) ||
+            !IsAuthorized(invocation.ActorLevel, registration.MinLevel))
         {
             invocation.Reply(UnknownCommandMessage);
 
@@ -102,20 +103,21 @@ public sealed class CommandService : ICommandService
         }
     }
 
-    public IReadOnlyList<CommandDescriptor> ListCommands(CommandSourceType source)
-        => _registry.Values
-            .Where(registration => registration.Sources.HasFlag(source))
-            .Distinct()
-            .Select(registration => new CommandDescriptor(
-                    registration.Name.Split('|')[0],
-                    registration.MinLevel,
-                    registration.Description
-                )
-            )
-            .ToList();
-
     public static bool IsAuthorized(AccountLevelType actorLevel, AccountLevelType minLevel)
         => actorLevel >= minLevel;
+
+    public IReadOnlyList<CommandDescriptor> ListCommands(CommandSourceType source)
+        => _registry.Values
+                    .Where(registration => registration.Sources.HasFlag(source))
+                    .Distinct()
+                    .Select(
+                        registration => new CommandDescriptor(
+                            registration.Name.Split('|')[0],
+                            registration.MinLevel,
+                            registration.Description
+                        )
+                    )
+                    .ToList();
 
     public static (string Name, string[] Arguments) Parse(string commandLine)
     {

--- a/src/Moongate.Server/Services/Events/LoopAffineEventBus.cs
+++ b/src/Moongate.Server/Services/Events/LoopAffineEventBus.cs
@@ -51,6 +51,11 @@ public sealed class LoopAffineEventBus : IEventBus
         return _inner.PublishAsync(eventData, cancellationToken);
     }
 
+    // Passed straight through, unguarded: there are no IEventListener<> subscribers today, so this path
+    // carries no loop-affine enforcement. Guard it here the same way Subscribe is if that changes.
+    public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
+        => _inner.RegisterListener(listener);
+
     public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
     {
         if (!typeof(ILoopAffineEvent).IsAssignableFrom(typeof(TEvent)))
@@ -58,7 +63,8 @@ public sealed class LoopAffineEventBus : IEventBus
             return _inner.Subscribe(handler);
         }
 
-        return _inner.Subscribe<TEvent>((evt, ct) =>
+        return _inner.Subscribe<TEvent>(
+            (evt, ct) =>
             {
                 if (!_loopThread.IsOnLoopThread)
                 {
@@ -80,9 +86,4 @@ public sealed class LoopAffineEventBus : IEventBus
             }
         );
     }
-
-    // Passed straight through, unguarded: there are no IEventListener<> subscribers today, so this path
-    // carries no loop-affine enforcement. Guard it here the same way Subscribe is if that changes.
-    public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
-        => _inner.RegisterListener(listener);
 }

--- a/src/Moongate.Server/Services/Game/GameLoopContext.cs
+++ b/src/Moongate.Server/Services/Game/GameLoopContext.cs
@@ -23,20 +23,12 @@ public sealed class GameLoopContext : IGameLoopContext
     public bool Cancel(string timerId)
         => Timers.UnregisterTimer(timerId);
 
-    public void Post(Action action)
-        => Dispatcher.Post(action);
-
-    public string Schedule(string name, TimeSpan delay, Action callback)
-        => Timers.RegisterTimer(name, delay, callback, repeat: false);
-
-    public string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null)
-        => Timers.RegisterTimer(name, interval, callback, delay, true);
-
     public async Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null)
     {
         var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        Dispatcher.Post(() =>
+        Dispatcher.Post(
+            () =>
             {
                 try
                 {
@@ -51,4 +43,13 @@ public sealed class GameLoopContext : IGameLoopContext
 
         return await completion.Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(5));
     }
+
+    public void Post(Action action)
+        => Dispatcher.Post(action);
+
+    public string Schedule(string name, TimeSpan delay, Action callback)
+        => Timers.RegisterTimer(name, delay, callback, repeat: false);
+
+    public string ScheduleRepeating(string name, TimeSpan interval, Action callback, TimeSpan? delay = null)
+        => Timers.RegisterTimer(name, interval, callback, delay, true);
 }

--- a/src/Moongate.Server/Services/Items/ItemFactoryService.cs
+++ b/src/Moongate.Server/Services/Items/ItemFactoryService.cs
@@ -20,13 +20,14 @@ public sealed class ItemFactoryService : IItemFactoryService
     public IReadOnlyList<ItemEntity> CreateByCategory(string category, int count = 1, int amount = 1, Hue? hue = null)
     {
         var matches = _templates.All
-            .Where(template => string.Equals(
-                    template.Category,
-                    category,
-                    StringComparison.OrdinalIgnoreCase
-                )
-            )
-            .ToList();
+                                .Where(
+                                    template => string.Equals(
+                                        template.Category,
+                                        category,
+                                        StringComparison.OrdinalIgnoreCase
+                                    )
+                                )
+                                .ToList();
 
         return CreateFromPool(matches, count, amount, hue);
     }
@@ -34,8 +35,8 @@ public sealed class ItemFactoryService : IItemFactoryService
     public IReadOnlyList<ItemEntity> CreateByTag(string tag, int count = 1, int amount = 1, Hue? hue = null)
     {
         var matches = _templates.All
-            .Where(template => template.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
-            .ToList();
+                                .Where(template => template.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+                                .ToList();
 
         return CreateFromPool(matches, count, amount, hue);
     }

--- a/src/Moongate.Server/Services/Items/ItemTemplateYamlDeserializer.cs
+++ b/src/Moongate.Server/Services/Items/ItemTemplateYamlDeserializer.cs
@@ -34,9 +34,9 @@ internal static class ItemTemplateYamlDeserializer
     };
 
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-        .WithDuplicateKeyChecking()
-        .WithEnforceNullability()
-        .Build();
+                                                         .WithDuplicateKeyChecking()
+                                                         .WithEnforceNullability()
+                                                         .Build();
 
     public static ItemTemplate[] DeserializeFromFile(string file, string relativePath)
     {

--- a/src/Moongate.Server/Services/Items/ItemTemplateYamlSerializer.cs
+++ b/src/Moongate.Server/Services/Items/ItemTemplateYamlSerializer.cs
@@ -7,13 +7,13 @@ namespace Moongate.Server.Services.Items;
 public static class ItemTemplateYamlSerializer
 {
     private static readonly ISerializer Serializer = new SerializerBuilder()
-        .ConfigureDefaultValuesHandling(
-            DefaultValuesHandling.OmitNull |
-            DefaultValuesHandling.OmitDefaults |
-            DefaultValuesHandling.OmitEmptyCollections
-        )
-        .DisableAliases()
-        .Build();
+                                                     .ConfigureDefaultValuesHandling(
+                                                         DefaultValuesHandling.OmitNull |
+                                                         DefaultValuesHandling.OmitDefaults |
+                                                         DefaultValuesHandling.OmitEmptyCollections
+                                                     )
+                                                     .DisableAliases()
+                                                     .Build();
 
     public static void SerializeToFile(string file, IReadOnlyList<ItemTemplate> templates)
     {

--- a/src/Moongate.Server/Services/Items/LootService.cs
+++ b/src/Moongate.Server/Services/Items/LootService.cs
@@ -64,8 +64,8 @@ public sealed class LootService : ILootService
     private IReadOnlyList<ItemEntity> Materialize(LootTemplateEntry entry)
     {
         var amount = entry is { AmountMin: { } low, AmountMax: { } high }
-            ? _random.Next(low, high + 1)
-            : entry.Amount ?? 1;
+                         ? _random.Next(low, high + 1)
+                         : entry.Amount ?? 1;
 
         var hasId = !string.IsNullOrWhiteSpace(entry.ItemTemplateId);
         var hasTag = !string.IsNullOrWhiteSpace(entry.ItemTag);
@@ -78,8 +78,8 @@ public sealed class LootService : ILootService
         }
 
         return hasId
-            ? _itemFactory.CreateFromTemplate(entry.ItemTemplateId!, amount: amount)
-            : _itemFactory.CreateByTag(entry.ItemTag!, amount: amount);
+                   ? _itemFactory.CreateFromTemplate(entry.ItemTemplateId!, amount: amount)
+                   : _itemFactory.CreateByTag(entry.ItemTag!, amount: amount);
     }
 
     private LootTemplateEntry? PickWeighted(LootTemplate template)

--- a/src/Moongate.Server/Services/Items/LootTemplateYamlDeserializer.cs
+++ b/src/Moongate.Server/Services/Items/LootTemplateYamlDeserializer.cs
@@ -15,9 +15,9 @@ internal static class LootTemplateYamlDeserializer
     };
 
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-        .WithDuplicateKeyChecking()
-        .WithEnforceNullability()
-        .Build();
+                                                         .WithDuplicateKeyChecking()
+                                                         .WithEnforceNullability()
+                                                         .Build();
 
     public static LootTemplate[] DeserializeFromFile(string file, string relativePath)
     {

--- a/src/Moongate.Server/Services/Mobiles/MobileTemplateYamlDeserializer.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileTemplateYamlDeserializer.cs
@@ -7,8 +7,8 @@ namespace Moongate.Server.Services.Mobiles;
 internal static class MobileTemplateYamlDeserializer
 {
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-        .WithDuplicateKeyChecking()
-        .Build();
+                                                         .WithDuplicateKeyChecking()
+                                                         .Build();
 
     public static MobileTemplate[] DeserializeFromFile(string file, string relativePath)
     {

--- a/src/Moongate.Server/Services/Network/NetworkService.cs
+++ b/src/Moongate.Server/Services/Network/NetworkService.cs
@@ -68,12 +68,12 @@ public sealed class NetworkService : INetworkService, ISquidStdService, IAsyncDi
         }
 
         _handlers[opCode] = (session, packet) =>
-        {
-            var reader = new SpanReader(packet);
-            var decoded = TPacket.Read(ref reader);
+                            {
+                                var reader = new SpanReader(packet);
+                                var decoded = TPacket.Read(ref reader);
 
-            handler.Handle(decoded, new(session));
-        };
+                                handler.Handle(decoded, new(session));
+                            };
     }
 
     public async ValueTask StartAsync(CancellationToken cancellationToken = default)

--- a/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
+++ b/src/Moongate.Server/Services/Notifications/NotificationTemplateService.cs
@@ -28,10 +28,10 @@ public sealed class NotificationTemplateService : INotificationTemplateService
         // template without one fails to parse under it. Channels with no subject write no front matter,
         // so both shapes have to be accepted.
         var mode = source.TrimStart().StartsWith(FrontMatterMarker, StringComparison.Ordinal)
-            ? ScriptMode.FrontMatterAndContent
-            : ScriptMode.Default;
+                       ? ScriptMode.FrontMatterAndContent
+                       : ScriptMode.Default;
 
-        var template = Template.Parse(source, templateId, null, new LexerOptions { Mode = mode });
+        var template = Template.Parse(source, templateId, null, new() { Mode = mode });
 
         if (template.HasErrors)
         {

--- a/src/Moongate.Server/Services/Plugins/PluginDiscovery.cs
+++ b/src/Moongate.Server/Services/Plugins/PluginDiscovery.cs
@@ -16,6 +16,15 @@ namespace Moongate.Server.Services.Plugins;
 /// </summary>
 public static class PluginDiscovery
 {
+    /// <summary>Activatable plugin types found in assemblies outside the host's compile-time graph.</summary>
+    public static IEnumerable<Type> ExternalPluginTypes(Assembly host, IEnumerable<Assembly> loaded)
+        => loaded.Where(assembly => IsExternal(host, assembly))
+                 .SelectMany(LoadableTypes)
+                 .Where(
+                     type => type is { IsAbstract: false, IsInterface: false } &&
+                             typeof(ISquidStdPlugin).IsAssignableFrom(type)
+                 );
+
     /// <summary>Whether <paramref name="candidate" /> lies outside the host's compile-time graph.</summary>
     public static bool IsExternal(Assembly host, Assembly candidate)
     {
@@ -28,14 +37,6 @@ public static class PluginDiscovery
 
         return !host.GetReferencedAssemblies().Any(reference => reference.Name == name);
     }
-
-    /// <summary>Activatable plugin types found in assemblies outside the host's compile-time graph.</summary>
-    public static IEnumerable<Type> ExternalPluginTypes(Assembly host, IEnumerable<Assembly> loaded)
-        => loaded.Where(assembly => IsExternal(host, assembly))
-            .SelectMany(LoadableTypes)
-            .Where(type => type is { IsAbstract: false, IsInterface: false }
-                           && typeof(ISquidStdPlugin).IsAssignableFrom(type)
-            );
 
     /// <summary>
     /// The types an assembly can actually give up. A plugin built against different dependency versions

--- a/src/Moongate.Server/Services/Server/ServerSettingsService.cs
+++ b/src/Moongate.Server/Services/Server/ServerSettingsService.cs
@@ -19,6 +19,16 @@ public sealed class ServerSettingsService : IServerSettingsService
         _store = persistenceService.GetStore<ServerSettingsEntity, Serial>();
     }
 
+    public void ClearAsset(ServerAssetSlotType slot)
+    {
+        var settings = Get();
+
+        if (settings.Assets.Remove(slot.ToString()))
+        {
+            _store.UpsertAsync(settings).WaitSync();
+        }
+    }
+
     public ServerSettingsEntity Get()
     {
         if (_store.Query().FirstOrDefault(entity => entity.Id == SettingsId) is { } existing)
@@ -30,6 +40,13 @@ public sealed class ServerSettingsService : IServerSettingsService
         _store.UpsertAsync(created).WaitSync();
 
         return created;
+    }
+
+    public void SetAsset(ServerAssetSlotType slot, ServerAssetMeta meta)
+    {
+        var settings = Get();
+        settings.Assets[slot.ToString()] = meta;
+        _store.UpsertAsync(settings).WaitSync();
     }
 
     public void Update(ServerSettingsUpdate update)
@@ -57,22 +74,5 @@ public sealed class ServerSettingsService : IServerSettingsService
         }
 
         _store.UpsertAsync(settings).WaitSync();
-    }
-
-    public void SetAsset(ServerAssetSlotType slot, ServerAssetMeta meta)
-    {
-        var settings = Get();
-        settings.Assets[slot.ToString()] = meta;
-        _store.UpsertAsync(settings).WaitSync();
-    }
-
-    public void ClearAsset(ServerAssetSlotType slot)
-    {
-        var settings = Get();
-
-        if (settings.Assets.Remove(slot.ToString()))
-        {
-            _store.UpsertAsync(settings).WaitSync();
-        }
     }
 }

--- a/src/Moongate.Server/Services/Server/ServerStatsService.cs
+++ b/src/Moongate.Server/Services/Server/ServerStatsService.cs
@@ -105,7 +105,8 @@ public sealed class ServerStatsService : IServerStatsService, ISquidStdService
         // for a whole interval. The event fires on the loop once the world is loaded, which is both the
         // earliest correct moment and the right thread. Refreshing inline here is not an option — StartAsync
         // runs off the loop, and reading the world stores from there is what this snapshot exists to avoid.
-        _eventBus.Subscribe<WorldReadyEvent>((_, _) =>
+        _eventBus.Subscribe<WorldReadyEvent>(
+            (_, _) =>
             {
                 Refresh();
 

--- a/src/Moongate.Server/Services/World/OplService.cs
+++ b/src/Moongate.Server/Services/World/OplService.cs
@@ -114,7 +114,7 @@ public sealed class OplService : IOplService
 
     private static string FirstNonEmpty(string? first, string? second, string fallback)
         => !string.IsNullOrWhiteSpace(first) ? first :
-            !string.IsNullOrWhiteSpace(second) ? second : fallback;
+           !string.IsNullOrWhiteSpace(second) ? second : fallback;
 
     private static int Fnv1a(string text)
     {

--- a/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/AccountRegistrationSubscriber.cs
@@ -58,6 +58,25 @@ public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
         eventBus.Subscribe<AccountRegistrationRequestedEvent>(OnRegistrationRequested);
     }
 
+    internal static string BuildVerificationUrl(string website, string token)
+    {
+        if (!Uri.TryCreate(website, UriKind.Absolute, out var websiteUri) ||
+            string.IsNullOrEmpty(websiteUri.Host) ||
+            websiteUri.Scheme != Uri.UriSchemeHttp && websiteUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new ArgumentException("Website must be an absolute HTTP(S) URI.", nameof(website));
+        }
+
+        var uriBuilder = new UriBuilder(websiteUri)
+        {
+            Path = string.Concat(websiteUri.AbsolutePath.TrimEnd('/'), "/verify"),
+            Query = $"token={Uri.EscapeDataString(token)}",
+            Fragment = string.Empty
+        };
+
+        return uriBuilder.Uri.AbsoluteUri;
+    }
+
     private Task OnRegistrationRequested(
         AccountRegistrationRequestedEvent message,
         CancellationToken cancellationToken
@@ -80,24 +99,5 @@ public sealed class AccountRegistrationSubscriber : IEventSubscriberRegistration
         );
 
         return Task.CompletedTask;
-    }
-
-    internal static string BuildVerificationUrl(string website, string token)
-    {
-        if (!Uri.TryCreate(website, UriKind.Absolute, out var websiteUri)
-            || string.IsNullOrEmpty(websiteUri.Host)
-            || (websiteUri.Scheme != Uri.UriSchemeHttp && websiteUri.Scheme != Uri.UriSchemeHttps))
-        {
-            throw new ArgumentException("Website must be an absolute HTTP(S) URI.", nameof(website));
-        }
-
-        var uriBuilder = new UriBuilder(websiteUri)
-        {
-            Path = string.Concat(websiteUri.AbsolutePath.TrimEnd('/'), "/verify"),
-            Query = $"token={Uri.EscapeDataString(token)}",
-            Fragment = string.Empty
-        };
-
-        return uriBuilder.Uri.AbsoluteUri;
     }
 }

--- a/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
+++ b/src/Moongate.Server/Subscribers/NpcBrainEventRouter.cs
@@ -41,6 +41,137 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
     }
 
+    public Task OnBrainDefinitionReloaded(
+        BrainDefinitionReloadedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!string.Equals(
+                message.BrainId,
+                message.Descriptor.BrainId,
+                StringComparison.Ordinal
+            ))
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var observer in _mobiles
+                                 .GetAll()
+                                 .Where(
+                                     mobile =>
+                                         string.Equals(
+                                             mobile.BrainScriptId,
+                                             message.BrainId,
+                                             StringComparison.Ordinal
+                                         )
+                                 )
+                                 .OrderBy(mobile => mobile.Id))
+        {
+            if (_scheduler.IsActive(observer.Id))
+            {
+                ReconcileObserverSet(observer, message.Descriptor);
+
+                continue;
+            }
+
+            _perceivedByObserver.Remove(observer.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileAttacked(
+        MobileAttackedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteCombatEvent(
+            message.Defender,
+            message.Attacker,
+            NpcBrainHookType.Attacked,
+            NpcBrainEventType.Attacked
+        );
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileCreated(
+        MobileCreatedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteSubjectArrival(message.Mobile);
+
+        if (!string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
+        {
+            RefreshObserverSet(message.Mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDamaged(
+        MobileDamagedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteCombatEvent(
+            message.Mobile,
+            message.Attacker,
+            NpcBrainHookType.Damage,
+            NpcBrainEventType.Damage,
+            message.Amount
+        );
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDeleted(
+        MobileDeletedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RemoveSubject(message.Mobile);
+        _perceivedByObserver.Remove(message.Mobile.Id);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDied(
+        MobileDiedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        RouteCombatEvent(
+            message.Mobile,
+            message.Killer,
+            NpcBrainHookType.Death,
+            NpcBrainEventType.Death
+        );
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileMoved(
+        MobileMovedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_mobiles.GetById(message.Mobile) is not { } subject)
+        {
+            return Task.CompletedTask;
+        }
+
+        RouteSubjectMovement(subject, message);
+
+        if (!string.IsNullOrWhiteSpace(subject.BrainScriptId))
+        {
+            RefreshObserverSet(subject);
+        }
+
+        return Task.CompletedTask;
+    }
+
     public Task OnMobileSpeech(
         MobileSpeechEvent message,
         CancellationToken cancellationToken
@@ -83,58 +214,44 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         return Task.CompletedTask;
     }
 
-    public Task OnMobileMoved(
-        MobileMovedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        if (_mobiles.GetById(message.Mobile) is not { } subject)
-        {
-            return Task.CompletedTask;
-        }
-
-        RouteSubjectMovement(subject, message);
-
-        if (!string.IsNullOrWhiteSpace(subject.BrainScriptId))
-        {
-            RefreshObserverSet(subject);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileCreated(
-        MobileCreatedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        RouteSubjectArrival(message.Mobile);
-
-        if (!string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
-        {
-            RefreshObserverSet(message.Mobile);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileDeleted(
-        MobileDeletedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        RemoveSubject(message.Mobile);
-        _perceivedByObserver.Remove(message.Mobile.Id);
-
-        return Task.CompletedTask;
-    }
-
     public Task OnPlayerEnteredWorld(
         PlayerEnteredWorldEvent message,
         CancellationToken cancellationToken
     )
     {
         RouteSubjectArrival(message.Mobile, true);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSectorActivated(
+        SectorActivatedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var mobile in _spatial
+                               .GetMobilesInSector(message.MapId, message.SectorX, message.SectorY)
+                               .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+                               .OrderBy(mobile => mobile.Id))
+        {
+            SeedObserver(mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSectorDeactivated(
+        SectorDeactivatedEvent message,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var mobile in _spatial
+                               .GetMobilesInSector(message.MapId, message.SectorX, message.SectorY)
+                               .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+                               .OrderBy(mobile => mobile.Id))
+        {
+            _perceivedByObserver.Remove(mobile.Id);
+        }
 
         return Task.CompletedTask;
     }
@@ -149,121 +266,6 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
             RemoveSubject(character, true);
             _perceivedByObserver.Remove(character.Id);
         }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnSectorActivated(
-        SectorActivatedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        foreach (var mobile in _spatial
-                     .GetMobilesInSector(message.MapId, message.SectorX, message.SectorY)
-                     .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
-                     .OrderBy(mobile => mobile.Id))
-        {
-            SeedObserver(mobile);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnSectorDeactivated(
-        SectorDeactivatedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        foreach (var mobile in _spatial
-                     .GetMobilesInSector(message.MapId, message.SectorX, message.SectorY)
-                     .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId))
-                     .OrderBy(mobile => mobile.Id))
-        {
-            _perceivedByObserver.Remove(mobile.Id);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnBrainDefinitionReloaded(
-        BrainDefinitionReloadedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        if (!string.Equals(
-                message.BrainId,
-                message.Descriptor.BrainId,
-                StringComparison.Ordinal
-            ))
-        {
-            return Task.CompletedTask;
-        }
-
-        foreach (var observer in _mobiles
-                     .GetAll()
-                     .Where(mobile =>
-                         string.Equals(
-                             mobile.BrainScriptId,
-                             message.BrainId,
-                             StringComparison.Ordinal
-                         )
-                     )
-                     .OrderBy(mobile => mobile.Id))
-        {
-            if (_scheduler.IsActive(observer.Id))
-            {
-                ReconcileObserverSet(observer, message.Descriptor);
-                continue;
-            }
-
-            _perceivedByObserver.Remove(observer.Id);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileAttacked(
-        MobileAttackedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        RouteCombatEvent(
-            message.Defender,
-            message.Attacker,
-            NpcBrainHookType.Attacked,
-            NpcBrainEventType.Attacked
-        );
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileDamaged(
-        MobileDamagedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        RouteCombatEvent(
-            message.Mobile,
-            message.Attacker,
-            NpcBrainHookType.Damage,
-            NpcBrainEventType.Damage,
-            message.Amount
-        );
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileDied(
-        MobileDiedEvent message,
-        CancellationToken cancellationToken
-    )
-    {
-        RouteCombatEvent(
-            message.Mobile,
-            message.Killer,
-            NpcBrainHookType.Death,
-            NpcBrainEventType.Death
-        );
 
         return Task.CompletedTask;
     }
@@ -284,101 +286,161 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         eventBus.Subscribe<MobileDiedEvent>(OnMobileDied);
     }
 
+    private void EnqueuePerception(
+        Serial observerId,
+        NpcBrainHookType hook,
+        NpcBrainEventType eventType,
+        BrainMobileSnapshot snapshot,
+        MobileMovedEvent movement
+    )
+        => _scheduler.EnqueueEvent(
+            observerId,
+            hook,
+            new(
+                eventType,
+                snapshot,
+                FromPosition: movement.FromPosition,
+                ToPosition: movement.ToPosition
+            )
+        );
+
+    private HashSet<Serial> GetPerceived(Serial observerId)
+    {
+        if (!_perceivedByObserver.TryGetValue(observerId, out var perceived))
+        {
+            perceived = [];
+            _perceivedByObserver[observerId] = perceived;
+        }
+
+        return perceived;
+    }
+
     private IEnumerable<MobileEntity> NearbyObservers(
         int mapId,
         Point3D position,
         int range
     )
         => _spatial
-            .GetMobilesInRange(mapId, position, range)
-            .OrderBy(mobile => mobile.Id);
+           .GetMobilesInRange(mapId, position, range)
+           .OrderBy(mobile => mobile.Id);
 
-    private void RouteSubjectMovement(MobileEntity subject, MobileMovedEvent movement)
+    private void ReconcileObserverSet(
+        MobileEntity observer,
+        BrainDescriptor descriptor
+    )
     {
-        var candidateIds = _spatial
-            .GetMobilesInRange(
-                movement.FromMapId,
-                movement.FromPosition,
-                _scheduler.MaxPerceptionRange
-            )
-            .Concat(
-                _spatial.GetMobilesInRange(
-                    movement.ToMapId,
-                    movement.ToPosition,
-                    _scheduler.MaxPerceptionRange
-                )
-            )
-            .Select(mobile => mobile.Id)
-            .Concat(
-                _perceivedByObserver
-                    .Where(pair => pair.Value.Contains(subject.Id))
-                    .Select(pair => pair.Key)
-            )
-            .Where(observerId => observerId != subject.Id)
-            .Distinct()
-            .Order()
-            .ToArray();
-        var snapshot = ToSnapshot(subject);
+        var current = _spatial
+                      .GetMobilesInRange(
+                          observer.MapId,
+                          observer.Position,
+                          descriptor.PerceptionRange
+                      )
+                      .Where(subject => subject.Id != observer.Id)
+                      .OrderBy(subject => subject.Id)
+                      .ToArray();
+        var previous = _perceivedByObserver.TryGetValue(observer.Id, out var perceived)
+                           ? perceived
+                           : [];
+        var currentIds = current.Select(subject => subject.Id).ToHashSet();
 
-        foreach (var observerId in candidateIds)
+        foreach (var subjectId in previous.Except(currentIds).Order())
         {
-            if (_mobiles.GetById(observerId) is not { } observer ||
-                !TryGetActiveDescriptor(observerId, out var descriptor))
+            if (_mobiles.GetById(subjectId) is { } subject)
             {
-                _perceivedByObserver.Remove(observerId);
-                continue;
+                _scheduler.EnqueueEvent(
+                    observer.Id,
+                    NpcBrainHookType.MobileLeftRange,
+                    new(
+                        NpcBrainEventType.MobileLeftRange,
+                        ToSnapshot(subject),
+                        FromPosition: subject.Position,
+                        ToPosition: subject.Position
+                    )
+                );
             }
+        }
 
-            var wasPerceived = _perceivedByObserver.TryGetValue(
-                observerId,
-                out var perceived
-            ) && perceived.Contains(subject.Id);
-            var isInside = observer.MapId == movement.ToMapId &&
-                           observer.Position.InRange(
-                               movement.ToPosition,
-                               descriptor.PerceptionRange
-                           );
-
-            if (!wasPerceived && !isInside)
-            {
-                continue;
-            }
-
-            if (!wasPerceived)
-            {
-                perceived = GetPerceived(observerId);
-                perceived.Add(subject.Id);
-                EnqueuePerception(
-                    observerId,
-                    NpcBrainHookType.MobileEnteredRange,
+        foreach (var subject in current.Where(subject => !previous.Contains(subject.Id)))
+        {
+            _scheduler.EnqueueEvent(
+                observer.Id,
+                NpcBrainHookType.MobileEnteredRange,
+                new(
                     NpcBrainEventType.MobileEnteredRange,
-                    snapshot,
-                    movement
-                );
-                continue;
-            }
-
-            if (isInside)
-            {
-                EnqueuePerception(
-                    observerId,
-                    NpcBrainHookType.MobileMoved,
-                    NpcBrainEventType.MobileMoved,
-                    snapshot,
-                    movement
-                );
-                continue;
-            }
-
-            _perceivedByObserver[observerId].Remove(subject.Id);
-            EnqueuePerception(
-                observerId,
-                NpcBrainHookType.MobileLeftRange,
-                NpcBrainEventType.MobileLeftRange,
-                snapshot,
-                movement
+                    ToSnapshot(subject),
+                    FromPosition: subject.Position,
+                    ToPosition: subject.Position
+                )
             );
         }
+
+        _perceivedByObserver[observer.Id] = currentIds;
+    }
+
+    private void RefreshObserverSet(MobileEntity observer)
+    {
+        if (
+            _scheduler.IsActive(observer.Id) &&
+            _sectors.IsActive(
+                observer.MapId,
+                observer.Position.X >> SectorShift,
+                observer.Position.Y >> SectorShift
+            )
+        )
+        {
+            SeedObserver(observer);
+
+            return;
+        }
+
+        _perceivedByObserver.Remove(observer.Id);
+    }
+
+    private void RemoveSubject(MobileEntity subject, bool? isPlayer = null)
+    {
+        var snapshot = ToSnapshot(subject, isPlayer);
+
+        foreach (var (observerId, perceived) in _perceivedByObserver.OrderBy(pair => pair.Key))
+        {
+            if (!perceived.Remove(subject.Id) || !_scheduler.IsActive(observerId))
+            {
+                continue;
+            }
+
+            _scheduler.EnqueueEvent(
+                observerId,
+                NpcBrainHookType.MobileLeftRange,
+                new(
+                    NpcBrainEventType.MobileLeftRange,
+                    snapshot,
+                    FromPosition: subject.Position,
+                    ToPosition: subject.Position
+                )
+            );
+        }
+    }
+
+    private void RouteCombatEvent(
+        Serial affected,
+        Serial other,
+        NpcBrainHookType hook,
+        NpcBrainEventType eventType,
+        int amount = 0
+    )
+    {
+        if (!_scheduler.IsActive(affected))
+        {
+            return;
+        }
+
+        var otherSnapshot = _mobiles.GetById(other) is { } mobile
+                                ? ToSnapshot(mobile)
+                                : null;
+        _scheduler.EnqueueEvent(
+            affected,
+            hook,
+            new(eventType, otherSnapshot, Amount: amount)
+        );
     }
 
     private void RouteSubjectArrival(MobileEntity subject, bool? isPlayer = null)
@@ -418,46 +480,96 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         }
     }
 
-    private void RemoveSubject(MobileEntity subject, bool? isPlayer = null)
+    private void RouteSubjectMovement(MobileEntity subject, MobileMovedEvent movement)
     {
-        var snapshot = ToSnapshot(subject, isPlayer);
+        var candidateIds = _spatial
+                           .GetMobilesInRange(
+                               movement.FromMapId,
+                               movement.FromPosition,
+                               _scheduler.MaxPerceptionRange
+                           )
+                           .Concat(
+                               _spatial.GetMobilesInRange(
+                                   movement.ToMapId,
+                                   movement.ToPosition,
+                                   _scheduler.MaxPerceptionRange
+                               )
+                           )
+                           .Select(mobile => mobile.Id)
+                           .Concat(
+                               _perceivedByObserver
+                                   .Where(pair => pair.Value.Contains(subject.Id))
+                                   .Select(pair => pair.Key)
+                           )
+                           .Where(observerId => observerId != subject.Id)
+                           .Distinct()
+                           .Order()
+                           .ToArray();
+        var snapshot = ToSnapshot(subject);
 
-        foreach (var (observerId, perceived) in _perceivedByObserver.OrderBy(pair => pair.Key))
+        foreach (var observerId in candidateIds)
         {
-            if (!perceived.Remove(subject.Id) || !_scheduler.IsActive(observerId))
+            if (_mobiles.GetById(observerId) is not { } observer ||
+                !TryGetActiveDescriptor(observerId, out var descriptor))
+            {
+                _perceivedByObserver.Remove(observerId);
+
+                continue;
+            }
+
+            var wasPerceived = _perceivedByObserver.TryGetValue(
+                                   observerId,
+                                   out var perceived
+                               ) &&
+                               perceived.Contains(subject.Id);
+            var isInside = observer.MapId == movement.ToMapId &&
+                           observer.Position.InRange(
+                               movement.ToPosition,
+                               descriptor.PerceptionRange
+                           );
+
+            if (!wasPerceived && !isInside)
             {
                 continue;
             }
 
-            _scheduler.EnqueueEvent(
+            if (!wasPerceived)
+            {
+                perceived = GetPerceived(observerId);
+                perceived.Add(subject.Id);
+                EnqueuePerception(
+                    observerId,
+                    NpcBrainHookType.MobileEnteredRange,
+                    NpcBrainEventType.MobileEnteredRange,
+                    snapshot,
+                    movement
+                );
+
+                continue;
+            }
+
+            if (isInside)
+            {
+                EnqueuePerception(
+                    observerId,
+                    NpcBrainHookType.MobileMoved,
+                    NpcBrainEventType.MobileMoved,
+                    snapshot,
+                    movement
+                );
+
+                continue;
+            }
+
+            _perceivedByObserver[observerId].Remove(subject.Id);
+            EnqueuePerception(
                 observerId,
                 NpcBrainHookType.MobileLeftRange,
-                new(
-                    NpcBrainEventType.MobileLeftRange,
-                    snapshot,
-                    FromPosition: subject.Position,
-                    ToPosition: subject.Position
-                )
+                NpcBrainEventType.MobileLeftRange,
+                snapshot,
+                movement
             );
         }
-    }
-
-    private void RefreshObserverSet(MobileEntity observer)
-    {
-        if (
-            _scheduler.IsActive(observer.Id) &&
-            _sectors.IsActive(
-                observer.MapId,
-                observer.Position.X >> SectorShift,
-                observer.Position.Y >> SectorShift
-            )
-        )
-        {
-            SeedObserver(observer);
-            return;
-        }
-
-        _perceivedByObserver.Remove(observer.Id);
     }
 
     private void SeedObserver(MobileEntity observer)
@@ -465,136 +577,11 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
         if (!TryGetActiveDescriptor(observer.Id, out var descriptor))
         {
             _perceivedByObserver.Remove(observer.Id);
+
             return;
         }
 
         ReconcileObserverSet(observer, descriptor);
-    }
-
-    private void ReconcileObserverSet(
-        MobileEntity observer,
-        BrainDescriptor descriptor
-    )
-    {
-        var current = _spatial
-            .GetMobilesInRange(
-                observer.MapId,
-                observer.Position,
-                descriptor.PerceptionRange
-            )
-            .Where(subject => subject.Id != observer.Id)
-            .OrderBy(subject => subject.Id)
-            .ToArray();
-        var previous = _perceivedByObserver.TryGetValue(observer.Id, out var perceived)
-            ? perceived
-            : [];
-        var currentIds = current.Select(subject => subject.Id).ToHashSet();
-
-        foreach (var subjectId in previous.Except(currentIds).Order())
-        {
-            if (_mobiles.GetById(subjectId) is { } subject)
-            {
-                _scheduler.EnqueueEvent(
-                    observer.Id,
-                    NpcBrainHookType.MobileLeftRange,
-                    new(
-                        NpcBrainEventType.MobileLeftRange,
-                        ToSnapshot(subject),
-                        FromPosition: subject.Position,
-                        ToPosition: subject.Position
-                    )
-                );
-            }
-        }
-
-        foreach (var subject in current.Where(subject => !previous.Contains(subject.Id)))
-        {
-            _scheduler.EnqueueEvent(
-                observer.Id,
-                NpcBrainHookType.MobileEnteredRange,
-                new(
-                    NpcBrainEventType.MobileEnteredRange,
-                    ToSnapshot(subject),
-                    FromPosition: subject.Position,
-                    ToPosition: subject.Position
-                )
-            );
-        }
-
-        _perceivedByObserver[observer.Id] = currentIds;
-    }
-
-    private void RouteCombatEvent(
-        Serial affected,
-        Serial other,
-        NpcBrainHookType hook,
-        NpcBrainEventType eventType,
-        int amount = 0
-    )
-    {
-        if (!_scheduler.IsActive(affected))
-        {
-            return;
-        }
-
-        var otherSnapshot = _mobiles.GetById(other) is { } mobile
-            ? ToSnapshot(mobile)
-            : null;
-        _scheduler.EnqueueEvent(
-            affected,
-            hook,
-            new(eventType, otherSnapshot, Amount: amount)
-        );
-    }
-
-    private bool TryGetActiveDescriptor(
-        Serial observerId,
-        [NotNullWhen(true)] out BrainDescriptor? descriptor
-    )
-    {
-        if (
-            _scheduler.IsActive(observerId) &&
-            _scheduler.TryGetDescriptor(observerId, out var found) &&
-            found is not null
-        )
-        {
-            descriptor = found;
-            return true;
-        }
-
-        descriptor = null;
-        return false;
-    }
-
-    private HashSet<Serial> GetPerceived(Serial observerId)
-    {
-        if (!_perceivedByObserver.TryGetValue(observerId, out var perceived))
-        {
-            perceived = [];
-            _perceivedByObserver[observerId] = perceived;
-        }
-
-        return perceived;
-    }
-
-    private void EnqueuePerception(
-        Serial observerId,
-        NpcBrainHookType hook,
-        NpcBrainEventType eventType,
-        BrainMobileSnapshot snapshot,
-        MobileMovedEvent movement
-    )
-    {
-        _scheduler.EnqueueEvent(
-            observerId,
-            hook,
-            new(
-                eventType,
-                snapshot,
-                FromPosition: movement.FromPosition,
-                ToPosition: movement.ToPosition
-            )
-        );
     }
 
     private BrainMobileSnapshot ToSnapshot(
@@ -614,4 +601,25 @@ public sealed class NpcBrainEventRouter : IEventSubscriberRegistration
             mobile.Criminal,
             mobile.Kills
         );
+
+    private bool TryGetActiveDescriptor(
+        Serial observerId,
+        [NotNullWhen(true)] out BrainDescriptor? descriptor
+    )
+    {
+        if (
+            _scheduler.IsActive(observerId) &&
+            _scheduler.TryGetDescriptor(observerId, out var found) &&
+            found is not null
+        )
+        {
+            descriptor = found;
+
+            return true;
+        }
+
+        descriptor = null;
+
+        return false;
+    }
 }

--- a/src/Moongate.Server/Subscribers/NpcBrainLifecycleSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/NpcBrainLifecycleSubscriber.cs
@@ -34,36 +34,12 @@ public sealed class NpcBrainLifecycleSubscriber : IEventSubscriberRegistration
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
     }
 
-    public Task OnWorldReady(WorldReadyEvent message, CancellationToken cancellationToken)
+    public Task OnBrainDefinitionReloaded(
+        BrainDefinitionReloadedEvent message,
+        CancellationToken cancellationToken
+    )
     {
-        var playerCharacters = PlayerCharacters();
-
-        foreach (var mobile in _mobiles.GetAll())
-        {
-            if (playerCharacters.Contains(mobile.Id) || string.IsNullOrWhiteSpace(mobile.BrainScriptId))
-            {
-                continue;
-            }
-
-            BindAndActivateWhenSectorIsActive(mobile);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileCreated(MobileCreatedEvent message, CancellationToken cancellationToken)
-    {
-        if (!IsPlayerCharacter(message.Mobile.Id) && !string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
-        {
-            BindAndActivateWhenSectorIsActive(message.Mobile);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnMobileDeleted(MobileDeletedEvent message, CancellationToken cancellationToken)
-    {
-        _scheduler.Unbind(message.Mobile.Id);
+        _scheduler.RefreshDescriptor(message.BrainId, message.Descriptor);
 
         return Task.CompletedTask;
     }
@@ -83,6 +59,23 @@ public sealed class NpcBrainLifecycleSubscriber : IEventSubscriberRegistration
         {
             _scheduler.Deactivate(message.Mobile);
         }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileCreated(MobileCreatedEvent message, CancellationToken cancellationToken)
+    {
+        if (!IsPlayerCharacter(message.Mobile.Id) && !string.IsNullOrWhiteSpace(message.Mobile.BrainScriptId))
+        {
+            BindAndActivateWhenSectorIsActive(message.Mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileDeleted(MobileDeletedEvent message, CancellationToken cancellationToken)
+    {
+        _scheduler.Unbind(message.Mobile.Id);
 
         return Task.CompletedTask;
     }
@@ -107,12 +100,19 @@ public sealed class NpcBrainLifecycleSubscriber : IEventSubscriberRegistration
         return Task.CompletedTask;
     }
 
-    public Task OnBrainDefinitionReloaded(
-        BrainDefinitionReloadedEvent message,
-        CancellationToken cancellationToken
-    )
+    public Task OnWorldReady(WorldReadyEvent message, CancellationToken cancellationToken)
     {
-        _scheduler.RefreshDescriptor(message.BrainId, message.Descriptor);
+        var playerCharacters = PlayerCharacters();
+
+        foreach (var mobile in _mobiles.GetAll())
+        {
+            if (playerCharacters.Contains(mobile.Id) || string.IsNullOrWhiteSpace(mobile.BrainScriptId))
+            {
+                continue;
+            }
+
+            BindAndActivateWhenSectorIsActive(mobile);
+        }
 
         return Task.CompletedTask;
     }
@@ -140,13 +140,13 @@ public sealed class NpcBrainLifecycleSubscriber : IEventSubscriberRegistration
 
     private IEnumerable<MobileEntity> BrainMobilesInSector(int mapId, int sectorX, int sectorY)
         => _spatial
-            .GetMobilesInSector(mapId, sectorX, sectorY)
-            .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId) && !IsPlayerCharacter(mobile.Id))
-            .OrderBy(mobile => mobile.Id);
-
-    private HashSet<Serial> PlayerCharacters()
-        => _accounts.GetAll().SelectMany(account => account.MobileIds).ToHashSet();
+           .GetMobilesInSector(mapId, sectorX, sectorY)
+           .Where(mobile => !string.IsNullOrWhiteSpace(mobile.BrainScriptId) && !IsPlayerCharacter(mobile.Id))
+           .OrderBy(mobile => mobile.Id);
 
     private bool IsPlayerCharacter(Serial mobileId)
         => _accounts.GetAll().Any(account => account.MobileIds.Contains(mobileId));
+
+    private HashSet<Serial> PlayerCharacters()
+        => _accounts.GetAll().SelectMany(account => account.MobileIds).ToHashSet();
 }

--- a/src/Moongate.Server/Subscribers/NpcMemoryLifecycleSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/NpcMemoryLifecycleSubscriber.cs
@@ -23,7 +23,5 @@ public sealed class NpcMemoryLifecycleSubscriber : IEventSubscriberRegistration
     }
 
     public void Subscribe(IEventBus eventBus)
-    {
-        eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
-    }
+        => eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
 }

--- a/src/Moongate.Server/Subscribers/SectorActivitySubscriber.cs
+++ b/src/Moongate.Server/Subscribers/SectorActivitySubscriber.cs
@@ -17,20 +17,20 @@ public sealed class SectorActivitySubscriber : IEventSubscriberRegistration
         _activity = activity;
     }
 
-    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent message, CancellationToken cancellationToken)
-    {
-        _players.Add(message.Mobile.Id);
-        _activity.TrackPlayer(message.Mobile);
-
-        return Task.CompletedTask;
-    }
-
     public Task OnMobileChangedSector(MobileChangedSectorEvent message, CancellationToken cancellationToken)
     {
         if (_players.Contains(message.Mobile))
         {
             _activity.MovePlayer(message.Mobile, message.ToMapId, message.ToSectorX, message.ToSectorY);
         }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent message, CancellationToken cancellationToken)
+    {
+        _players.Add(message.Mobile.Id);
+        _activity.TrackPlayer(message.Mobile);
 
         return Task.CompletedTask;
     }

--- a/src/Moongate.UO.Data/Bodies/Body.cs
+++ b/src/Moongate.UO.Data/Bodies/Body.cs
@@ -37,6 +37,9 @@ public readonly struct Body : IEquatable<Body>
     public override int GetHashCode()
         => Value.GetHashCode();
 
+    public override string ToString()
+        => $"0x{Value:X4}";
+
     public static bool operator ==(Body left, Body right)
         => left.Value == right.Value;
 
@@ -48,7 +51,4 @@ public readonly struct Body : IEquatable<Body>
 
     public static bool operator !=(Body left, Body right)
         => left.Value != right.Value;
-
-    public override string ToString()
-        => $"0x{Value:X4}";
 }

--- a/src/Moongate.UO.Data/Hues/Hue.cs
+++ b/src/Moongate.UO.Data/Hues/Hue.cs
@@ -27,6 +27,9 @@ public readonly struct Hue : IEquatable<Hue>
     public override int GetHashCode()
         => Value.GetHashCode();
 
+    public override string ToString()
+        => $"0x{Value:X4}";
+
     public static bool operator ==(Hue left, Hue right)
         => left.Value == right.Value;
 
@@ -38,7 +41,4 @@ public readonly struct Hue : IEquatable<Hue>
 
     public static bool operator !=(Hue left, Hue right)
         => left.Value != right.Value;
-
-    public override string ToString()
-        => $"0x{Value:X4}";
 }

--- a/src/Moongate.UO.Data/Mobiles/Templates/HueSpec.cs
+++ b/src/Moongate.UO.Data/Mobiles/Templates/HueSpec.cs
@@ -29,8 +29,8 @@ public static partial class HueSpec
         }
 
         return ushort.TryParse(spec, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
-            ? value
-            : (ushort)0;
+                   ? value
+                   : (ushort)0;
     }
 
     [GeneratedRegex(@"^hue\(\s*(\d+)\s*:\s*(\d+)\s*\)$", RegexOptions.IgnoreCase)]

--- a/src/Moongate.UO.Data/Version/ClientVersion.cs
+++ b/src/Moongate.UO.Data/Version/ClientVersion.cs
@@ -261,6 +261,9 @@ public class ClientVersion : IComparable<ClientVersion>, IComparer<ClientVersion
     public static bool IsNull(object? x)
         => ReferenceEquals(x, null);
 
+    public override string ToString()
+        => SourceString;
+
     public static bool operator ==(ClientVersion? l, ClientVersion? r)
         => Equals(l, r);
 
@@ -278,9 +281,6 @@ public class ClientVersion : IComparable<ClientVersion>, IComparer<ClientVersion
 
     public static bool operator <=(ClientVersion? l, ClientVersion? r)
         => Compare(l, r) <= 0;
-
-    public override string ToString()
-        => SourceString;
 
     int IComparer<ClientVersion>.Compare(ClientVersion? x, ClientVersion? y)
         => Compare(x, y);

--- a/src/Moongate.Ultima/Animation/AnimationEdit.cs
+++ b/src/Moongate.Ultima/Animation/AnimationEdit.cs
@@ -35,7 +35,7 @@ public sealed class AnimationEdit
                 bin.Write((short)6);
                 var animLength = Animations.GetAnimLength(body, fileType);
                 var currType = animLength == 22 ? 0 :
-                    animLength == 13 ? 1 : 2;
+                               animLength == 13 ? 1 : 2;
                 bin.Write((short)currType);
                 var indexPos = bin.BaseStream.Position;
                 var animPos = bin.BaseStream.Position + 12 * animLength * 5;

--- a/src/Moongate.Ultima/Animation/Animations.cs
+++ b/src/Moongate.Ultima/Animation/Animations.cs
@@ -82,6 +82,58 @@ public static class Animations
         => AnimationsUopLoader.GetAllUopBodyIds();
 
     /// <summary>
+    /// Returns Animation count in given anim file
+    /// </summary>
+    /// <param name="fileType"></param>
+    /// <returns></returns>
+    public static int GetAnimCount(int fileType)
+    {
+        switch (fileType)
+        {
+            case 1:
+            default:
+                return 400 + (int)(_fileIndex.IdxLength - 35000 * 12) / (12 * 175);
+            case 2:
+                return 200 + (int)(_fileIndex2.IdxLength - 22000 * 12) / (12 * 65);
+            case 3:
+                return 400 + (int)(_fileIndex3.IdxLength - 35000 * 12) / (12 * 175);
+            case 4:
+                return 400 + (int)(_fileIndex4.IdxLength - 35000 * 12) / (12 * 175);
+            case 5:
+                return 400 + (int)(_fileIndex5.IdxLength - 35000 * 12) / (12 * 175);
+            case 6:
+                return 400 + (int)(_fileIndex6.IdxLength - 35000 * 12) / (12 * 175);
+        }
+    }
+
+    /// <summary>
+    /// Action count of given Body in given anim file.
+    /// When <c>mobtypes.txt</c> is loaded, the count is taken from the
+    /// body's mobtype category; otherwise falls back to the historical
+    /// body-id range heuristic.
+    /// </summary>
+    /// <param name="body"></param>
+    /// <param name="fileType"></param>
+    /// <returns></returns>
+    public static int GetAnimLength(int body, int fileType)
+    {
+        // The physical idx block reserved for a body is fixed by the id-range
+        // stride used in GetFileIndex. Never report more actions than that
+        // block holds: callers iterate this count and read idx records at
+        // index + action*5, so a count larger than the block (e.g. a body
+        // classed HUMAN/35 in mobtypes.txt but sitting in a 110-record/
+        // 22-action id range) would walk into the next body's records.
+        var capacity = GetActionCapacity(body, fileType);
+
+        if (MobTypes.IsLoaded)
+        {
+            return Math.Min(MobTypes.GetActionCount(GetBodyMobType(body, fileType)), capacity);
+        }
+
+        return Math.Min(GetAnimLengthLegacy(body, fileType), capacity);
+    }
+
+    /// <summary>
     /// Returns animation frames
     /// </summary>
     /// <param name="body"></param>
@@ -256,58 +308,6 @@ public static class Animations
 
             return frames;
         }
-    }
-
-    /// <summary>
-    /// Returns Animation count in given anim file
-    /// </summary>
-    /// <param name="fileType"></param>
-    /// <returns></returns>
-    public static int GetAnimCount(int fileType)
-    {
-        switch (fileType)
-        {
-            case 1:
-            default:
-                return 400 + (int)(_fileIndex.IdxLength - 35000 * 12) / (12 * 175);
-            case 2:
-                return 200 + (int)(_fileIndex2.IdxLength - 22000 * 12) / (12 * 65);
-            case 3:
-                return 400 + (int)(_fileIndex3.IdxLength - 35000 * 12) / (12 * 175);
-            case 4:
-                return 400 + (int)(_fileIndex4.IdxLength - 35000 * 12) / (12 * 175);
-            case 5:
-                return 400 + (int)(_fileIndex5.IdxLength - 35000 * 12) / (12 * 175);
-            case 6:
-                return 400 + (int)(_fileIndex6.IdxLength - 35000 * 12) / (12 * 175);
-        }
-    }
-
-    /// <summary>
-    /// Action count of given Body in given anim file.
-    /// When <c>mobtypes.txt</c> is loaded, the count is taken from the
-    /// body's mobtype category; otherwise falls back to the historical
-    /// body-id range heuristic.
-    /// </summary>
-    /// <param name="body"></param>
-    /// <param name="fileType"></param>
-    /// <returns></returns>
-    public static int GetAnimLength(int body, int fileType)
-    {
-        // The physical idx block reserved for a body is fixed by the id-range
-        // stride used in GetFileIndex. Never report more actions than that
-        // block holds: callers iterate this count and read idx records at
-        // index + action*5, so a count larger than the block (e.g. a body
-        // classed HUMAN/35 in mobtypes.txt but sitting in a 110-record/
-        // 22-action id range) would walk into the next body's records.
-        var capacity = GetActionCapacity(body, fileType);
-
-        if (MobTypes.IsLoaded)
-        {
-            return Math.Min(MobTypes.GetActionCount(GetBodyMobType(body, fileType)), capacity);
-        }
-
-        return Math.Min(GetAnimLengthLegacy(body, fileType), capacity);
     }
 
     /// <summary>

--- a/src/Moongate.Ultima/Animation/AnimationsUopLoader.cs
+++ b/src/Moongate.Ultima/Animation/AnimationsUopLoader.cs
@@ -46,8 +46,8 @@ internal static class AnimationsUopLoader
 
     public static IEnumerable<int> GetAllUopBodyIds()
         => MobTypes.GetDefinedBodies()
-            .Where(id => (MobTypes.GetFlags(id) & 0x10000u) != 0)
-            .OrderBy(id => id);
+                   .Where(id => (MobTypes.GetFlags(id) & 0x10000u) != 0)
+                   .OrderBy(id => id);
 
     public static AnimationFrame[] GetAnimation(
         int body,
@@ -114,8 +114,8 @@ internal static class AnimationsUopLoader
         }
 
         var result = firstFrame && frames.Length > 1
-            ? new[] { frames[0] }
-            : frames;
+                         ? new[] { frames[0] }
+                         : frames;
 
         Animations.Cache.Set(cacheKey, result);
 

--- a/src/Moongate.Ultima/Animation/Animdata.cs
+++ b/src/Moongate.Ultima/Animation/Animdata.cs
@@ -23,9 +23,7 @@ public sealed class Animdata
         public byte FrameStart { get; set; }
 
         // Empty constructor needed for deserialization.
-        public AnimdataEntry()
-        {
-        }
+        public AnimdataEntry() { }
 
         public AnimdataEntry(sbyte[] frame, byte unk, byte frameCount, byte frameInterval, byte frameStart)
         {

--- a/src/Moongate.Ultima/Audio/WaveFormatException.cs
+++ b/src/Moongate.Ultima/Audio/WaveFormatException.cs
@@ -2,15 +2,9 @@ namespace Moongate.Ultima.Audio;
 
 public class WaveFormatException : Exception
 {
-    public WaveFormatException()
-    {
-    }
+    public WaveFormatException() { }
 
-    public WaveFormatException(string message) : base(message)
-    {
-    }
+    public WaveFormatException(string message) : base(message) { }
 
-    public WaveFormatException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
+    public WaveFormatException(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/src/Moongate.Ultima/Graphics/Art.cs
+++ b/src/Moongate.Ultima/Graphics/Art.cs
@@ -493,8 +493,8 @@ public static class Art
                             // GetLand / GetStatic transparently check _replaced
                             // first, then the LRU cache, then decode from disk.
                             var bmp = index < 0x4000
-                                ? GetLand(index)
-                                : GetStatic(index - 0x4000, false);
+                                          ? GetLand(index)
+                                          : GetStatic(index - 0x4000, false);
 
                             if (bmp == null || _removed[index])
                             {

--- a/src/Moongate.Ultima/Graphics/Gumps.cs
+++ b/src/Moongate.Ultima/Graphics/Gumps.cs
@@ -141,7 +141,7 @@ public sealed class Gumps
                         var pPixelEnd = pPixel + width;
 
                         ushort color,
-                            count;
+                               count;
 
                         if (onlyHueGrayPixels)
                         {

--- a/src/Moongate.Ultima/Helpers/MapHelper.cs
+++ b/src/Moongate.Ultima/Helpers/MapHelper.cs
@@ -24,14 +24,14 @@ public sealed class MapHelper
         if (Files.GetFilePath("map1.mul") != null || Files.GetFilePath("map1legacymul.uop") != null)
         {
             Map.Trammel = Map.Trammel.Width == 7168
-                ? new(1, 1, 7168, 4096)
-                : new Map(1, 1, 6144, 4096);
+                              ? new(1, 1, 7168, 4096)
+                              : new Map(1, 1, 6144, 4096);
         }
         else
         {
             Map.Trammel = Map.Trammel.Width == 7168
-                ? new(0, 1, 7168, 4096)
-                : new Map(0, 1, 6144, 4096);
+                              ? new(0, 1, 7168, 4096)
+                              : new Map(0, 1, 6144, 4096);
         }
     }
 }

--- a/src/Moongate.Ultima/Helpers/MythicDecompress.cs
+++ b/src/Moongate.Ultima/Helpers/MythicDecompress.cs
@@ -65,7 +65,7 @@ public static class MythicDecompress
         var output = new byte[input.Length + nonZeroCount + 1024];
 
         for (int i = 0,
-             m = 0;
+                 m = 0;
              i < nonZeroCount;
              ++i)
         {
@@ -117,7 +117,7 @@ public static class MythicDecompress
         } while (count >= 0);
 
         for (int i = 0,
-             m = 0;
+                 m = 0;
              i < nonZeroCount;
              ++i)
         {
@@ -285,7 +285,7 @@ public static class MythicDecompress
             Frequency(partialInput, frequency);
 
             for (int i = 0,
-                 m = 0;
+                     m = 0;
                  i < nonZeroCount;
                  ++i)
             {

--- a/src/Moongate.Ultima/Helpers/UopUtils.cs
+++ b/src/Moongate.Ultima/Helpers/UopUtils.cs
@@ -70,11 +70,11 @@ public static class UopUtils
     public static ulong HashFileName(string s)
     {
         uint eax,
-            ecx,
-            edx,
-            ebx,
-            esi,
-            edi;
+             ecx,
+             edx,
+             ebx,
+             esi,
+             edi;
 
         eax = ecx = edx = ebx = esi = edi = 0;
         ebx = edi = esi = (uint)s.Length + 0xDEADBEEF;

--- a/src/Moongate.Ultima/Imaging/UltimaBitmap.cs
+++ b/src/Moongate.Ultima/Imaging/UltimaBitmap.cs
@@ -148,7 +148,8 @@ public sealed unsafe class UltimaBitmap : IDisposable
         ArgumentNullException.ThrowIfNull(source);
 
         var result = new UltimaBitmap(source.Width, source.Height);
-        source.ProcessPixelRows(accessor =>
+        source.ProcessPixelRows(
+            accessor =>
             {
                 for (var y = 0; y < accessor.Height; y++)
                 {
@@ -186,7 +187,8 @@ public sealed unsafe class UltimaBitmap : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         var image = new Image<Bgra32>(Width, Height);
-        image.ProcessPixelRows(accessor =>
+        image.ProcessPixelRows(
+            accessor =>
             {
                 for (var y = 0; y < accessor.Height; y++)
                 {

--- a/src/Moongate.Ultima/Io/FileIndex.cs
+++ b/src/Moongate.Ultima/Io/FileIndex.cs
@@ -31,9 +31,7 @@ public sealed class FileIndex : IDisposable
         ".dat",
         -1,
         false
-    )
-    {
-    }
+    ) { }
 
     public FileIndex(
         string idxFile,

--- a/src/Moongate.Ultima/Localization/SpeechEntry.cs
+++ b/src/Moongate.Ultima/Localization/SpeechEntry.cs
@@ -7,7 +7,8 @@ public sealed class SpeechEntry
     public short Id { get; }
     public string KeyWord { get; set; }
 
-    [Browsable(false)] public int Order { get; }
+    [Browsable(false)]
+    public int Order { get; }
 
     public SpeechEntry(short id, string keyword, int order)
     {

--- a/src/Moongate.Ultima/Localization/StringList.cs
+++ b/src/Moongate.Ultima/Localization/StringList.cs
@@ -133,8 +133,8 @@ public sealed class StringList
 
         public int Compare(StringEntry x, StringEntry y)
             => _sortDescending
-                ? string.CompareOrdinal(y.Text, x.Text)
-                : string.CompareOrdinal(x.Text, y.Text);
+                   ? string.CompareOrdinal(y.Text, x.Text)
+                   : string.CompareOrdinal(x.Text, y.Text);
     }
 
     public StringEntry GetEntry(int number)

--- a/src/Moongate.Ultima/Maps/Map.cs
+++ b/src/Moongate.Ultima/Maps/Map.cs
@@ -514,7 +514,7 @@ public sealed class Map
         var pStart = (byte*)bmp.Scan0;
 
         for (int oy = 0,
-             by = y;
+                 by = y;
              oy < height;
              ++oy, ++by, pStart += blockStride)
         {
@@ -528,7 +528,7 @@ public sealed class Map
             var pRow7 = (int*)(pStart + 7 * stride);
 
             for (int ox = 0,
-                 bx = x;
+                     bx = x;
                  ox < width;
                  ++ox, ++bx)
             {
@@ -594,7 +594,7 @@ public sealed class Map
         var pStart = (byte*)bmp.Scan0;
 
         for (int oy = 0,
-             by = y;
+                 by = y;
              oy < height;
              ++oy, ++by, pStart += blockStride)
         {
@@ -604,7 +604,7 @@ public sealed class Map
             var pRow3 = (int*)(pStart + 3 * stride);
 
             for (int ox = 0,
-                 bx = x;
+                     bx = x;
                  ox < width;
                  ++ox, ++bx)
             {
@@ -639,7 +639,7 @@ public sealed class Map
         var pStart = (byte*)bmp.Scan0;
 
         for (int oy = 0,
-             by = y;
+                 by = y;
              oy < height;
              ++oy, ++by, pStart += blockStride)
         {
@@ -647,7 +647,7 @@ public sealed class Map
             var pRow1 = (int*)(pStart + 1 * stride);
 
             for (int ox = 0,
-                 bx = x;
+                     bx = x;
                  ox < width;
                  ++ox, ++bx)
             {
@@ -1505,7 +1505,7 @@ public sealed class Map
         return data;
     }
 
-    #region Altitude Map Rendering
+#region Altitude Map Rendering
 
     /// <summary>
     /// Returns Bitmap with altitude rendering mode support
@@ -1562,7 +1562,7 @@ public sealed class Map
         {
             // Grayscale altitude mode (formerly 8bpp indexed with a gray palette)
             for (int oy = 0,
-                 by = y;
+                     by = y;
                  oy < height;
                  ++oy, ++by, pStart += blockStride)
             {
@@ -1576,7 +1576,7 @@ public sealed class Map
                 var pRow7 = (ushort*)(pStart + 7 * stride);
 
                 for (int ox = 0,
-                     bx = x;
+                         bx = x;
                      ox < width;
                      ++ox, ++bx)
                 {
@@ -1635,7 +1635,7 @@ public sealed class Map
             var withAltitude = altitudeMode == MapAltitudeModeType.NormalWithAltitude;
 
             for (int oy = 0,
-                 by = y;
+                     by = y;
                  oy < height;
                  ++oy, ++by, pStart += blockStride)
             {
@@ -1649,13 +1649,13 @@ public sealed class Map
                 var pRow7 = (ushort*)(pStart + 7 * stride);
 
                 for (int ox = 0,
-                     bx = x;
+                         bx = x;
                      ox < width;
                      ++ox, ++bx)
                 {
                     var colorData = withAltitude
-                        ? GetLitBlock(bx, by, statics)
-                        : GetRenderedBlock(bx, by, statics);
+                                        ? GetLitBlock(bx, by, statics)
+                                        : GetRenderedBlock(bx, by, statics);
 
                     fixed (ushort* pData = colorData)
                     {
@@ -1827,8 +1827,8 @@ public sealed class Map
     {
         // Get current shading settings based on preset
         var settings = ShadingPreset == AltitudeShadingPresetType.Custom
-            ? CustomShadingSettings
-            : AltitudeShadingSettings.GetPreset(ShadingPreset);
+                           ? CustomShadingSettings
+                           : AltitudeShadingSettings.GetPreset(ShadingPreset);
 
         // Use configurable intensity (lower = more contrast, higher = softer)
         var maxSlope = Math.Clamp(AltitudeIntensity, 1, 20);
@@ -1929,5 +1929,5 @@ public sealed class Map
         return (ushort)(OpaqueBit | (red << 10) | (green << 5) | blue);
     }
 
-    #endregion
+#endregion
 }

--- a/src/Moongate.Ultima/Maps/TileMatrix.cs
+++ b/src/Moongate.Ultima/Maps/TileMatrix.cs
@@ -383,8 +383,8 @@ public sealed class TileMatrix : IDisposable
         if (_map?.CanRead != true || !_map.CanSeek)
         {
             _map = _mapPath == null
-                ? null
-                : new FileStream(_mapPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                       ? null
+                       : new FileStream(_mapPath, FileMode.Open, FileAccess.Read, FileShare.Read);
 
             if (IsUOPFormat && _mapPath != null && !IsUOPAlreadyRead)
             {
@@ -427,8 +427,8 @@ public sealed class TileMatrix : IDisposable
         if (_statics?.CanRead != true || !_statics.CanSeek)
         {
             _statics = _staticsPath == null
-                ? null
-                : new FileStream(_staticsPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                           ? null
+                           : new FileStream(_staticsPath, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
         if (_statics == null)

--- a/src/Moongate.Ultima/Maps/TileMatrixPatch.cs
+++ b/src/Moongate.Ultima/Maps/TileMatrixPatch.cs
@@ -23,7 +23,7 @@ public sealed class TileMatrixPatch
 
         LandBlocksCount = StaticBlocksCount = 0;
         string mapDataPath,
-            mapIndexPath;
+               mapIndexPath;
 
         if (path == null)
         {
@@ -54,8 +54,8 @@ public sealed class TileMatrixPatch
         }
 
         string staDataPath,
-            staIndexPath,
-            staLookupPath;
+               staIndexPath,
+               staLookupPath;
 
         if (path == null)
         {
@@ -217,7 +217,7 @@ public sealed class TileMatrixPatch
                 using (var fsLookup = new FileStream(lookupPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     using (BinaryReader indexReader = new(fsIndex),
-                           lookupReader = new(fsLookup))
+                                        lookupReader = new(fsLookup))
                     {
                         var count = Math.Min(
                             (int)(indexReader.BaseStream.Length / 4),

--- a/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
@@ -25,8 +25,131 @@ public class ConsoleAdminIntegrationTests
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+    }
+
+    [Fact]
+    public async Task GmLogsInAndBroadcasts()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, chat) = Build(accounts);
+        await service.StartAsync();
+
+        try
         {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "secret");
+                await writer.WriteLineAsync("broadcast hello world");
+
+                await ReadUntilAsync(reader, "Broadcast sent.");
+                Assert.Equal("hello world", Assert.Single(chat.Broadcasts));
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task HelpListsBroadcast()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "secret");
+                await writer.WriteLineAsync("help");
+                await ReadUntilAsync(reader, "broadcast");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task PlayerLevelIsRejected()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("player", "secret", AccountLevelType.Player);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+
+            using (client)
+            {
+                await LoginAsync(reader, writer, "player", "secret");
+                await ReadUntilAsync(reader, "Insufficient privileges.");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UnknownCommandRepliesUnknown()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "secret");
+                await writer.WriteLineAsync("frobnicate");
+                await ReadUntilAsync(reader, "Unknown command.");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task WrongPasswordIsRejected()
+    {
+        var accounts = new SeededAccountService();
+        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
+        var (service, _) = Build(accounts);
+        await service.StartAsync();
+
+        try
+        {
+            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
+
+            using (client)
+            {
+                await LoginAsync(reader, writer, "gm", "wrong");
+                await ReadUntilAsync(reader, "Login failed.");
+            }
+        }
+        finally
+        {
+            await service.StopAsync();
         }
     }
 
@@ -58,6 +181,14 @@ public class ConsoleAdminIntegrationTests
         return (reader, writer, client);
     }
 
+    private static async Task LoginAsync(StreamReader reader, StreamWriter writer, string user, string password)
+    {
+        await ReadUntilAsync(reader, "login:");
+        await writer.WriteLineAsync(user);
+        await ReadUntilAsync(reader, "password:");
+        await writer.WriteLineAsync(password);
+    }
+
     /// <summary>Reads lines until one contains <paramref name="needle" />, or throws on timeout/EOF.</summary>
     private static async Task<string> ReadUntilAsync(StreamReader reader, string needle)
     {
@@ -72,134 +203,6 @@ public class ConsoleAdminIntegrationTests
             {
                 return line;
             }
-        }
-    }
-
-    private static async Task LoginAsync(StreamReader reader, StreamWriter writer, string user, string password)
-    {
-        await ReadUntilAsync(reader, "login:");
-        await writer.WriteLineAsync(user);
-        await ReadUntilAsync(reader, "password:");
-        await writer.WriteLineAsync(password);
-    }
-
-    [Fact]
-    public async Task GmLogsInAndBroadcasts()
-    {
-        var accounts = new SeededAccountService();
-        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
-        var (service, chat) = Build(accounts);
-        await service.StartAsync();
-
-        try
-        {
-            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
-            using (client)
-            {
-                await LoginAsync(reader, writer, "gm", "secret");
-                await writer.WriteLineAsync("broadcast hello world");
-
-                await ReadUntilAsync(reader, "Broadcast sent.");
-                Assert.Equal("hello world", Assert.Single(chat.Broadcasts));
-            }
-        }
-        finally
-        {
-            await service.StopAsync();
-        }
-    }
-
-    [Fact]
-    public async Task PlayerLevelIsRejected()
-    {
-        var accounts = new SeededAccountService();
-        accounts.Seed("player", "secret", AccountLevelType.Player);
-        var (service, _) = Build(accounts);
-        await service.StartAsync();
-
-        try
-        {
-            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
-            using (client)
-            {
-                await LoginAsync(reader, writer, "player", "secret");
-                await ReadUntilAsync(reader, "Insufficient privileges.");
-            }
-        }
-        finally
-        {
-            await service.StopAsync();
-        }
-    }
-
-    [Fact]
-    public async Task WrongPasswordIsRejected()
-    {
-        var accounts = new SeededAccountService();
-        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
-        var (service, _) = Build(accounts);
-        await service.StartAsync();
-
-        try
-        {
-            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
-            using (client)
-            {
-                await LoginAsync(reader, writer, "gm", "wrong");
-                await ReadUntilAsync(reader, "Login failed.");
-            }
-        }
-        finally
-        {
-            await service.StopAsync();
-        }
-    }
-
-    [Fact]
-    public async Task UnknownCommandRepliesUnknown()
-    {
-        var accounts = new SeededAccountService();
-        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
-        var (service, _) = Build(accounts);
-        await service.StartAsync();
-
-        try
-        {
-            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
-            using (client)
-            {
-                await LoginAsync(reader, writer, "gm", "secret");
-                await writer.WriteLineAsync("frobnicate");
-                await ReadUntilAsync(reader, "Unknown command.");
-            }
-        }
-        finally
-        {
-            await service.StopAsync();
-        }
-    }
-
-    [Fact]
-    public async Task HelpListsBroadcast()
-    {
-        var accounts = new SeededAccountService();
-        accounts.Seed("gm", "secret", AccountLevelType.GrandMaster);
-        var (service, _) = Build(accounts);
-        await service.StartAsync();
-
-        try
-        {
-            var (reader, writer, client) = await ConnectAsync(service.BoundPort);
-            using (client)
-            {
-                await LoginAsync(reader, writer, "gm", "secret");
-                await writer.WriteLineAsync("help");
-                await ReadUntilAsync(reader, "broadcast");
-            }
-        }
-        finally
-        {
-            await service.StopAsync();
         }
     }
 }

--- a/tests/Moongate.Tests/Console/ConsoleAuthTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAuthTests.cs
@@ -8,8 +8,12 @@ namespace Moongate.Tests.Console;
 
 public class ConsoleAuthTests
 {
-    private static AccountAuthResult Ok() => AccountAuthResult.Ok("gm");
-    private static AccountAuthResult Denied() => AccountAuthResult.Denied(LoginDeniedReasonType.IncorrectCredentials);
+    [Fact]
+    public void Evaluate_AuthFailure_IsLoginFailed()
+        => Assert.Equal(
+            ConsoleAuthResultType.LoginFailed,
+            ConsoleAuth.Evaluate(Denied(), null, AccountLevelType.GrandMaster)
+        );
 
     [Fact]
     public void Evaluate_SuccessAtOrAboveMinLevel_IsAllowed()
@@ -26,16 +30,15 @@ public class ConsoleAuthTests
         );
 
     [Fact]
-    public void Evaluate_AuthFailure_IsLoginFailed()
-        => Assert.Equal(
-            ConsoleAuthResultType.LoginFailed,
-            ConsoleAuth.Evaluate(Denied(), null, AccountLevelType.GrandMaster)
-        );
-
-    [Fact]
     public void Evaluate_SuccessButUnknownAccount_IsLoginFailed()
         => Assert.Equal(
             ConsoleAuthResultType.LoginFailed,
             ConsoleAuth.Evaluate(Ok(), null, AccountLevelType.GrandMaster)
         );
+
+    private static AccountAuthResult Denied()
+        => AccountAuthResult.Denied(LoginDeniedReasonType.IncorrectCredentials);
+
+    private static AccountAuthResult Ok()
+        => AccountAuthResult.Ok("gm");
 }

--- a/tests/Moongate.Tests/Console/ConsoleConfigFileTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleConfigFileTests.cs
@@ -3,7 +3,6 @@ using Moongate.Console.Admin.Plugin;
 using Moongate.Console.Admin.Plugin.Data.Config;
 using SquidStd.Core.Config;
 using SquidStd.Core.Directories;
-using SquidStd.Plugin.Abstractions.Data;
 
 namespace Moongate.Tests.Console;
 
@@ -28,7 +27,7 @@ public class ConsoleConfigFileTests
             container.RegisterInstance(SquidStdConfig.Load("moongate", root));
             container.RegisterInstance(directories);
 
-            new MoongateConsolePlugin().Configure(container, new PluginContext());
+            new MoongateConsolePlugin().Configure(container, new());
 
             var config = container.Resolve<MoongateConsoleConfig>();
             Assert.True(config.Enabled);
@@ -36,7 +35,7 @@ public class ConsoleConfigFileTests
         }
         finally
         {
-            Directory.Delete(root, recursive: true);
+            Directory.Delete(root, true);
         }
     }
 }

--- a/tests/Moongate.Tests/Console/ConsoleInputTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleInputTests.cs
@@ -5,14 +5,10 @@ namespace Moongate.Tests.Console;
 
 public class ConsoleInputTests
 {
-    [Theory]
-    [InlineData("", ConsoleInputKind.Empty)]
-    [InlineData("   ", ConsoleInputKind.Empty)]
-    [InlineData("help", ConsoleInputKind.Help)]
-    [InlineData("HELP", ConsoleInputKind.Help)]
-    [InlineData("quit", ConsoleInputKind.Quit)]
-    [InlineData("exit", ConsoleInputKind.Quit)]
-    [InlineData("broadcast hi", ConsoleInputKind.Command)]
+    [Theory, InlineData("", ConsoleInputKind.Empty), InlineData("   ", ConsoleInputKind.Empty),
+     InlineData("help", ConsoleInputKind.Help), InlineData("HELP", ConsoleInputKind.Help),
+     InlineData("quit", ConsoleInputKind.Quit), InlineData("exit", ConsoleInputKind.Quit),
+     InlineData("broadcast hi", ConsoleInputKind.Command)]
     public void Classify_MapsLinesToKinds(string line, ConsoleInputKind expected)
         => Assert.Equal(expected, ConsoleInput.Classify(line));
 }

--- a/tests/Moongate.Tests/Console/ConsoleServerServiceLifecycleTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleServerServiceLifecycleTests.cs
@@ -9,13 +9,6 @@ namespace Moongate.Tests.Console;
 
 public class ConsoleServerServiceLifecycleTests
 {
-    private static ConsoleServerService Service(MoongateConsoleConfig config)
-    {
-        var commands = new CommandService([], new Container(), new StubAccountService());
-
-        return new ConsoleServerService(config, commands, new StubAccountService(), new InlineMainThreadDispatcher());
-    }
-
     [Fact]
     public async Task StartAsync_Disabled_DoesNotBind()
     {
@@ -43,5 +36,12 @@ public class ConsoleServerServiceLifecycleTests
         }
 
         await service.StopAsync();
+    }
+
+    private static ConsoleServerService Service(MoongateConsoleConfig config)
+    {
+        var commands = new CommandService([], new Container(), new StubAccountService());
+
+        return new(config, commands, new StubAccountService(), new InlineMainThreadDispatcher());
     }
 }

--- a/tests/Moongate.Tests/Data/FlippableTemplatesTests.cs
+++ b/tests/Moongate.Tests/Data/FlippableTemplatesTests.cs
@@ -19,8 +19,8 @@ public class FlippableTemplatesTests
             await new ItemTemplatesLoader(templates, directories).LoadAsync();
 
             var withFlip = templates.All
-                .Where(t => t.FlippableItemIds is { Count: > 0 })
-                .ToList();
+                                    .Where(t => t.FlippableItemIds is { Count: > 0 })
+                                    .ToList();
 
             // The port added flip data well beyond the 3 hand-authored files.
             Assert.True(withFlip.Count > 20, $"Expected many flippable templates, got {withFlip.Count}");

--- a/tests/Moongate.Tests/Data/ItemTemplateSplitDataTests.cs
+++ b/tests/Moongate.Tests/Data/ItemTemplateSplitDataTests.cs
@@ -35,8 +35,8 @@ public class ItemTemplateSplitDataTests
         var repositoryRoot = FindRepositoryRoot();
         var splitRoot = Path.Combine(repositoryRoot, "src", "Moongate.Server", "Assets", "Templates", "Items");
         var splitFiles = Directory.GetFiles(splitRoot, "*.yaml", SearchOption.AllDirectories)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+                                  .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                                  .ToArray();
         var splitByFile = splitFiles.ToDictionary(
             path => Path.GetRelativePath(splitRoot, path).Replace(Path.DirectorySeparatorChar, '/'),
             path => YamlUtils.DeserializeFromFile<ItemTemplate[]>(path) ?? [],

--- a/tests/Moongate.Tests/Http/ApiEndpointRegistrationExtensionsTests.cs
+++ b/tests/Moongate.Tests/Http/ApiEndpointRegistrationExtensionsTests.cs
@@ -9,16 +9,12 @@ public class ApiEndpointRegistrationExtensionsTests
 {
     private sealed class FirstEndpoints : IApiEndpointRegistration
     {
-        public void Register(IEndpointRouteBuilder routes)
-        {
-        }
+        public void Register(IEndpointRouteBuilder routes) { }
     }
 
     private sealed class SecondEndpoints : IApiEndpointRegistration
     {
-        public void Register(IEndpointRouteBuilder routes)
-        {
-        }
+        public void Register(IEndpointRouteBuilder routes) { }
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/ContainerSharingTests.cs
+++ b/tests/Moongate.Tests/Http/ContainerSharingTests.cs
@@ -44,12 +44,13 @@ public class ContainerSharingTests
     [Fact]
     public async Task Endpoint_ServesMutationsMadeThroughTheGameContainerAfterStartup()
     {
-        await using var server = await TestHttpServer.StartAsync(container =>
-            {
-                container.Register<GameSingleton>(Reuse.Singleton);
-                container.RegisterApiEndpoint<SingletonProbeEndpoints>();
-            }
-        );
+        await using var server = await TestHttpServer.StartAsync(
+                                     container =>
+                                     {
+                                         container.Register<GameSingleton>(Reuse.Singleton);
+                                         container.RegisterApiEndpoint<SingletonProbeEndpoints>();
+                                     }
+                                 );
 
         // Mutated after the routes are mapped, through the container rather than the endpoint: the marker
         // only comes back changed if the endpoint holds the game's own instance and reads it live. This is

--- a/tests/Moongate.Tests/Http/Endpoints/Accounts/AccountEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Accounts/AccountEndpointsTests.cs
@@ -16,11 +16,28 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/accounts",
-            new { username, password }
-        );
+                           "/api/v1/admin/accounts",
+                           new { username, password }
+                       );
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_LoopNeverAnswers_Is503()
+    {
+        await using var server = await TestApiServer.StartAsync(
+                                     loop: new StubGameLoopContext(false),
+                                     deleteTimeout: TimeSpan.FromMilliseconds(50)
+                                 );
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/admin/accounts",
+                           new { username = "alice", password = "secret" }
+                       );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
     }
 
     [Fact]
@@ -30,9 +47,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/accounts",
-            new { username = "alice", password = "secret", email = "a@b.c", level = "Player" }
-        );
+                           "/api/v1/admin/accounts",
+                           new { username = "alice", password = "secret", email = "a@b.c", level = "Player" }
+                       );
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal("/api/v1/admin/accounts/alice", response.Headers.Location?.ToString());
@@ -70,32 +87,15 @@ public class AccountEndpointsTests
     }
 
     [Fact]
-    public async Task Create_LoopNeverAnswers_Is503()
-    {
-        await using var server = await TestApiServer.StartAsync(
-            loop: new StubGameLoopContext(false),
-            deleteTimeout: TimeSpan.FromMilliseconds(50)
-        );
-        await server.AuthenticateAsync();
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/accounts",
-            new { username = "alice", password = "secret" }
-        );
-
-        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-    }
-
-    [Fact]
     public async Task Create_TakenUsername_Is409()
     {
         await using var server = await TestApiServer.StartAsync();
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/accounts",
-            new { username = "tom", password = "secret" }
-        );
+                           "/api/v1/admin/accounts",
+                           new { username = "tom", password = "secret" }
+                       );
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -108,9 +108,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/accounts",
-            new { username = "alice", password = "secret", level = "Wizard" }
-        );
+                           "/api/v1/admin/accounts",
+                           new { username = "alice", password = "secret", level = "Wizard" }
+                       );
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Null(server.Accounts.GetByUsername("alice"));
@@ -149,9 +149,9 @@ public class AccountEndpointsTests
     public async Task Delete_LoopNeverAnswers_Is503()
     {
         await using var server = await TestApiServer.StartAsync(
-            loop: new StubGameLoopContext(false),
-            deleteTimeout: TimeSpan.FromMilliseconds(50)
-        );
+                                     loop: new StubGameLoopContext(false),
+                                     deleteTimeout: TimeSpan.FromMilliseconds(50)
+                                 );
         await server.AuthenticateAsync();
 
         var response = await server.Client.DeleteAsync("/api/v1/admin/accounts/tom");
@@ -226,17 +226,6 @@ public class AccountEndpointsTests
     }
 
     [Fact]
-    public async Task List_WithoutAToken_Is401()
-    {
-        await using var server = await TestApiServer.StartAsync();
-
-        Assert.Equal(
-            HttpStatusCode.Unauthorized,
-            (await server.Client.GetAsync("/api/v1/admin/accounts")).StatusCode
-        );
-    }
-
-    [Fact]
     public async Task List_WithPlayerToken_Is403()
     {
         await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
@@ -244,6 +233,17 @@ public class AccountEndpointsTests
 
         Assert.Equal(
             HttpStatusCode.Forbidden,
+            (await server.Client.GetAsync("/api/v1/admin/accounts")).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task List_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
             (await server.Client.GetAsync("/api/v1/admin/accounts")).StatusCode
         );
     }
@@ -272,9 +272,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
-            "/api/v1/admin/accounts/tom",
-            new { isActive = false }
-        );
+                           "/api/v1/admin/accounts/tom",
+                           new { isActive = false }
+                       );
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -332,9 +332,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
-            "/api/v1/admin/accounts/nobody",
-            new { isActive = false }
-        );
+                           "/api/v1/admin/accounts/nobody",
+                           new { isActive = false }
+                       );
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -346,9 +346,9 @@ public class AccountEndpointsTests
         await server.AuthenticateAsync();
 
         var response = await server.Client.PatchAsJsonAsync(
-            "/api/v1/admin/accounts/tom",
-            new { level = "Wizard", isActive = false }
-        );
+                           "/api/v1/admin/accounts/tom",
+                           new { level = "Wizard", isActive = false }
+                       );
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 

--- a/tests/Moongate.Tests/Http/Endpoints/Admin/AdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Admin/AdminEndpointsTests.cs
@@ -7,14 +7,6 @@ namespace Moongate.Tests.Http.Endpoints.Admin;
 public class AdminEndpointsTests
 {
     [Fact]
-    public async Task AdminStatus_WithoutAToken_Is401()
-    {
-        await using var server = await TestApiServer.StartAsync();
-
-        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
-    }
-
-    [Fact]
     public async Task AdminStatus_WithPlayerToken_Is403()
     {
         // The test that proves the admin/player split exists rather than being asserted: a valid token
@@ -32,6 +24,14 @@ public class AdminEndpointsTests
         await server.AuthenticateAsync();
 
         Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminStatus_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Endpoints/Auth/AuthEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Auth/AuthEndpointsTests.cs
@@ -16,9 +16,9 @@ public class AuthEndpointsTests
         server.Accounts.SetActive("tom", false);
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "secret" }
-        );
+                           "/api/v1/auth/login",
+                           new { username = "tom", password = "secret" }
+                       );
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         Assert.DoesNotContain("block", await response.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
@@ -30,9 +30,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "secret" }
-        );
+                           "/api/v1/auth/login",
+                           new { username = "tom", password = "secret" }
+                       );
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -48,9 +48,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "secret" }
-        );
+                           "/api/v1/auth/login",
+                           new { username = "tom", password = "secret" }
+                       );
 
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("\"expiresAt\"", body, StringComparison.Ordinal);
@@ -63,9 +63,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "nobody", password = "secret" }
-        );
+                           "/api/v1/auth/login",
+                           new { username = "nobody", password = "secret" }
+                       );
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -76,9 +76,9 @@ public class AuthEndpointsTests
         await using var server = await TestApiServer.StartAsync();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "wrong" }
-        );
+                           "/api/v1/auth/login",
+                           new { username = "tom", password = "wrong" }
+                       );
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }

--- a/tests/Moongate.Tests/Http/Endpoints/Auth/AuthRenewEndpointTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Auth/AuthRenewEndpointTests.cs
@@ -12,31 +12,19 @@ public class AuthRenewEndpointTests
     private const string Route = "/api/v1/auth/renew";
 
     [Fact]
-    public async Task Renew_WithoutAToken_Is401()
+    public async Task Renew_ForADeactivatedAccount_Is401()
     {
-        await using var server = await TestApiServer.StartAsync();
-
-        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.PostAsync(Route, null)).StatusCode);
-    }
-
-    [Fact]
-    public async Task Renew_WithAValidToken_ReturnsAFreshToken()
-    {
+        // Coarse revocation: the account is re-read rather than trusted from the claims, so suspending it
+        // stops renewals even though the token it presents is still cryptographically valid.
         var clock = MutableTimeProvider.StartingNow();
         await using var server = await TestApiServer.StartAsync(clock: clock);
         await server.AuthenticateAsync();
 
-        // Move on inside the session so the new token's expiry genuinely differs from the old one.
-        clock.Advance(TimeSpan.FromMinutes(30));
+        Assert.True(server.Accounts.SetActive("tom", false));
 
-        var response = await server.Client.PostAsync(Route, null);
+        clock.Advance(TimeSpan.FromMinutes(5));
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var renewed = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
-
-        Assert.False(string.IsNullOrWhiteSpace(renewed.Token));
-        Assert.Equal(clock.GetUtcNow().AddMinutes(60), renewed.ExpiresAt);
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.PostAsync(Route, null)).StatusCode);
     }
 
     [Fact]
@@ -53,7 +41,7 @@ public class AuthRenewEndpointTests
         clock.Advance(TimeSpan.FromMinutes(45));
 
         var renewed = (await (await server.Client.PostAsync(Route, null)).Content
-            .ReadFromJsonAsync<ApiTokenResult>()).Token;
+                                                                         .ReadFromJsonAsync<ApiTokenResult>()).Token;
 
         Assert.Equal(loginAuthTime, AuthTimeOf(renewed));
     }
@@ -70,22 +58,6 @@ public class AuthRenewEndpointTests
         Assert.Equal(HttpStatusCode.OK, (await server.Client.PostAsync(Route, null)).StatusCode);
 
         clock.Advance(TimeSpan.FromHours(12));
-
-        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.PostAsync(Route, null)).StatusCode);
-    }
-
-    [Fact]
-    public async Task Renew_ForADeactivatedAccount_Is401()
-    {
-        // Coarse revocation: the account is re-read rather than trusted from the claims, so suspending it
-        // stops renewals even though the token it presents is still cryptographically valid.
-        var clock = MutableTimeProvider.StartingNow();
-        await using var server = await TestApiServer.StartAsync(clock: clock);
-        await server.AuthenticateAsync();
-
-        Assert.True(server.Accounts.SetActive("tom", false));
-
-        clock.Advance(TimeSpan.FromMinutes(5));
 
         Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.PostAsync(Route, null)).StatusCode);
     }
@@ -109,6 +81,34 @@ public class AuthRenewEndpointTests
         server.Client.DefaultRequestHeaders.Authorization = new("Bearer", renewed.Token);
 
         Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/api/v1/admin/status")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Renew_WithAValidToken_ReturnsAFreshToken()
+    {
+        var clock = MutableTimeProvider.StartingNow();
+        await using var server = await TestApiServer.StartAsync(clock: clock);
+        await server.AuthenticateAsync();
+
+        // Move on inside the session so the new token's expiry genuinely differs from the old one.
+        clock.Advance(TimeSpan.FromMinutes(30));
+
+        var response = await server.Client.PostAsync(Route, null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var renewed = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
+
+        Assert.False(string.IsNullOrWhiteSpace(renewed.Token));
+        Assert.Equal(clock.GetUtcNow().AddMinutes(60), renewed.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task Renew_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.PostAsync(Route, null)).StatusCode);
     }
 
     /// <summary>Reads the raw <c>auth_time</c> claim out of a token without validating it.</summary>

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterAdminEndpointsTests.cs
@@ -156,13 +156,13 @@ public class CharacterAdminEndpointsTests
 
     private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
         => await TestApiServer.StartAsync(
-            level,
-            configure: container =>
-            {
-                container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
-                container.RegisterApiEndpointInstance(
-                    new CharacterAdminEndpoints(container.Resolve<ICharacterQueryService>())
-                );
-            }
-        );
+               level,
+               configure: container =>
+                          {
+                              container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
+                              container.RegisterApiEndpointInstance(
+                                  new CharacterAdminEndpoints(container.Resolve<ICharacterQueryService>())
+                              );
+                          }
+           );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterEndpointsTests.cs
@@ -19,8 +19,8 @@ public class CharacterEndpointsTests
         // Every NPC on a real shard looks like this in the store: a mobile no account lists.
         await using var server = await TestApiServer.StartAsync();
         await server.Persistence
-            .Store<MobileEntity>()
-            .UpsertAsync(new() { Name = "a wandering healer" });
+                    .Store<MobileEntity>()
+                    .UpsertAsync(new() { Name = "a wandering healer" });
         await server.AuthenticateAsync();
 
         var characters = await server.Client.GetFromJsonAsync<List<CharacterResponse>>(Route);

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
@@ -16,7 +16,6 @@ using Moongate.Server.Services.Commands;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.Console;
 
@@ -24,51 +23,9 @@ public class ConsoleEndpointsTests
 {
     private sealed class RecordingChat : IChatService
     {
-        public void Broadcast(string text, Hue? hue = null)
-        {
-        }
+        public void Broadcast(string text, Hue? hue = null) { }
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
-        {
-        }
-    }
-
-    // Wires the real ConsoleEndpoints (over real HTTP) against the given registry, an inline dispatcher
-    // (so a POSTed command runs before the request returns) and a broadcast command opted into Rest.
-    private static Task<TestApiServer> StartAsync(ConsoleStreamRegistry registry)
-        => TestApiServer.StartAsync(
-            AccountLevelType.GrandMaster,
-            configure: container =>
-            {
-                var registration = new CommandRegistration(
-                    "broadcast|bc",
-                    AccountLevelType.GrandMaster,
-                    "Sends a server-wide system message.",
-                    CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
-                    _ => new BroadcastCommand(new RecordingChat())
-                );
-                var commands = new CommandService([registration], container, container.Resolve<IAccountService>());
-
-                container.RegisterInstance<IConsoleStreamRegistry>(registry);
-                container.RegisterApiEndpointInstance(
-                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher())
-                );
-            }
-        );
-
-    [Fact]
-    public async Task Post_with_unknown_connection_returns_404()
-    {
-        var registry = new ConsoleStreamRegistry();
-        await using var server = await StartAsync(registry);
-        await server.AuthenticateAsync();
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/console",
-            new { command = "broadcast hi", connectionId = "nope" }
-        );
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
     }
 
     [Fact]
@@ -80,14 +37,15 @@ public class ConsoleEndpointsTests
         var (id, reader) = registry.Open();
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/console",
-            new { command = "broadcast hi", connectionId = id }
-        );
+                           "/api/v1/admin/console",
+                           new { command = "broadcast hi", connectionId = id }
+                       );
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         registry.Close(id); // inline dispatch already ran the command; complete the channel so we can drain it
 
         var events = new List<ConsoleStreamEvent>();
+
         await foreach (var evt in reader.ReadAllAsync())
         {
             events.Add(evt);
@@ -96,4 +54,43 @@ public class ConsoleEndpointsTests
         Assert.Contains(events, e => e.Event == "line" && e.Text == "Broadcast sent.");
         Assert.Contains(events, e => e.Event == "done" && e.Text == "broadcast hi");
     }
+
+    [Fact]
+    public async Task Post_with_unknown_connection_returns_404()
+    {
+        var registry = new ConsoleStreamRegistry();
+        await using var server = await StartAsync(registry);
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/admin/console",
+                           new { command = "broadcast hi", connectionId = "nope" }
+                       );
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // Wires the real ConsoleEndpoints (over real HTTP) against the given registry, an inline dispatcher
+    // (so a POSTed command runs before the request returns) and a broadcast command opted into Rest.
+    private static Task<TestApiServer> StartAsync(ConsoleStreamRegistry registry)
+        => TestApiServer.StartAsync(
+            AccountLevelType.GrandMaster,
+            configure: container =>
+                       {
+                           var registration = new CommandRegistration(
+                               "broadcast|bc",
+                               AccountLevelType.GrandMaster,
+                               "Sends a server-wide system message.",
+                               CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
+                               _ => new BroadcastCommand(new RecordingChat())
+                           );
+                           var commands =
+                               new CommandService([registration], container, container.Resolve<IAccountService>());
+
+                           container.RegisterInstance<IConsoleStreamRegistry>(registry);
+                           container.RegisterApiEndpointInstance(
+                               new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher())
+                           );
+                       }
+        );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleSseStreamTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleSseStreamTests.cs
@@ -1,7 +1,5 @@
 using System.Net.ServerSentEvents;
-using Moongate.Http.Plugin.Data.Console;
 using Moongate.Http.Plugin.Services.Console;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.Console;
 
@@ -14,11 +12,12 @@ public class ConsoleSseStreamTests
         var (id, reader) = registry.Open();
         Assert.True(registry.TryGetWriter(id, out var writer));
 
-        writer.TryWrite(new ConsoleStreamEvent("line", "hello"));
-        writer.TryWrite(new ConsoleStreamEvent("done", "broadcast hello"));
+        writer.TryWrite(new("line", "hello"));
+        writer.TryWrite(new("done", "broadcast hello"));
         registry.Close(id); // completes the channel so the enumeration ends
 
         var items = new List<SseItem<string>>();
+
         await foreach (var item in ConsoleSseStream.From(id, reader, CancellationToken.None))
         {
             items.Add(item);

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleStreamRegistryTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleStreamRegistryTests.cs
@@ -1,11 +1,21 @@
 using Moongate.Http.Plugin.Data.Console;
 using Moongate.Http.Plugin.Services.Console;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.Console;
 
 public class ConsoleStreamRegistryTests
 {
+    [Fact]
+    public void Close_makes_the_id_unresolvable()
+    {
+        var registry = new ConsoleStreamRegistry();
+        var (id, _) = registry.Open();
+
+        registry.Close(id);
+
+        Assert.False(registry.TryGetWriter(id, out _));
+    }
+
     [Fact]
     public void Open_returns_a_unique_id_and_a_live_writer()
     {
@@ -25,26 +35,16 @@ public class ConsoleStreamRegistryTests
         var (id, reader) = registry.Open();
         Assert.True(registry.TryGetWriter(id, out var writer));
 
-        writer.TryWrite(new ConsoleStreamEvent("line", "hello"));
+        writer.TryWrite(new("line", "hello"));
         registry.Close(id);
 
         var events = new List<ConsoleStreamEvent>();
+
         await foreach (var evt in reader.ReadAllAsync())
         {
             events.Add(evt);
         }
 
-        Assert.Equal(new ConsoleStreamEvent("line", "hello"), Assert.Single(events));
-    }
-
-    [Fact]
-    public void Close_makes_the_id_unresolvable()
-    {
-        var registry = new ConsoleStreamRegistry();
-        var (id, _) = registry.Open();
-
-        registry.Close(id);
-
-        Assert.False(registry.TryGetWriter(id, out _));
+        Assert.Equal(new("line", "hello"), Assert.Single(events));
     }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
@@ -16,7 +16,6 @@ using Moongate.Server.Services.Commands;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.Console;
 
@@ -29,9 +28,7 @@ public class RestConsoleIntegrationTests
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
-        {
-        }
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
     }
 
     [Fact]
@@ -40,33 +37,43 @@ public class RestConsoleIntegrationTests
         var chat = new RecordingChat();
         var registry = new ConsoleStreamRegistry();
         await using var server = await TestApiServer.StartAsync(
-            AccountLevelType.GrandMaster,
-            configure: container =>
-            {
-                var registration = new CommandRegistration(
-                    "broadcast|bc",
-                    AccountLevelType.GrandMaster,
-                    "Sends a server-wide system message.",
-                    CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest,
-                    _ => new BroadcastCommand(chat)
-                );
-                var commands = new CommandService([registration], container, container.Resolve<IAccountService>());
+                                     AccountLevelType.GrandMaster,
+                                     configure: container =>
+                                                {
+                                                    var registration = new CommandRegistration(
+                                                        "broadcast|bc",
+                                                        AccountLevelType.GrandMaster,
+                                                        "Sends a server-wide system message.",
+                                                        CommandSourceType.InGame |
+                                                        CommandSourceType.Console |
+                                                        CommandSourceType.Rest,
+                                                        _ => new BroadcastCommand(chat)
+                                                    );
+                                                    var commands = new CommandService(
+                                                        [registration],
+                                                        container,
+                                                        container.Resolve<IAccountService>()
+                                                    );
 
-                container.RegisterInstance<IConsoleStreamRegistry>(registry);
-                container.RegisterApiEndpointInstance(
-                    new ConsoleEndpoints(registry, commands, new InlineMainThreadDispatcher())
-                );
-            }
-        );
+                                                    container.RegisterInstance<IConsoleStreamRegistry>(registry);
+                                                    container.RegisterApiEndpointInstance(
+                                                        new ConsoleEndpoints(
+                                                            registry,
+                                                            commands,
+                                                            new InlineMainThreadDispatcher()
+                                                        )
+                                                    );
+                                                }
+                                 );
         await server.AuthenticateAsync();
 
         using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
 
         using var streamResponse = await server.Client.GetAsync(
-            "/api/v1/admin/console/stream",
-            HttpCompletionOption.ResponseHeadersRead,
-            timeout.Token
-        );
+                                       "/api/v1/admin/console/stream",
+                                       HttpCompletionOption.ResponseHeadersRead,
+                                       timeout.Token
+                                   );
         Assert.Equal("text/event-stream", streamResponse.Content.Headers.ContentType?.MediaType);
 
         await using var body = await streamResponse.Content.ReadAsStreamAsync(timeout.Token);
@@ -77,10 +84,10 @@ public class RestConsoleIntegrationTests
         var connectionId = events.Current.Data;
 
         var post = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/console",
-            new { command = "broadcast hello world", connectionId },
-            timeout.Token
-        );
+                       "/api/v1/admin/console",
+                       new { command = "broadcast hello world", connectionId },
+                       timeout.Token
+                   );
         Assert.Equal(HttpStatusCode.Accepted, post.StatusCode);
 
         Assert.True(await events.MoveNextAsync());

--- a/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageAdminEndpointsTests.cs
@@ -55,19 +55,19 @@ public class ItemImageAdminEndpointsTests
 
     private static async Task<TestApiServer> StartAsync(ItemImageFixture fixture)
         => await TestApiServer.StartAsync(
-            configure: container =>
-            {
-                container.RegisterInstance(fixture.Directories);
-                container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
-                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-                container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
-                container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
-                container.RegisterApiEndpointInstance(
-                    new ItemImageAdminEndpoints(
-                        container.Resolve<IItemImageExportJob>(),
-                        container.Resolve<IItemImageService>()
-                    )
-                );
-            }
-        );
+               configure: container =>
+                          {
+                              container.RegisterInstance(fixture.Directories);
+                              container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                              container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                              container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+                              container.Register<IItemImageExportJob, ItemImageExportJob>(Reuse.Singleton);
+                              container.RegisterApiEndpointInstance(
+                                  new ItemImageAdminEndpoints(
+                                      container.Resolve<IItemImageExportJob>(),
+                                      container.Resolve<IItemImageService>()
+                                  )
+                              );
+                          }
+           );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Images/ItemImageEndpointsTests.cs
@@ -17,23 +17,6 @@ namespace Moongate.Tests.Http.Endpoints.Images;
 public class ItemImageEndpointsTests
 {
     [Fact]
-    public async Task Get_Hued_ReturnsDifferentPixelsFromThePlainArt()
-    {
-        using var fixture = ItemImageFixture.Create();
-        await using var server = await StartAsync(fixture);
-
-        var plain = await server.Client.GetByteArrayAsync($"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png");
-        var hued = await server.Client.GetByteArrayAsync(
-            $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x{ItemImageFixture.Hue:x4}"
-        );
-
-        using var plainImage = Image.Load<Bgra32>(plain);
-        using var huedImage = Image.Load<Bgra32>(hued);
-
-        Assert.NotEqual(plainImage[0, 0], huedImage[0, 0]);
-    }
-
-    [Fact]
     public async Task Get_HueOutOfRange_IsBadRequest()
     {
         // Hues.GetHue never fails: it masks the index and falls back to hue 0. Without this check the
@@ -44,6 +27,23 @@ public class ItemImageEndpointsTests
         var response = await server.Client.GetAsync($"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x9999");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_Hued_ReturnsDifferentPixelsFromThePlainArt()
+    {
+        using var fixture = ItemImageFixture.Create();
+        await using var server = await StartAsync(fixture);
+
+        var plain = await server.Client.GetByteArrayAsync($"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png");
+        var hued = await server.Client.GetByteArrayAsync(
+                       $"/api/v1/images/items/0x{ItemImageFixture.ItemId:x4}.png?hue=0x{ItemImageFixture.Hue:x4}"
+                   );
+
+        using var plainImage = Image.Load<Bgra32>(plain);
+        using var huedImage = Image.Load<Bgra32>(hued);
+
+        Assert.NotEqual(plainImage[0, 0], huedImage[0, 0]);
     }
 
     [Fact]
@@ -108,13 +108,14 @@ public class ItemImageEndpointsTests
     }
 
     private static async Task<TestHttpServer> StartAsync(ItemImageFixture fixture)
-        => await TestHttpServer.StartAsync(container =>
-            {
-                container.RegisterInstance(fixture.Directories);
-                container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
-                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-                container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
-                container.RegisterApiEndpointInstance(new ItemImageEndpoints(container.Resolve<IItemImageService>()));
-            }
-        );
+        => await TestHttpServer.StartAsync(
+               container =>
+               {
+                   container.RegisterInstance(fixture.Directories);
+                   container.Register<IItemCatalog, ItemCatalog>(Reuse.Singleton);
+                   container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                   container.Register<IItemImageService, ItemImageService>(Reuse.Singleton);
+                   container.RegisterApiEndpointInstance(new ItemImageEndpoints(container.Resolve<IItemImageService>()));
+               }
+           );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Items/ItemTemplateEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Items/ItemTemplateEndpointsTests.cs
@@ -90,8 +90,8 @@ public class ItemTemplateEndpointsTests
         await server.AuthenticateAsync();
 
         var page = await server.Client.GetFromJsonAsync<PagedResponse<ItemTemplateSummaryResponse>>(
-            $"{Route}?search=nothing"
-        );
+                       $"{Route}?search=nothing"
+                   );
 
         Assert.Equal(0, page!.Total);
         Assert.Empty(page.Items);
@@ -122,26 +122,26 @@ public class ItemTemplateEndpointsTests
 
     private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
         => await TestApiServer.StartAsync(
-            level,
-            configure: container =>
-            {
-                var templates = new ItemTemplateService();
-                templates.Register(Template("katana", "a katana", "weapons", 0x13FF, ["weapon", "sword"]));
-                templates.Register(Template("bread", "a bread loaf", "food", 0x103B, ["food"]));
-                templates.Register(
-                    Template(
-                        "elder_katana",
-                        "an elder katana",
-                        "weapons",
-                        0x13FF,
-                        ["weapon", "sword"],
-                        ItemRarityType.Legendary
-                    )
-                );
-                container.RegisterInstance<IItemTemplateService>(templates);
-                container.RegisterApiEndpointInstance(new ItemTemplateEndpoints(templates));
-            }
-        );
+               level,
+               configure: container =>
+                          {
+                              var templates = new ItemTemplateService();
+                              templates.Register(Template("katana", "a katana", "weapons", 0x13FF, ["weapon", "sword"]));
+                              templates.Register(Template("bread", "a bread loaf", "food", 0x103B, ["food"]));
+                              templates.Register(
+                                  Template(
+                                      "elder_katana",
+                                      "an elder katana",
+                                      "weapons",
+                                      0x13FF,
+                                      ["weapon", "sword"],
+                                      ItemRarityType.Legendary
+                                  )
+                              );
+                              container.RegisterInstance<IItemTemplateService>(templates);
+                              container.RegisterApiEndpointInstance(new ItemTemplateEndpoints(templates));
+                          }
+           );
 
     private static ItemTemplate Template(
         string id,
@@ -163,7 +163,7 @@ public class ItemTemplateEndpointsTests
             Rarity = rarity,
             Tags = [.. tags],
             Params = id == "katana"
-                ? new() { ["durability"] = new() { Type = "int", Value = "100" } }
-                : null
+                         ? new() { ["durability"] = new() { Type = "int", Value = "100" } }
+                         : null
         };
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Maps/MapImageEndpointsTests.cs
@@ -139,18 +139,19 @@ public class MapImageEndpointsTests
     }
 
     private static async Task<TestHttpServer> StartAsync(MapImageFixture fixture)
-        => await TestHttpServer.StartAsync(container =>
-            {
-                container.RegisterInstance(fixture.Directories);
-                container.RegisterInstance(fixture.Provider);
-                container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
-                container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
-                container.RegisterApiEndpointInstance(
-                    new MapImageEndpoints(
-                        container.Resolve<IMapImageService>(),
-                        container.Resolve<IUltimaMapProvider>()
-                    )
-                );
-            }
-        );
+        => await TestHttpServer.StartAsync(
+               container =>
+               {
+                   container.RegisterInstance(fixture.Directories);
+                   container.RegisterInstance(fixture.Provider);
+                   container.Register<IUltimaReadGate, UltimaReadGate>(Reuse.Singleton);
+                   container.Register<IMapImageService, MapImageService>(Reuse.Singleton);
+                   container.RegisterApiEndpointInstance(
+                       new MapImageEndpoints(
+                           container.Resolve<IMapImageService>(),
+                           container.Resolve<IUltimaMapProvider>()
+                       )
+                   );
+               }
+           );
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileImageEndpointsTests.cs
@@ -49,8 +49,8 @@ public sealed class MobileImageEndpointsTests : IDisposable
 
         var hair = await server.Client.GetFromJsonAsync<PagedResponse<HairStyleSummary>>("/api/v1/admin/hair-styles");
         var facial = await server.Client.GetFromJsonAsync<PagedResponse<HairStyleSummary>>(
-            "/api/v1/admin/hair-styles?facial=true"
-        );
+                         "/api/v1/admin/hair-styles?facial=true"
+                     );
 
         Assert.Equal(10, hair!.Total);
         Assert.Equal(7, facial!.Total);
@@ -164,41 +164,41 @@ public sealed class MobileImageEndpointsTests : IDisposable
         templates.Register(new() { Id = "villager", Appearance = new() { Body = 400 } });
 
         return await TestApiServer.StartAsync(
-            level,
-            configure: container =>
-            {
-                var gate = new StubUltimaReadGate();
-                var directories = new DirectoriesConfig(_root, Array.Empty<string>());
-                var bodies = new BodyImageService(catalog, directories, gate);
-                var renderer = new MobileFigureRenderer(catalog, new ItemTemplateService());
+                   level,
+                   configure: container =>
+                              {
+                                  var gate = new StubUltimaReadGate();
+                                  var directories = new DirectoriesConfig(_root, Array.Empty<string>());
+                                  var bodies = new BodyImageService(catalog, directories, gate);
+                                  var renderer = new MobileFigureRenderer(catalog, new ItemTemplateService());
 
-                container.RegisterApiEndpointInstance(new BodyImageEndpoints(bodies));
-                container.RegisterApiEndpointInstance(
-                    new HairImageEndpoints(new HairImageService(renderer, directories, gate))
-                );
-                container.RegisterApiEndpointInstance(
-                    new MobileTemplateImageEndpoints(
-                        new MobileTemplateImageService(renderer, templates, directories, gate)
-                    )
-                );
-                container.RegisterApiEndpointInstance(
-                    new MobileImageAdminEndpoints(catalog, new BodyImageExportJob(bodies, catalog), bodies)
-                );
+                                  container.RegisterApiEndpointInstance(new BodyImageEndpoints(bodies));
+                                  container.RegisterApiEndpointInstance(
+                                      new HairImageEndpoints(new HairImageService(renderer, directories, gate))
+                                  );
+                                  container.RegisterApiEndpointInstance(
+                                      new MobileTemplateImageEndpoints(
+                                          new MobileTemplateImageService(renderer, templates, directories, gate)
+                                      )
+                                  );
+                                  container.RegisterApiEndpointInstance(
+                                      new MobileImageAdminEndpoints(catalog, new BodyImageExportJob(bodies, catalog), bodies)
+                                  );
 
-                var gumps = new FakeGumpCatalog();
-                gumps.Gumps[(0x000C, 0)] = (W: 40, H: 100); // male body gump
+                                  var gumps = new FakeGumpCatalog();
+                                  gumps.Gumps[(0x000C, 0)] = (W: 40, H: 100); // male body gump
 
-                container.RegisterApiEndpointInstance(
-                    new PaperdollEndpoints(
-                        new PaperdollImageService(
-                            new PaperdollRenderer(gumps, catalog, new ItemTemplateService()),
-                            templates,
-                            directories,
-                            gate
-                        )
-                    )
-                );
-            }
-        );
+                                  container.RegisterApiEndpointInstance(
+                                      new PaperdollEndpoints(
+                                          new PaperdollImageService(
+                                              new PaperdollRenderer(gumps, catalog, new ItemTemplateService()),
+                                              templates,
+                                              directories,
+                                              gate
+                                          )
+                                      )
+                                  );
+                              }
+               );
     }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Players/OnlinePlayerAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Players/OnlinePlayerAdminEndpointsTests.cs
@@ -10,7 +10,6 @@ using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Tests.Support;
-using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 using SquidStd.Network.Client;
 
@@ -19,14 +18,6 @@ namespace Moongate.Tests.Http.Endpoints.Players;
 public class OnlinePlayerAdminEndpointsTests
 {
     private const string Route = "/api/v1/admin/players/online";
-
-    [Fact]
-    public async Task List_WithoutToken_IsUnauthorized()
-    {
-        await using var server = await StartAsync();
-
-        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
-    }
 
     [Fact]
     public async Task List_AsPlayer_IsForbidden()
@@ -51,6 +42,29 @@ public class OnlinePlayerAdminEndpointsTests
     }
 
     [Fact]
+    public async Task List_OrdersByCharacterNameThenSerial()
+    {
+        await using var server = await StartAsync();
+        server.Sessions.Connections.Add(
+            Session("one", new(1), new() { Id = new(3), Name = "Cedric" }, SessionStateType.InWorld)
+        );
+        server.Sessions.Connections.Add(
+            Session("two", new(2), new() { Id = new(2), Name = "aramis" }, SessionStateType.InWorld)
+        );
+        server.Sessions.Connections.Add(
+            Session("three", new(3), new() { Id = new(1), Name = "Aramis" }, SessionStateType.InWorld)
+        );
+        await server.AuthenticateAsync();
+
+        var players = await server.Client.GetFromJsonAsync<OnlinePlayerMapResponse[]>(Route);
+
+        Assert.Equal(
+            ["0x00000001", "0x00000002", "0x00000003"],
+            players!.Select(player => player.CharacterSerial)
+        );
+    }
+
+    [Fact]
     public async Task List_ReturnsOnlyInWorldPlayersWithMapFields()
     {
         await using var server = await StartAsync();
@@ -66,7 +80,7 @@ public class OnlinePlayerAdminEndpointsTests
                     Position = new(1420, 1698, 10),
                     Direction = DirectionType.SouthEast | DirectionType.Running,
                     Body = 401,
-                    SkinHue = new Hue(1002),
+                    SkinHue = new(1002),
                     Hits = 48,
                     HitsMax = 70,
                     Warmode = true
@@ -126,26 +140,11 @@ public class OnlinePlayerAdminEndpointsTests
     }
 
     [Fact]
-    public async Task List_OrdersByCharacterNameThenSerial()
+    public async Task List_WithoutToken_IsUnauthorized()
     {
         await using var server = await StartAsync();
-        server.Sessions.Connections.Add(
-            Session("one", new(1), new() { Id = new(3), Name = "Cedric" }, SessionStateType.InWorld)
-        );
-        server.Sessions.Connections.Add(
-            Session("two", new(2), new() { Id = new(2), Name = "aramis" }, SessionStateType.InWorld)
-        );
-        server.Sessions.Connections.Add(
-            Session("three", new(3), new() { Id = new(1), Name = "Aramis" }, SessionStateType.InWorld)
-        );
-        await server.AuthenticateAsync();
 
-        var players = await server.Client.GetFromJsonAsync<OnlinePlayerMapResponse[]>(Route);
-
-        Assert.Equal(
-            ["0x00000001", "0x00000002", "0x00000003"],
-            players!.Select(player => player.CharacterSerial)
-        );
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
     }
 
     private static PlayerSession Session(
@@ -172,9 +171,7 @@ public class OnlinePlayerAdminEndpointsTests
         return session;
     }
 
-    private static Task<TestApiServer> StartAsync(
-        AccountLevelType level = AccountLevelType.Administrator
-    )
+    private static Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
         => TestApiServer.StartAsync(
             level,
             configure: container => container.RegisterApiEndpoint<OnlinePlayerAdminEndpoints>()

--- a/tests/Moongate.Tests/Http/Endpoints/Plugins/PluginAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Plugins/PluginAdminEndpointsTests.cs
@@ -13,57 +13,6 @@ public class PluginAdminEndpointsTests
     private const string HostId = "moongate.host";
 
     [Fact]
-    public async Task Plugins_WithoutAToken_Is401()
-    {
-        await using var server = await TestApiServer.StartAsync();
-
-        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
-    }
-
-    [Fact]
-    public async Task Plugins_WithPlayerToken_Is403()
-    {
-        await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
-        await server.AuthenticateAsync();
-
-        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
-    }
-
-    [Fact]
-    public async Task Plugins_WithStaffToken_ListsTheActivatedPlugins()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        await server.AuthenticateAsync();
-
-        var plugins = await GetPluginsAsync(server);
-
-        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
-
-        Assert.Equal("Moongate.Http.Plugin", http.Assembly);
-        Assert.False(http.IsExternal);
-    }
-
-    [Fact]
-    public async Task Plugins_ReportsRoutesWithTheirVerbAndPolicy()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        await server.AuthenticateAsync();
-
-        var plugins = await GetPluginsAsync(server);
-        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
-
-        var status = Assert.Single(http.Routes, route => route.Path == "/api/v1/admin/status");
-
-        Assert.Equal("GET", status.Method);
-        Assert.Equal("admin", status.Policy);
-
-        var login = Assert.Single(http.Routes, route => route.Path == "/api/v1/auth/login");
-
-        Assert.Equal("POST", login.Method);
-        Assert.Null(login.Policy);
-    }
-
-    [Fact]
     public async Task Plugins_AttributesHealthToTheHttpPluginNotToTheHost()
     {
         // /health is a lambda inside HttpServerService, so its closure lives in the HTTP plugin's assembly
@@ -93,6 +42,57 @@ public class PluginAdminEndpointsTests
         var host = Assert.Single(plugins, plugin => plugin.Id == HostId);
 
         Assert.DoesNotContain(host.Routes, route => route.Path.StartsWith("/api/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Plugins_ReportsRoutesWithTheirVerbAndPolicy()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var plugins = await GetPluginsAsync(server);
+        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
+
+        var status = Assert.Single(http.Routes, route => route.Path == "/api/v1/admin/status");
+
+        Assert.Equal("GET", status.Method);
+        Assert.Equal("admin", status.Policy);
+
+        var login = Assert.Single(http.Routes, route => route.Path == "/api/v1/auth/login");
+
+        Assert.Equal("POST", login.Method);
+        Assert.Null(login.Policy);
+    }
+
+    [Fact]
+    public async Task Plugins_WithPlayerToken_Is403()
+    {
+        await using var server = await TestApiServer.StartAsync(AccountLevelType.Player);
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task Plugins_WithStaffToken_ListsTheActivatedPlugins()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+
+        var plugins = await GetPluginsAsync(server);
+
+        var http = Assert.Single(plugins, plugin => plugin.Id == HttpPluginId);
+
+        Assert.Equal("Moongate.Http.Plugin", http.Assembly);
+        Assert.False(http.IsExternal);
+    }
+
+    [Fact]
+    public async Task Plugins_WithoutAToken_Is401()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
     }
 
     private static async Task<IReadOnlyList<PluginInfoResponse>> GetPluginsAsync(TestApiServer server)

--- a/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Registration/RegistrationEndpointsTests.cs
@@ -6,98 +6,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moongate.Core.Types;
 using Moongate.Http.Plugin.Data.Api.Registration;
-using Moongate.Server.Abstractions.Data;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.Registration;
 
 public sealed class RegistrationEndpointsTests
 {
-    [Fact]
-    public async Task Register_WhenDisabled_Is403()
-    {
-        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
-        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("newbie", "secret99", "new@bie.test")
-        );
-
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-        Assert.Empty(limiter.Keys);
-    }
-
-    [Fact]
-    public async Task Register_WhenEnabled_CreatesInactive_202()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate
-                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
-        );
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("newbie", "secret99", "new@bie.test")
-        );
-
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Assert.False(server.Accounts.GetByUsername("newbie")!.IsActive);
-    }
-
-    [Fact]
-    public async Task Register_WhenRuntimeEmailIsUnavailable_Is503()
-    {
-        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
-        await using var server = await TestApiServer.StartAsync(
-            emailChannelReady: false,
-            registrationRateLimiter: limiter
-        );
-        EnableRegistration(server);
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("newbie", "secret99", "new@bie.test")
-        );
-
-        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-        Assert.Empty(limiter.Keys);
-    }
-
-    [Fact]
-    public async Task Register_InvalidUsername_IsValidationProblem400()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        EnableRegistration(server);
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("ab", "secret99", "new@bie.test")
-        );
-
-        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Contains("username", problem!.Errors.Keys);
-    }
-
-    [Fact]
-    public async Task Register_InvalidPassword_IsValidationProblem400()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        EnableRegistration(server);
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("newbie", "short", "new@bie.test")
-        );
-
-        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Contains("password", problem!.Errors.Keys);
-    }
-
     [Fact]
     public async Task Register_DuplicateUsernameOrEmail_IsGeneric409()
     {
@@ -110,13 +24,13 @@ public sealed class RegistrationEndpointsTests
         );
 
         var duplicateUsername = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("newbie", "secret99", "other@bie.test")
-        );
+                                    "/api/v1/register",
+                                    new RegisterRequest("newbie", "secret99", "other@bie.test")
+                                );
         var duplicateEmail = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("othername", "secret99", "new@bie.test")
-        );
+                                 "/api/v1/register",
+                                 new RegisterRequest("othername", "secret99", "new@bie.test")
+                             );
         var usernameProblem = await duplicateUsername.Content.ReadFromJsonAsync<ProblemDetails>();
         var emailProblem = await duplicateEmail.Content.ReadFromJsonAsync<ProblemDetails>();
 
@@ -128,71 +42,287 @@ public sealed class RegistrationEndpointsTests
     }
 
     [Fact]
-    public async Task Verify_ActivatesAccount()
+    public async Task Register_InvalidPassword_IsValidationProblem400()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        EnableRegistration(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register",
+                           new RegisterRequest("newbie", "short", "new@bie.test")
+                       );
+
+        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("password", problem!.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task Register_InvalidUsername_IsValidationProblem400()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        EnableRegistration(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register",
+                           new RegisterRequest("ab", "secret99", "new@bie.test")
+                       );
+
+        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("username", problem!.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task Register_RateLimited_429()
+    {
+        // The fixture seeds a limiter of 2/window; the 3rd call from the same loopback IP is throttled.
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new() { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        );
+
+        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("first", "secret99", "a@b.test"));
+        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("second", "secret99", "b@b.test"));
+        var third = await server.Client.PostAsJsonAsync(
+                        "/api/v1/register",
+                        new RegisterRequest("third", "secret99", "c@b.test")
+                    );
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, third.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WhenDisabled_Is403()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register",
+                           new RegisterRequest("newbie", "secret99", "new@bie.test")
+                       );
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Empty(limiter.Keys);
+    }
+
+    [Fact]
+    public async Task Register_WhenEnabled_CreatesInactive_202()
     {
         await using var server = await TestApiServer.StartAsync();
         server.ServerSettings.Update(
-            new ServerSettingsUpdate
-                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+            new() { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
         );
-        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-
-        var response = await server.Client.PostAsJsonAsync("/api/v1/register/verify", new VerifyEmailRequest(token));
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
-    }
-
-    [Fact]
-    public async Task Verify_ExpiredToken_Is410()
-    {
-        var clock = MutableTimeProvider.StartingNow();
-        await using var server = await TestApiServer.StartAsync(clock: clock);
-        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-        clock.Advance(TimeSpan.FromHours(24));
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/verify",
-            new VerifyEmailRequest(token)
-        );
+                           "/api/v1/register",
+                           new RegisterRequest("newbie", "secret99", "new@bie.test")
+                       );
 
-        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.False(server.Accounts.GetByUsername("newbie")!.IsActive);
     }
 
     [Fact]
-    public async Task Verify_WhenRegistrationWasDisabledAfterCreation_StillActivates()
+    public async Task Register_WhenRuntimeEmailIsUnavailable_Is503()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(
+                                     emailChannelReady: false,
+                                     registrationRateLimiter: limiter
+                                 );
+        EnableRegistration(server);
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register",
+                           new RegisterRequest("newbie", "secret99", "new@bie.test")
+                       );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Empty(limiter.Keys);
+    }
+
+    [Theory, InlineData("ab", "new@bie.test", "username"), InlineData("newbie", "not-an-email", "email")]
+    public async Task Resend_InvalidInput_Is400(string username, string email, string expectedKey)
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/resend",
+                           new { username, email }
+                       );
+        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(expectedKey, problem!.Errors.Keys);
+        Assert.Equal(2, limiter.Keys.Count);
+        Assert.StartsWith("resend:ip:", limiter.Keys[0], StringComparison.Ordinal);
+        Assert.StartsWith("resend:target:", limiter.Keys[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Resend_MatchingPendingAccount_RotatesToken_202()
     {
         await using var server = await TestApiServer.StartAsync();
-        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+        var originalHash = server.Accounts.GetByUsername("newbie")!.ActivationTokenHash;
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/verify",
-            new VerifyEmailRequest(token)
-        );
+                           "/api/v1/register/resend",
+                           new { username = "newbie", email = "new@bie.test" }
+                       );
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.NotEqual(originalHash, server.Accounts.GetByUsername("newbie")!.ActivationTokenHash);
+    }
+
+    [Theory, InlineData("missing", "missing@bie.test"), InlineData("tom", "tom@bie.test"),
+     InlineData("newbie", "other@bie.test")]
+    public async Task Resend_MissingActiveOrMismatched_IsAlways202(string username, string email)
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/resend",
+                           new { username, email }
+                       );
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Resend_NullInput_Is400()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/resend",
+                           new { username = (string?)null, email = (string?)null }
+                       );
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(2, limiter.Keys.Count);
+        Assert.StartsWith("resend:target:", limiter.Keys[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Resend_TargetBudgetIsIndependentFromIpBudget()
+    {
+        var limiter = new RecordingRegistrationRateLimiter(
+            (key, attempt) => key.StartsWith("resend:ip:", StringComparison.Ordinal) || attempt <= 2
+        );
+        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+
+        var first = await server.Client.PostAsJsonAsync(
+                        "/api/v1/register/resend",
+                        new { username = " newbie ", email = " new@bie.test " }
+                    );
+        var second = await server.Client.PostAsJsonAsync(
+                         "/api/v1/register/resend",
+                         new { username = " newbie ", email = " NEW@BIE.TEST " }
+                     );
+        var third = await server.Client.PostAsJsonAsync(
+                        "/api/v1/register/resend",
+                        new { username = " newbie ", email = " new@bie.test " }
+                    );
+        var targetKeys = limiter.Keys.Where(key => key.StartsWith("resend:target:", StringComparison.Ordinal)).ToArray();
+
+        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, second.StatusCode);
+        Assert.Equal(HttpStatusCode.TooManyRequests, third.StatusCode);
+        Assert.Equal(3, targetKeys.Length);
+        Assert.Single(targetKeys.Distinct(StringComparer.Ordinal));
+        Assert.DoesNotContain("newbie", targetKeys[0], StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("new@bie.test", targetKeys[0], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Resend_ThirdIpAttempt_Is429()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "first", email = "first@bie.test" }
+        );
+        await server.Client.PostAsJsonAsync(
+            "/api/v1/register/resend",
+            new { username = "second", email = "second@bie.test" }
+        );
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/resend",
+                           new { username = "third", email = "third@bie.test" }
+                       );
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Resend_WhenEmailUnavailable_Is503()
+    {
+        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
+        await using var server = await TestApiServer.StartAsync(
+                                     emailChannelReady: false,
+                                     registrationRateLimiter: limiter
+                                 );
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/resend",
+                           new { username = "newbie", email = "new@bie.test" }
+                       );
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Empty(limiter.Keys);
+    }
+
+    [Fact]
+    public async Task Resend_WhenRegistrationDisabled_StillQueuesForPendingAccount()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
+        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+        var originalHash = server.Accounts.GetByUsername("newbie")!.ActivationTokenHash;
+
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/resend",
+                           new { username = "newbie", email = "new@bie.test" }
+                       );
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
+        Assert.NotEqual(originalHash, server.Accounts.GetByUsername("newbie")!.ActivationTokenHash);
     }
 
     [Fact]
     public async Task VerifyAndResend_AdminBlockedPendingAccount_CannotReactivateOrRotate()
     {
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
         var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
 
         Assert.True(server.Accounts.SetActive("newbie", false));
 
         var verify = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/verify",
-            new VerifyEmailRequest(token)
-        );
+                         "/api/v1/register/verify",
+                         new VerifyEmailRequest(token)
+                     );
         var resend = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "newbie", email = "new@bie.test" }
-        );
+                         "/api/v1/register/resend",
+                         new { username = "newbie", email = "new@bie.test" }
+                     );
         var account = server.Accounts.GetByUsername("newbie")!;
 
         Assert.Equal(HttpStatusCode.BadRequest, verify.StatusCode);
@@ -207,9 +337,7 @@ public sealed class RegistrationEndpointsTests
     public async Task VerifyAndResend_PrivilegedAccount_CannotReactivateOrRotate()
     {
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
+        server.ServerSettings.Update(new() { Contacts = new() { Website = "https://shard.example" } });
         server.Accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
         server.Accounts.SetActive("staff", false);
         var account = server.Accounts.GetByUsername("staff")!;
@@ -218,18 +346,33 @@ public sealed class RegistrationEndpointsTests
         account.ActivationTokenExpiresAtUtc = DateTimeOffset.UtcNow.AddHours(1);
 
         var verify = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/verify",
-            new VerifyEmailRequest("staff-token")
-        );
+                         "/api/v1/register/verify",
+                         new VerifyEmailRequest("staff-token")
+                     );
         var resend = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "staff", email = "staff@bie.test" }
-        );
+                         "/api/v1/register/resend",
+                         new { username = "staff", email = "staff@bie.test" }
+                     );
 
         Assert.Equal(HttpStatusCode.BadRequest, verify.StatusCode);
         Assert.Equal(HttpStatusCode.Accepted, resend.StatusCode);
         Assert.False(account.IsActive);
         Assert.Equal(HashToken("staff-token"), account.ActivationTokenHash);
+    }
+
+    [Fact]
+    public async Task Verify_ActivatesAccount()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(
+            new() { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        );
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+
+        var response = await server.Client.PostAsJsonAsync("/api/v1/register/verify", new VerifyEmailRequest(token));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
     }
 
     [Fact]
@@ -243,215 +386,40 @@ public sealed class RegistrationEndpointsTests
     }
 
     [Fact]
-    public async Task Register_RateLimited_429()
+    public async Task Verify_ExpiredToken_Is410()
     {
-        // The fixture seeds a limiter of 2/window; the 3rd call from the same loopback IP is throttled.
-        await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate
-                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
-        );
+        var clock = MutableTimeProvider.StartingNow();
+        await using var server = await TestApiServer.StartAsync(clock: clock);
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        clock.Advance(TimeSpan.FromHours(24));
 
-        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("first", "secret99", "a@b.test"));
-        await server.Client.PostAsJsonAsync("/api/v1/register", new RegisterRequest("second", "secret99", "b@b.test"));
-        var third = await server.Client.PostAsJsonAsync(
-            "/api/v1/register",
-            new RegisterRequest("third", "secret99", "c@b.test")
-        );
+        var response = await server.Client.PostAsJsonAsync(
+                           "/api/v1/register/verify",
+                           new VerifyEmailRequest(token)
+                       );
 
-        Assert.Equal(HttpStatusCode.TooManyRequests, third.StatusCode);
+        Assert.Equal(HttpStatusCode.Gone, response.StatusCode);
     }
 
     [Fact]
-    public async Task Resend_MatchingPendingAccount_RotatesToken_202()
+    public async Task Verify_WhenRegistrationWasDisabledAfterCreation_StillActivates()
     {
         await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
-        var originalHash = server.Accounts.GetByUsername("newbie")!.ActivationTokenHash;
+        var token = server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
 
         var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "newbie", email = "new@bie.test" }
-        );
+                           "/api/v1/register/verify",
+                           new VerifyEmailRequest(token)
+                       );
 
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Assert.NotEqual(originalHash, server.Accounts.GetByUsername("newbie")!.ActivationTokenHash);
-    }
-
-    [Theory]
-    [InlineData("missing", "missing@bie.test")]
-    [InlineData("tom", "tom@bie.test")]
-    [InlineData("newbie", "other@bie.test")]
-    public async Task Resend_MissingActiveOrMismatched_IsAlways202(string username, string email)
-    {
-        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
-        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username, email }
-        );
-
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-    }
-
-    [Theory]
-    [InlineData("ab", "new@bie.test", "username")]
-    [InlineData("newbie", "not-an-email", "email")]
-    public async Task Resend_InvalidInput_Is400(string username, string email, string expectedKey)
-    {
-        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
-        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username, email }
-        );
-        var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Contains(expectedKey, problem!.Errors.Keys);
-        Assert.Equal(2, limiter.Keys.Count);
-        Assert.StartsWith("resend:ip:", limiter.Keys[0], StringComparison.Ordinal);
-        Assert.StartsWith("resend:target:", limiter.Keys[1], StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task Resend_WhenRegistrationDisabled_StillQueuesForPendingAccount()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
-        var originalHash = server.Accounts.GetByUsername("newbie")!.ActivationTokenHash;
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "newbie", email = "new@bie.test" }
-        );
-
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
-        Assert.NotEqual(originalHash, server.Accounts.GetByUsername("newbie")!.ActivationTokenHash);
-    }
-
-    [Fact]
-    public async Task Resend_WhenEmailUnavailable_Is503()
-    {
-        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
-        await using var server = await TestApiServer.StartAsync(
-            emailChannelReady: false,
-            registrationRateLimiter: limiter
-        );
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "newbie", email = "new@bie.test" }
-        );
-
-        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-        Assert.Empty(limiter.Keys);
-    }
-
-    [Fact]
-    public async Task Resend_ThirdIpAttempt_Is429()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-
-        await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "first", email = "first@bie.test" }
-        );
-        await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "second", email = "second@bie.test" }
-        );
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = "third", email = "third@bie.test" }
-        );
-
-        Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Resend_TargetBudgetIsIndependentFromIpBudget()
-    {
-        var limiter = new RecordingRegistrationRateLimiter(
-            (key, attempt) => key.StartsWith("resend:ip:", StringComparison.Ordinal) || attempt <= 2
-        );
-        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-        server.Accounts.RegisterPending("newbie", "secret99", "new@bie.test");
-
-        var first = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = " newbie ", email = " new@bie.test " }
-        );
-        var second = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = " newbie ", email = " NEW@BIE.TEST " }
-        );
-        var third = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = " newbie ", email = " new@bie.test " }
-        );
-        var targetKeys = limiter.Keys.Where(key => key.StartsWith("resend:target:", StringComparison.Ordinal)).ToArray();
-
-        Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
-        Assert.Equal(HttpStatusCode.Accepted, second.StatusCode);
-        Assert.Equal(HttpStatusCode.TooManyRequests, third.StatusCode);
-        Assert.Equal(3, targetKeys.Length);
-        Assert.Single(targetKeys.Distinct(StringComparer.Ordinal));
-        Assert.DoesNotContain("newbie", targetKeys[0], StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("new@bie.test", targetKeys[0], StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task Resend_NullInput_Is400()
-    {
-        var limiter = new RecordingRegistrationRateLimiter((_, _) => true);
-        await using var server = await TestApiServer.StartAsync(registrationRateLimiter: limiter);
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate { Contacts = new() { Website = "https://shard.example" } }
-        );
-
-        var response = await server.Client.PostAsJsonAsync(
-            "/api/v1/register/resend",
-            new { username = (string?)null, email = (string?)null }
-        );
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Equal(2, limiter.Keys.Count);
-        Assert.StartsWith("resend:target:", limiter.Keys[1], StringComparison.Ordinal);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(server.Accounts.GetByUsername("newbie")!.IsActive);
     }
 
     private static void EnableRegistration(TestApiServer server)
-    {
-        server.ServerSettings.Update(
-            new ServerSettingsUpdate
-                { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
+        => server.ServerSettings.Update(
+            new() { RegistrationEnabled = true, Contacts = new() { Website = "https://shard.example" } }
         );
-    }
 
     private static string HashToken(string token)
         => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerInfoEndpointsTests.cs
@@ -1,20 +1,48 @@
 using System.Net;
 using System.Net.Http.Json;
 using Moongate.Http.Plugin.Data.Api.ServerInfo;
-using Moongate.Server.Abstractions.Data;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.ServerInfo;
 
 public sealed class ServerInfoEndpointsTests
 {
     [Fact]
+    public async Task Asset_MissingSlot_Is404()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.GetAsync("/api/v1/server-info/assets/logo");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Asset_UnknownSlot_Is400()
+    {
+        await using var server = await TestApiServer.StartAsync();
+
+        var response = await server.Client.GetAsync("/api/v1/server-info/assets/wallpaper");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ServerInfo_EnabledWithoutWebsite_ReportsRegistrationClosed()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.ServerSettings.Update(new() { RegistrationEnabled = true });
+
+        var response = await server.Client.GetAsync("/api/v1/server-info");
+        var info = await response.Content.ReadFromJsonAsync<ServerInfoResponse>();
+
+        Assert.False(info!.RegistrationEnabled);
+    }
+
+    [Fact]
     public async Task ServerInfo_IsPublic_AndReflectsSettings()
     {
         await using var server = await TestApiServer.StartAsync();
         server.ServerSettings.Update(
-            new ServerSettingsUpdate
+            new()
             {
                 Description = "A fun shard",
                 Tagline = "Sosaria never sleeps.",
@@ -33,23 +61,8 @@ public sealed class ServerInfoEndpointsTests
         Assert.True(info.RegistrationEnabled);
     }
 
-    [Fact]
-    public async Task ServerInfo_EnabledWithoutWebsite_ReportsRegistrationClosed()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        server.ServerSettings.Update(new ServerSettingsUpdate { RegistrationEnabled = true });
-
-        var response = await server.Client.GetAsync("/api/v1/server-info");
-        var info = await response.Content.ReadFromJsonAsync<ServerInfoResponse>();
-
-        Assert.False(info!.RegistrationEnabled);
-    }
-
-    [Theory]
-    [InlineData(true, "email", true, true)]
-    [InlineData(false, "email", true, false)]
-    [InlineData(true, "log", true, false)]
-    [InlineData(true, "email", false, false)]
+    [Theory, InlineData(true, "email", true, true), InlineData(false, "email", true, false),
+     InlineData(true, "log", true, false), InlineData(true, "email", false, false)]
     public async Task ServerInfo_ReportsRegistrationOpenOnlyWhenToggleAndPrerequisitesAreReady(
         bool registrationEnabled,
         string accountVerificationChannel,
@@ -58,9 +71,9 @@ public sealed class ServerInfoEndpointsTests
     )
     {
         await using var server = await TestApiServer.StartAsync(
-            emailChannelReady: emailChannelReady,
-            accountVerificationChannel: accountVerificationChannel
-        );
+                                     emailChannelReady: emailChannelReady,
+                                     accountVerificationChannel: accountVerificationChannel
+                                 );
         server.ServerSettings.Update(
             new()
             {
@@ -73,23 +86,5 @@ public sealed class ServerInfoEndpointsTests
         var info = await response.Content.ReadFromJsonAsync<ServerInfoResponse>();
 
         Assert.Equal(expectedRegistrationEnabled, info!.RegistrationEnabled);
-    }
-
-    [Fact]
-    public async Task Asset_MissingSlot_Is404()
-    {
-        await using var server = await TestApiServer.StartAsync();
-
-        var response = await server.Client.GetAsync("/api/v1/server-info/assets/logo");
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Asset_UnknownSlot_Is400()
-    {
-        await using var server = await TestApiServer.StartAsync();
-
-        var response = await server.Client.GetAsync("/api/v1/server-info/assets/wallpaper");
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/ServerInfo/ServerSettingsAdminEndpointsTests.cs
@@ -1,18 +1,30 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Moongate.Http.Plugin.Data.Api.ServerInfo;
-using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Http.Endpoints.ServerInfo;
 
 public sealed class ServerSettingsAdminEndpointsTests
 {
+    [Fact]
+    public async Task DeleteAsset_RemovesIt()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        await server.AuthenticateAsync();
+        server.ServerSettings.SetAsset(
+            ServerAssetSlotType.Logo,
+            new() { FileName = "Logo.png", ContentType = "image/png" }
+        );
+
+        var response = await server.Client.DeleteAsync("/api/v1/admin/server-settings/assets/logo");
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.DoesNotContain("Logo", server.ServerSettings.Get().Assets.Keys);
+    }
+
     [Fact]
     public async Task Get_RequiresAdmin()
     {
@@ -20,29 +32,6 @@ public sealed class ServerSettingsAdminEndpointsTests
 
         var response = await server.Client.GetAsync("/api/v1/admin/server-settings"); // no token
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Put_UpdatesSettings()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        await server.AuthenticateAsync();
-
-        var response = await server.Client.PutAsJsonAsync(
-            "/api/v1/admin/server-settings",
-            new UpdateServerSettingsRequest
-            {
-                RegistrationEnabled = true,
-                Description = "Hi",
-                Tagline = "Welcome",
-                Contacts = new("https://shard.example", null, null)
-            }
-        );
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        Assert.True(server.ServerSettings.Get().RegistrationEnabled);
-        Assert.Equal("Hi", server.ServerSettings.Get().Description);
-        Assert.Equal("Welcome", server.ServerSettings.Get().Tagline);
     }
 
     [Fact]
@@ -68,38 +57,27 @@ public sealed class ServerSettingsAdminEndpointsTests
         Assert.True(settings.RegistrationReadiness.EmailChannelAvailable);
     }
 
-    [Theory]
-    [InlineData("ftp://shard.example", "email", true)]
-    [InlineData("https://shard.example", "log", true)]
-    [InlineData("https://shard.example", "email", false)]
-    public async Task Put_EnablingWithoutReadiness_RejectsAndPersistsNothing(
-        string website,
-        string accountVerificationChannel,
-        bool emailChannelReady
-    )
+    [Fact]
+    public async Task OpenApi_UpdateDocumentsValidationProblemResponse()
     {
-        await using var server = await TestApiServer.StartAsync(
-            emailChannelReady: emailChannelReady,
-            accountVerificationChannel: accountVerificationChannel
-        );
-        await server.AuthenticateAsync();
+        await using var server = await TestApiServer.StartAsync();
 
-        var response = await server.Client.PutAsJsonAsync(
-            "/api/v1/admin/server-settings",
-            new UpdateServerSettingsRequest
-            {
-                Description = "Must not persist",
-                RegistrationEnabled = true,
-                Contacts = new(website, null, null)
-            }
-        );
+        var document = await server.Client.GetStringAsync("/swagger/v1/swagger.json");
+        using var json = JsonDocument.Parse(document);
+        var responses = json.RootElement
+                            .GetProperty("paths")
+                            .GetProperty("/api/v1/admin/server-settings")
+                            .GetProperty("put")
+                            .GetProperty("responses");
+        var schemaReference = responses
+                              .GetProperty("400")
+                              .GetProperty("content")
+                              .GetProperty("application/problem+json")
+                              .GetProperty("schema")
+                              .GetProperty("$ref")
+                              .GetString();
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
-        Assert.Contains("registrationEnabled", problem!.Errors.Keys);
-        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
-        Assert.Null(server.ServerSettings.Get().Description);
-        Assert.Null(server.ServerSettings.Get().Contacts.Website);
+        Assert.Equal("#/components/schemas/HttpValidationProblemDetails", schemaReference);
     }
 
     [Fact]
@@ -110,55 +88,67 @@ public sealed class ServerSettingsAdminEndpointsTests
         server.ServerSettings.Update(new() { RegistrationEnabled = true });
 
         var response = await server.Client.PutAsJsonAsync(
-            "/api/v1/admin/server-settings",
-            new UpdateServerSettingsRequest { RegistrationEnabled = false }
-        );
+                           "/api/v1/admin/server-settings",
+                           new UpdateServerSettingsRequest { RegistrationEnabled = false }
+                       );
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.False(server.ServerSettings.Get().RegistrationEnabled);
     }
 
-    [Fact]
-    public async Task OpenApi_UpdateDocumentsValidationProblemResponse()
+    [Theory, InlineData("ftp://shard.example", "email", true), InlineData("https://shard.example", "log", true),
+     InlineData("https://shard.example", "email", false)]
+    public async Task Put_EnablingWithoutReadiness_RejectsAndPersistsNothing(
+        string website,
+        string accountVerificationChannel,
+        bool emailChannelReady
+    )
     {
-        await using var server = await TestApiServer.StartAsync();
+        await using var server = await TestApiServer.StartAsync(
+                                     emailChannelReady: emailChannelReady,
+                                     accountVerificationChannel: accountVerificationChannel
+                                 );
+        await server.AuthenticateAsync();
 
-        var document = await server.Client.GetStringAsync("/swagger/v1/swagger.json");
-        using var json = JsonDocument.Parse(document);
-        var responses = json.RootElement
-            .GetProperty("paths")
-            .GetProperty("/api/v1/admin/server-settings")
-            .GetProperty("put")
-            .GetProperty("responses");
-        var schemaReference = responses
-            .GetProperty("400")
-            .GetProperty("content")
-            .GetProperty("application/problem+json")
-            .GetProperty("schema")
-            .GetProperty("$ref")
-            .GetString();
+        var response = await server.Client.PutAsJsonAsync(
+                           "/api/v1/admin/server-settings",
+                           new UpdateServerSettingsRequest
+                           {
+                               Description = "Must not persist",
+                               RegistrationEnabled = true,
+                               Contacts = new(website, null, null)
+                           }
+                       );
 
-        Assert.Equal("#/components/schemas/HttpValidationProblemDetails", schemaReference);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        Assert.Contains("registrationEnabled", problem!.Errors.Keys);
+        Assert.False(server.ServerSettings.Get().RegistrationEnabled);
+        Assert.Null(server.ServerSettings.Get().Description);
+        Assert.Null(server.ServerSettings.Get().Contacts.Website);
     }
 
     [Fact]
-    public async Task UploadAsset_StoresAndServes()
+    public async Task Put_UpdatesSettings()
     {
         await using var server = await TestApiServer.StartAsync();
         await server.AuthenticateAsync();
 
-        using var content = new MultipartFormDataContent();
-        var file = new ByteArrayContent(new byte[] { 1, 2, 3 });
-        file.Headers.ContentType = new MediaTypeHeaderValue("image/png");
-        content.Add(file, "file", "logo.png");
+        var response = await server.Client.PutAsJsonAsync(
+                           "/api/v1/admin/server-settings",
+                           new UpdateServerSettingsRequest
+                           {
+                               RegistrationEnabled = true,
+                               Description = "Hi",
+                               Tagline = "Welcome",
+                               Contacts = new("https://shard.example", null, null)
+                           }
+                       );
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var upload = await server.Client.PostAsync("/api/v1/admin/server-settings/assets/logo", content);
-        Assert.Equal(HttpStatusCode.OK, upload.StatusCode);
-
-        // now public serving finds it
-        var served = await server.Client.GetAsync("/api/v1/server-info/assets/logo");
-        Assert.Equal(HttpStatusCode.OK, served.StatusCode);
-        Assert.Equal("image/png", served.Content.Headers.ContentType!.MediaType);
+        Assert.True(server.ServerSettings.Get().RegistrationEnabled);
+        Assert.Equal("Hi", server.ServerSettings.Get().Description);
+        Assert.Equal("Welcome", server.ServerSettings.Get().Tagline);
     }
 
     [Fact]
@@ -169,7 +159,7 @@ public sealed class ServerSettingsAdminEndpointsTests
 
         using var content = new MultipartFormDataContent();
         var file = new ByteArrayContent(new byte[] { 1 });
-        file.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+        file.Headers.ContentType = new("application/zip");
         content.Add(file, "file", "x.zip");
 
         var upload = await server.Client.PostAsync("/api/v1/admin/server-settings/assets/logo", content);
@@ -177,17 +167,22 @@ public sealed class ServerSettingsAdminEndpointsTests
     }
 
     [Fact]
-    public async Task DeleteAsset_RemovesIt()
+    public async Task UploadAsset_StoresAndServes()
     {
         await using var server = await TestApiServer.StartAsync();
         await server.AuthenticateAsync();
-        server.ServerSettings.SetAsset(
-            ServerAssetSlotType.Logo,
-            new ServerAssetMeta { FileName = "Logo.png", ContentType = "image/png" }
-        );
 
-        var response = await server.Client.DeleteAsync("/api/v1/admin/server-settings/assets/logo");
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-        Assert.DoesNotContain("Logo", server.ServerSettings.Get().Assets.Keys);
+        using var content = new MultipartFormDataContent();
+        var file = new ByteArrayContent(new byte[] { 1, 2, 3 });
+        file.Headers.ContentType = new("image/png");
+        content.Add(file, "file", "logo.png");
+
+        var upload = await server.Client.PostAsync("/api/v1/admin/server-settings/assets/logo", content);
+        Assert.Equal(HttpStatusCode.OK, upload.StatusCode);
+
+        // now public serving finds it
+        var served = await server.Client.GetAsync("/api/v1/server-info/assets/logo");
+        Assert.Equal(HttpStatusCode.OK, served.StatusCode);
+        Assert.Equal("image/png", served.Content.Headers.ContentType!.MediaType);
     }
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Stats/StatsEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Stats/StatsEndpointsTests.cs
@@ -8,40 +8,6 @@ namespace Moongate.Tests.Http.Endpoints.Stats;
 public sealed class StatsEndpointsTests
 {
     [Fact]
-    public async Task Stats_IsPublic_AndGroupsTheSnapshot()
-    {
-        await using var server = await TestApiServer.StartAsync();
-        server.Stats.Current = new(
-            new DateTimeOffset(2026, 7, 21, 8, 31, 0, TimeSpan.Zero),
-            TimeSpan.FromHours(12),
-            OnlinePlayers: 12,
-            Connections: 15,
-            Accounts: 340,
-            ActiveAccounts: 300,
-            Characters: 512,
-            Npcs: 1840,
-            WorldItems: 27310,
-            ItemTemplates: 412,
-            MobileTemplates: 19
-        );
-
-        var response = await server.Client.GetAsync("/api/v1/stats"); // no auth header
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var stats = await response.Content.ReadFromJsonAsync<ServerStatsResponse>();
-        Assert.Equal(43200, stats!.UptimeSeconds);
-        Assert.Equal(12, stats.Players.Online);
-        Assert.Equal(15, stats.Players.Connections);
-        Assert.Equal(340, stats.Accounts.Total);
-        Assert.Equal(300, stats.Accounts.Active);
-        Assert.Equal(512, stats.Accounts.Characters);
-        Assert.Equal(1840, stats.World.Npcs);
-        Assert.Equal(27310, stats.World.Items);
-        Assert.Equal(412, stats.Content.ItemTemplates);
-        Assert.Equal(19, stats.Content.MobileTemplates);
-    }
-
-    [Fact]
     public async Task Stats_BeforeTheFirstRefresh_AnswersOkWithAnUncomputedTimestamp()
     {
         await using var server = await TestApiServer.StartAsync();
@@ -62,5 +28,39 @@ public sealed class StatsEndpointsTests
         var response = await server.Client.GetAsync("/api/v1/stats");
 
         Assert.Equal("public, max-age=30", response.Headers.CacheControl!.ToString());
+    }
+
+    [Fact]
+    public async Task Stats_IsPublic_AndGroupsTheSnapshot()
+    {
+        await using var server = await TestApiServer.StartAsync();
+        server.Stats.Current = new(
+            new(2026, 7, 21, 8, 31, 0, TimeSpan.Zero),
+            TimeSpan.FromHours(12),
+            12,
+            15,
+            340,
+            300,
+            512,
+            1840,
+            27310,
+            412,
+            19
+        );
+
+        var response = await server.Client.GetAsync("/api/v1/stats"); // no auth header
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var stats = await response.Content.ReadFromJsonAsync<ServerStatsResponse>();
+        Assert.Equal(43200, stats!.UptimeSeconds);
+        Assert.Equal(12, stats.Players.Online);
+        Assert.Equal(15, stats.Players.Connections);
+        Assert.Equal(340, stats.Accounts.Total);
+        Assert.Equal(300, stats.Accounts.Active);
+        Assert.Equal(512, stats.Accounts.Characters);
+        Assert.Equal(1840, stats.World.Npcs);
+        Assert.Equal(27310, stats.World.Items);
+        Assert.Equal(412, stats.Content.ItemTemplates);
+        Assert.Equal(19, stats.Content.MobileTemplates);
     }
 }

--- a/tests/Moongate.Tests/Http/MapTileGeometryTests.cs
+++ b/tests/Moongate.Tests/Http/MapTileGeometryTests.cs
@@ -47,6 +47,15 @@ public class MapTileGeometryTests
     }
 
     [Fact]
+    public void TileSize_IsAWholeNumberOfBlocks()
+    {
+        // The reason 256 was chosen: a native tile is exactly 32 blocks, so GetImage never gets a
+        // fractional block and tiles never straddle one.
+        Assert.Equal(0, MapTileGeometry.TileSize % 8);
+        Assert.Equal(MapTileGeometry.TileSize / 8, MapTileGeometry.BlocksPerTile);
+    }
+
+    [Fact]
     public void TilesAcross_AtNative_IsTheMapRoundedUpToWholeTiles()
     {
         Assert.Equal(24, MapTileGeometry.TilesAcross(6144, 5, 5));
@@ -58,13 +67,4 @@ public class MapTileGeometryTests
 
         // 1448 is 5.65 tiles across at native. Rounding down would drop the right edge of Tokuno.
         => Assert.Equal(6, MapTileGeometry.TilesAcross(1448, 3, 3));
-
-    [Fact]
-    public void TileSize_IsAWholeNumberOfBlocks()
-    {
-        // The reason 256 was chosen: a native tile is exactly 32 blocks, so GetImage never gets a
-        // fractional block and tiles never straddle one.
-        Assert.Equal(0, MapTileGeometry.TileSize % 8);
-        Assert.Equal(MapTileGeometry.TileSize / 8, MapTileGeometry.BlocksPerTile);
-    }
 }

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -34,11 +34,11 @@ public class MoongateHttpPluginTests
         // Registrations rather than instances: the game-facing groups need services this bare
         // container has no reason to hold; what the plugin is responsible for is the registering.
         var registered = Configured()
-            .GetServiceRegistrations()
-            .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
-            .Select(registration => registration.ImplementationType)
-            .OrderBy(type => type!.Name)
-            .ToArray();
+                         .GetServiceRegistrations()
+                         .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+                         .Select(registration => registration.ImplementationType)
+                         .OrderBy(type => type!.Name)
+                         .ToArray();
 
         Assert.Equal(
             [

--- a/tests/Moongate.Tests/Http/PageRequestTests.cs
+++ b/tests/Moongate.Tests/Http/PageRequestTests.cs
@@ -28,19 +28,19 @@ public class PageRequestTests
         Assert.Empty(response.Items);
     }
 
-    [Theory, InlineData("0"), InlineData("-1"), InlineData("abc")]
-    public void TryParse_BadPage_IsRejectedRatherThanClamped(string page)
-    {
-        // Serving page 1 to someone who asked for page 0 hides their bug instead of reporting it.
-        Assert.False(PageRequest.TryParse(page, null, null, out _, out var error));
-        Assert.NotNull(error);
-    }
-
     [Theory, InlineData("0"), InlineData("-5"), InlineData("101"), InlineData("5000"), InlineData("abc")]
     public void TryParse_BadPageSize_IsRejectedRatherThanClamped(string pageSize)
     {
         // Silently capping 5000 to 100 leaves the caller believing it read everything.
         Assert.False(PageRequest.TryParse(null, pageSize, null, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Theory, InlineData("0"), InlineData("-1"), InlineData("abc")]
+    public void TryParse_BadPage_IsRejectedRatherThanClamped(string page)
+    {
+        // Serving page 1 to someone who asked for page 0 hides their bug instead of reporting it.
+        Assert.False(PageRequest.TryParse(page, null, null, out _, out var error));
         Assert.NotNull(error);
     }
 

--- a/tests/Moongate.Tests/Http/Services/Assets/AssetUploadValidationTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Assets/AssetUploadValidationTests.cs
@@ -1,17 +1,12 @@
 using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Http.Plugin.Types;
-using Xunit;
 
 namespace Moongate.Tests.Http.Services.Assets;
 
 public sealed class AssetUploadValidationTests
 {
-    [Theory]
-    [InlineData("image/png", "png")]
-    [InlineData("image/jpeg", "jpg")]
-    [InlineData("image/webp", "webp")]
-    [InlineData("image/svg+xml", "svg")]
-    [InlineData("image/x-icon", "ico")]
+    [Theory, InlineData("image/png", "png"), InlineData("image/jpeg", "jpg"), InlineData("image/webp", "webp"),
+     InlineData("image/svg+xml", "svg"), InlineData("image/x-icon", "ico")]
     public void Validate_AcceptsWhitelistedTypes(string contentType, string extension)
     {
         var result = AssetUploadValidation.Validate(contentType, 1024, 2_097_152);
@@ -21,20 +16,20 @@ public sealed class AssetUploadValidationTests
     }
 
     [Fact]
-    public void Validate_RejectsUnknownType()
-    {
-        var result = AssetUploadValidation.Validate("application/zip", 10, 2_097_152);
-
-        Assert.False(result.Ok);
-        Assert.Equal(AssetValidationError.UnsupportedType, result.Error);
-    }
-
-    [Fact]
     public void Validate_RejectsTooLarge()
     {
         var result = AssetUploadValidation.Validate("image/png", 5_000, 4_096);
 
         Assert.False(result.Ok);
         Assert.Equal(AssetValidationError.TooLarge, result.Error);
+    }
+
+    [Fact]
+    public void Validate_RejectsUnknownType()
+    {
+        var result = AssetUploadValidation.Validate("application/zip", 10, 2_097_152);
+
+        Assert.False(result.Ok);
+        Assert.Equal(AssetValidationError.UnsupportedType, result.Error);
     }
 }

--- a/tests/Moongate.Tests/Http/Services/Assets/ServerAssetFileStoreTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Assets/ServerAssetFileStoreTests.cs
@@ -1,12 +1,33 @@
 using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Server.Abstractions.Types;
-using Xunit;
 
 namespace Moongate.Tests.Http.Services.Assets;
 
 public sealed class ServerAssetFileStoreTests : IDisposable
 {
     private readonly string _dir = Path.Combine(Path.GetTempPath(), "mg-assets-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+        {
+            Directory.Delete(_dir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Save_OverwritesPreviousSlotFile()
+    {
+        var store = new ServerAssetFileStore(_dir);
+        await store.SaveAsync(ServerAssetSlotType.Logo, "png", new MemoryStream(new byte[] { 1 }));
+        await store.SaveAsync(ServerAssetSlotType.Logo, "png", new MemoryStream(new byte[] { 2, 2 }));
+
+        var opened = store.TryOpen("Logo.png")!.Value;
+        using var ms = new MemoryStream();
+        await opened.stream.CopyToAsync(ms);
+        opened.stream.Dispose();
+        Assert.Equal(new byte[] { 2, 2 }, ms.ToArray());
+    }
 
     [Fact]
     public async Task Save_ThenOpen_RoundTripsBytes()
@@ -30,27 +51,5 @@ public sealed class ServerAssetFileStoreTests : IDisposable
         var store = new ServerAssetFileStore(_dir);
 
         Assert.Null(store.TryOpen("Logo.png"));
-    }
-
-    [Fact]
-    public async Task Save_OverwritesPreviousSlotFile()
-    {
-        var store = new ServerAssetFileStore(_dir);
-        await store.SaveAsync(ServerAssetSlotType.Logo, "png", new MemoryStream(new byte[] { 1 }));
-        await store.SaveAsync(ServerAssetSlotType.Logo, "png", new MemoryStream(new byte[] { 2, 2 }));
-
-        var opened = store.TryOpen("Logo.png")!.Value;
-        using var ms = new MemoryStream();
-        await opened.stream.CopyToAsync(ms);
-        opened.stream.Dispose();
-        Assert.Equal(new byte[] { 2, 2 }, ms.ToArray());
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_dir))
-        {
-            Directory.Delete(_dir, recursive: true);
-        }
     }
 }

--- a/tests/Moongate.Tests/Http/Services/Auth/JwtTokenServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Auth/JwtTokenServiceTests.cs
@@ -21,6 +21,23 @@ public class JwtTokenServiceTests
     }
 
     [Fact]
+    public void Issue_CarriesTheSessionStartRatherThanTheMintingInstant()
+    {
+        // The renewal endpoint reads this back to cap the session, so it must be the value handed in — not
+        // "now" — or a chain of renewals would never age.
+        var mintedAt = SessionStart.AddHours(3);
+
+        var token = Read(Service(now: mintedAt).Issue(new(5), "tom", AccountLevelType.Player, SessionStart).Token);
+
+        // The literal rather than the constant: the claim name is a wire contract, so renaming it in the
+        // source has to fail here instead of quietly agreeing with itself.
+        Assert.Equal(
+            SessionStart.ToUnixTimeSeconds().ToString(),
+            token.Claims.First(c => c.Type == "auth_time").Value
+        );
+    }
+
+    [Fact]
     public void Issue_ExpiresAfterTheConfiguredLifetime()
     {
         var now = new DateTimeOffset(2026, 7, 16, 12, 0, 0, TimeSpan.Zero);
@@ -35,8 +52,7 @@ public class JwtTokenServiceTests
         // HS256 needs at least 32 bytes. Failing loudly beats minting tokens nobody can verify.
         var service = Service(signingKey);
 
-        Assert.Throws<InvalidOperationException>(() => service.Issue(new(5), "tom", AccountLevelType.Player, SessionStart)
-        );
+        Assert.Throws<InvalidOperationException>(() => service.Issue(new(5), "tom", AccountLevelType.Player, SessionStart));
     }
 
     [Fact]
@@ -53,23 +69,6 @@ public class JwtTokenServiceTests
         var token = Read(Service().Issue(new(5), "tom", AccountLevelType.Player, SessionStart).Token);
 
         Assert.Equal("moongate", token.Issuer);
-    }
-
-    [Fact]
-    public void Issue_CarriesTheSessionStartRatherThanTheMintingInstant()
-    {
-        // The renewal endpoint reads this back to cap the session, so it must be the value handed in — not
-        // "now" — or a chain of renewals would never age.
-        var mintedAt = SessionStart.AddHours(3);
-
-        var token = Read(Service(now: mintedAt).Issue(new(5), "tom", AccountLevelType.Player, SessionStart).Token);
-
-        // The literal rather than the constant: the claim name is a wire contract, so renaming it in the
-        // source has to fail here instead of quietly agreeing with itself.
-        Assert.Equal(
-            SessionStart.ToUnixTimeSeconds().ToString(),
-            token.Claims.First(c => c.Type == "auth_time").Value
-        );
     }
 
     private static JwtSecurityToken Read(string token)

--- a/tests/Moongate.Tests/Http/Services/Hosting/HttpServerServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Hosting/HttpServerServiceTests.cs
@@ -66,8 +66,7 @@ public class HttpServerServiceTests
     public async Task StartAsync_MapsRegisteredEndpointGroups()
     {
         await using var server =
-            await TestHttpServer.StartAsync(container => container.RegisterApiEndpointInstance(new ProbeEndpoints())
-            );
+            await TestHttpServer.StartAsync(container => container.RegisterApiEndpointInstance(new ProbeEndpoints()));
 
         Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/probe")).StatusCode);
     }
@@ -129,8 +128,9 @@ public class HttpServerServiceTests
         // still serves and Scalar still renders — just with every description blank. Nothing else here
         // would notice, which is why this asserts on the prose rather than on a 200.
         await using var server =
-            await TestHttpServer.StartAsync(container =>
-                container.RegisterApiEndpointInstance(new DocumentedProbeEndpoints())
+            await TestHttpServer.StartAsync(
+                container =>
+                    container.RegisterApiEndpointInstance(new DocumentedProbeEndpoints())
             );
 
         var document = await server.Client.GetStringAsync(HttpServerService.SwaggerDocumentRoute);
@@ -191,8 +191,7 @@ public class HttpServerServiceTests
         var configManager = new StubConfigManagerService();
 
         await using var server =
-            await TestHttpServer.StartAsync(container => container.RegisterInstance<IConfigManagerService>(configManager)
-            );
+            await TestHttpServer.StartAsync(container => container.RegisterInstance<IConfigManagerService>(configManager));
 
         Assert.Equal(TestHttpServer.SigningKey, server.Container.Resolve<MoongateHttpConfig>().Jwt.SigningKey);
         Assert.Equal(0, configManager.SaveCount);
@@ -204,9 +203,10 @@ public class HttpServerServiceTests
         // The web app runs on the game's container, so disposing the WebApplication disposes that
         // container's singletons — the game's, not the API's. They would go down while the game is still
         // running, and its own StopAsync would then fail on objects already disposed.
-        var server = await TestHttpServer.StartAsync(container =>
-            container.Register<DisposableGameSingleton>(Reuse.Singleton)
-        );
+        var server = await TestHttpServer.StartAsync(
+                         container =>
+                             container.Register<DisposableGameSingleton>(Reuse.Singleton)
+                     );
         var singleton = server.Container.Resolve<DisposableGameSingleton>();
 
         await server.DisposeAsync();

--- a/tests/Moongate.Tests/Http/Services/Hosting/StaticPortalTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Hosting/StaticPortalTests.cs
@@ -15,17 +15,6 @@ public sealed class StaticPortalTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task Root_ServesThePortalIndex()
-    {
-        await using var server = await TestApiServer.StartAsync(uiDistPath: _root);
-
-        var response = await server.Client.GetAsync("/");
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Contains("PORTAL_INDEX", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
-    }
-
-    [Fact]
     public async Task DeepLink_ServesTheIndexSoTheRouterCanHandleIt()
     {
         await using var server = await TestApiServer.StartAsync(uiDistPath: _root);
@@ -34,6 +23,21 @@ public sealed class StaticPortalTests : IAsyncDisposable
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains("PORTAL_INDEX", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Directory.Delete(_root, true);
+
+        return ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ExistingApiRoute_StillAnswers()
+    {
+        await using var server = await TestApiServer.StartAsync(uiDistPath: _root);
+
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/health")).StatusCode);
     }
 
     [Fact]
@@ -58,6 +62,17 @@ public sealed class StaticPortalTests : IAsyncDisposable
         var response = await server.Client.GetAsync("/");
 
         Assert.Equal("no-cache", response.Headers.CacheControl?.ToString());
+    }
+
+    [Fact]
+    public async Task Root_ServesThePortalIndex()
+    {
+        await using var server = await TestApiServer.StartAsync(uiDistPath: _root);
+
+        var response = await server.Client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("PORTAL_INDEX", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -86,26 +101,11 @@ public sealed class StaticPortalTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task ExistingApiRoute_StillAnswers()
-    {
-        await using var server = await TestApiServer.StartAsync(uiDistPath: _root);
-
-        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/health")).StatusCode);
-    }
-
-    [Fact]
     public async Task WithoutAWebRoot_TheServerStillRuns()
     {
         // A backend contributor who never ran npm must still get a working server.
         await using var server = await TestApiServer.StartAsync();
 
         Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync("/health")).StatusCode);
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        Directory.Delete(_root, recursive: true);
-
-        return ValueTask.CompletedTask;
     }
 }

--- a/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Maps/MapImageServiceTests.cs
@@ -52,9 +52,9 @@ public class MapImageServiceTests
         var zoom = service.MaxZoomFor(MapType.Felucca);
 
         var paths = await Task.WhenAll(
-            Enumerable.Range(0, 4)
-                .Select(x => service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, x, 0))
-        );
+                        Enumerable.Range(0, 4)
+                                  .Select(x => service.GetTileAsync(MapType.Felucca, MapRenderStyleType.Flat, zoom, x, 0))
+                    );
 
         Assert.All(paths, path => Assert.True(File.Exists(path)));
     }
@@ -82,12 +82,12 @@ public class MapImageServiceTests
         var service = Service(fixture);
 
         var path = await service.GetTileAsync(
-            MapType.Felucca,
-            MapRenderStyleType.Flat,
-            service.MaxZoomFor(MapType.Felucca),
-            0,
-            0
-        );
+                       MapType.Felucca,
+                       MapRenderStyleType.Flat,
+                       service.MaxZoomFor(MapType.Felucca),
+                       0,
+                       0
+                   );
 
         Assert.NotNull(path);
 
@@ -107,12 +107,12 @@ public class MapImageServiceTests
         var service = Service(fixture);
 
         var path = await service.GetTileAsync(
-            MapType.Felucca,
-            MapRenderStyleType.Flat,
-            service.MaxZoomFor(MapType.Felucca),
-            0,
-            0
-        );
+                       MapType.Felucca,
+                       MapRenderStyleType.Flat,
+                       service.MaxZoomFor(MapType.Felucca),
+                       0,
+                       0
+                   );
 
         using var image = await Image.LoadAsync<Bgra32>(path!);
         var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];
@@ -138,12 +138,12 @@ public class MapImageServiceTests
         var service = Service(fixture);
 
         var path = await service.GetTileAsync(
-            MapType.Felucca,
-            MapRenderStyleType.Relief,
-            service.MaxZoomFor(MapType.Felucca),
-            0,
-            0
-        );
+                       MapType.Felucca,
+                       MapRenderStyleType.Relief,
+                       service.MaxZoomFor(MapType.Felucca),
+                       0,
+                       0
+                   );
 
         using var image = await Image.LoadAsync<Bgra32>(path!);
         var centre = image[MapTileGeometry.TileSize / 2, MapTileGeometry.TileSize / 2];

--- a/tests/Moongate.Tests/Http/Services/Plugins/EndpointPluginRouteInspectorTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Plugins/EndpointPluginRouteInspectorTests.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Primitives;
-using Moongate.Http.Plugin.Data.Plugins;
 using Moongate.Http.Plugin.Services.Plugins;
 
 namespace Moongate.Tests.Http.Services.Plugins;
@@ -17,42 +16,17 @@ public class EndpointPluginRouteInspectorTests
             BindingFlags.NonPublic | BindingFlags.Static
         )!;
 
-    [Fact]
-    public void RoutesByAssembly_GroupsUnderTheAssemblyDeclaringTheHandler()
+    private sealed class StubEndpointDataSource : EndpointDataSource
     {
-        var inspector = new EndpointPluginRouteInspector();
+        public StubEndpointDataSource(params Endpoint[] endpoints)
+        {
+            Endpoints = endpoints;
+        }
 
-        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news", "GET")));
+        public override IReadOnlyList<Endpoint> Endpoints { get; }
 
-        var assembly = typeof(EndpointPluginRouteInspectorTests).Assembly.GetName().Name!;
-        var routes = Assert.Contains(assembly, result);
-
-        Assert.Equal(new PluginRouteInfo("GET", "/api/v1/news", null), Assert.Single(routes));
-    }
-
-    [Fact]
-    public void RoutesByAssembly_ReportsTheAuthorizationPolicy()
-    {
-        var inspector = new EndpointPluginRouteInspector();
-
-        var result = inspector.RoutesByAssembly(
-            new StubEndpointDataSource(Route("/api/v1/admin/news", "POST", policy: "admin"))
-        );
-
-        Assert.Equal("admin", Assert.Single(result.Values.Single()).Policy);
-    }
-
-    [Fact]
-    public void RoutesByAssembly_ReportsAllowAnonymousAsNoPolicy()
-    {
-        // AllowAnonymous wins at runtime over any policy also present, so it must win here too.
-        var inspector = new EndpointPluginRouteInspector();
-
-        var result = inspector.RoutesByAssembly(
-            new StubEndpointDataSource(Route("/api/v1/news", "GET", policy: "admin", allowAnonymous: true))
-        );
-
-        Assert.Null(Assert.Single(result.Values.Single()).Policy);
+        public override IChangeToken GetChangeToken()
+            => new CancellationChangeToken(CancellationToken.None);
     }
 
     [Fact]
@@ -63,16 +37,6 @@ public class EndpointPluginRouteInspectorTests
         var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news", "GET", "HEAD")));
 
         Assert.Equal(["GET", "HEAD"], result.Values.Single().Select(route => route.Method));
-    }
-
-    [Fact]
-    public void RoutesByAssembly_UsesAStarWhenNoVerbIsDeclared()
-    {
-        var inspector = new EndpointPluginRouteInspector();
-
-        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news")));
-
-        Assert.Equal("*", Assert.Single(result.Values.Single()).Method);
     }
 
     [Fact]
@@ -95,8 +59,52 @@ public class EndpointPluginRouteInspectorTests
         Assert.Equal("/scalar/v1", Assert.Single(result[string.Empty]).Path);
     }
 
-    private static void SampleHandler()
+    [Fact]
+    public void RoutesByAssembly_GroupsUnderTheAssemblyDeclaringTheHandler()
     {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news", "GET")));
+
+        var assembly = typeof(EndpointPluginRouteInspectorTests).Assembly.GetName().Name!;
+        var routes = Assert.Contains(assembly, result);
+
+        Assert.Equal(new("GET", "/api/v1/news", null), Assert.Single(routes));
+    }
+
+    [Fact]
+    public void RoutesByAssembly_ReportsAllowAnonymousAsNoPolicy()
+    {
+        // AllowAnonymous wins at runtime over any policy also present, so it must win here too.
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(
+            new StubEndpointDataSource(Route("/api/v1/news", "GET", policy: "admin", allowAnonymous: true))
+        );
+
+        Assert.Null(Assert.Single(result.Values.Single()).Policy);
+    }
+
+    [Fact]
+    public void RoutesByAssembly_ReportsTheAuthorizationPolicy()
+    {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(
+            new StubEndpointDataSource(Route("/api/v1/admin/news", "POST", policy: "admin"))
+        );
+
+        Assert.Equal("admin", Assert.Single(result.Values.Single()).Policy);
+    }
+
+    [Fact]
+    public void RoutesByAssembly_UsesAStarWhenNoVerbIsDeclared()
+    {
+        var inspector = new EndpointPluginRouteInspector();
+
+        var result = inspector.RoutesByAssembly(new StubEndpointDataSource(Route("/api/v1/news")));
+
+        Assert.Equal("*", Assert.Single(result.Values.Single()).Method);
     }
 
     private static RouteEndpoint Route(
@@ -131,17 +139,5 @@ public class EndpointPluginRouteInspectorTests
         return new(_ => Task.CompletedTask, RoutePatternFactory.Parse(pattern), 0, new(metadata), pattern);
     }
 
-    private sealed class StubEndpointDataSource : EndpointDataSource
-    {
-        private readonly IReadOnlyList<Endpoint> _endpoints;
-
-        public StubEndpointDataSource(params Endpoint[] endpoints)
-        {
-            _endpoints = endpoints;
-        }
-
-        public override IReadOnlyList<Endpoint> Endpoints => _endpoints;
-
-        public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
-    }
+    private static void SampleHandler() { }
 }

--- a/tests/Moongate.Tests/Http/Services/Registration/RegistrationRateLimiterTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Registration/RegistrationRateLimiterTests.cs
@@ -1,18 +1,14 @@
 using Moongate.Http.Plugin.Services.Registration;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Http.Services.Registration;
 
 public sealed class RegistrationRateLimiterTests
 {
-    private static MutableTimeProvider Time()
-        => new(DateTimeOffset.UnixEpoch);
-
     [Fact]
     public void AllowsUpToLimitThenBlocks()
     {
-        var limiter = new RegistrationRateLimiter(Time(), permitPerWindow: 2, window: TimeSpan.FromMinutes(10));
+        var limiter = new RegistrationRateLimiter(Time(), 2, TimeSpan.FromMinutes(10));
 
         Assert.True(limiter.TryAcquire("1.1.1.1"));
         Assert.True(limiter.TryAcquire("1.1.1.1"));
@@ -41,4 +37,7 @@ public sealed class RegistrationRateLimiterTests
         time.Advance(TimeSpan.FromMinutes(11));
         Assert.True(limiter.TryAcquire("1.1.1.1"));
     }
+
+    private static MutableTimeProvider Time()
+        => new(DateTimeOffset.UnixEpoch);
 }

--- a/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Services/Registration/RegistrationReadinessServiceTests.cs
@@ -1,41 +1,30 @@
 using Moongate.Http.Plugin.Services.Registration;
-using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Http.Services.Registration;
 
 public sealed class RegistrationReadinessServiceTests
 {
-    [Theory]
-    [InlineData("https://shard.example", "email", true, true)]
-    [InlineData("http://shard.example/moongate", "EMAIL", true, true)]
-    [InlineData(null, "email", true, false)]
-    [InlineData("ftp://shard.example", "email", true, false)]
-    [InlineData("https://shard.example", "log", true, false)]
-    [InlineData("https://shard.example", "email", false, false)]
-    public void Evaluate_RequiresWebsiteSelectedEmailAndRegisteredChannel(
-        string? website,
-        string selected,
-        bool channelRegistered,
-        bool expected
-    )
+    [Theory, InlineData("http:/portal"), InlineData("https:/portal"), InlineData("http:portal"),
+     InlineData("http:///portal")]
+    public void Evaluate_HostlessHttpWebsite_IsNotValidOrReady(string website)
     {
-        INotificationChannel[] channels = channelRegistered ? [new RecordingNotificationChannel("email")] : [];
         var service = new RegistrationReadinessService(
-            new NotificationConfig { AccountVerificationChannel = selected },
-            channels
+            new() { AccountVerificationChannel = "email" },
+            [new RecordingNotificationChannel("email")]
         );
 
-        Assert.Equal(expected, service.Evaluate(website).Ready);
+        var readiness = service.Evaluate(website);
+
+        Assert.False(readiness.WebsiteValid);
+        Assert.False(readiness.Ready);
     }
 
-    [Theory]
-    [InlineData(null, "email", "email", false, true, true)]
-    [InlineData("https://shard.example", "log", "email", true, false, true)]
-    [InlineData("https://shard.example", "email", null, true, true, false)]
-    [InlineData("https://shard.example", "EMAIL", "EMAIL", true, true, true)]
+    [Theory, InlineData(null, "email", "email", false, true, true),
+     InlineData("https://shard.example", "log", "email", true, false, true),
+     InlineData("https://shard.example", "email", null, true, true, false),
+     InlineData("https://shard.example", "EMAIL", "EMAIL", true, true, true)]
     public void Evaluate_ReportsEveryReadinessProperty(
         string? website,
         string selected,
@@ -46,10 +35,10 @@ public sealed class RegistrationReadinessServiceTests
     )
     {
         INotificationChannel[] channels = registeredChannel is null
-            ? []
-            : [new RecordingNotificationChannel(registeredChannel)];
+                                              ? []
+                                              : [new RecordingNotificationChannel(registeredChannel)];
         var service = new RegistrationReadinessService(
-            new NotificationConfig { AccountVerificationChannel = selected },
+            new() { AccountVerificationChannel = selected },
             channels
         );
 
@@ -61,21 +50,23 @@ public sealed class RegistrationReadinessServiceTests
         Assert.Equal(websiteValid && emailChannelSelected && emailChannelAvailable, readiness.Ready);
     }
 
-    [Theory]
-    [InlineData("http:/portal")]
-    [InlineData("https:/portal")]
-    [InlineData("http:portal")]
-    [InlineData("http:///portal")]
-    public void Evaluate_HostlessHttpWebsite_IsNotValidOrReady(string website)
+    [Theory, InlineData("https://shard.example", "email", true, true),
+     InlineData("http://shard.example/moongate", "EMAIL", true, true), InlineData(null, "email", true, false),
+     InlineData("ftp://shard.example", "email", true, false), InlineData("https://shard.example", "log", true, false),
+     InlineData("https://shard.example", "email", false, false)]
+    public void Evaluate_RequiresWebsiteSelectedEmailAndRegisteredChannel(
+        string? website,
+        string selected,
+        bool channelRegistered,
+        bool expected
+    )
     {
+        INotificationChannel[] channels = channelRegistered ? [new RecordingNotificationChannel("email")] : [];
         var service = new RegistrationReadinessService(
-            new NotificationConfig { AccountVerificationChannel = "email" },
-            [new RecordingNotificationChannel("email")]
+            new() { AccountVerificationChannel = selected },
+            channels
         );
 
-        var readiness = service.Evaluate(website);
-
-        Assert.False(readiness.WebsiteValid);
-        Assert.False(readiness.Ready);
+        Assert.Equal(expected, service.Evaluate(website).Ready);
     }
 }

--- a/tests/Moongate.Tests/Network/LoginFlowPacketsTests.cs
+++ b/tests/Moongate.Tests/Network/LoginFlowPacketsTests.cs
@@ -9,20 +9,6 @@ namespace Moongate.Tests.Network;
 public class LoginFlowPacketsTests
 {
     [Fact]
-    public void ConnectToGameServer_WritesAddressInNormalOrder()
-    {
-        var packet = new ConnectToGameServerPacket(IPAddress.Parse("192.168.1.50"), 2593, 1);
-
-        var writer = new SpanWriter(16);
-        packet.Write(ref writer);
-        var bytes = writer.Span.ToArray();
-
-        // The 0x8C redirect writes the IP in normal order (unlike the 0xA8 server list,
-        // which reverses it); otherwise the client dials a mangled address and cannot reconnect.
-        Assert.Equal(new byte[] { 192, 168, 1, 50 }, bytes.AsSpan(1, 4).ToArray());
-    }
-
-    [Fact]
     public void ConnectToGameServerPacket_Write_Is11BytesWithPortAndKey()
     {
         var packet = new ConnectToGameServerPacket(IPAddress.Parse("127.0.0.1"), 2593, 0xDEADBEEF);
@@ -35,6 +21,20 @@ public class LoginFlowPacketsTests
         Assert.Equal(0x8C, bytes[0]);
         Assert.Equal(2593, (bytes[5] << 8) | bytes[6]); // port big-endian
         Assert.Equal(0xDEADBEEFu, ((uint)bytes[7] << 24) | ((uint)bytes[8] << 16) | ((uint)bytes[9] << 8) | bytes[10]);
+    }
+
+    [Fact]
+    public void ConnectToGameServer_WritesAddressInNormalOrder()
+    {
+        var packet = new ConnectToGameServerPacket(IPAddress.Parse("192.168.1.50"), 2593, 1);
+
+        var writer = new SpanWriter(16);
+        packet.Write(ref writer);
+        var bytes = writer.Span.ToArray();
+
+        // The 0x8C redirect writes the IP in normal order (unlike the 0xA8 server list,
+        // which reverses it); otherwise the client dials a mangled address and cannot reconnect.
+        Assert.Equal(new byte[] { 192, 168, 1, 50 }, bytes.AsSpan(1, 4).ToArray());
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Network/UoCompressionMiddlewareTests.cs
+++ b/tests/Moongate.Tests/Network/UoCompressionMiddlewareTests.cs
@@ -28,6 +28,16 @@ public class UoCompressionMiddlewareTests
     }
 
     [Fact]
+    public async Task ProcessSendAsync_EnabledButEmpty_ReturnsEmpty()
+    {
+        var middleware = new UoCompressionMiddleware { Enabled = true };
+
+        var result = await middleware.ProcessSendAsync(null, ReadOnlyMemory<byte>.Empty);
+
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
     public async Task ProcessSendAsync_Enabled_CompressesToHuffmanBytes()
     {
         var middleware = new UoCompressionMiddleware { Enabled = true };
@@ -39,15 +49,5 @@ public class UoCompressionMiddlewareTests
         var written = HuffmanEncoder.Compress(data, expected);
 
         Assert.Equal(expected.AsSpan(0, written).ToArray(), result.ToArray());
-    }
-
-    [Fact]
-    public async Task ProcessSendAsync_EnabledButEmpty_ReturnsEmpty()
-    {
-        var middleware = new UoCompressionMiddleware { Enabled = true };
-
-        var result = await middleware.ProcessSendAsync(null, ReadOnlyMemory<byte>.Empty);
-
-        Assert.True(result.IsEmpty);
     }
 }

--- a/tests/Moongate.Tests/News/MoongateNewsPluginTests.cs
+++ b/tests/Moongate.Tests/News/MoongateNewsPluginTests.cs
@@ -3,7 +3,6 @@ using Moongate.Http.Plugin.Interfaces.Endpoints;
 using Moongate.News.Plugin;
 using Moongate.News.Plugin.Endpoints;
 using Moongate.News.Plugin.Interfaces;
-using Xunit;
 
 namespace Moongate.Tests.News;
 
@@ -18,9 +17,9 @@ public class MoongateNewsPluginTests
 
         Assert.True(container.IsRegistered<INewsService>());
         var endpoints = container.GetServiceRegistrations()
-            .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
-            .Select(registration => registration.ImplementationType)
-            .ToArray();
+                                 .Where(registration => registration.ServiceType == typeof(IApiEndpointRegistration))
+                                 .Select(registration => registration.ImplementationType)
+                                 .ToArray();
         Assert.Contains(typeof(NewsAdminEndpoints), endpoints);
         Assert.Contains(typeof(NewsEndpoints), endpoints);
     }

--- a/tests/Moongate.Tests/News/NewsEndpointsTests.cs
+++ b/tests/Moongate.Tests/News/NewsEndpointsTests.cs
@@ -7,26 +7,11 @@ using Moongate.News.Plugin.Endpoints;
 using Moongate.News.Plugin.Interfaces;
 using Moongate.News.Plugin.Services;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.News;
 
 public class NewsEndpointsTests
 {
-    // Wires the real news endpoints over real HTTP. TestApiServer already registers a fake
-    // IPersistenceService, so NewsService gets an in-memory store.
-    private static Task<TestApiServer> StartAsync()
-        => TestApiServer.StartAsync(
-            AccountLevelType.GrandMaster,
-            configure: container =>
-            {
-                container.Register<INewsService, NewsService>(Reuse.Singleton);
-                var news = container.Resolve<INewsService>();
-                container.RegisterApiEndpointInstance(new NewsAdminEndpoints(news));
-                container.RegisterApiEndpointInstance(new NewsEndpoints(news));
-            }
-        );
-
     [Fact]
     public async Task Admin_can_create_then_read_it_back()
     {
@@ -34,9 +19,9 @@ public class NewsEndpointsTests
         await server.AuthenticateAsync();
 
         var create = await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/news",
-            new CreateNewsRequest("Patch 1", "notes", IsPublished: true)
-        );
+                         "/api/v1/admin/news",
+                         new CreateNewsRequest("Patch 1", "notes", true)
+                     );
         Assert.Equal(HttpStatusCode.Created, create.StatusCode);
         var created = await create.Content.ReadFromJsonAsync<NewsResponse>();
         Assert.Equal("Patch 1", created!.Title);
@@ -57,19 +42,18 @@ public class NewsEndpointsTests
     }
 
     [Fact]
-    public async Task Update_and_delete_report_404_for_missing()
+    public async Task Public_get_hides_drafts_as_404()
     {
         await using var server = await StartAsync();
         await server.AuthenticateAsync();
+        var draft = await (await server.Client.PostAsJsonAsync(
+                               "/api/v1/admin/news",
+                               new CreateNewsRequest("draft", "b", false)
+                           )).Content.ReadFromJsonAsync<NewsResponse>();
 
-        var put = await server.Client.PutAsJsonAsync(
-            "/api/v1/admin/news/999999",
-            new UpdateNewsRequest("x", "y", true)
-        );
-        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
+        var res = await server.Client.GetAsync($"/api/v1/news/{draft!.Id}");
 
-        var del = await server.Client.DeleteAsync("/api/v1/admin/news/999999");
-        Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, res.StatusCode);
     }
 
     [Fact]
@@ -86,17 +70,32 @@ public class NewsEndpointsTests
     }
 
     [Fact]
-    public async Task Public_get_hides_drafts_as_404()
+    public async Task Update_and_delete_report_404_for_missing()
     {
         await using var server = await StartAsync();
         await server.AuthenticateAsync();
-        var draft = await (await server.Client.PostAsJsonAsync(
-            "/api/v1/admin/news",
-            new CreateNewsRequest("draft", "b", false)
-        )).Content.ReadFromJsonAsync<NewsResponse>();
 
-        var res = await server.Client.GetAsync($"/api/v1/news/{draft!.Id}");
+        var put = await server.Client.PutAsJsonAsync(
+                      "/api/v1/admin/news/999999",
+                      new UpdateNewsRequest("x", "y", true)
+                  );
+        Assert.Equal(HttpStatusCode.NotFound, put.StatusCode);
 
-        Assert.Equal(HttpStatusCode.NotFound, res.StatusCode);
+        var del = await server.Client.DeleteAsync("/api/v1/admin/news/999999");
+        Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
     }
+
+    // Wires the real news endpoints over real HTTP. TestApiServer already registers a fake
+    // IPersistenceService, so NewsService gets an in-memory store.
+    private static Task<TestApiServer> StartAsync()
+        => TestApiServer.StartAsync(
+            AccountLevelType.GrandMaster,
+            configure: container =>
+                       {
+                           container.Register<INewsService, NewsService>(Reuse.Singleton);
+                           var news = container.Resolve<INewsService>();
+                           container.RegisterApiEndpointInstance(new NewsAdminEndpoints(news));
+                           container.RegisterApiEndpointInstance(new NewsEndpoints(news));
+                       }
+        );
 }

--- a/tests/Moongate.Tests/News/NewsServiceTests.cs
+++ b/tests/Moongate.Tests/News/NewsServiceTests.cs
@@ -1,25 +1,43 @@
-using Moongate.Core.Primitives;
 using Moongate.News.Plugin.Services;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.News;
 
 public class NewsServiceTests
 {
-    private static NewsService Build()
-        => new(new FakePersistenceService());
-
     [Fact]
     public async Task CreateAsync_assigns_an_id_and_timestamps()
     {
         var before = DateTime.UtcNow;
-        var news = await Build().CreateAsync("Patch 1", "notes", "gm", isPublished: true);
+        var news = await Build().CreateAsync("Patch 1", "notes", "gm", true);
 
         Assert.True(news.Id.IsValid);
         Assert.Equal("gm", news.Author);
         Assert.True(news.PublishedAt >= before);
         Assert.Equal(news.PublishedAt, news.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_removes_the_entry()
+    {
+        var service = Build();
+        var created = await service.CreateAsync("t", "b", "gm", true);
+
+        Assert.True(await service.DeleteAsync(created.Id));
+        Assert.Null(service.Get(created.Id));
+        Assert.False(await service.DeleteAsync(created.Id));
+    }
+
+    [Fact]
+    public async Task GetPublished_excludes_drafts()
+    {
+        var service = Build();
+        await service.CreateAsync("draft", "b", "gm", false);
+        var pub = await service.CreateAsync("live", "b", "gm", true);
+
+        var published = service.GetPublished();
+        Assert.Equal(pub.Id, Assert.Single(published).Id);
+        Assert.Equal(2, service.GetAll().Count);
     }
 
     [Fact]
@@ -34,29 +52,9 @@ public class NewsServiceTests
         Assert.False(updated.IsPublished);
         Assert.True(updated.UpdatedAt >= updated.PublishedAt);
 
-        Assert.Null(await service.UpdateAsync(new Serial(999999), "x", "y", true));
+        Assert.Null(await service.UpdateAsync(new(999999), "x", "y", true));
     }
 
-    [Fact]
-    public async Task GetPublished_excludes_drafts()
-    {
-        var service = Build();
-        await service.CreateAsync("draft", "b", "gm", isPublished: false);
-        var pub = await service.CreateAsync("live", "b", "gm", isPublished: true);
-
-        var published = service.GetPublished();
-        Assert.Equal(pub.Id, Assert.Single(published).Id);
-        Assert.Equal(2, service.GetAll().Count);
-    }
-
-    [Fact]
-    public async Task DeleteAsync_removes_the_entry()
-    {
-        var service = Build();
-        var created = await service.CreateAsync("t", "b", "gm", true);
-
-        Assert.True(await service.DeleteAsync(created.Id));
-        Assert.Null(service.Get(created.Id));
-        Assert.False(await service.DeleteAsync(created.Id));
-    }
+    private static NewsService Build()
+        => new(new FakePersistenceService());
 }

--- a/tests/Moongate.Tests/Persistence/Entities/AccountEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/AccountEntityTests.cs
@@ -33,7 +33,7 @@ public sealed class AccountEntityTests
             Username = "pending-account",
             PasswordHash = "password-hash",
             ActivationToken = string.Empty,
-            ActivationTokenHash = new string('A', 64),
+            ActivationTokenHash = new('A', 64),
             ActivationTokenExpiresAtUtc = expiresAt,
             IsPublicRegistrationPending = true
         };

--- a/tests/Moongate.Tests/Persistence/Entities/MobileEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/MobileEntityTests.cs
@@ -10,9 +10,7 @@ public class MobileEntityTests
 {
     [Fact]
     public void CombatantId_DefaultsToZero()
-    {
-        Assert.Equal(Serial.Zero, new MobileEntity().CombatantId);
-    }
+        => Assert.Equal(Serial.Zero, new MobileEntity().CombatantId);
 
     [Fact]
     public void Deserialize_SaveWrittenBeforeTheNewFieldsExisted_KeepsTheDefaults()

--- a/tests/Moongate.Tests/Persistence/Entities/NpcMemoryEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/NpcMemoryEntityTests.cs
@@ -1,6 +1,5 @@
 using MessagePack;
 using MessagePack.Resolvers;
-using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
 
@@ -24,7 +23,7 @@ public class NpcMemoryEntityTests
 
         var loaded = RoundTrip(entity);
 
-        Assert.Equal(new Serial(0x2A), loaded.Id);
+        Assert.Equal(new(0x2A), loaded.Id);
         Assert.Equal(3, loaded.Memory.Count);
 
         Assert.Equal(MemoryValueType.String, loaded.Memory["name"].Type);
@@ -36,7 +35,7 @@ public class NpcMemoryEntityTests
     [Fact]
     public void RoundTrip_EmptyMemory_IsPreserved()
     {
-        var loaded = RoundTrip(new NpcMemoryEntity { Id = new(0x1) });
+        var loaded = RoundTrip(new() { Id = new(0x1) });
 
         Assert.Empty(loaded.Memory);
     }

--- a/tests/Moongate.Tests/Scripting/BrainAssetSeederTests.cs
+++ b/tests/Moongate.Tests/Scripting/BrainAssetSeederTests.cs
@@ -15,10 +15,10 @@ public class BrainAssetSeederTests
             BrainAssetSeeder.SeedMissing(brainsDirectory);
 
             var files = Directory
-                .GetFiles(brainsDirectory)
-                .Select(Path.GetFileName)
-                .Order(StringComparer.Ordinal)
-                .ToArray();
+                        .GetFiles(brainsDirectory)
+                        .Select(Path.GetFileName)
+                        .Order(StringComparer.Ordinal)
+                        .ToArray();
 
             Assert.Equal(["guard.lua", "orion.lua", "vega.lua"], files);
         }

--- a/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
+++ b/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
@@ -22,7 +22,8 @@ public class GameLoopModuleTests
 
         var bootstrap = SquidStdBootstrap.Create(new SquidStdOptions { ConfigName = "moongate", RootDirectory = root });
 
-        bootstrap.ConfigureServices(container =>
+        bootstrap.ConfigureServices(
+            container =>
             {
                 // RegisterCoreServices already provides IMainThreadDispatcher and ITimerService.
                 container.RegisterCoreServices();

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -1,5 +1,4 @@
 using DryIoc;
-using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Scripting.AI;
 using Moongate.Server.Abstractions.Data.AI;
@@ -12,7 +11,6 @@ using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
 using Serilog.Events;
 using SquidStd.Core.Directories;
-using SquidStd.Scripting.Lua.Data.Config;
 using SquidStd.Scripting.Lua.Services;
 using ISynchronizeInvoke = System.ComponentModel.ISynchronizeInvoke;
 
@@ -22,314 +20,269 @@ namespace Moongate.Tests.Scripting;
 public class LuaNpcBrainRuntimeTests
 {
     private const string CounterBrain = """
-                                              return {
-                                                id = "counter",
-                                                default_tick_ms = 1000,
-                                                perception_range = 12,
-                                                hearing_range = 15,
-                                                think = function(ctx, state)
-                                                  state.count = (state.count or 0) + 1
-                                                  ai.say(tostring(state.count))
-                                                end
-                                              }
-                                              """;
+                                        return {
+                                          id = "counter",
+                                          default_tick_ms = 1000,
+                                          perception_range = 12,
+                                          hearing_range = 15,
+                                          think = function(ctx, state)
+                                            state.count = (state.count or 0) + 1
+                                            ai.say(tostring(state.count))
+                                          end
+                                        }
+                                        """;
 
-    [Fact]
-    public void TryBind_ResolvesOnlyTheExactBrainsDirectory()
+    private sealed class BrainRuntimeFixture : IDisposable
     {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteScript("counter.lua", CounterBrain);
+        private readonly Container _container = new();
+        private readonly DirectoriesConfig _directories;
+        private readonly LuaScriptEngineService _engine;
+        private readonly bool _queueWatcherCallbacks;
+        private readonly string _root;
+        private readonly string _scripts;
+        private readonly List<string> _aiActions = [];
 
-        var outsideResult = fixture.Runtime.TryBind(new(1), "counter", out _, out var outsideError);
+        public BrainContext Context { get; }
 
-        Assert.False(outsideResult);
-        Assert.NotNull(outsideError);
+        public NpcAiMetrics Metrics { get; } = new();
 
-        fixture.WriteBrain("counter", CounterBrain);
+        public StubEventBus Bus { get; } = new();
 
-        var result = fixture.Runtime.TryBind(new(1), "counter", out var descriptor, out var error);
+        public StubGameLoopContext Loop { get; } = new();
 
-        Assert.True(result, error);
-        Assert.Equal(new("counter", 1000, 12, 15), descriptor);
-    }
+        public MutableTimeProvider Time { get; } = new(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-    [Theory]
-    [InlineData("../counter")]
-    [InlineData("Counter")]
-    [InlineData("-counter")]
-    [InlineData("counter.lua")]
-    [InlineData("counter/other")]
-    public void TryBind_InvalidBrainId_IsRejected(string brainId)
-    {
-        using var fixture = new BrainRuntimeFixture();
+        public QueueingSynchronizer WatcherCallbacks { get; } = new();
 
-        var result = fixture.Runtime.TryBind(new(1), brainId, out var descriptor, out var error);
+        public List<ControllableFileSystemWatcher> Watchers { get; } = [];
 
-        Assert.False(result);
-        Assert.Null(descriptor);
-        Assert.Contains("invalid", error, StringComparison.OrdinalIgnoreCase);
-    }
+        public List<string> AiSays { get; } = [];
 
-    [Fact]
-    public void TryBind_MissingFile_IsRejected()
-    {
-        using var fixture = new BrainRuntimeFixture();
+        public IReadOnlyList<string> AiActions => _aiActions;
 
-        var result = fixture.Runtime.TryBind(new(1), "missing", out var descriptor, out var error);
-
-        Assert.False(result);
-        Assert.Null(descriptor);
-        Assert.Contains("not found", error, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Theory]
-    [InlineData("other", 1000, 12, 15, "think = function() end", "id")]
-    [InlineData("invalid", 99, 12, 15, "think = function() end", "default_tick_ms")]
-    [InlineData("invalid", 60001, 12, 15, "think = function() end", "default_tick_ms")]
-    [InlineData("invalid", 1000, -1, 15, "think = function() end", "perception_range")]
-    [InlineData("invalid", 1000, 12, 65, "think = function() end", "hearing_range")]
-    [InlineData("invalid", 1000, 12, 15, "think = nil", "think")]
-    [InlineData("invalid", 1000, 12, 15, "think = function() end, on_activate = 42", "on_activate")]
-    public void TryBind_InvalidDefinition_IsRejected(
-        string returnedId,
-        int defaultTickMilliseconds,
-        int perceptionRange,
-        int hearingRange,
-        string hooks,
-        string expectedError
-    )
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain(
-            "invalid",
-            $$"""
-              return {
-                id = "{{returnedId}}",
-                default_tick_ms = {{defaultTickMilliseconds}},
-                perception_range = {{perceptionRange}},
-                hearing_range = {{hearingRange}},
-                {{hooks}}
-              }
-              """
+        public BrainMobileSnapshot Other { get; } = new(
+            new(2),
+            "Other",
+            true,
+            3,
+            new(105, 205, 7),
+            80,
+            100,
+            false,
+            new(1),
+            false,
+            0
         );
 
-        var result = fixture.Runtime.TryBind(new(1), "invalid", out var descriptor, out var error);
+        public LuaNpcBrainRuntime Runtime { get; }
 
-        Assert.False(result);
-        Assert.Null(descriptor);
-        Assert.Contains(expectedError, error, StringComparison.OrdinalIgnoreCase);
-    }
+        public BrainRuntimeFixture(int maxIntentsPerDecision = 8, bool queueWatcherCallbacks = false)
+        {
+            _queueWatcherCallbacks = queueWatcherCallbacks;
+            _root = Path.Combine(Path.GetTempPath(), "mg-brain-" + Guid.NewGuid().ToString("N"));
+            _directories = new(_root, ["scripts"]);
+            _scripts = _directories.GetPath("scripts");
+            _engine = new(
+                _directories,
+                _container,
+                new(_root, _scripts, "MoongateTests", "1.0.0")
+            );
+            var config = new MoongateConfig
+            {
+                NpcAi = new()
+                {
+                    Advanced = new()
+                    {
+                        MinTickMilliseconds = 100,
+                        MaxTickMilliseconds = 60_000,
+                        MaxIntentsPerDecision = maxIntentsPerDecision,
+                        InstructionBudget = 2_000
+                    }
+                }
+            };
+            Runtime = new(_engine, _directories, config, Metrics, Loop, Bus, Time, CreateWatcher);
+            InstallRecordingAi();
+            var self = new BrainMobileSnapshot(
+                new(1),
+                "Self",
+                false,
+                3,
+                new(100, 200, 7),
+                25,
+                100,
+                true,
+                Serial.Zero,
+                true,
+                5
+            );
+            Context = new(
+                DateTimeOffset.FromUnixTimeMilliseconds(1_714_566_896_789),
+                self,
+                3,
+                new(90, 190, 0),
+                [Other]
+            );
+        }
 
-    [Fact]
-    public void TryBind_FileLargerThanLimit_IsRejected()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("oversized", new string('-', (256 * 1024) + 1));
+        public void Bind(uint mobileId, string brainId)
+        {
+            var result = Runtime.TryBind(new(mobileId), brainId, out _, out var error);
 
-        var result = fixture.Runtime.TryBind(new(1), "oversized", out var descriptor, out var error);
+            Assert.True(result, error);
+        }
 
-        Assert.False(result);
-        Assert.Null(descriptor);
-        Assert.Contains("256", error, StringComparison.OrdinalIgnoreCase);
-    }
+        public void ClearAi()
+        {
+            AiSays.Clear();
+            _aiActions.Clear();
+        }
 
-    [Fact]
-    public void TryBind_SymbolicLinkOutsideBrainsDirectory_IsRejected()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.CreateBrainSymbolicLink(
-            "linked",
-            """
-            return {
-              id = "linked",
-              default_tick_ms = 1000,
-              perception_range = 12,
-              hearing_range = 15,
-              think = function() end
+        public void CreateBrainSymbolicLink(string brainId, string targetContent)
+        {
+            var brainDirectory = Path.Combine(_scripts, "brains");
+            Directory.CreateDirectory(brainDirectory);
+            var targetPath = Path.Combine(_root, brainId + "-outside.lua");
+            File.WriteAllText(targetPath, targetContent);
+            File.CreateSymbolicLink(Path.Combine(brainDirectory, brainId + ".lua"), targetPath);
+        }
+
+        public void Dispose()
+        {
+            Runtime.Dispose();
+            _engine.Dispose();
+            _container.Dispose();
+            Directory.Delete(_root, true);
+        }
+
+        public void InstallPrivilegedGlobal(string moduleName, string functionName, Action callback)
+        {
+            var module = new Table(_engine.LuaScript);
+            module.Set(
+                functionName,
+                DynValue.NewCallback(
+                    (_, _) =>
+                    {
+                        callback();
+
+                        return DynValue.Nil;
+                    }
+                )
+            );
+            _engine.LuaScript.Globals.Set(moduleName, DynValue.NewTable(module));
+        }
+
+        public NpcBrainInvocationResult Think(uint mobileId)
+            => Runtime.Invoke(new(mobileId), NpcBrainHookType.Think, Context);
+
+        public void WriteBrain(string brainId, string content)
+        {
+            var brainDirectory = Path.Combine(_scripts, "brains");
+            Directory.CreateDirectory(brainDirectory);
+            File.WriteAllText(Path.Combine(brainDirectory, brainId + ".lua"), content);
+        }
+
+        public void WriteScript(string relativePath, string content)
+            => File.WriteAllText(Path.Combine(_scripts, relativePath), content);
+
+        private FileSystemWatcher CreateWatcher(string path)
+        {
+            var watcher = new ControllableFileSystemWatcher(path);
+
+            if (_queueWatcherCallbacks)
+            {
+                watcher.SynchronizingObject = WatcherCallbacks;
             }
-            """
-        );
 
-        var result = fixture.Runtime.TryBind(new(1), "linked", out var descriptor, out var error);
+            Watchers.Add(watcher);
 
-        Assert.False(result);
-        Assert.Null(descriptor);
-        Assert.Contains("link", error, StringComparison.OrdinalIgnoreCase);
+            return watcher;
+        }
+
+        private void InstallRecordingAi()
+        {
+            var ai = new Table(_engine.LuaScript);
+            ai.Set(
+                "say",
+                DynValue.NewCallback(
+                    (_, arguments) =>
+                    {
+                        AiSays.Add(arguments.Count > 0 ? arguments[0].ToPrintString() : "");
+                        _aiActions.Add("say");
+
+                        return DynValue.True;
+                    }
+                )
+            );
+            RecordAction(ai, "patrol");
+            RecordAction(ai, "return_home");
+            RecordAction(ai, "clear_target");
+            RecordTargetAction(ai, "move_toward");
+            RecordTargetAction(ai, "move_away");
+            RecordTargetAction(ai, "engage");
+            _engine.LuaScript.Globals.Set("ai", DynValue.NewTable(ai));
+        }
+
+        private void RecordAction(Table ai, string name)
+            => ai.Set(
+                name,
+                DynValue.NewCallback(
+                    (_, _) =>
+                    {
+                        _aiActions.Add(name);
+
+                        return DynValue.True;
+                    }
+                )
+            );
+
+        private void RecordTargetAction(Table ai, string name)
+            => ai.Set(
+                name,
+                DynValue.NewCallback(
+                    (_, arguments) =>
+                    {
+                        _aiActions.Add(name + ":" + (arguments.Count > 0 ? arguments[0].ToPrintString() : ""));
+
+                        return DynValue.True;
+                    }
+                )
+            );
     }
 
-    [Fact]
-    public void TryBind_InfiniteTopLevelChunk_ReturnsBudgetFailure()
+    private sealed class ControllableFileSystemWatcher : FileSystemWatcher
     {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("infinite", "while true do end");
+        public ControllableFileSystemWatcher(string path) : base(path) { }
 
-        var result = fixture.Runtime.TryBind(new(1), "infinite", out var descriptor, out var error);
-
-        Assert.False(result);
-        Assert.Null(descriptor);
-        Assert.Contains("budget", error, StringComparison.OrdinalIgnoreCase);
+        public void RaiseChanged(string fileName)
+            => OnChanged(new(WatcherChangeTypes.Changed, Path, fileName));
     }
 
-    [Fact]
-    public void Invoke_BlackboardsAreIsolatedPerMobile()
+    private sealed class QueueingSynchronizer : ISynchronizeInvoke
     {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.Bind(1, "counter");
-        fixture.Bind(2, "counter");
+        private readonly Queue<Action> _pending = [];
 
-        fixture.Think(1);
-        fixture.Think(2);
+        public bool InvokeRequired => true;
 
-        Assert.Equal(new[] { "1", "1" }, fixture.AiSays);
-    }
+        public int PendingCount => _pending.Count;
 
-    [Fact]
-    public void Invoke_ReusesOneMobilesBlackboard()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.Bind(1, "counter");
+        public IAsyncResult BeginInvoke(Delegate method, object?[]? arguments)
+        {
+            _pending.Enqueue(() => method.DynamicInvoke(arguments));
 
-        fixture.Think(1);
-        fixture.Think(1);
+            return Task.CompletedTask;
+        }
 
-        Assert.Equal(new[] { "1", "2" }, fixture.AiSays);
-    }
+        public object? EndInvoke(IAsyncResult result)
+            => null;
 
-    [Fact]
-    public void Reset_ClearsStateWithoutRemovingBinding()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
+        public object? Invoke(Delegate method, object?[]? arguments)
+            => method.DynamicInvoke(arguments);
 
-        fixture.Runtime.Reset(new(1));
-        fixture.Think(1);
-
-        Assert.True(fixture.Runtime.TryGetDescriptor(new(1), out _));
-        Assert.Equal("1", fixture.AiSays[^1]);
-    }
-
-    [Fact]
-    public void UnbindAndRebind_ClearsState()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
-
-        fixture.Runtime.Unbind(new(1));
-
-        Assert.False(fixture.Runtime.TryGetDescriptor(new(1), out _));
-
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
-
-        Assert.Equal("1", fixture.AiSays[^1]);
-    }
-
-    [Fact]
-    public void TryBind_DifferentBrain_ClearsState()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.WriteBrain(
-            "reader",
-            """
-            return {
-              id = "reader",
-              default_tick_ms = 1000,
-              perception_range = 12,
-              hearing_range = 15,
-              think = function(ctx, state)
-                state.count = (state.count or 0) + 1
-                ai.say(tostring(state.count))
-              end
-            }
-            """
-        );
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
-
-        fixture.Bind(1, "reader");
-        fixture.Think(1);
-
-        Assert.Equal("1", fixture.AiSays[^1]);
-    }
-
-    [Fact]
-    public void TryBind_SameBrainPreservesState()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
-
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
-
-        Assert.Equal("2", fixture.AiSays[^1]);
-    }
-
-    [Fact]
-    public void Invoke_InfiniteHook_ReturnsBudgetFailureRecordsMetricAndDoesNotLog()
-    {
-        using var logs = new GlobalSerilogCapture();
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain(
-            "infinite",
-            """
-            return {
-              id = "infinite",
-              default_tick_ms = 1000,
-              perception_range = 12,
-              hearing_range = 15,
-              think = function() while true do end end
-            }
-            """
-        );
-        fixture.Bind(1, "infinite");
-
-        var result = fixture.Think(1);
-
-        Assert.False(result.Success);
-        Assert.True(result.InstructionBudgetExceeded);
-        Assert.Null(result.NextTickMs);
-        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
-        Assert.Equal(1, fixture.Metrics.Current.InstructionBudgetBreaches);
-        Assert.DoesNotContain(logs.Events, logEvent => logEvent.Level >= LogEventLevel.Warning);
-    }
-
-    [Fact]
-    public void Invoke_StandardLibraryUsage_Works()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain(
-            "native_normal",
-            """
-            return {
-              id = "native_normal",
-              default_tick_ms = 1000,
-              perception_range = 12,
-              hearing_range = 15,
-              think = function()
-                local values = { "a", "b" }
-                table.insert(values, "c")
-                local direct = string.rep(table.concat(values), 2)
-                local colon = ("xy"):rep(2, ":")
-                ai.say(direct .. "|" .. colon)
-              end
-            }
-            """
-        );
-        fixture.Bind(1, "native_normal");
-
-        var result = fixture.Think(1);
-
-        Assert.True(result.Success, result.Error);
-        Assert.Equal("abcabc|xy:xy", Assert.Single(fixture.AiSays));
+        public void RunNext()
+        {
+            Assert.True(_pending.TryDequeue(out var callback));
+            callback();
+        }
     }
 
     [Fact]
@@ -347,100 +300,17 @@ public class LuaNpcBrainRuntimeTests
     }
 
     [Fact]
-    public void Invoke_UnknownHookValue_ReturnsNeutralFailure()
+    public void Invoke_BlackboardsAreIsolatedPerMobile()
     {
         using var fixture = new BrainRuntimeFixture();
         fixture.WriteBrain("counter", CounterBrain);
         fixture.Bind(1, "counter");
+        fixture.Bind(2, "counter");
 
-        var result = fixture.Runtime.Invoke(new(1), (NpcBrainHookType)999, fixture.Context);
+        fixture.Think(1);
+        fixture.Think(2);
 
-        Assert.False(result.Success);
-        Assert.Null(result.NextTickMs);
-        Assert.Contains("unsupported", result.Error, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
-    }
-
-    [Fact]
-    public void Invoke_HookCanCallGlobalModules()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        var logged = 0;
-        fixture.InstallPrivilegedGlobal("log", "info", () => logged++);
-        fixture.WriteBrain(
-            "logger",
-            """
-            return {
-              id = "logger",
-              default_tick_ms = 1000,
-              perception_range = 12,
-              hearing_range = 15,
-              think = function()
-                log.info("hello")
-                return 750
-              end
-            }
-            """
-        );
-        fixture.Bind(1, "logger");
-
-        var result = fixture.Think(1);
-
-        Assert.True(result.Success, result.Error);
-        Assert.Equal(750, result.NextTickMs);
-        Assert.Equal(1, logged);
-    }
-
-    [Fact]
-    public void Invoke_NumericReturn_SetsNextTick()
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain(
-            "tick",
-            """
-            return {
-              id = "tick",
-              default_tick_ms = 1000,
-              perception_range = 4,
-              hearing_range = 4,
-              think = function() return 750 end
-            }
-            """
-        );
-        fixture.Bind(1, "tick");
-
-        var result = fixture.Think(1);
-
-        Assert.True(result.Success, result.Error);
-        Assert.Equal(750, result.NextTickMs);
-    }
-
-    [Theory]
-    [InlineData("return 'text'")]
-    [InlineData("return true")]
-    [InlineData("return {}")]
-    [InlineData("return")]
-    public void Invoke_NonNumericReturn_HasNullNextTick(string body)
-    {
-        using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain(
-            "noret",
-            $$"""
-              return {
-                id = "noret",
-                default_tick_ms = 1000,
-                perception_range = 4,
-                hearing_range = 4,
-                think = function() {{body}} end
-              }
-              """
-        );
-        fixture.Bind(1, "noret");
-
-        var result = fixture.Think(1);
-
-        Assert.True(result.Success, result.Error);
-        Assert.Null(result.NextTickMs);
+        Assert.Equal(new[] { "1", "1" }, fixture.AiSays);
     }
 
     [Fact]
@@ -606,83 +476,240 @@ public class LuaNpcBrainRuntimeTests
     }
 
     [Fact]
-    public void TryReload_ValidReplacement_SwapsBehaviorPreservesStateAndPublishesOnce()
+    public void Invoke_HookCanCallGlobalModules()
     {
         using var fixture = new BrainRuntimeFixture();
-        fixture.WriteBrain("counter", CounterBrain);
-        fixture.Bind(1, "counter");
-        fixture.Think(1);
+        var logged = 0;
+        fixture.InstallPrivilegedGlobal("log", "info", () => logged++);
         fixture.WriteBrain(
-            "counter",
+            "logger",
             """
             return {
-              id = "counter",
-              default_tick_ms = 1500,
-              perception_range = 10,
-              hearing_range = 12,
-              think = function(ctx, state)
-                state.count = (state.count or 0) + 1
-                ai.say("reloaded:" .. tostring(state.count))
+              id = "logger",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function()
+                log.info("hello")
+                return 750
               end
             }
             """
         );
+        fixture.Bind(1, "logger");
 
-        var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
-        var invocation = fixture.Think(1);
+        var result = fixture.Think(1);
 
-        Assert.True(reloadResult, error);
-        Assert.Equal(new("counter", 1500, 10, 12), descriptor);
-        Assert.True(invocation.Success, invocation.Error);
-        Assert.Equal("reloaded:2", fixture.AiSays[^1]);
-        var reloaded = Assert.IsType<BrainDefinitionReloadedEvent>(Assert.Single(fixture.Bus.Published));
-        Assert.Equal("counter", reloaded.BrainId);
-        Assert.Equal(descriptor, reloaded.Descriptor);
-        Assert.Equal(1, fixture.Metrics.Current.ReloadSuccesses);
-        Assert.Equal(0, fixture.Metrics.Current.ReloadFallbacks);
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(750, result.NextTickMs);
+        Assert.Equal(1, logged);
     }
 
-    [Theory]
-    [InlineData("return {")]
-    [InlineData(
-        """
-        return {
-          id = "other",
-          default_tick_ms = 1000,
-          perception_range = 12,
-          hearing_range = 15,
-          think = function() end
-        }
-        """
-    )]
-    [InlineData(
-        """
-        return {
-          id = "counter",
-          default_tick_ms = 1000,
-          perception_range = 12,
-          hearing_range = 15
-        }
-        """
-    )]
-    public void TryReload_InvalidReplacement_PreservesBehaviorAndPublishesNothing(string replacement)
+    [Fact]
+    public void Invoke_InfiniteHook_ReturnsBudgetFailureRecordsMetricAndDoesNotLog()
+    {
+        using var logs = new GlobalSerilogCapture();
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "infinite",
+            """
+            return {
+              id = "infinite",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function() while true do end end
+            }
+            """
+        );
+        fixture.Bind(1, "infinite");
+
+        var result = fixture.Think(1);
+
+        Assert.False(result.Success);
+        Assert.True(result.InstructionBudgetExceeded);
+        Assert.Null(result.NextTickMs);
+        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
+        Assert.Equal(1, fixture.Metrics.Current.InstructionBudgetBreaches);
+        Assert.DoesNotContain(logs.Events, logEvent => logEvent.Level >= LogEventLevel.Warning);
+    }
+
+    [Theory, InlineData("return 'text'"), InlineData("return true"), InlineData("return {}"), InlineData("return")]
+    public void Invoke_NonNumericReturn_HasNullNextTick(string body)
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "noret",
+            $$"""
+              return {
+                id = "noret",
+                default_tick_ms = 1000,
+                perception_range = 4,
+                hearing_range = 4,
+                think = function() {{body}} end
+              }
+              """
+        );
+        fixture.Bind(1, "noret");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Null(result.NextTickMs);
+    }
+
+    [Fact]
+    public void Invoke_NumericReturn_SetsNextTick()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "tick",
+            """
+            return {
+              id = "tick",
+              default_tick_ms = 1000,
+              perception_range = 4,
+              hearing_range = 4,
+              think = function() return 750 end
+            }
+            """
+        );
+        fixture.Bind(1, "tick");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(750, result.NextTickMs);
+    }
+
+    [Fact]
+    public void Invoke_ReusesOneMobilesBlackboard()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+
+        fixture.Think(1);
+        fixture.Think(1);
+
+        Assert.Equal(new[] { "1", "2" }, fixture.AiSays);
+    }
+
+    [Fact]
+    public void Invoke_StandardLibraryUsage_Works()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "native_normal",
+            """
+            return {
+              id = "native_normal",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function()
+                local values = { "a", "b" }
+                table.insert(values, "c")
+                local direct = string.rep(table.concat(values), 2)
+                local colon = ("xy"):rep(2, ":")
+                ai.say(direct .. "|" .. colon)
+              end
+            }
+            """
+        );
+        fixture.Bind(1, "native_normal");
+
+        var result = fixture.Think(1);
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("abcabc|xy:xy", Assert.Single(fixture.AiSays));
+    }
+
+    [Fact]
+    public void Invoke_UnknownHookValue_ReturnsNeutralFailure()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+
+        var result = fixture.Runtime.Invoke(new(1), (NpcBrainHookType)999, fixture.Context);
+
+        Assert.False(result.Success);
+        Assert.Null(result.NextTickMs);
+        Assert.Contains("unsupported", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, fixture.Metrics.Current.HookFailures);
+    }
+
+    [Fact]
+    public void Reset_ClearsStateWithoutRemovingBinding()
     {
         using var fixture = new BrainRuntimeFixture();
         fixture.WriteBrain("counter", CounterBrain);
         fixture.Bind(1, "counter");
         fixture.Think(1);
-        fixture.WriteBrain("counter", replacement);
 
-        var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
-        var invocation = fixture.Think(1);
+        fixture.Runtime.Reset(new(1));
+        fixture.Think(1);
 
-        Assert.False(reloadResult);
-        Assert.Null(descriptor);
-        Assert.NotNull(error);
-        Assert.True(invocation.Success, invocation.Error);
-        Assert.Equal("2", fixture.AiSays[^1]);
-        Assert.Equal(1, fixture.Metrics.Current.ReloadFallbacks);
-        Assert.Empty(fixture.Bus.Published);
+        Assert.True(fixture.Runtime.TryGetDescriptor(new(1), out _));
+        Assert.Equal("1", fixture.AiSays[^1]);
+    }
+
+    [Fact]
+    public async Task StartAsync_BuiltInBrainsExposeDeterministicDescriptorsAndBehavior()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        await fixture.Runtime.StartAsync();
+
+        Assert.True(fixture.Runtime.TryBind(new(1), "guard", out var guard, out var guardError), guardError);
+        Assert.Equal(new("guard", 1000, 12, 15), guard);
+
+        fixture.ClearAi();
+        fixture.Runtime.Invoke(
+            new(1),
+            NpcBrainHookType.SpeechHeard,
+            fixture.Context,
+            new(NpcBrainEventType.SpeechHeard, fixture.Context.Self, "hello", ChatMessageType.Regular)
+        );
+        Assert.Empty(fixture.AiSays);
+
+        fixture.ClearAi();
+        fixture.Runtime.Invoke(
+            new(1),
+            NpcBrainHookType.SpeechHeard,
+            fixture.Context,
+            new(NpcBrainEventType.SpeechHeard, fixture.Other, "hello", ChatMessageType.Regular)
+        );
+        Assert.Equal("I haven't seen you before.", Assert.Single(fixture.AiSays));
+
+        fixture.ClearAi();
+        fixture.Runtime.Invoke(
+            new(1),
+            NpcBrainHookType.SpeechHeard,
+            fixture.Context,
+            new(NpcBrainEventType.SpeechHeard, fixture.Other, "hello", ChatMessageType.Regular)
+        );
+        Assert.Equal("Welcome back.", Assert.Single(fixture.AiSays));
+
+        fixture.ClearAi();
+        var guardThink = fixture.Think(1);
+        Assert.True(guardThink.Success, guardThink.Error);
+        Assert.Empty(fixture.AiSays);
+        Assert.Empty(fixture.AiActions);
+
+        Assert.True(fixture.Runtime.TryBind(new(2), "orion", out var orion, out var orionError), orionError);
+        Assert.Equal(new("orion", 1500, 10, 12), orion);
+        fixture.ClearAi();
+        fixture.Runtime.Invoke(new(2), NpcBrainHookType.Think, fixture.Context);
+        Assert.Equal("patrol", Assert.Single(fixture.AiActions));
+
+        Assert.True(fixture.Runtime.TryBind(new(3), "vega", out var vega, out var vegaError), vegaError);
+        Assert.Equal(new("vega", 1500, 10, 12), vega);
+        fixture.ClearAi();
+        fixture.Runtime.Invoke(new(3), NpcBrainHookType.Think, fixture.Context);
+        Assert.Equal("patrol", Assert.Single(fixture.AiActions));
+
+        await fixture.Runtime.StopAsync();
     }
 
     [Fact]
@@ -763,68 +790,272 @@ public class LuaNpcBrainRuntimeTests
     }
 
     [Fact]
-    public async Task StartAsync_BuiltInBrainsExposeDeterministicDescriptorsAndBehavior()
+    public void TryBind_DifferentBrain_ClearsState()
     {
         using var fixture = new BrainRuntimeFixture();
-        await fixture.Runtime.StartAsync();
-
-        Assert.True(fixture.Runtime.TryBind(new(1), "guard", out var guard, out var guardError), guardError);
-        Assert.Equal(new("guard", 1000, 12, 15), guard);
-
-        fixture.ClearAi();
-        fixture.Runtime.Invoke(
-            new(1),
-            NpcBrainHookType.SpeechHeard,
-            fixture.Context,
-            new(NpcBrainEventType.SpeechHeard, fixture.Context.Self, "hello", ChatMessageType.Regular)
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.WriteBrain(
+            "reader",
+            """
+            return {
+              id = "reader",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function(ctx, state)
+                state.count = (state.count or 0) + 1
+                ai.say(tostring(state.count))
+              end
+            }
+            """
         );
-        Assert.Empty(fixture.AiSays);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
 
-        fixture.ClearAi();
-        fixture.Runtime.Invoke(
-            new(1),
-            NpcBrainHookType.SpeechHeard,
-            fixture.Context,
-            new(NpcBrainEventType.SpeechHeard, fixture.Other, "hello", ChatMessageType.Regular)
-        );
-        Assert.Equal("I haven't seen you before.", Assert.Single(fixture.AiSays));
+        fixture.Bind(1, "reader");
+        fixture.Think(1);
 
-        fixture.ClearAi();
-        fixture.Runtime.Invoke(
-            new(1),
-            NpcBrainHookType.SpeechHeard,
-            fixture.Context,
-            new(NpcBrainEventType.SpeechHeard, fixture.Other, "hello", ChatMessageType.Regular)
-        );
-        Assert.Equal("Welcome back.", Assert.Single(fixture.AiSays));
-
-        fixture.ClearAi();
-        var guardThink = fixture.Think(1);
-        Assert.True(guardThink.Success, guardThink.Error);
-        Assert.Empty(fixture.AiSays);
-        Assert.Empty(fixture.AiActions);
-
-        Assert.True(fixture.Runtime.TryBind(new(2), "orion", out var orion, out var orionError), orionError);
-        Assert.Equal(new("orion", 1500, 10, 12), orion);
-        fixture.ClearAi();
-        fixture.Runtime.Invoke(new(2), NpcBrainHookType.Think, fixture.Context);
-        Assert.Equal("patrol", Assert.Single(fixture.AiActions));
-
-        Assert.True(fixture.Runtime.TryBind(new(3), "vega", out var vega, out var vegaError), vegaError);
-        Assert.Equal(new("vega", 1500, 10, 12), vega);
-        fixture.ClearAi();
-        fixture.Runtime.Invoke(new(3), NpcBrainHookType.Think, fixture.Context);
-        Assert.Equal("patrol", Assert.Single(fixture.AiActions));
-
-        await fixture.Runtime.StopAsync();
+        Assert.Equal("1", fixture.AiSays[^1]);
     }
 
-    private static async Task DrainContinuationsAsync(Func<bool>? condition = null)
+    [Fact]
+    public void TryBind_FileLargerThanLimit_IsRejected()
     {
-        for (var iteration = 0; iteration < 100 && condition?.Invoke() != true; iteration++)
-        {
-            await Task.Yield();
-        }
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("oversized", new('-', 256 * 1024 + 1));
+
+        var result = fixture.Runtime.TryBind(new(1), "oversized", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("256", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_InfiniteTopLevelChunk_ReturnsBudgetFailure()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("infinite", "while true do end");
+
+        var result = fixture.Runtime.TryBind(new(1), "infinite", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("budget", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory, InlineData("../counter"), InlineData("Counter"), InlineData("-counter"), InlineData("counter.lua"),
+     InlineData("counter/other")]
+    public void TryBind_InvalidBrainId_IsRejected(string brainId)
+    {
+        using var fixture = new BrainRuntimeFixture();
+
+        var result = fixture.Runtime.TryBind(new(1), brainId, out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("invalid", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory, InlineData("other", 1000, 12, 15, "think = function() end", "id"),
+     InlineData("invalid", 99, 12, 15, "think = function() end", "default_tick_ms"),
+     InlineData("invalid", 60001, 12, 15, "think = function() end", "default_tick_ms"),
+     InlineData("invalid", 1000, -1, 15, "think = function() end", "perception_range"),
+     InlineData("invalid", 1000, 12, 65, "think = function() end", "hearing_range"),
+     InlineData("invalid", 1000, 12, 15, "think = nil", "think"),
+     InlineData("invalid", 1000, 12, 15, "think = function() end, on_activate = 42", "on_activate")]
+    public void TryBind_InvalidDefinition_IsRejected(
+        string returnedId,
+        int defaultTickMilliseconds,
+        int perceptionRange,
+        int hearingRange,
+        string hooks,
+        string expectedError
+    )
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain(
+            "invalid",
+            $$"""
+              return {
+                id = "{{returnedId}}",
+                default_tick_ms = {{defaultTickMilliseconds}},
+                perception_range = {{perceptionRange}},
+                hearing_range = {{hearingRange}},
+                {{hooks}}
+              }
+              """
+        );
+
+        var result = fixture.Runtime.TryBind(new(1), "invalid", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains(expectedError, error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_MissingFile_IsRejected()
+    {
+        using var fixture = new BrainRuntimeFixture();
+
+        var result = fixture.Runtime.TryBind(new(1), "missing", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryBind_ResolvesOnlyTheExactBrainsDirectory()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteScript("counter.lua", CounterBrain);
+
+        var outsideResult = fixture.Runtime.TryBind(new(1), "counter", out _, out var outsideError);
+
+        Assert.False(outsideResult);
+        Assert.NotNull(outsideError);
+
+        fixture.WriteBrain("counter", CounterBrain);
+
+        var result = fixture.Runtime.TryBind(new(1), "counter", out var descriptor, out var error);
+
+        Assert.True(result, error);
+        Assert.Equal(new("counter", 1000, 12, 15), descriptor);
+    }
+
+    [Fact]
+    public void TryBind_SameBrainPreservesState()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        Assert.Equal("2", fixture.AiSays[^1]);
+    }
+
+    [Fact]
+    public void TryBind_SymbolicLinkOutsideBrainsDirectory_IsRejected()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.CreateBrainSymbolicLink(
+            "linked",
+            """
+            return {
+              id = "linked",
+              default_tick_ms = 1000,
+              perception_range = 12,
+              hearing_range = 15,
+              think = function() end
+            }
+            """
+        );
+
+        var result = fixture.Runtime.TryBind(new(1), "linked", out var descriptor, out var error);
+
+        Assert.False(result);
+        Assert.Null(descriptor);
+        Assert.Contains("link", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory, InlineData("return {"), InlineData(
+         """
+         return {
+           id = "other",
+           default_tick_ms = 1000,
+           perception_range = 12,
+           hearing_range = 15,
+           think = function() end
+         }
+         """
+     ), InlineData(
+         """
+         return {
+           id = "counter",
+           default_tick_ms = 1000,
+           perception_range = 12,
+           hearing_range = 15
+         }
+         """
+     )]
+    public void TryReload_InvalidReplacement_PreservesBehaviorAndPublishesNothing(string replacement)
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+        fixture.WriteBrain("counter", replacement);
+
+        var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
+        var invocation = fixture.Think(1);
+
+        Assert.False(reloadResult);
+        Assert.Null(descriptor);
+        Assert.NotNull(error);
+        Assert.True(invocation.Success, invocation.Error);
+        Assert.Equal("2", fixture.AiSays[^1]);
+        Assert.Equal(1, fixture.Metrics.Current.ReloadFallbacks);
+        Assert.Empty(fixture.Bus.Published);
+    }
+
+    [Fact]
+    public void TryReload_ValidReplacement_SwapsBehaviorPreservesStateAndPublishesOnce()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+        fixture.WriteBrain(
+            "counter",
+            """
+            return {
+              id = "counter",
+              default_tick_ms = 1500,
+              perception_range = 10,
+              hearing_range = 12,
+              think = function(ctx, state)
+                state.count = (state.count or 0) + 1
+                ai.say("reloaded:" .. tostring(state.count))
+              end
+            }
+            """
+        );
+
+        var reloadResult = fixture.Runtime.TryReload("counter", out var descriptor, out var error);
+        var invocation = fixture.Think(1);
+
+        Assert.True(reloadResult, error);
+        Assert.Equal(new("counter", 1500, 10, 12), descriptor);
+        Assert.True(invocation.Success, invocation.Error);
+        Assert.Equal("reloaded:2", fixture.AiSays[^1]);
+        var reloaded = Assert.IsType<BrainDefinitionReloadedEvent>(Assert.Single(fixture.Bus.Published));
+        Assert.Equal("counter", reloaded.BrainId);
+        Assert.Equal(descriptor, reloaded.Descriptor);
+        Assert.Equal(1, fixture.Metrics.Current.ReloadSuccesses);
+        Assert.Equal(0, fixture.Metrics.Current.ReloadFallbacks);
+    }
+
+    [Fact]
+    public void UnbindAndRebind_ClearsState()
+    {
+        using var fixture = new BrainRuntimeFixture();
+        fixture.WriteBrain("counter", CounterBrain);
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        fixture.Runtime.Unbind(new(1));
+
+        Assert.False(fixture.Runtime.TryGetDescriptor(new(1), out _));
+
+        fixture.Bind(1, "counter");
+        fixture.Think(1);
+
+        Assert.Equal("1", fixture.AiSays[^1]);
     }
 
     private static void AssertHookText(
@@ -841,256 +1072,11 @@ public class LuaNpcBrainRuntimeTests
         Assert.Equal(expected, Assert.Single(fixture.AiSays));
     }
 
-    private sealed class BrainRuntimeFixture : IDisposable
+    private static async Task DrainContinuationsAsync(Func<bool>? condition = null)
     {
-        private readonly Container _container = new();
-        private readonly DirectoriesConfig _directories;
-        private readonly LuaScriptEngineService _engine;
-        private readonly bool _queueWatcherCallbacks;
-        private readonly string _root;
-        private readonly string _scripts;
-        private readonly List<string> _aiActions = [];
-
-        public BrainContext Context { get; }
-
-        public NpcAiMetrics Metrics { get; } = new();
-
-        public StubEventBus Bus { get; } = new();
-
-        public StubGameLoopContext Loop { get; } = new();
-
-        public MutableTimeProvider Time { get; } = new(
-            new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
-        );
-
-        public QueueingSynchronizer WatcherCallbacks { get; } = new();
-
-        public List<ControllableFileSystemWatcher> Watchers { get; } = [];
-
-        public List<string> AiSays { get; } = [];
-
-        public IReadOnlyList<string> AiActions => _aiActions;
-
-        public BrainMobileSnapshot Other { get; } = new(
-            new(2),
-            "Other",
-            true,
-            3,
-            new(105, 205, 7),
-            80,
-            100,
-            false,
-            new(1),
-            false,
-            0
-        );
-
-        public LuaNpcBrainRuntime Runtime { get; }
-
-        public BrainRuntimeFixture(int maxIntentsPerDecision = 8, bool queueWatcherCallbacks = false)
+        for (var iteration = 0; iteration < 100 && condition?.Invoke() != true; iteration++)
         {
-            _queueWatcherCallbacks = queueWatcherCallbacks;
-            _root = Path.Combine(Path.GetTempPath(), "mg-brain-" + Guid.NewGuid().ToString("N"));
-            _directories = new(_root, ["scripts"]);
-            _scripts = _directories.GetPath("scripts");
-            _engine = new(
-                _directories,
-                _container,
-                new LuaEngineConfig(_root, _scripts, "MoongateTests", "1.0.0")
-            );
-            var config = new MoongateConfig
-            {
-                NpcAi = new()
-                {
-                    Advanced = new()
-                    {
-                        MinTickMilliseconds = 100,
-                        MaxTickMilliseconds = 60_000,
-                        MaxIntentsPerDecision = maxIntentsPerDecision,
-                        InstructionBudget = 2_000
-                    }
-                }
-            };
-            Runtime = new(_engine, _directories, config, Metrics, Loop, Bus, Time, CreateWatcher);
-            InstallRecordingAi();
-            var self = new BrainMobileSnapshot(
-                new(1),
-                "Self",
-                false,
-                3,
-                new(100, 200, 7),
-                25,
-                100,
-                true,
-                Serial.Zero,
-                true,
-                5
-            );
-            Context = new(
-                DateTimeOffset.FromUnixTimeMilliseconds(1_714_566_896_789),
-                self,
-                3,
-                new(90, 190, 0),
-                [Other]
-            );
-        }
-
-        public void Bind(uint mobileId, string brainId)
-        {
-            var result = Runtime.TryBind(new(mobileId), brainId, out _, out var error);
-
-            Assert.True(result, error);
-        }
-
-        public void ClearAi()
-        {
-            AiSays.Clear();
-            _aiActions.Clear();
-        }
-
-        public void CreateBrainSymbolicLink(string brainId, string targetContent)
-        {
-            var brainDirectory = Path.Combine(_scripts, "brains");
-            Directory.CreateDirectory(brainDirectory);
-            var targetPath = Path.Combine(_root, brainId + "-outside.lua");
-            File.WriteAllText(targetPath, targetContent);
-            File.CreateSymbolicLink(Path.Combine(brainDirectory, brainId + ".lua"), targetPath);
-        }
-
-        public void InstallPrivilegedGlobal(string moduleName, string functionName, Action callback)
-        {
-            var module = new Table(_engine.LuaScript);
-            module.Set(
-                functionName,
-                DynValue.NewCallback(
-                    (_, _) =>
-                    {
-                        callback();
-                        return DynValue.Nil;
-                    }
-                )
-            );
-            _engine.LuaScript.Globals.Set(moduleName, DynValue.NewTable(module));
-        }
-
-        public NpcBrainInvocationResult Think(uint mobileId)
-            => Runtime.Invoke(new(mobileId), NpcBrainHookType.Think, Context);
-
-        public void WriteBrain(string brainId, string content)
-        {
-            var brainDirectory = Path.Combine(_scripts, "brains");
-            Directory.CreateDirectory(brainDirectory);
-            File.WriteAllText(Path.Combine(brainDirectory, brainId + ".lua"), content);
-        }
-
-        public void WriteScript(string relativePath, string content)
-            => File.WriteAllText(Path.Combine(_scripts, relativePath), content);
-
-        private void InstallRecordingAi()
-        {
-            var ai = new Table(_engine.LuaScript);
-            ai.Set(
-                "say",
-                DynValue.NewCallback(
-                    (_, arguments) =>
-                    {
-                        AiSays.Add(arguments.Count > 0 ? arguments[0].ToPrintString() : "");
-                        _aiActions.Add("say");
-                        return DynValue.True;
-                    }
-                )
-            );
-            RecordAction(ai, "patrol");
-            RecordAction(ai, "return_home");
-            RecordAction(ai, "clear_target");
-            RecordTargetAction(ai, "move_toward");
-            RecordTargetAction(ai, "move_away");
-            RecordTargetAction(ai, "engage");
-            _engine.LuaScript.Globals.Set("ai", DynValue.NewTable(ai));
-        }
-
-        private void RecordAction(Table ai, string name)
-            => ai.Set(
-                name,
-                DynValue.NewCallback(
-                    (_, _) =>
-                    {
-                        _aiActions.Add(name);
-                        return DynValue.True;
-                    }
-                )
-            );
-
-        private void RecordTargetAction(Table ai, string name)
-            => ai.Set(
-                name,
-                DynValue.NewCallback(
-                    (_, arguments) =>
-                    {
-                        _aiActions.Add(name + ":" + (arguments.Count > 0 ? arguments[0].ToPrintString() : ""));
-                        return DynValue.True;
-                    }
-                )
-            );
-
-        private FileSystemWatcher CreateWatcher(string path)
-        {
-            var watcher = new ControllableFileSystemWatcher(path);
-
-            if (_queueWatcherCallbacks)
-            {
-                watcher.SynchronizingObject = WatcherCallbacks;
-            }
-
-            Watchers.Add(watcher);
-
-            return watcher;
-        }
-
-        public void Dispose()
-        {
-            Runtime.Dispose();
-            _engine.Dispose();
-            _container.Dispose();
-            Directory.Delete(_root, true);
-        }
-    }
-
-    private sealed class ControllableFileSystemWatcher : FileSystemWatcher
-    {
-        public ControllableFileSystemWatcher(string path) : base(path)
-        {
-        }
-
-        public void RaiseChanged(string fileName)
-            => OnChanged(new(WatcherChangeTypes.Changed, Path, fileName));
-    }
-
-    private sealed class QueueingSynchronizer : ISynchronizeInvoke
-    {
-        private readonly Queue<Action> _pending = [];
-
-        public bool InvokeRequired => true;
-
-        public int PendingCount => _pending.Count;
-
-        public IAsyncResult BeginInvoke(Delegate method, object?[]? arguments)
-        {
-            _pending.Enqueue(() => method.DynamicInvoke(arguments));
-
-            return Task.CompletedTask;
-        }
-
-        public object? EndInvoke(IAsyncResult result)
-            => null;
-
-        public object? Invoke(Delegate method, object?[]? arguments)
-            => method.DynamicInvoke(arguments);
-
-        public void RunNext()
-        {
-            Assert.True(_pending.TryDequeue(out var callback));
-            callback();
+            await Task.Yield();
         }
     }
 }

--- a/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
@@ -3,6 +3,7 @@ using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.AI;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Services.AI;
@@ -14,10 +15,321 @@ namespace Moongate.Tests.Server.AI;
 
 public class AiActionServiceTests
 {
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
+    private sealed class RecordingChatService : IChatService
+    {
+        public List<(Serial Speaker, ChatMessageType Type, string Text, Hue Hue, int Range)> Messages { get; } = [];
+
+        public void Broadcast(string text, Hue? hue = null) { }
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
+            => Messages.Add((speaker.Id, type, text, hue, range));
+    }
+
+    private sealed class RecordingMovementService : IMovementService
+    {
+        public List<(Serial MobileId, DirectionType Direction)> Moves { get; } = [];
+
+        public void TryMove(PlayerSession session, DirectionType direction, byte sequence) { }
+
+        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+        {
+            Moves.Add((mobileId, direction));
+
+            return true;
+        }
+    }
+
+    private sealed class FixedRandom : Random
+    {
+        private readonly int _result;
+
+        public FixedRandom(int result)
+        {
+            _result = result;
+        }
+
+        public override int Next(int minValue, int maxValue)
+            => minValue + _result;
+    }
+
+    [Fact]
+    public void Action_WithoutActiveContext_Throws()
+    {
+        var (service, _, _, _, _) = Build();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Patrol());
+        Assert.Contains("brain tick", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Begin_RestoresPreviousContextOnDispose()
+    {
+        var (service, persistence, _, _, _) = Build();
+        var outer = AddOwner(persistence, 0x1, x: 12, y: 8);
+        var inner = AddMobile(persistence, 0x2, 0, 12, 8);
+
+        using (service.Begin(Context(outer)))
+        {
+            using (service.Begin(Context(inner)))
+            {
+                Assert.True(service.Patrol());
+            }
+
+            Assert.True(service.Patrol());
+        }
+
+        Assert.Throws<InvalidOperationException>(() => service.Patrol());
+    }
+
+    [Fact]
+    public void ClearTarget_ClearsCombatPostureAndPersists()
+    {
+        var (service, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.ClearTarget());
+        }
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(Serial.Zero, stored.CombatantId);
+        Assert.False(stored.Warmode);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Theory, InlineData(0x1, true, 0), InlineData(0x2, false, 0), InlineData(0x2, true, 1)]
+    public void Engage_InvalidTarget_Rejects(uint targetId, bool includeNearby, int targetMapId)
+    {
+        var (service, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = targetId == owner.Id.Value ? owner : AddMobile(persistence, targetId, targetMapId, 12, 10);
+        var nearby = includeNearby ? new[] { Snapshot(target) } : [];
+
+        using (service.Begin(Context(owner, nearby: nearby)))
+        {
+            Assert.False(service.Engage(new(targetId)));
+        }
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(Serial.Zero, stored.CombatantId);
+        Assert.False(stored.Warmode);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Engage_MissingTarget_Rejects()
+    {
+        var (service, persistence, _, _, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.False(service.Engage(Serial.Zero));
+        }
+
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void Engage_VisibleTarget_SetsCombatPostureWithoutMovingOrAttacking()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 12, 10);
+
+        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
+        {
+            Assert.True(service.Engage(target.Id));
+        }
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(target.Id, stored.CombatantId);
+        Assert.True(stored.Warmode);
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveAway_UsesEightWayDirection()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 14, 8);
+
+        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
+        {
+            Assert.True(service.MoveAway(target.Id));
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.SouthWest)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveTo_AlreadyAtCoordinate_AcceptsWithoutMoving()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.MoveTo(10, 10));
+        }
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveTo_StepsGreedilyTowardCoordinate()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.MoveTo(14, 8));
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveToward_EqualPosition_AcceptsWithoutDelegating()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 10, 10);
+
+        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
+        {
+            Assert.True(service.MoveToward(target.Id));
+        }
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void MoveToward_TargetOutsidePerception_Rejects()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 12, 10);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.False(service.MoveToward(target.Id));
+            Assert.False(service.MoveAway(target.Id));
+        }
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(0, metrics.Current.IntentsAccepted);
+        Assert.Equal(2, metrics.Current.IntentsRejected);
+    }
+
+    [Fact]
+    public void MoveToward_UsesEightWayDirection()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+        var target = AddMobile(persistence, 0x2, 0, 14, 8);
+
+        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
+        {
+            Assert.True(service.MoveToward(target.Id));
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void OrderedActions_ApplyInSequenceAndRevalidate()
+    {
+        var (service, persistence, chat, movement, metrics) = Build();
+        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
+        var target = AddMobile(persistence, 0x2, 0, 11, 10);
+
+        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
+        {
+            Assert.True(service.ClearTarget());
+            Assert.True(service.MoveToward(target.Id));
+            Assert.True(service.Say("Advance"));
+        }
+
+        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
+        Assert.Equal(Serial.Zero, stored.CombatantId);
+        Assert.False(stored.Warmode);
+        Assert.Equal([(owner.Id, DirectionType.East)], movement.Moves);
+        Assert.Equal("Advance", Assert.Single(chat.Messages).Text);
+        Assert.Equal(3, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Patrol_OutsideLeash_ReturnsTowardHome()
+    {
+        var (service, persistence, _, movement, metrics) = Build(3);
+        var owner = AddOwner(persistence, x: 19, y: 10);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.Patrol());
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.West)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void Patrol_WithinLeash_UsesInjectedRandomDirection()
+    {
+        var (service, persistence, _, movement, metrics) = Build(3);
+        var owner = AddOwner(persistence, x: 12, y: 8);
+
+        using (service.Begin(Context(owner)))
+        {
+            Assert.True(service.Patrol());
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.SouthEast)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void ReturnHome_OnHomeMapMovesTowardHome()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence);
+
+        using (service.Begin(Context(owner, homePosition: new(8, 12, 0))))
+        {
+            Assert.True(service.ReturnHome());
+        }
+
+        Assert.Equal([(owner.Id, DirectionType.SouthWest)], movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsAccepted);
+    }
+
+    [Fact]
+    public void ReturnHome_OutsideHomeMap_Rejects()
+    {
+        var (service, persistence, _, movement, metrics) = Build();
+        var owner = AddOwner(persistence, mapId: 1);
+
+        using (service.Begin(Context(owner, 0)))
+        {
+            Assert.False(service.ReturnHome());
+        }
+
+        Assert.Empty(movement.Moves);
+        Assert.Equal(1, metrics.Current.IntentsRejected);
+    }
+
+    [Theory, InlineData(null), InlineData(""), InlineData("   ")]
     public void Say_BlankText_Rejects(string? text)
     {
         var (service, persistence, chat, _, metrics) = Build();
@@ -69,205 +381,6 @@ public class AiActionServiceTests
     }
 
     [Fact]
-    public void Engage_VisibleTarget_SetsCombatPostureWithoutMovingOrAttacking()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-        var target = AddMobile(persistence, 0x2, 0, 12, 10);
-
-        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
-        {
-            Assert.True(service.Engage(target.Id));
-        }
-
-        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
-        Assert.Equal(target.Id, stored.CombatantId);
-        Assert.True(stored.Warmode);
-        Assert.Empty(movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Theory]
-    [InlineData(0x1, true, 0)]
-    [InlineData(0x2, false, 0)]
-    [InlineData(0x2, true, 1)]
-    public void Engage_InvalidTarget_Rejects(uint targetId, bool includeNearby, int targetMapId)
-    {
-        var (service, persistence, _, _, metrics) = Build();
-        var owner = AddOwner(persistence);
-        var target = targetId == owner.Id.Value ? owner : AddMobile(persistence, targetId, targetMapId, 12, 10);
-        var nearby = includeNearby ? new[] { Snapshot(target) } : [];
-
-        using (service.Begin(Context(owner, nearby: nearby)))
-        {
-            Assert.False(service.Engage(new(targetId)));
-        }
-
-        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
-        Assert.Equal(Serial.Zero, stored.CombatantId);
-        Assert.False(stored.Warmode);
-        Assert.Equal(0, metrics.Current.IntentsAccepted);
-        Assert.Equal(1, metrics.Current.IntentsRejected);
-    }
-
-    [Fact]
-    public void Engage_MissingTarget_Rejects()
-    {
-        var (service, persistence, _, _, metrics) = Build();
-        var owner = AddOwner(persistence);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.False(service.Engage(Serial.Zero));
-        }
-
-        Assert.Equal(1, metrics.Current.IntentsRejected);
-    }
-
-    [Fact]
-    public void ClearTarget_ClearsCombatPostureAndPersists()
-    {
-        var (service, persistence, _, _, metrics) = Build();
-        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.True(service.ClearTarget());
-        }
-
-        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
-        Assert.Equal(Serial.Zero, stored.CombatantId);
-        Assert.False(stored.Warmode);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void MoveToward_UsesEightWayDirection()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-        var target = AddMobile(persistence, 0x2, 0, 14, 8);
-
-        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
-        {
-            Assert.True(service.MoveToward(target.Id));
-        }
-
-        Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void MoveAway_UsesEightWayDirection()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-        var target = AddMobile(persistence, 0x2, 0, 14, 8);
-
-        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
-        {
-            Assert.True(service.MoveAway(target.Id));
-        }
-
-        Assert.Equal([(owner.Id, DirectionType.SouthWest)], movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void MoveToward_EqualPosition_AcceptsWithoutDelegating()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-        var target = AddMobile(persistence, 0x2, 0, 10, 10);
-
-        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
-        {
-            Assert.True(service.MoveToward(target.Id));
-        }
-
-        Assert.Empty(movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void MoveToward_TargetOutsidePerception_Rejects()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-        var target = AddMobile(persistence, 0x2, 0, 12, 10);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.False(service.MoveToward(target.Id));
-            Assert.False(service.MoveAway(target.Id));
-        }
-
-        Assert.Empty(movement.Moves);
-        Assert.Equal(0, metrics.Current.IntentsAccepted);
-        Assert.Equal(2, metrics.Current.IntentsRejected);
-    }
-
-    [Fact]
-    public void ReturnHome_OnHomeMapMovesTowardHome()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-
-        using (service.Begin(Context(owner, homePosition: new(8, 12, 0))))
-        {
-            Assert.True(service.ReturnHome());
-        }
-
-        Assert.Equal([(owner.Id, DirectionType.SouthWest)], movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void ReturnHome_OutsideHomeMap_Rejects()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence, mapId: 1);
-
-        using (service.Begin(Context(owner, homeMapId: 0)))
-        {
-            Assert.False(service.ReturnHome());
-        }
-
-        Assert.Empty(movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsRejected);
-    }
-
-    [Fact]
-    public void Patrol_WithinLeash_UsesInjectedRandomDirection()
-    {
-        var (service, persistence, _, movement, metrics) = Build(randomResult: 3);
-        var owner = AddOwner(persistence, x: 12, y: 8);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.True(service.Patrol());
-        }
-
-        Assert.Equal([(owner.Id, DirectionType.SouthEast)], movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void Patrol_OutsideLeash_ReturnsTowardHome()
-    {
-        var (service, persistence, _, movement, metrics) = Build(randomResult: 3);
-        var owner = AddOwner(persistence, x: 19, y: 10);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.True(service.Patrol());
-        }
-
-        Assert.Equal([(owner.Id, DirectionType.West)], movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
     public void Step_MovesInGivenDirection()
     {
         var (service, persistence, _, movement, metrics) = Build();
@@ -281,120 +394,6 @@ public class AiActionServiceTests
         Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
         Assert.Equal(1, metrics.Current.IntentsAccepted);
     }
-
-    [Fact]
-    public void MoveTo_StepsGreedilyTowardCoordinate()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.True(service.MoveTo(14, 8));
-        }
-
-        Assert.Equal([(owner.Id, DirectionType.NorthEast)], movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void MoveTo_AlreadyAtCoordinate_AcceptsWithoutMoving()
-    {
-        var (service, persistence, _, movement, metrics) = Build();
-        var owner = AddOwner(persistence);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.True(service.MoveTo(10, 10));
-        }
-
-        Assert.Empty(movement.Moves);
-        Assert.Equal(1, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void OrderedActions_ApplyInSequenceAndRevalidate()
-    {
-        var (service, persistence, chat, movement, metrics) = Build();
-        var owner = AddOwner(persistence, combatantId: new(0x2), warmode: true);
-        var target = AddMobile(persistence, 0x2, 0, 11, 10);
-
-        using (service.Begin(Context(owner, nearby: [Snapshot(target)])))
-        {
-            Assert.True(service.ClearTarget());
-            Assert.True(service.MoveToward(target.Id));
-            Assert.True(service.Say("Advance"));
-        }
-
-        var stored = persistence.Store<MobileEntity>().GetById(owner.Id)!;
-        Assert.Equal(Serial.Zero, stored.CombatantId);
-        Assert.False(stored.Warmode);
-        Assert.Equal([(owner.Id, DirectionType.East)], movement.Moves);
-        Assert.Equal("Advance", Assert.Single(chat.Messages).Text);
-        Assert.Equal(3, metrics.Current.IntentsAccepted);
-    }
-
-    [Fact]
-    public void Action_WithoutActiveContext_Throws()
-    {
-        var (service, _, _, _, _) = Build();
-
-        var exception = Assert.Throws<InvalidOperationException>(() => service.Patrol());
-        Assert.Contains("brain tick", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void Begin_RestoresPreviousContextOnDispose()
-    {
-        var (service, persistence, _, _, _) = Build();
-        var outer = AddOwner(persistence, id: 0x1, x: 12, y: 8);
-        var inner = AddMobile(persistence, 0x2, 0, 12, 8);
-
-        using (service.Begin(Context(outer)))
-        {
-            using (service.Begin(Context(inner)))
-            {
-                Assert.True(service.Patrol());
-            }
-
-            Assert.True(service.Patrol());
-        }
-
-        Assert.Throws<InvalidOperationException>(() => service.Patrol());
-    }
-
-    private static AiActionService Build(
-        out FakePersistenceService persistence,
-        out RecordingChatService chat,
-        out RecordingMovementService movement,
-        out NpcAiMetrics metrics,
-        int randomResult = 0
-    )
-    {
-        persistence = new();
-        chat = new();
-        movement = new();
-        metrics = new();
-
-        return new(persistence, movement, chat, new FixedRandom(randomResult), new StubLoopAffinity(), metrics);
-    }
-
-    private static (AiActionService Service, FakePersistenceService Persistence, RecordingChatService Chat, RecordingMovementService Movement, NpcAiMetrics Metrics) Build(int randomResult = 0)
-    {
-        var service = Build(out var persistence, out var chat, out var movement, out var metrics, randomResult);
-        return (service, persistence, chat, movement, metrics);
-    }
-
-    private static MobileEntity AddOwner(
-        FakePersistenceService persistence,
-        uint id = 0x1,
-        int mapId = 0,
-        int x = 10,
-        int y = 10,
-        Serial? combatantId = null,
-        bool warmode = false
-    )
-        => AddMobile(persistence, id, mapId, x, y, combatantId, warmode);
 
     private static MobileEntity AddMobile(
         FakePersistenceService persistence,
@@ -416,7 +415,43 @@ public class AiActionServiceTests
             Warmode = warmode
         };
         persistence.Store<MobileEntity>().UpsertAsync(mobile).AsTask().Wait();
+
         return mobile;
+    }
+
+    private static MobileEntity AddOwner(
+        FakePersistenceService persistence,
+        uint id = 0x1,
+        int mapId = 0,
+        int x = 10,
+        int y = 10,
+        Serial? combatantId = null,
+        bool warmode = false
+    )
+        => AddMobile(persistence, id, mapId, x, y, combatantId, warmode);
+
+    private static AiActionService Build(
+        out FakePersistenceService persistence,
+        out RecordingChatService chat,
+        out RecordingMovementService movement,
+        out NpcAiMetrics metrics,
+        int randomResult = 0
+    )
+    {
+        persistence = new();
+        chat = new();
+        movement = new();
+        metrics = new();
+
+        return new(persistence, movement, chat, new FixedRandom(randomResult), new StubLoopAffinity(), metrics);
+    }
+
+    private static (AiActionService Service, FakePersistenceService Persistence, RecordingChatService Chat,
+        RecordingMovementService Movement, NpcAiMetrics Metrics) Build(int randomResult = 0)
+    {
+        var service = Build(out var persistence, out var chat, out var movement, out var metrics, randomResult);
+
+        return (service, persistence, chat, movement, metrics);
     }
 
     private static BrainContext Context(
@@ -447,48 +482,4 @@ public class AiActionServiceTests
             mobile.Criminal,
             mobile.Kills
         );
-
-    private sealed class RecordingChatService : IChatService
-    {
-        public List<(Serial Speaker, ChatMessageType Type, string Text, Hue Hue, int Range)> Messages { get; } = [];
-
-        public void Broadcast(string text, Hue? hue = null)
-        {
-        }
-
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
-        {
-            Messages.Add((speaker.Id, type, text, hue, range));
-        }
-    }
-
-    private sealed class RecordingMovementService : IMovementService
-    {
-        public List<(Serial MobileId, DirectionType Direction)> Moves { get; } = [];
-
-        public void TryMove(Moongate.Server.Abstractions.Data.Session.PlayerSession session, DirectionType direction, byte sequence)
-        {
-        }
-
-        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
-        {
-            Moves.Add((mobileId, direction));
-            return true;
-        }
-    }
-
-    private sealed class FixedRandom : Random
-    {
-        private readonly int _result;
-
-        public FixedRandom(int result)
-        {
-            _result = result;
-        }
-
-        public override int Next(int minValue, int maxValue)
-        {
-            return minValue + _result;
-        }
-    }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcAiMetricsTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcAiMetricsTests.cs
@@ -41,6 +41,36 @@ public class NpcAiMetricsTests
     }
 
     [Fact]
+    public void RecordHookFailure_TracksBudgetBreachesSeparately()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordHookFailure(false);
+        metrics.RecordHookFailure(true);
+
+        var current = metrics.Current;
+
+        Assert.Equal(2, current.HookFailures);
+        Assert.Equal(1, current.InstructionBudgetBreaches);
+    }
+
+    [Fact]
+    public void RecordHookInvocation_TracksCountTotalMaximumAndAverageDuration()
+    {
+        var metrics = new NpcAiMetrics();
+
+        metrics.RecordHookInvocation(TimeSpan.FromTicks(10));
+        metrics.RecordHookInvocation(TimeSpan.FromTicks(30));
+
+        var current = metrics.Current;
+
+        Assert.Equal(2, current.HookInvocations);
+        Assert.Equal(40, current.TotalHookDurationTicks);
+        Assert.Equal(30, current.MaxHookDurationTicks);
+        Assert.Equal(TimeSpan.FromTicks(20), current.AverageHookDuration);
+    }
+
+    [Fact]
     public void RecordIntent_AcceptedAndRejectedIncrementSeparateCounters()
     {
         var metrics = new NpcAiMetrics();
@@ -66,35 +96,5 @@ public class NpcAiMetricsTests
 
         Assert.Equal(1, current.ReloadSuccesses);
         Assert.Equal(1, current.ReloadFallbacks);
-    }
-
-    [Fact]
-    public void RecordHookInvocation_TracksCountTotalMaximumAndAverageDuration()
-    {
-        var metrics = new NpcAiMetrics();
-
-        metrics.RecordHookInvocation(TimeSpan.FromTicks(10));
-        metrics.RecordHookInvocation(TimeSpan.FromTicks(30));
-
-        var current = metrics.Current;
-
-        Assert.Equal(2, current.HookInvocations);
-        Assert.Equal(40, current.TotalHookDurationTicks);
-        Assert.Equal(30, current.MaxHookDurationTicks);
-        Assert.Equal(TimeSpan.FromTicks(20), current.AverageHookDuration);
-    }
-
-    [Fact]
-    public void RecordHookFailure_TracksBudgetBreachesSeparately()
-    {
-        var metrics = new NpcAiMetrics();
-
-        metrics.RecordHookFailure(false);
-        metrics.RecordHookFailure(true);
-
-        var current = metrics.Current;
-
-        Assert.Equal(2, current.HookFailures);
-        Assert.Equal(1, current.InstructionBudgetBreaches);
     }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcBrainContextFactoryTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainContextFactoryTests.cs
@@ -1,7 +1,5 @@
 using Moongate.Core.Geometry;
-using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Services.AI;
 using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
@@ -11,12 +9,31 @@ namespace Moongate.Tests.Server.AI;
 public class NpcBrainContextFactoryTests
 {
     [Fact]
+    public async Task Create_DescriptorPerceptionRange_ExcludesMobileJustOutsideRange()
+    {
+        var persistence = new FakePersistenceService();
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), new StubEventBus());
+        var owner = await AddMobileAsync(persistence, spatial, 0x1, "owner", 0, 10, 10);
+        var inRange = await AddMobileAsync(persistence, spatial, 0x2, "inside", 0, 14, 10);
+        await AddMobileAsync(persistence, spatial, 0x3, "outside", 0, 15, 10);
+        var factory = new NpcBrainContextFactory(
+            spatial,
+            new StubSessionManager(),
+            new MutableTimeProvider(DateTimeOffset.UnixEpoch)
+        );
+
+        var context = factory.Create(owner, 0, owner.Position, new("guard", 1000, 4, 15));
+
+        Assert.Equal([inRange.Id], context.Nearby.Select(snapshot => snapshot.Id));
+    }
+
+    [Fact]
     public async Task Create_WorldState_ProducesDeterministicDetachedSnapshot()
     {
         var persistence = new FakePersistenceService();
         var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), new StubEventBus());
         var sessions = new StubSessionManager();
-        var time = new MutableTimeProvider(new DateTimeOffset(2026, 7, 24, 10, 30, 0, TimeSpan.Zero));
+        var time = new MutableTimeProvider(new(2026, 7, 24, 10, 30, 0, TimeSpan.Zero));
         var owner = await AddMobileAsync(persistence, spatial, 0x5, "owner", 0, 10, 10);
         var laterSerial = await AddMobileAsync(persistence, spatial, 0x9, "later", 0, 12, 10);
         var earlierSerial = await AddMobileAsync(persistence, spatial, 0x2, "earlier", 0, 11, 10);
@@ -25,7 +42,7 @@ public class NpcBrainContextFactoryTests
         var factory = new NpcBrainContextFactory(spatial, sessions, time);
         var homePosition = new Point3D(4, 5, 6);
 
-        var context = factory.Create(owner, 1, homePosition, new BrainDescriptor("guard", 1000, 3, 15));
+        var context = factory.Create(owner, 1, homePosition, new("guard", 1000, 3, 15));
 
         Assert.Equal(time.Now, context.Now);
         Assert.Equal(owner.Id, context.Self.Id);
@@ -44,25 +61,6 @@ public class NpcBrainContextFactoryTests
         Assert.Equal("earlier", context.Nearby[0].Name);
     }
 
-    [Fact]
-    public async Task Create_DescriptorPerceptionRange_ExcludesMobileJustOutsideRange()
-    {
-        var persistence = new FakePersistenceService();
-        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), new StubEventBus());
-        var owner = await AddMobileAsync(persistence, spatial, 0x1, "owner", 0, 10, 10);
-        var inRange = await AddMobileAsync(persistence, spatial, 0x2, "inside", 0, 14, 10);
-        await AddMobileAsync(persistence, spatial, 0x3, "outside", 0, 15, 10);
-        var factory = new NpcBrainContextFactory(
-            spatial,
-            new StubSessionManager(),
-            new MutableTimeProvider(DateTimeOffset.UnixEpoch)
-        );
-
-        var context = factory.Create(owner, 0, owner.Position, new BrainDescriptor("guard", 1000, 4, 15));
-
-        Assert.Equal([inRange.Id], context.Nearby.Select(snapshot => snapshot.Id));
-    }
-
     private static async Task<MobileEntity> AddMobileAsync(
         FakePersistenceService persistence,
         SpatialIndexService spatial,
@@ -75,14 +73,14 @@ public class NpcBrainContextFactoryTests
     {
         var mobile = new MobileEntity
         {
-            Id = new Serial(serial),
+            Id = new(serial),
             Name = name,
             MapId = mapId,
-            Position = new Point3D(x, y, 0),
+            Position = new(x, y, 0),
             Hits = 25,
             HitsMax = 50,
             Warmode = true,
-            CombatantId = new Serial(0x20),
+            CombatantId = new(0x20),
             Criminal = true,
             Kills = 3
         };

--- a/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainEventRouterTests.cs
@@ -22,437 +22,6 @@ namespace Moongate.Tests.Server.AI;
 
 public class NpcBrainEventRouterTests
 {
-    [Fact]
-    public async Task OnMobileSpeech_ActiveBrainsInExactHearingRange_ReceivePreservedSpeechSnapshot()
-    {
-        var fixture = new RouterFixture();
-        var speaker = fixture.AddMobile(0x1, "Player One", 0, 10, 10);
-        var shortRange = fixture.AddBrain(0x2, "Short", 0, 15, 10, 8, 5, true);
-        var longRange = fixture.AddBrain(0x3, "Long", 0, 17, 10, 8, 7, true);
-        fixture.AddBrain(0x4, "Outside Exact", 0, 16, 10, 8, 5, true);
-        fixture.AddBrain(0x5, "Sleeping", 0, 11, 10, 8, 20, false);
-        fixture.AddBrain(0x6, "Other Map", 1, 10, 10, 8, 20, true);
-        fixture.Sessions.Played.Add(speaker.Id);
-
-        await fixture.Router.OnMobileSpeech(
-            new(speaker.Id, ChatMessageType.Yell, "Guards!"),
-            CancellationToken.None
-        );
-
-        Assert.Equal([shortRange.Id, longRange.Id], fixture.Scheduler.Events.Select(entry => entry.MobileId));
-        var routed = fixture.Scheduler.Events[0];
-        Assert.Equal(NpcBrainHookType.SpeechHeard, routed.Hook);
-        Assert.Equal(NpcBrainEventType.SpeechHeard, routed.Event.Type);
-        Assert.Equal("Guards!", routed.Event.Text);
-        Assert.Equal(ChatMessageType.Yell, routed.Event.SpeechType);
-        Assert.Equal(speaker.Id, routed.Event.Mobile!.Id);
-        Assert.Equal("Player One", routed.Event.Mobile.Name);
-        Assert.True(routed.Event.Mobile.IsPlayer);
-    }
-
-    [Fact]
-    public async Task OnMobileSpeech_LaterNpcReply_ExcludesEachSpeakerAndOnlyEnqueues()
-    {
-        var fixture = new RouterFixture();
-        var player = fixture.AddMobile(0x1, "Player", 0, 10, 10);
-        var firstNpc = fixture.AddBrain(0x2, "First", 0, 11, 10, 8, 8, true);
-        var secondNpc = fixture.AddBrain(0x3, "Second", 0, 12, 10, 8, 8, true);
-
-        await fixture.Router.OnMobileSpeech(
-            new(player.Id, ChatMessageType.Regular, "hello"),
-            CancellationToken.None
-        );
-        fixture.Scheduler.Events.Clear();
-
-        await fixture.Router.OnMobileSpeech(
-            new(firstNpc.Id, ChatMessageType.Regular, "greetings"),
-            CancellationToken.None
-        );
-
-        var routed = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(secondNpc.Id, routed.MobileId);
-        Assert.Equal(firstNpc.Id, routed.Event.Mobile!.Id);
-        Assert.Equal("greetings", routed.Event.Text);
-        Assert.Equal(0, fixture.Scheduler.TickCalls);
-    }
-
-    [Fact]
-    public async Task OnMobileMoved_SubjectCrossesObserverRange_EmitsEnterMoveAndLeaveOnce()
-    {
-        var fixture = new RouterFixture();
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
-        var subject = fixture.AddMobile(0x2, "Subject", 0, 20, 10);
-
-        await fixture.MoveAsync(subject, 15, 10);
-        await fixture.MoveAsync(subject, 13, 10);
-        await fixture.MoveAsync(subject, 20, 10);
-
-        Assert.Equal(
-            [
-                NpcBrainHookType.MobileEnteredRange,
-                NpcBrainHookType.MobileMoved,
-                NpcBrainHookType.MobileLeftRange
-            ],
-            fixture.Scheduler.Events.Select(entry => entry.Hook)
-        );
-        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(observer.Id, entry.MobileId));
-        Assert.Equal(new Point3D(15, 10, 0), fixture.Scheduler.Events[0].Event.ToPosition);
-        Assert.Equal(new Point3D(13, 10, 0), fixture.Scheduler.Events[1].Event.ToPosition);
-        Assert.Equal(new Point3D(20, 10, 0), fixture.Scheduler.Events[2].Event.ToPosition);
-    }
-
-    [Fact]
-    public async Task OnMobileMoved_RepeatedInsideMovement_MailboxRetainsLatestPosition()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
-        var subject = fixture.AddMobile(0x2, "Subject", 0, 11, 10);
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-        fixture.Scheduler.Events.Clear();
-
-        await fixture.MoveAsync(subject, 12, 10);
-        await fixture.MoveAsync(subject, 13, 10);
-
-        var queued = Assert.Single(fixture.Scheduler.CoalescedEventsFor(observer.Id));
-        Assert.Equal(NpcBrainHookType.MobileMoved, queued.Hook);
-        Assert.Equal(subject.Id, queued.Event.Mobile!.Id);
-        Assert.Equal(new Point3D(12, 10, 0), queued.Event.FromPosition);
-        Assert.Equal(new Point3D(13, 10, 0), queued.Event.ToPosition);
-        Assert.Equal(new Point3D(13, 10, 0), queued.Event.Mobile.Position);
-    }
-
-    [Fact]
-    public async Task OnMobileCreated_RouterBeforeBrainBinding_FirstInsideMovementRecoversWithEnter()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var observer = fixture.AddMobile(0x1, "Observer", 0, 5, 5, "guard");
-        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
-
-        await fixture.Router.OnMobileCreated(new(observer), CancellationToken.None);
-        fixture.Scheduler.Descriptors[observer.Id] = new("guard", 1000, 5, 5);
-        fixture.Scheduler.Active.Add(observer.Id);
-        await fixture.MoveAsync(subject, 9, 5);
-
-        var recovered = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(observer.Id, recovered.MobileId);
-        Assert.Equal(NpcBrainHookType.MobileEnteredRange, recovered.Hook);
-        Assert.Equal(subject.Id, recovered.Event.Mobile!.Id);
-    }
-
-    [Fact]
-    public async Task OnMobileMoved_UnperceivedSubjectLeavesRange_DoesNotEmitLeave()
-    {
-        var fixture = new RouterFixture();
-        fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
-        var subject = fixture.AddMobile(0x2, "Subject", 0, 14, 10);
-
-        await fixture.MoveAsync(subject, 20, 10);
-
-        Assert.Empty(fixture.Scheduler.Events);
-    }
-
-    [Fact]
-    public async Task BrainDefinitionReloaded_RouterBeforeLifecycle_ReconcilesExpandedAndShrunkRanges()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
-        var near = fixture.AddMobile(0x2, "Near", 0, 13, 10);
-        var far = fixture.AddMobile(0x3, "Far", 0, 18, 10);
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-        fixture.Scheduler.Events.Clear();
-        var eventBus = new RecordingSubscriptionEventBus();
-        fixture.Router.Subscribe(eventBus);
-        var expanded = new BrainDescriptor("guard", 1000, 10, 5);
-
-        await eventBus.PublishAsync(
-            new BrainDefinitionReloadedEvent("guard", expanded),
-            CancellationToken.None
-        );
-
-        var entered = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(observer.Id, entered.MobileId);
-        Assert.Equal(NpcBrainHookType.MobileEnteredRange, entered.Hook);
-        Assert.Equal(far.Id, entered.Event.Mobile!.Id);
-
-        fixture.Scheduler.Descriptors[observer.Id] = expanded;
-        fixture.Scheduler.Events.Clear();
-        await eventBus.PublishAsync(
-            new BrainDefinitionReloadedEvent(
-                "guard",
-                new("guard", 1000, 2, 5)
-            ),
-            CancellationToken.None
-        );
-
-        Assert.Equal(
-            [near.Id, far.Id],
-            fixture.Scheduler.Events.Select(entry => entry.Event.Mobile!.Id)
-        );
-        Assert.All(
-            fixture.Scheduler.Events,
-            entry => Assert.Equal(NpcBrainHookType.MobileLeftRange, entry.Hook)
-        );
-    }
-
-    [Fact]
-    public async Task OnMobileMoved_ActiveBrainObserver_RecomputesStationaryEntriesAndLeaves()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 4, 4, true);
-        var leftBehind = fixture.AddMobile(0x2, "Left", 0, 4, 5);
-        var newlySeen = fixture.AddMobile(0x3, "New", 0, 13, 5);
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-        fixture.Scheduler.Events.Clear();
-
-        await fixture.MoveAsync(observer, 10, 5);
-
-        Assert.Collection(
-            fixture.Scheduler.Events,
-            entry =>
-            {
-                Assert.Equal(observer.Id, entry.MobileId);
-                Assert.Equal(NpcBrainHookType.MobileLeftRange, entry.Hook);
-                Assert.Equal(leftBehind.Id, entry.Event.Mobile!.Id);
-            },
-            entry =>
-            {
-                Assert.Equal(observer.Id, entry.MobileId);
-                Assert.Equal(NpcBrainHookType.MobileEnteredRange, entry.Hook);
-                Assert.Equal(newlySeen.Id, entry.Event.Mobile!.Id);
-            }
-        );
-    }
-
-    [Fact]
-    public async Task SectorLifecycle_ActivationSeedsAndSleepingObserverRetainsNoPerceptionSet()
-    {
-        var fixture = new RouterFixture();
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
-        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
-        fixture.Sectors.Active.Add((0, 0, 0));
-
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-
-        var initial = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(observer.Id, initial.MobileId);
-        Assert.Equal(NpcBrainHookType.MobileEnteredRange, initial.Hook);
-        Assert.Equal(subject.Id, initial.Event.Mobile!.Id);
-
-        fixture.Scheduler.Events.Clear();
-        fixture.Scheduler.Active.Remove(observer.Id);
-        fixture.Sectors.Active.Remove((0, 0, 0));
-        await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
-        await fixture.MoveAsync(subject, 20, 5);
-        await fixture.MoveAsync(subject, 8, 5);
-        Assert.Empty(fixture.Scheduler.Events);
-
-        fixture.Scheduler.Active.Add(observer.Id);
-        fixture.Sectors.Active.Add((0, 0, 0));
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-
-        var reseeded = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(NpcBrainHookType.MobileEnteredRange, reseeded.Hook);
-        Assert.Equal(subject.Id, reseeded.Event.Mobile!.Id);
-    }
-
-    [Fact]
-    public async Task OnMobileMoved_ExternallySleepingBrain_ClearsObserverSetWithoutLifecycleCall()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
-        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-        fixture.Scheduler.Events.Clear();
-
-        fixture.Scheduler.Active.Remove(observer.Id);
-        await fixture.MoveAsync(observer, 32, 5);
-        await fixture.MoveAsync(subject, 9, 5);
-
-        Assert.False(fixture.Scheduler.IsActive(observer.Id));
-        Assert.DoesNotContain(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
-        Assert.Empty(fixture.Scheduler.DeactivateCalls);
-
-        fixture.Scheduler.Active.Add(observer.Id);
-        fixture.Sectors.Active.Add((0, 2, 0));
-        await fixture.Router.OnSectorActivated(new(0, 2, 0), CancellationToken.None);
-        fixture.Scheduler.Events.Clear();
-        await fixture.MoveAsync(subject, 33, 5);
-
-        var enter = Assert.Single(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
-        Assert.Equal(NpcBrainHookType.MobileEnteredRange, enter.Hook);
-    }
-
-    [Fact]
-    public async Task PlayerLifecycle_UsesEventSnapshotsBeforeSpatialSubscriberAndEmitsRangeTransitions()
-    {
-        var fixture = new RouterFixture();
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
-        var player = fixture.Mobile(0x2, "Player", 0, 14, 10);
-
-        await fixture.Router.OnPlayerEnteredWorld(
-            new(7, new Serial(0x900), player),
-            CancellationToken.None
-        );
-
-        var enter = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(observer.Id, enter.MobileId);
-        Assert.Equal(NpcBrainHookType.MobileEnteredRange, enter.Hook);
-        Assert.True(enter.Event.Mobile!.IsPlayer);
-        fixture.Scheduler.Events.Clear();
-
-        var session = SessionWithCharacter(player);
-        await fixture.Router.OnSessionDestroyed(new(session), CancellationToken.None);
-
-        var leave = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(observer.Id, leave.MobileId);
-        Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
-        Assert.Equal(player.Id, leave.Event.Mobile!.Id);
-    }
-
-    [Fact]
-    public async Task MobileLifecycle_ExternallyActiveCreateRoutesBothRolesAndDeleteClearsWithoutLifecycleCalls()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-        fixture.Scheduler.Events.Clear();
-        var created = fixture.Mobile(0x2, "Created Brain", 0, 8, 5, "guard");
-        fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
-        fixture.Scheduler.Active.Add(created.Id);
-
-        await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
-
-        Assert.Empty(fixture.Scheduler.BindCalls);
-        Assert.Collection(
-            fixture.Scheduler.Events,
-            entry =>
-            {
-                Assert.Equal(observer.Id, entry.MobileId);
-                Assert.Equal(created.Id, entry.Event.Mobile!.Id);
-            },
-            entry =>
-            {
-                Assert.Equal(created.Id, entry.MobileId);
-                Assert.Equal(observer.Id, entry.Event.Mobile!.Id);
-            }
-        );
-        fixture.Scheduler.Events.Clear();
-
-        await fixture.Router.OnMobileDeleted(new(created), CancellationToken.None);
-
-        var leave = Assert.Single(fixture.Scheduler.Events);
-        Assert.Equal(observer.Id, leave.MobileId);
-        Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
-        Assert.Empty(fixture.Scheduler.UnbindCalls);
-    }
-
-    [Fact]
-    public async Task CanonicalEventHandlers_NeverControlSchedulerLifecycle()
-    {
-        var fixture = new RouterFixture();
-        fixture.Sectors.Active.Add((0, 0, 0));
-        var existing = fixture.AddBrain(0x1, "Existing", 0, 5, 5, 5, 5, true);
-        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-
-        fixture.Scheduler.Active.Remove(existing.Id);
-        await fixture.MoveAsync(existing, 32, 5);
-
-        var created = fixture.Mobile(0x2, "Created", 0, 6, 5, "guard");
-        fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
-        fixture.Scheduler.Active.Add(created.Id);
-        await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
-        await fixture.Router.OnMobileDeleted(new(created), CancellationToken.None);
-        await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
-
-        Assert.Empty(fixture.Scheduler.BindCalls);
-        Assert.Empty(fixture.Scheduler.ActivateCalls);
-        Assert.Empty(fixture.Scheduler.DeactivateCalls);
-        Assert.Empty(fixture.Scheduler.UnbindCalls);
-    }
-
-    [Fact]
-    public async Task CombatEvents_OnlyActiveAffectedBrainReceivesAttackerAndDamagePayloads()
-    {
-        var fixture = new RouterFixture();
-        var active = fixture.AddBrain(0x1, "Active", 0, 10, 10, 5, 5, true);
-        var sleeping = fixture.AddBrain(0x2, "Sleeping", 0, 10, 10, 5, 5, false);
-        var attacker = fixture.AddMobile(0x3, "Attacker", 0, 11, 10);
-
-        await fixture.Router.OnMobileAttacked(new(active.Id, attacker.Id), CancellationToken.None);
-        await fixture.Router.OnMobileDamaged(new(active.Id, attacker.Id, 17), CancellationToken.None);
-        await fixture.Router.OnMobileDied(new(active.Id, attacker.Id), CancellationToken.None);
-        await fixture.Router.OnMobileAttacked(new(sleeping.Id, attacker.Id), CancellationToken.None);
-        await fixture.Router.OnMobileDamaged(new(sleeping.Id, attacker.Id, 9), CancellationToken.None);
-        await fixture.Router.OnMobileDied(new(sleeping.Id, attacker.Id), CancellationToken.None);
-
-        Assert.Equal(
-            [NpcBrainHookType.Attacked, NpcBrainHookType.Damage, NpcBrainHookType.Death],
-            fixture.Scheduler.Events.Select(entry => entry.Hook)
-        );
-        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(active.Id, entry.MobileId));
-        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(attacker.Id, entry.Event.Mobile!.Id));
-        Assert.Equal(17, fixture.Scheduler.Events[1].Event.Amount);
-    }
-
-    [Fact]
-    public async Task PerceptionTransitions_DifferentMapsNeverInteract()
-    {
-        var fixture = new RouterFixture();
-        fixture.AddBrain(0x1, "Observer", 0, 10, 10, 20, 20, true);
-        var subject = fixture.AddMobile(0x2, "Subject", 1, 10, 10);
-
-        await fixture.MoveAsync(subject, 11, 10);
-        await fixture.Router.OnMobileSpeech(
-            new(subject.Id, ChatMessageType.Regular, "other map"),
-            CancellationToken.None
-        );
-
-        Assert.Empty(fixture.Scheduler.Events);
-    }
-
-    [Fact]
-    public void Subscribe_RegistersAllCanonicalEventHandlers()
-    {
-        var fixture = new RouterFixture();
-        var eventBus = new RecordingSubscriptionEventBus();
-
-        fixture.Router.Subscribe(eventBus);
-
-        Assert.Equal(
-            [
-                typeof(MobileSpeechEvent),
-                typeof(MobileMovedEvent),
-                typeof(MobileCreatedEvent),
-                typeof(MobileDeletedEvent),
-                typeof(PlayerEnteredWorldEvent),
-                typeof(SessionDestroyedEvent),
-                typeof(SectorActivatedEvent),
-                typeof(SectorDeactivatedEvent),
-                typeof(BrainDefinitionReloadedEvent),
-                typeof(MobileAttackedEvent),
-                typeof(MobileDamagedEvent),
-                typeof(MobileDiedEvent)
-            ],
-            eventBus.EventTypes
-        );
-    }
-
-    private static PlayerSession SessionWithCharacter(MobileEntity character)
-    {
-        var session = (PlayerSession)RuntimeHelpers.GetUninitializedObject(typeof(PlayerSession));
-        var property = typeof(PlayerSession).GetProperty(nameof(PlayerSession.Character)) ??
-                       throw new InvalidOperationException("Player session character property was not found.");
-        property.SetValue(session, character);
-
-        return session;
-    }
-
     private sealed class RouterFixture
     {
         public FakePersistenceService Persistence { get; } = new();
@@ -567,18 +136,6 @@ public class NpcBrainEventRouterTests
 
         public int MaxPerceptionRange => Descriptors.Values.Select(value => value.PerceptionRange).DefaultIfEmpty().Max();
 
-        public void Bind(MobileEntity mobile)
-        {
-            BindCalls.Add(mobile.Id);
-        }
-
-        public void Unbind(Serial mobileId)
-        {
-            UnbindCalls.Add(mobileId);
-            Active.Remove(mobileId);
-            Descriptors.Remove(mobileId);
-        }
-
         public void Activate(Serial mobileId)
         {
             ActivateCalls.Add(mobileId);
@@ -589,35 +146,10 @@ public class NpcBrainEventRouterTests
             }
         }
 
-        public void Deactivate(Serial mobileId)
-        {
-            DeactivateCalls.Add(mobileId);
-            Active.Remove(mobileId);
-        }
+        public void Bind(MobileEntity mobile)
+            => BindCalls.Add(mobile.Id);
 
-        public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
-        {
-        }
-
-        public bool IsActive(Serial mobileId)
-            => Active.Contains(mobileId);
-
-        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
-        {
-            var found = Descriptors.TryGetValue(mobileId, out var value);
-            descriptor = value;
-
-            return found;
-        }
-
-        public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
-        {
-            Events.Add((mobileId, hook, brainEvent));
-        }
-
-        public IReadOnlyList<(NpcBrainHookType Hook, NpcBrainEvent Event)> CoalescedEventsFor(
-            Serial mobileId
-        )
+        public IReadOnlyList<(NpcBrainHookType Hook, NpcBrainEvent Event)> CoalescedEventsFor(Serial mobileId)
         {
             var mailbox = new NpcBrainMailbox(16, new NpcAiMetrics());
 
@@ -629,9 +161,36 @@ public class NpcBrainEventRouterTests
             return mailbox.Dequeue(16);
         }
 
-        public void Tick()
+        public void Deactivate(Serial mobileId)
         {
-            TickCalls++;
+            DeactivateCalls.Add(mobileId);
+            Active.Remove(mobileId);
+        }
+
+        public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
+            => Events.Add((mobileId, hook, brainEvent));
+
+        public bool IsActive(Serial mobileId)
+            => Active.Contains(mobileId);
+
+        public void RefreshDescriptor(string brainId, BrainDescriptor descriptor) { }
+
+        public void Tick()
+            => TickCalls++;
+
+        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+        {
+            var found = Descriptors.TryGetValue(mobileId, out var value);
+            descriptor = value;
+
+            return found;
+        }
+
+        public void Unbind(Serial mobileId)
+        {
+            UnbindCalls.Add(mobileId);
+            Active.Remove(mobileId);
+            Descriptors.Remove(mobileId);
         }
     }
 
@@ -644,21 +203,13 @@ public class NpcBrainEventRouterTests
         public bool IsActive(int mapId, int sectorX, int sectorY)
             => Active.Contains((mapId, sectorX, sectorY));
 
-        public void TrackPlayer(MobileEntity player)
-        {
-        }
+        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY) { }
 
-        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
-        {
-        }
+        public void Tick() { }
 
-        public void UntrackPlayer(Serial playerId)
-        {
-        }
+        public void TrackPlayer(MobileEntity player) { }
 
-        public void Tick()
-        {
-        }
+        public void UntrackPlayer(Serial playerId) { }
     }
 
     private sealed class RecordingSubscriptionEventBus : IEventBus
@@ -670,9 +221,7 @@ public class NpcBrainEventRouterTests
 
         public List<Type> EventTypes { get; } = [];
 
-        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
-        {
-        }
+        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent { }
 
         public Task PublishAsync<TEvent>(
             TEvent eventData,
@@ -680,21 +229,19 @@ public class NpcBrainEventRouterTests
         )
             where TEvent : IEvent
             => _handlers.TryGetValue(typeof(TEvent), out var handler)
-                ? handler(eventData, cancellationToken)
-                : Task.CompletedTask;
+                   ? handler(eventData, cancellationToken)
+                   : Task.CompletedTask;
 
         public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener)
             where TEvent : IEvent
             => NoopDisposable.Instance;
 
-        public IDisposable Subscribe<TEvent>(
-            Func<TEvent, CancellationToken, Task> handler
-        )
+        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler)
             where TEvent : IEvent
         {
             EventTypes.Add(typeof(TEvent));
             _handlers[typeof(TEvent)] = (eventData, cancellationToken) =>
-                handler((TEvent)eventData, cancellationToken);
+                                            handler((TEvent)eventData, cancellationToken);
 
             return NoopDisposable.Instance;
         }
@@ -704,8 +251,437 @@ public class NpcBrainEventRouterTests
     {
         public static readonly NoopDisposable Instance = new();
 
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public async Task BrainDefinitionReloaded_RouterBeforeLifecycle_ReconcilesExpandedAndShrunkRanges()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var near = fixture.AddMobile(0x2, "Near", 0, 13, 10);
+        var far = fixture.AddMobile(0x3, "Far", 0, 18, 10);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+        var eventBus = new RecordingSubscriptionEventBus();
+        fixture.Router.Subscribe(eventBus);
+        var expanded = new BrainDescriptor("guard", 1000, 10, 5);
+
+        await eventBus.PublishAsync(
+            new BrainDefinitionReloadedEvent("guard", expanded),
+            CancellationToken.None
+        );
+
+        var entered = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, entered.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, entered.Hook);
+        Assert.Equal(far.Id, entered.Event.Mobile!.Id);
+
+        fixture.Scheduler.Descriptors[observer.Id] = expanded;
+        fixture.Scheduler.Events.Clear();
+        await eventBus.PublishAsync(
+            new BrainDefinitionReloadedEvent(
+                "guard",
+                new("guard", 1000, 2, 5)
+            ),
+            CancellationToken.None
+        );
+
+        Assert.Equal(
+            [near.Id, far.Id],
+            fixture.Scheduler.Events.Select(entry => entry.Event.Mobile!.Id)
+        );
+        Assert.All(
+            fixture.Scheduler.Events,
+            entry => Assert.Equal(NpcBrainHookType.MobileLeftRange, entry.Hook)
+        );
+    }
+
+    [Fact]
+    public async Task CanonicalEventHandlers_NeverControlSchedulerLifecycle()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var existing = fixture.AddBrain(0x1, "Existing", 0, 5, 5, 5, 5, true);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+
+        fixture.Scheduler.Active.Remove(existing.Id);
+        await fixture.MoveAsync(existing, 32, 5);
+
+        var created = fixture.Mobile(0x2, "Created", 0, 6, 5, "guard");
+        fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
+        fixture.Scheduler.Active.Add(created.Id);
+        await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
+        await fixture.Router.OnMobileDeleted(new(created), CancellationToken.None);
+        await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
+
+        Assert.Empty(fixture.Scheduler.BindCalls);
+        Assert.Empty(fixture.Scheduler.ActivateCalls);
+        Assert.Empty(fixture.Scheduler.DeactivateCalls);
+        Assert.Empty(fixture.Scheduler.UnbindCalls);
+    }
+
+    [Fact]
+    public async Task CombatEvents_OnlyActiveAffectedBrainReceivesAttackerAndDamagePayloads()
+    {
+        var fixture = new RouterFixture();
+        var active = fixture.AddBrain(0x1, "Active", 0, 10, 10, 5, 5, true);
+        var sleeping = fixture.AddBrain(0x2, "Sleeping", 0, 10, 10, 5, 5, false);
+        var attacker = fixture.AddMobile(0x3, "Attacker", 0, 11, 10);
+
+        await fixture.Router.OnMobileAttacked(new(active.Id, attacker.Id), CancellationToken.None);
+        await fixture.Router.OnMobileDamaged(new(active.Id, attacker.Id, 17), CancellationToken.None);
+        await fixture.Router.OnMobileDied(new(active.Id, attacker.Id), CancellationToken.None);
+        await fixture.Router.OnMobileAttacked(new(sleeping.Id, attacker.Id), CancellationToken.None);
+        await fixture.Router.OnMobileDamaged(new(sleeping.Id, attacker.Id, 9), CancellationToken.None);
+        await fixture.Router.OnMobileDied(new(sleeping.Id, attacker.Id), CancellationToken.None);
+
+        Assert.Equal(
+            [NpcBrainHookType.Attacked, NpcBrainHookType.Damage, NpcBrainHookType.Death],
+            fixture.Scheduler.Events.Select(entry => entry.Hook)
+        );
+        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(active.Id, entry.MobileId));
+        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(attacker.Id, entry.Event.Mobile!.Id));
+        Assert.Equal(17, fixture.Scheduler.Events[1].Event.Amount);
+    }
+
+    [Fact]
+    public async Task MobileLifecycle_ExternallyActiveCreateRoutesBothRolesAndDeleteClearsWithoutLifecycleCalls()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+        var created = fixture.Mobile(0x2, "Created Brain", 0, 8, 5, "guard");
+        fixture.Scheduler.Descriptors[created.Id] = new("guard", 1000, 5, 5);
+        fixture.Scheduler.Active.Add(created.Id);
+
+        await fixture.Router.OnMobileCreated(new(created), CancellationToken.None);
+
+        Assert.Empty(fixture.Scheduler.BindCalls);
+        Assert.Collection(
+            fixture.Scheduler.Events,
+            entry =>
+            {
+                Assert.Equal(observer.Id, entry.MobileId);
+                Assert.Equal(created.Id, entry.Event.Mobile!.Id);
+            },
+            entry =>
+            {
+                Assert.Equal(created.Id, entry.MobileId);
+                Assert.Equal(observer.Id, entry.Event.Mobile!.Id);
+            }
+        );
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.Router.OnMobileDeleted(new(created), CancellationToken.None);
+
+        var leave = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, leave.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
+        Assert.Empty(fixture.Scheduler.UnbindCalls);
+    }
+
+    [Fact]
+    public async Task OnMobileCreated_RouterBeforeBrainBinding_FirstInsideMovementRecoversWithEnter()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddMobile(0x1, "Observer", 0, 5, 5, "guard");
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
+
+        await fixture.Router.OnMobileCreated(new(observer), CancellationToken.None);
+        fixture.Scheduler.Descriptors[observer.Id] = new("guard", 1000, 5, 5);
+        fixture.Scheduler.Active.Add(observer.Id);
+        await fixture.MoveAsync(subject, 9, 5);
+
+        var recovered = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, recovered.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, recovered.Hook);
+        Assert.Equal(subject.Id, recovered.Event.Mobile!.Id);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_ActiveBrainObserver_RecomputesStationaryEntriesAndLeaves()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 4, 4, true);
+        var leftBehind = fixture.AddMobile(0x2, "Left", 0, 4, 5);
+        var newlySeen = fixture.AddMobile(0x3, "New", 0, 13, 5);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.MoveAsync(observer, 10, 5);
+
+        Assert.Collection(
+            fixture.Scheduler.Events,
+            entry =>
+            {
+                Assert.Equal(observer.Id, entry.MobileId);
+                Assert.Equal(NpcBrainHookType.MobileLeftRange, entry.Hook);
+                Assert.Equal(leftBehind.Id, entry.Event.Mobile!.Id);
+            },
+            entry =>
+            {
+                Assert.Equal(observer.Id, entry.MobileId);
+                Assert.Equal(NpcBrainHookType.MobileEnteredRange, entry.Hook);
+                Assert.Equal(newlySeen.Id, entry.Event.Mobile!.Id);
+            }
+        );
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_ExternallySleepingBrain_ClearsObserverSetWithoutLifecycleCall()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+
+        fixture.Scheduler.Active.Remove(observer.Id);
+        await fixture.MoveAsync(observer, 32, 5);
+        await fixture.MoveAsync(subject, 9, 5);
+
+        Assert.False(fixture.Scheduler.IsActive(observer.Id));
+        Assert.DoesNotContain(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
+        Assert.Empty(fixture.Scheduler.DeactivateCalls);
+
+        fixture.Scheduler.Active.Add(observer.Id);
+        fixture.Sectors.Active.Add((0, 2, 0));
+        await fixture.Router.OnSectorActivated(new(0, 2, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+        await fixture.MoveAsync(subject, 33, 5);
+
+        var enter = Assert.Single(fixture.Scheduler.Events, entry => entry.MobileId == observer.Id);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, enter.Hook);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_RepeatedInsideMovement_MailboxRetainsLatestPosition()
+    {
+        var fixture = new RouterFixture();
+        fixture.Sectors.Active.Add((0, 0, 0));
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 11, 10);
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.MoveAsync(subject, 12, 10);
+        await fixture.MoveAsync(subject, 13, 10);
+
+        var queued = Assert.Single(fixture.Scheduler.CoalescedEventsFor(observer.Id));
+        Assert.Equal(NpcBrainHookType.MobileMoved, queued.Hook);
+        Assert.Equal(subject.Id, queued.Event.Mobile!.Id);
+        Assert.Equal(new Point3D(12, 10, 0), queued.Event.FromPosition);
+        Assert.Equal(new Point3D(13, 10, 0), queued.Event.ToPosition);
+        Assert.Equal(new(13, 10, 0), queued.Event.Mobile.Position);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_SubjectCrossesObserverRange_EmitsEnterMoveAndLeaveOnce()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 20, 10);
+
+        await fixture.MoveAsync(subject, 15, 10);
+        await fixture.MoveAsync(subject, 13, 10);
+        await fixture.MoveAsync(subject, 20, 10);
+
+        Assert.Equal(
+            [
+                NpcBrainHookType.MobileEnteredRange,
+                NpcBrainHookType.MobileMoved,
+                NpcBrainHookType.MobileLeftRange
+            ],
+            fixture.Scheduler.Events.Select(entry => entry.Hook)
+        );
+        Assert.All(fixture.Scheduler.Events, entry => Assert.Equal(observer.Id, entry.MobileId));
+        Assert.Equal(new Point3D(15, 10, 0), fixture.Scheduler.Events[0].Event.ToPosition);
+        Assert.Equal(new Point3D(13, 10, 0), fixture.Scheduler.Events[1].Event.ToPosition);
+        Assert.Equal(new Point3D(20, 10, 0), fixture.Scheduler.Events[2].Event.ToPosition);
+    }
+
+    [Fact]
+    public async Task OnMobileMoved_UnperceivedSubjectLeavesRange_DoesNotEmitLeave()
+    {
+        var fixture = new RouterFixture();
+        fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 14, 10);
+
+        await fixture.MoveAsync(subject, 20, 10);
+
+        Assert.Empty(fixture.Scheduler.Events);
+    }
+
+    [Fact]
+    public async Task OnMobileSpeech_ActiveBrainsInExactHearingRange_ReceivePreservedSpeechSnapshot()
+    {
+        var fixture = new RouterFixture();
+        var speaker = fixture.AddMobile(0x1, "Player One", 0, 10, 10);
+        var shortRange = fixture.AddBrain(0x2, "Short", 0, 15, 10, 8, 5, true);
+        var longRange = fixture.AddBrain(0x3, "Long", 0, 17, 10, 8, 7, true);
+        fixture.AddBrain(0x4, "Outside Exact", 0, 16, 10, 8, 5, true);
+        fixture.AddBrain(0x5, "Sleeping", 0, 11, 10, 8, 20, false);
+        fixture.AddBrain(0x6, "Other Map", 1, 10, 10, 8, 20, true);
+        fixture.Sessions.Played.Add(speaker.Id);
+
+        await fixture.Router.OnMobileSpeech(
+            new(speaker.Id, ChatMessageType.Yell, "Guards!"),
+            CancellationToken.None
+        );
+
+        Assert.Equal([shortRange.Id, longRange.Id], fixture.Scheduler.Events.Select(entry => entry.MobileId));
+        var routed = fixture.Scheduler.Events[0];
+        Assert.Equal(NpcBrainHookType.SpeechHeard, routed.Hook);
+        Assert.Equal(NpcBrainEventType.SpeechHeard, routed.Event.Type);
+        Assert.Equal("Guards!", routed.Event.Text);
+        Assert.Equal(ChatMessageType.Yell, routed.Event.SpeechType);
+        Assert.Equal(speaker.Id, routed.Event.Mobile!.Id);
+        Assert.Equal("Player One", routed.Event.Mobile.Name);
+        Assert.True(routed.Event.Mobile.IsPlayer);
+    }
+
+    [Fact]
+    public async Task OnMobileSpeech_LaterNpcReply_ExcludesEachSpeakerAndOnlyEnqueues()
+    {
+        var fixture = new RouterFixture();
+        var player = fixture.AddMobile(0x1, "Player", 0, 10, 10);
+        var firstNpc = fixture.AddBrain(0x2, "First", 0, 11, 10, 8, 8, true);
+        var secondNpc = fixture.AddBrain(0x3, "Second", 0, 12, 10, 8, 8, true);
+
+        await fixture.Router.OnMobileSpeech(
+            new(player.Id, ChatMessageType.Regular, "hello"),
+            CancellationToken.None
+        );
+        fixture.Scheduler.Events.Clear();
+
+        await fixture.Router.OnMobileSpeech(
+            new(firstNpc.Id, ChatMessageType.Regular, "greetings"),
+            CancellationToken.None
+        );
+
+        var routed = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(secondNpc.Id, routed.MobileId);
+        Assert.Equal(firstNpc.Id, routed.Event.Mobile!.Id);
+        Assert.Equal("greetings", routed.Event.Text);
+        Assert.Equal(0, fixture.Scheduler.TickCalls);
+    }
+
+    [Fact]
+    public async Task PerceptionTransitions_DifferentMapsNeverInteract()
+    {
+        var fixture = new RouterFixture();
+        fixture.AddBrain(0x1, "Observer", 0, 10, 10, 20, 20, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 1, 10, 10);
+
+        await fixture.MoveAsync(subject, 11, 10);
+        await fixture.Router.OnMobileSpeech(
+            new(subject.Id, ChatMessageType.Regular, "other map"),
+            CancellationToken.None
+        );
+
+        Assert.Empty(fixture.Scheduler.Events);
+    }
+
+    [Fact]
+    public async Task PlayerLifecycle_UsesEventSnapshotsBeforeSpatialSubscriberAndEmitsRangeTransitions()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 10, 10, 5, 5, true);
+        var player = fixture.Mobile(0x2, "Player", 0, 14, 10);
+
+        await fixture.Router.OnPlayerEnteredWorld(
+            new(7, new(0x900), player),
+            CancellationToken.None
+        );
+
+        var enter = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, enter.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, enter.Hook);
+        Assert.True(enter.Event.Mobile!.IsPlayer);
+        fixture.Scheduler.Events.Clear();
+
+        var session = SessionWithCharacter(player);
+        await fixture.Router.OnSessionDestroyed(new(session), CancellationToken.None);
+
+        var leave = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, leave.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileLeftRange, leave.Hook);
+        Assert.Equal(player.Id, leave.Event.Mobile!.Id);
+    }
+
+    [Fact]
+    public async Task SectorLifecycle_ActivationSeedsAndSleepingObserverRetainsNoPerceptionSet()
+    {
+        var fixture = new RouterFixture();
+        var observer = fixture.AddBrain(0x1, "Observer", 0, 5, 5, 5, 5, true);
+        var subject = fixture.AddMobile(0x2, "Subject", 0, 8, 5);
+        fixture.Sectors.Active.Add((0, 0, 0));
+
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+
+        var initial = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(observer.Id, initial.MobileId);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, initial.Hook);
+        Assert.Equal(subject.Id, initial.Event.Mobile!.Id);
+
+        fixture.Scheduler.Events.Clear();
+        fixture.Scheduler.Active.Remove(observer.Id);
+        fixture.Sectors.Active.Remove((0, 0, 0));
+        await fixture.Router.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
+        await fixture.MoveAsync(subject, 20, 5);
+        await fixture.MoveAsync(subject, 8, 5);
+        Assert.Empty(fixture.Scheduler.Events);
+
+        fixture.Scheduler.Active.Add(observer.Id);
+        fixture.Sectors.Active.Add((0, 0, 0));
+        await fixture.Router.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+
+        var reseeded = Assert.Single(fixture.Scheduler.Events);
+        Assert.Equal(NpcBrainHookType.MobileEnteredRange, reseeded.Hook);
+        Assert.Equal(subject.Id, reseeded.Event.Mobile!.Id);
+    }
+
+    [Fact]
+    public void Subscribe_RegistersAllCanonicalEventHandlers()
+    {
+        var fixture = new RouterFixture();
+        var eventBus = new RecordingSubscriptionEventBus();
+
+        fixture.Router.Subscribe(eventBus);
+
+        Assert.Equal(
+            [
+                typeof(MobileSpeechEvent),
+                typeof(MobileMovedEvent),
+                typeof(MobileCreatedEvent),
+                typeof(MobileDeletedEvent),
+                typeof(PlayerEnteredWorldEvent),
+                typeof(SessionDestroyedEvent),
+                typeof(SectorActivatedEvent),
+                typeof(SectorDeactivatedEvent),
+                typeof(BrainDefinitionReloadedEvent),
+                typeof(MobileAttackedEvent),
+                typeof(MobileDamagedEvent),
+                typeof(MobileDiedEvent)
+            ],
+            eventBus.EventTypes
+        );
+    }
+
+    private static PlayerSession SessionWithCharacter(MobileEntity character)
+    {
+        var session = (PlayerSession)RuntimeHelpers.GetUninitializedObject(typeof(PlayerSession));
+        var property = typeof(PlayerSession).GetProperty(nameof(PlayerSession.Character)) ??
+                       throw new InvalidOperationException("Player session character property was not found.");
+        property.SetValue(session, character);
+
+        return session;
     }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
@@ -1,5 +1,4 @@
 using DryIoc;
-using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Core.Types;
 using Moongate.Persistence.Entities;
@@ -19,7 +18,6 @@ using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 using MoonSharp.Interpreter;
 using SquidStd.Core.Directories;
-using SquidStd.Scripting.Lua.Data.Config;
 using SquidStd.Scripting.Lua.Services;
 using SquidStd.Services.Core.Services;
 
@@ -29,6 +27,207 @@ public sealed class NpcBrainIntegrationTests
 {
     private const string FirstMeetingReply = "I haven't seen you before.";
     private const string ReturningPlayerReply = "Welcome back.";
+
+    private sealed class IntegrationFixture : IDisposable
+    {
+        private readonly Container _container = new();
+        private readonly LuaScriptEngineService _engine;
+        private readonly LuaNpcBrainRuntime _luaRuntime;
+        private readonly string _root;
+
+        public EventBusService Bus { get; } = new();
+
+        public RecordingChatService Chat { get; } = new();
+
+        public MoongateConfig Config { get; } = new();
+
+        public MobileEntity Guard { get; } = new()
+        {
+            Id = new(0x2),
+            Name = "Guard",
+            BrainScriptId = "guard",
+            MapId = 0,
+            Position = new(40, 32, 0),
+            Hits = 100,
+            HitsMax = 100
+        };
+
+        public StubGameLoopContext Loop { get; } = new();
+
+        public NpcAiMetrics Metrics { get; } = new();
+
+        public FakePersistenceService Persistence { get; } = new();
+
+        public MobileEntity Player { get; } = new()
+        {
+            Id = new(0x1),
+            Name = "Player",
+            MapId = 0,
+            Position = new(32, 32, 0),
+            Hits = 100,
+            HitsMax = 100
+        };
+
+        public StubSessionManager Sessions { get; } = new();
+
+        public MutableTimeProvider Time { get; } = new(new(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+
+        public SectorActivityService Activity { get; }
+
+        public RecordingLuaNpcBrainRuntime Runtime { get; }
+
+        public NpcBrainScheduler Scheduler { get; }
+
+        public SpatialIndexService Spatial { get; }
+
+        public IntegrationFixture()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "mg-npc-brain-integration-" + Guid.NewGuid().ToString("N"));
+            var directories = new DirectoriesConfig(_root, ["scripts"]);
+            _engine = new(
+                directories,
+                _container,
+                new(_root, directories.GetPath("scripts"), "MoongateTests", "1.0.0")
+            );
+            BrainAssetSeeder.SeedMissing(Path.Combine(directories.GetPath("scripts"), "brains"));
+
+            var loopAffinity = new StubLoopAffinity();
+            Spatial = new(Persistence, loopAffinity, Bus);
+            Activity = new(Loop, Bus, Time, Config, Metrics);
+            _luaRuntime = new(_engine, directories, Config, Metrics, Loop, Bus, Time);
+            Runtime = new(_luaRuntime);
+            var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
+            var aiActions = new AiActionService(
+                Persistence,
+                new UnexpectedMovementService(),
+                Chat,
+                new(42),
+                loopAffinity,
+                Metrics
+            );
+            InstallAiModule(aiActions);
+            Scheduler = new(
+                Loop,
+                Runtime,
+                aiActions,
+                new StubNpcMemoryService(),
+                Activity,
+                Persistence,
+                contextFactory,
+                Time,
+                Config,
+                Metrics
+            );
+
+            new NpcBrainLifecycleSubscriber(Spatial, Persistence, Scheduler, Activity).Subscribe(Bus);
+            new NpcBrainEventRouter(Spatial, Persistence, Sessions, Scheduler, Activity).Subscribe(Bus);
+        }
+
+        public void Dispose()
+        {
+            _luaRuntime.Dispose();
+            _engine.Dispose();
+            Bus.Dispose();
+            _container.Dispose();
+            Directory.Delete(_root, true);
+        }
+
+        public async Task SeedAsync()
+        {
+            await Persistence.Store<MobileEntity>().UpsertAsync(Player);
+            await Persistence.Store<MobileEntity>().UpsertAsync(Guard);
+            await Persistence.Store<AccountEntity>()
+                             .UpsertAsync(
+                                 new()
+                                 {
+                                     Id = new(0x100),
+                                     Username = "player",
+                                     MobileIds = [Player.Id]
+                                 }
+                             );
+            Sessions.Played.Add(Player.Id);
+        }
+
+        private void InstallAiModule(AiActionService actions)
+        {
+            var ai = new Table(_engine.LuaScript);
+            ai.Set(
+                "say",
+                DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.Say(a.Count > 0 ? a[0].ToPrintString() : "")))
+            );
+            ai.Set("patrol", DynValue.NewCallback((_, _) => DynValue.NewBoolean(actions.Patrol())));
+            ai.Set("return_home", DynValue.NewCallback((_, _) => DynValue.NewBoolean(actions.ReturnHome())));
+            ai.Set("clear_target", DynValue.NewCallback((_, _) => DynValue.NewBoolean(actions.ClearTarget())));
+            ai.Set(
+                "move_toward",
+                DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.MoveToward(new((uint)a[0].Number))))
+            );
+            ai.Set(
+                "move_away",
+                DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.MoveAway(new((uint)a[0].Number))))
+            );
+            ai.Set("engage", DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.Engage(new((uint)a[0].Number)))));
+            _engine.LuaScript.Globals.Set("ai", DynValue.NewTable(ai));
+        }
+    }
+
+    private sealed class RecordingLuaNpcBrainRuntime : INpcBrainRuntime
+    {
+        private readonly LuaNpcBrainRuntime _inner;
+        private readonly List<NpcBrainHookType> _invocations = [];
+
+        public IReadOnlyList<NpcBrainHookType> Invocations => _invocations;
+
+        public RecordingLuaNpcBrainRuntime(LuaNpcBrainRuntime inner)
+        {
+            _inner = inner;
+        }
+
+        public NpcBrainInvocationResult Invoke(
+            Serial mobileId,
+            NpcBrainHookType hook,
+            BrainContext context,
+            NpcBrainEvent? brainEvent = null
+        )
+        {
+            _invocations.Add(hook);
+
+            return _inner.Invoke(mobileId, hook, context, brainEvent);
+        }
+
+        public void Reset(Serial mobileId)
+            => _inner.Reset(mobileId);
+
+        public bool TryBind(
+            Serial mobileId,
+            string brainId,
+            out BrainDescriptor? descriptor,
+            out string? error
+        )
+            => _inner.TryBind(mobileId, brainId, out descriptor, out error);
+
+        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+            => _inner.TryGetDescriptor(mobileId, out descriptor);
+
+        public bool TryReload(
+            string brainId,
+            out BrainDescriptor? descriptor,
+            out string? error
+        )
+            => _inner.TryReload(brainId, out descriptor, out error);
+
+        public void Unbind(Serial mobileId)
+            => _inner.Unbind(mobileId);
+    }
+
+    private sealed class UnexpectedMovementService : IMovementService
+    {
+        public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
+            => throw new InvalidOperationException("The guard integration flow must not move a player.");
+
+        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+            => throw new InvalidOperationException("The built-in guard flow must not emit movement intents.");
+    }
 
     [Fact]
     public async Task PlayerSpeech_CompleteGuardLifecycle_RepliesWithRetainedMemory()
@@ -199,206 +398,5 @@ public sealed class NpcBrainIntegrationTests
         Assert.Equal(expected, fixture.Runtime.Invocations.Skip(offset));
         offset += expected.Length;
         Assert.Equal(offset, fixture.Runtime.Invocations.Count);
-    }
-
-    private sealed class IntegrationFixture : IDisposable
-    {
-        private readonly Container _container = new();
-        private readonly LuaScriptEngineService _engine;
-        private readonly LuaNpcBrainRuntime _luaRuntime;
-        private readonly string _root;
-
-        public EventBusService Bus { get; } = new();
-
-        public RecordingChatService Chat { get; } = new();
-
-        public MoongateConfig Config { get; } = new();
-
-        public MobileEntity Guard { get; } = new()
-        {
-            Id = new(0x2),
-            Name = "Guard",
-            BrainScriptId = "guard",
-            MapId = 0,
-            Position = new(40, 32, 0),
-            Hits = 100,
-            HitsMax = 100
-        };
-
-        public StubGameLoopContext Loop { get; } = new();
-
-        public NpcAiMetrics Metrics { get; } = new();
-
-        public FakePersistenceService Persistence { get; } = new();
-
-        public MobileEntity Player { get; } = new()
-        {
-            Id = new(0x1),
-            Name = "Player",
-            MapId = 0,
-            Position = new(32, 32, 0),
-            Hits = 100,
-            HitsMax = 100
-        };
-
-        public StubSessionManager Sessions { get; } = new();
-
-        public MutableTimeProvider Time { get; } = new(
-            new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero)
-        );
-
-        public SectorActivityService Activity { get; }
-
-        public RecordingLuaNpcBrainRuntime Runtime { get; }
-
-        public NpcBrainScheduler Scheduler { get; }
-
-        public SpatialIndexService Spatial { get; }
-
-        public IntegrationFixture()
-        {
-            _root = Path.Combine(Path.GetTempPath(), "mg-npc-brain-integration-" + Guid.NewGuid().ToString("N"));
-            var directories = new DirectoriesConfig(_root, ["scripts"]);
-            _engine = new(
-                directories,
-                _container,
-                new LuaEngineConfig(_root, directories.GetPath("scripts"), "MoongateTests", "1.0.0")
-            );
-            BrainAssetSeeder.SeedMissing(Path.Combine(directories.GetPath("scripts"), "brains"));
-
-            var loopAffinity = new StubLoopAffinity();
-            Spatial = new(Persistence, loopAffinity, Bus);
-            Activity = new(Loop, Bus, Time, Config, Metrics);
-            _luaRuntime = new(_engine, directories, Config, Metrics, Loop, Bus, Time);
-            Runtime = new(_luaRuntime);
-            var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
-            var aiActions = new AiActionService(
-                Persistence,
-                new UnexpectedMovementService(),
-                Chat,
-                new Random(42),
-                loopAffinity,
-                Metrics
-            );
-            InstallAiModule(aiActions);
-            Scheduler = new(
-                Loop,
-                Runtime,
-                aiActions,
-                new StubNpcMemoryService(),
-                Activity,
-                Persistence,
-                contextFactory,
-                Time,
-                Config,
-                Metrics
-            );
-
-            new NpcBrainLifecycleSubscriber(Spatial, Persistence, Scheduler, Activity).Subscribe(Bus);
-            new NpcBrainEventRouter(Spatial, Persistence, Sessions, Scheduler, Activity).Subscribe(Bus);
-        }
-
-        private void InstallAiModule(AiActionService actions)
-        {
-            var ai = new Table(_engine.LuaScript);
-            ai.Set("say", DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.Say(a.Count > 0 ? a[0].ToPrintString() : ""))));
-            ai.Set("patrol", DynValue.NewCallback((_, _) => DynValue.NewBoolean(actions.Patrol())));
-            ai.Set("return_home", DynValue.NewCallback((_, _) => DynValue.NewBoolean(actions.ReturnHome())));
-            ai.Set("clear_target", DynValue.NewCallback((_, _) => DynValue.NewBoolean(actions.ClearTarget())));
-            ai.Set("move_toward", DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.MoveToward(new((uint)a[0].Number)))));
-            ai.Set("move_away", DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.MoveAway(new((uint)a[0].Number)))));
-            ai.Set("engage", DynValue.NewCallback((_, a) => DynValue.NewBoolean(actions.Engage(new((uint)a[0].Number)))));
-            _engine.LuaScript.Globals.Set("ai", DynValue.NewTable(ai));
-        }
-
-        public async Task SeedAsync()
-        {
-            await Persistence.Store<MobileEntity>().UpsertAsync(Player);
-            await Persistence.Store<MobileEntity>().UpsertAsync(Guard);
-            await Persistence.Store<AccountEntity>().UpsertAsync(
-                new()
-                {
-                    Id = new(0x100),
-                    Username = "player",
-                    MobileIds = [Player.Id]
-                }
-            );
-            Sessions.Played.Add(Player.Id);
-        }
-
-        public void Dispose()
-        {
-            _luaRuntime.Dispose();
-            _engine.Dispose();
-            Bus.Dispose();
-            _container.Dispose();
-            Directory.Delete(_root, true);
-        }
-    }
-
-    private sealed class RecordingLuaNpcBrainRuntime : INpcBrainRuntime
-    {
-        private readonly LuaNpcBrainRuntime _inner;
-        private readonly List<NpcBrainHookType> _invocations = [];
-
-        public IReadOnlyList<NpcBrainHookType> Invocations => _invocations;
-
-        public RecordingLuaNpcBrainRuntime(LuaNpcBrainRuntime inner)
-        {
-            _inner = inner;
-        }
-
-        public bool TryBind(
-            Serial mobileId,
-            string brainId,
-            out BrainDescriptor? descriptor,
-            out string? error
-        )
-            => _inner.TryBind(mobileId, brainId, out descriptor, out error);
-
-        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
-            => _inner.TryGetDescriptor(mobileId, out descriptor);
-
-        public NpcBrainInvocationResult Invoke(
-            Serial mobileId,
-            NpcBrainHookType hook,
-            BrainContext context,
-            NpcBrainEvent? brainEvent = null
-        )
-        {
-            _invocations.Add(hook);
-
-            return _inner.Invoke(mobileId, hook, context, brainEvent);
-        }
-
-        public bool TryReload(
-            string brainId,
-            out BrainDescriptor? descriptor,
-            out string? error
-        )
-            => _inner.TryReload(brainId, out descriptor, out error);
-
-        public void Reset(Serial mobileId)
-        {
-            _inner.Reset(mobileId);
-        }
-
-        public void Unbind(Serial mobileId)
-        {
-            _inner.Unbind(mobileId);
-        }
-    }
-
-    private sealed class UnexpectedMovementService : IMovementService
-    {
-        public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
-        {
-            throw new InvalidOperationException("The guard integration flow must not move a player.");
-        }
-
-        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
-        {
-            throw new InvalidOperationException("The built-in guard flow must not emit movement intents.");
-        }
     }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcBrainLifecycleSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainLifecycleSubscriberTests.cs
@@ -1,5 +1,5 @@
-using Moongate.Core.Primitives;
 using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Abstractions.Data.Events;
@@ -16,154 +16,6 @@ namespace Moongate.Tests.Server.AI;
 
 public sealed class NpcBrainLifecycleSubscriberTests
 {
-    [Fact]
-    public async Task OnWorldReady_AccountOwnedMobileWithBrainId_BindsOnlyNpcBrains()
-    {
-        var fixture = new LifecycleFixture();
-        var npc = fixture.AddMobile(0x1, "guard");
-        var player = fixture.AddMobile(0x2, "guard");
-        await fixture.Persistence.Store<AccountEntity>()
-            .UpsertAsync(new() { Id = new(0x100), Username = "player", MobileIds = [player.Id] });
-
-        await fixture.Subscriber.OnWorldReady(new(), CancellationToken.None);
-
-        Assert.Equal([npc.Id], fixture.Scheduler.Bound);
-        Assert.Empty(fixture.Scheduler.Active);
-    }
-
-    [Fact]
-    public async Task OnWorldReady_ActiveNpcSector_BindsAndActivatesBrain()
-    {
-        var fixture = new LifecycleFixture();
-        var npc = fixture.AddMobile(0x1, "guard", x: 32, y: 48);
-        fixture.Sectors.Active.Add((0, 2, 3));
-
-        await fixture.Subscriber.OnWorldReady(new(), CancellationToken.None);
-
-        Assert.Equal([npc.Id], fixture.Scheduler.Bound);
-        Assert.Equal([npc.Id], fixture.Scheduler.Activated);
-    }
-
-    [Fact]
-    public async Task OnMobileCreated_ActiveSector_BindsAndActivatesBrain()
-    {
-        var fixture = new LifecycleFixture();
-        var mobile = fixture.AddMobile(0x1, "guard", x: 32, y: 48);
-        fixture.Sectors.Active.Add((0, 2, 3));
-
-        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
-
-        Assert.Equal([mobile.Id], fixture.Scheduler.Bound);
-        Assert.Equal([mobile.Id], fixture.Scheduler.Active);
-    }
-
-    [Fact]
-    public async Task OnMobileDeleted_BoundBrain_UnbindsIt()
-    {
-        var fixture = new LifecycleFixture();
-        var mobile = fixture.AddMobile(0x1, "guard");
-        fixture.Scheduler.Bound.Add(mobile.Id);
-
-        await fixture.Subscriber.OnMobileDeleted(new(mobile), CancellationToken.None);
-
-        Assert.Empty(fixture.Scheduler.Bound);
-        Assert.Equal([mobile.Id], fixture.Scheduler.Unbound);
-    }
-
-    [Fact]
-    public async Task OnMobileChangedSector_BoundBrain_UsesTargetSectorActivity()
-    {
-        var fixture = new LifecycleFixture();
-        var mobile = fixture.AddMobile(0x1, "guard");
-        fixture.Scheduler.Bound.Add(mobile.Id);
-        fixture.Sectors.Active.Add((0, 1, 1));
-
-        await fixture.Subscriber.OnMobileChangedSector(
-            new(mobile.Id, 0, 0, 0, 0, 1, 1),
-            CancellationToken.None
-        );
-
-        Assert.Equal([mobile.Id], fixture.Scheduler.Active);
-
-        await fixture.Subscriber.OnMobileChangedSector(
-            new(mobile.Id, 0, 1, 1, 0, 2, 2),
-            CancellationToken.None
-        );
-
-        Assert.Empty(fixture.Scheduler.Active);
-        Assert.Equal([mobile.Id], fixture.Scheduler.Deactivated);
-    }
-
-    [Fact]
-    public async Task OnSectorEvents_ExactSector_ActivatesAndDeactivatesBrainMobiles()
-    {
-        var fixture = new LifecycleFixture();
-        var first = fixture.AddMobile(0x1, "guard", x: 5, y: 5);
-        var second = fixture.AddMobile(0x2, "guard", x: 6, y: 6);
-        fixture.AddMobile(0x3, "", x: 7, y: 7);
-        fixture.AddMobile(0x4, "guard", x: 32, y: 5);
-        fixture.Scheduler.Bound.UnionWith([first.Id, second.Id]);
-
-        await fixture.Subscriber.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
-        await fixture.Subscriber.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
-
-        Assert.Equal([first.Id, second.Id], fixture.Scheduler.Activated);
-        Assert.Equal([first.Id, second.Id], fixture.Scheduler.Deactivated);
-    }
-
-    [Fact]
-    public async Task OnBrainDefinitionReloaded_MatchingDescriptor_RefreshesScheduler()
-    {
-        var fixture = new LifecycleFixture();
-        var descriptor = new BrainDescriptor("guard", 1000, 8, 10);
-
-        await fixture.Subscriber.OnBrainDefinitionReloaded(new("guard", descriptor), CancellationToken.None);
-
-        Assert.Equal([("guard", descriptor)], fixture.Scheduler.Refreshed);
-    }
-
-    [Fact]
-    public async Task DuplicateLifecycleEvents_IdempotentSchedulerOperations_LeaveOneBindingAndStateTransition()
-    {
-        var fixture = new LifecycleFixture();
-        var mobile = fixture.AddMobile(0x1, "guard", x: 16, y: 16);
-        fixture.Sectors.Active.Add((0, 1, 1));
-
-        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
-        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
-        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 0, 0, 0, 1, 1), CancellationToken.None);
-        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 0, 0, 0, 1, 1), CancellationToken.None);
-        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 1, 1, 0, 2, 2), CancellationToken.None);
-        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 1, 1, 0, 2, 2), CancellationToken.None);
-
-        Assert.Equal([mobile.Id], fixture.Scheduler.Bound);
-        Assert.Empty(fixture.Scheduler.Active);
-        Assert.Equal([mobile.Id], fixture.Scheduler.Activated);
-        Assert.Equal([mobile.Id], fixture.Scheduler.Deactivated);
-    }
-
-    [Fact]
-    public void Subscribe_RegistersEveryLifecycleEvent()
-    {
-        var fixture = new LifecycleFixture();
-        var eventBus = new RecordingEventBus();
-
-        fixture.Subscriber.Subscribe(eventBus);
-
-        Assert.Equal(
-            [
-                typeof(WorldReadyEvent),
-                typeof(MobileCreatedEvent),
-                typeof(MobileDeletedEvent),
-                typeof(MobileChangedSectorEvent),
-                typeof(SectorActivatedEvent),
-                typeof(SectorDeactivatedEvent),
-                typeof(BrainDefinitionReloadedEvent)
-            ],
-            eventBus.Subscribed
-        );
-    }
-
     private sealed class LifecycleFixture
     {
         public FakePersistenceService Persistence { get; } = new();
@@ -217,9 +69,40 @@ public sealed class NpcBrainLifecycleSubscriberTests
 
         public int MaxPerceptionRange => 0;
 
-        public void Bind(MobileEntity mobile)
+        public void Activate(Serial mobileId)
         {
-            Bound.Add(mobile.Id);
+            if (Bound.Contains(mobileId) && Active.Add(mobileId))
+            {
+                Activated.Add(mobileId);
+            }
+        }
+
+        public void Bind(MobileEntity mobile)
+            => Bound.Add(mobile.Id);
+
+        public void Deactivate(Serial mobileId)
+        {
+            if (Active.Remove(mobileId))
+            {
+                Deactivated.Add(mobileId);
+            }
+        }
+
+        public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent) { }
+
+        public bool IsActive(Serial mobileId)
+            => Active.Contains(mobileId);
+
+        public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
+            => Refreshed.Add((brainId, descriptor));
+
+        public void Tick() { }
+
+        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
+        {
+            descriptor = null;
+
+            return false;
         }
 
         public void Unbind(Serial mobileId)
@@ -232,44 +115,6 @@ public sealed class NpcBrainLifecycleSubscriberTests
             Active.Remove(mobileId);
             Unbound.Add(mobileId);
         }
-
-        public void Activate(Serial mobileId)
-        {
-            if (Bound.Contains(mobileId) && Active.Add(mobileId))
-            {
-                Activated.Add(mobileId);
-            }
-        }
-
-        public void Deactivate(Serial mobileId)
-        {
-            if (Active.Remove(mobileId))
-            {
-                Deactivated.Add(mobileId);
-            }
-        }
-
-        public void RefreshDescriptor(string brainId, BrainDescriptor descriptor)
-        {
-            Refreshed.Add((brainId, descriptor));
-        }
-
-        public bool IsActive(Serial mobileId)
-            => Active.Contains(mobileId);
-
-        public bool TryGetDescriptor(Serial mobileId, out BrainDescriptor? descriptor)
-        {
-            descriptor = null;
-            return false;
-        }
-
-        public void EnqueueEvent(Serial mobileId, NpcBrainHookType hook, NpcBrainEvent brainEvent)
-        {
-        }
-
-        public void Tick()
-        {
-        }
     }
 
     private sealed class StubSectorActivityService : ISectorActivityService
@@ -281,30 +126,20 @@ public sealed class NpcBrainLifecycleSubscriberTests
         public bool IsActive(int mapId, int sectorX, int sectorY)
             => Active.Contains((mapId, sectorX, sectorY));
 
-        public void TrackPlayer(MobileEntity player)
-        {
-        }
+        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY) { }
 
-        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
-        {
-        }
+        public void Tick() { }
 
-        public void UntrackPlayer(Serial playerId)
-        {
-        }
+        public void TrackPlayer(MobileEntity player) { }
 
-        public void Tick()
-        {
-        }
+        public void UntrackPlayer(Serial playerId) { }
     }
 
     private sealed class RecordingEventBus : IEventBus
     {
         public List<Type> Subscribed { get; } = [];
 
-        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
-        {
-        }
+        public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent { }
 
         public Task PublishAsync<TEvent>(TEvent eventData, CancellationToken cancellationToken = default)
             where TEvent : IEvent
@@ -316,6 +151,7 @@ public sealed class NpcBrainLifecycleSubscriberTests
         public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
         {
             Subscribed.Add(typeof(TEvent));
+
             return NoopDisposable.Instance;
         }
     }
@@ -324,8 +160,155 @@ public sealed class NpcBrainLifecycleSubscriberTests
     {
         public static readonly NoopDisposable Instance = new();
 
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public async Task DuplicateLifecycleEvents_IdempotentSchedulerOperations_LeaveOneBindingAndStateTransition()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard", 16, 16);
+        fixture.Sectors.Active.Add((0, 1, 1));
+
+        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
+        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 0, 0, 0, 1, 1), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 0, 0, 0, 1, 1), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 1, 1, 0, 2, 2), CancellationToken.None);
+        await fixture.Subscriber.OnMobileChangedSector(new(mobile.Id, 0, 1, 1, 0, 2, 2), CancellationToken.None);
+
+        Assert.Equal([mobile.Id], fixture.Scheduler.Bound);
+        Assert.Empty(fixture.Scheduler.Active);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Activated);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Deactivated);
+    }
+
+    [Fact]
+    public async Task OnBrainDefinitionReloaded_MatchingDescriptor_RefreshesScheduler()
+    {
+        var fixture = new LifecycleFixture();
+        var descriptor = new BrainDescriptor("guard", 1000, 8, 10);
+
+        await fixture.Subscriber.OnBrainDefinitionReloaded(new("guard", descriptor), CancellationToken.None);
+
+        Assert.Equal([("guard", descriptor)], fixture.Scheduler.Refreshed);
+    }
+
+    [Fact]
+    public async Task OnMobileChangedSector_BoundBrain_UsesTargetSectorActivity()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard");
+        fixture.Scheduler.Bound.Add(mobile.Id);
+        fixture.Sectors.Active.Add((0, 1, 1));
+
+        await fixture.Subscriber.OnMobileChangedSector(
+            new(mobile.Id, 0, 0, 0, 0, 1, 1),
+            CancellationToken.None
+        );
+
+        Assert.Equal([mobile.Id], fixture.Scheduler.Active);
+
+        await fixture.Subscriber.OnMobileChangedSector(
+            new(mobile.Id, 0, 1, 1, 0, 2, 2),
+            CancellationToken.None
+        );
+
+        Assert.Empty(fixture.Scheduler.Active);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Deactivated);
+    }
+
+    [Fact]
+    public async Task OnMobileCreated_ActiveSector_BindsAndActivatesBrain()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard", 32, 48);
+        fixture.Sectors.Active.Add((0, 2, 3));
+
+        await fixture.Subscriber.OnMobileCreated(new(mobile), CancellationToken.None);
+
+        Assert.Equal([mobile.Id], fixture.Scheduler.Bound);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Active);
+    }
+
+    [Fact]
+    public async Task OnMobileDeleted_BoundBrain_UnbindsIt()
+    {
+        var fixture = new LifecycleFixture();
+        var mobile = fixture.AddMobile(0x1, "guard");
+        fixture.Scheduler.Bound.Add(mobile.Id);
+
+        await fixture.Subscriber.OnMobileDeleted(new(mobile), CancellationToken.None);
+
+        Assert.Empty(fixture.Scheduler.Bound);
+        Assert.Equal([mobile.Id], fixture.Scheduler.Unbound);
+    }
+
+    [Fact]
+    public async Task OnSectorEvents_ExactSector_ActivatesAndDeactivatesBrainMobiles()
+    {
+        var fixture = new LifecycleFixture();
+        var first = fixture.AddMobile(0x1, "guard", 5, 5);
+        var second = fixture.AddMobile(0x2, "guard", 6, 6);
+        fixture.AddMobile(0x3, "", 7, 7);
+        fixture.AddMobile(0x4, "guard", 32, 5);
+        fixture.Scheduler.Bound.UnionWith([first.Id, second.Id]);
+
+        await fixture.Subscriber.OnSectorActivated(new(0, 0, 0), CancellationToken.None);
+        await fixture.Subscriber.OnSectorDeactivated(new(0, 0, 0), CancellationToken.None);
+
+        Assert.Equal([first.Id, second.Id], fixture.Scheduler.Activated);
+        Assert.Equal([first.Id, second.Id], fixture.Scheduler.Deactivated);
+    }
+
+    [Fact]
+    public async Task OnWorldReady_AccountOwnedMobileWithBrainId_BindsOnlyNpcBrains()
+    {
+        var fixture = new LifecycleFixture();
+        var npc = fixture.AddMobile(0x1, "guard");
+        var player = fixture.AddMobile(0x2, "guard");
+        await fixture.Persistence
+                     .Store<AccountEntity>()
+                     .UpsertAsync(new() { Id = new(0x100), Username = "player", MobileIds = [player.Id] });
+
+        await fixture.Subscriber.OnWorldReady(new(), CancellationToken.None);
+
+        Assert.Equal([npc.Id], fixture.Scheduler.Bound);
+        Assert.Empty(fixture.Scheduler.Active);
+    }
+
+    [Fact]
+    public async Task OnWorldReady_ActiveNpcSector_BindsAndActivatesBrain()
+    {
+        var fixture = new LifecycleFixture();
+        var npc = fixture.AddMobile(0x1, "guard", 32, 48);
+        fixture.Sectors.Active.Add((0, 2, 3));
+
+        await fixture.Subscriber.OnWorldReady(new(), CancellationToken.None);
+
+        Assert.Equal([npc.Id], fixture.Scheduler.Bound);
+        Assert.Equal([npc.Id], fixture.Scheduler.Activated);
+    }
+
+    [Fact]
+    public void Subscribe_RegistersEveryLifecycleEvent()
+    {
+        var fixture = new LifecycleFixture();
+        var eventBus = new RecordingEventBus();
+
+        fixture.Subscriber.Subscribe(eventBus);
+
+        Assert.Equal(
+            [
+                typeof(WorldReadyEvent),
+                typeof(MobileCreatedEvent),
+                typeof(MobileDeletedEvent),
+                typeof(MobileChangedSectorEvent),
+                typeof(SectorActivatedEvent),
+                typeof(SectorDeactivatedEvent),
+                typeof(BrainDefinitionReloadedEvent)
+            ],
+            eventBus.Subscribed
+        );
     }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcBrainMailboxTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainMailboxTests.cs
@@ -10,6 +10,20 @@ namespace Moongate.Tests.Server.AI;
 public class NpcBrainMailboxTests
 {
     [Fact]
+    public void Clear_QueuedEvents_RemovesAllWithoutRecordingDelivery()
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(4, metrics);
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.MobileMoved, Event(NpcBrainEventType.MobileMoved, 0x2));
+
+        mailbox.Clear();
+
+        Assert.Empty(mailbox.Dequeue(4));
+        Assert.Equal(0, metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
     public void Dequeue_LifecycleCombatSpeechAndRangeEvents_PreservesFifoOrder()
     {
         var mailbox = new NpcBrainMailbox(4, new NpcAiMetrics());
@@ -32,29 +46,55 @@ public class NpcBrainMailboxTests
     }
 
     [Fact]
-    public void Enqueue_SecondMovementForSameMobile_ReplacesPendingEventAndRecordsCoalesced()
+    public void Dequeue_LimitBelowCount_DeliversAtMostLimitAndRetainsRemainder()
     {
         var metrics = new NpcAiMetrics();
         var mailbox = new NpcBrainMailbox(4, metrics);
-        mailbox.Enqueue(
-            NpcBrainHookType.MobileMoved,
-            Event(NpcBrainEventType.MobileMoved, 0x2, new(10, 10, 0), new(11, 10, 0))
-        );
+        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
+        mailbox.Enqueue(NpcBrainHookType.Attacked, Event(NpcBrainEventType.Attacked, 0x2));
+        mailbox.Enqueue(NpcBrainHookType.SpeechHeard, Event(NpcBrainEventType.SpeechHeard, 0x3));
 
-        mailbox.Enqueue(
-            NpcBrainHookType.MobileMoved,
-            Event(NpcBrainEventType.MobileMoved, 0x2, new(11, 10, 0), new(12, 10, 0))
-        );
+        var first = mailbox.Dequeue(2);
+        var second = mailbox.Dequeue(2);
 
-        var delivered = Assert.Single(mailbox.Dequeue(4));
-        Assert.Equal(new Point3D(12, 10, 0), delivered.Event.ToPosition);
-        Assert.Equal(1, metrics.Current.EventsCoalesced);
-        Assert.Equal(1, metrics.Current.EventsDelivered);
+        Assert.Equal(2, first.Count);
+        Assert.Single(second);
+        Assert.Equal(NpcBrainHookType.SpeechHeard, second[0].Hook);
+        Assert.Equal(3, metrics.Current.EventsDelivered);
     }
 
-    [Theory]
-    [InlineData(NpcBrainHookType.MobileEnteredRange, NpcBrainEventType.MobileEnteredRange)]
-    [InlineData(NpcBrainHookType.MobileLeftRange, NpcBrainEventType.MobileLeftRange)]
+    [Theory, InlineData(true), InlineData(false)]
+    public void Enqueue_AlternatingRangeTransitions_RetainsTransitionsAndSuppressesOnlyLatestDuplicate(bool enterFirst)
+    {
+        var metrics = new NpcAiMetrics();
+        var mailbox = new NpcBrainMailbox(8, metrics);
+        var firstHook = enterFirst
+                            ? NpcBrainHookType.MobileEnteredRange
+                            : NpcBrainHookType.MobileLeftRange;
+        var firstType = enterFirst
+                            ? NpcBrainEventType.MobileEnteredRange
+                            : NpcBrainEventType.MobileLeftRange;
+        var secondHook = enterFirst
+                             ? NpcBrainHookType.MobileLeftRange
+                             : NpcBrainHookType.MobileEnteredRange;
+        var secondType = enterFirst
+                             ? NpcBrainEventType.MobileLeftRange
+                             : NpcBrainEventType.MobileEnteredRange;
+
+        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
+        mailbox.Enqueue(secondHook, Event(secondType, 0x2));
+        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
+        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
+
+        var delivered = mailbox.Dequeue(8);
+
+        Assert.Equal([firstHook, secondHook, firstHook], delivered.Select(entry => entry.Hook));
+        Assert.Equal(1, metrics.Current.EventsCoalesced);
+        Assert.Equal(3, metrics.Current.EventsDelivered);
+    }
+
+    [Theory, InlineData(NpcBrainHookType.MobileEnteredRange, NpcBrainEventType.MobileEnteredRange),
+     InlineData(NpcBrainHookType.MobileLeftRange, NpcBrainEventType.MobileLeftRange)]
     public void Enqueue_DuplicateRangeTransition_SuppressesDuplicateAndRecordsCoalesced(
         NpcBrainHookType hook,
         NpcBrainEventType type
@@ -69,40 +109,6 @@ public class NpcBrainMailboxTests
         Assert.Single(mailbox.Dequeue(4));
         Assert.Equal(1, metrics.Current.EventsCoalesced);
         Assert.Equal(1, metrics.Current.EventsDelivered);
-    }
-
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void Enqueue_AlternatingRangeTransitions_RetainsTransitionsAndSuppressesOnlyLatestDuplicate(
-        bool enterFirst
-    )
-    {
-        var metrics = new NpcAiMetrics();
-        var mailbox = new NpcBrainMailbox(8, metrics);
-        var firstHook = enterFirst
-            ? NpcBrainHookType.MobileEnteredRange
-            : NpcBrainHookType.MobileLeftRange;
-        var firstType = enterFirst
-            ? NpcBrainEventType.MobileEnteredRange
-            : NpcBrainEventType.MobileLeftRange;
-        var secondHook = enterFirst
-            ? NpcBrainHookType.MobileLeftRange
-            : NpcBrainHookType.MobileEnteredRange;
-        var secondType = enterFirst
-            ? NpcBrainEventType.MobileLeftRange
-            : NpcBrainEventType.MobileEnteredRange;
-
-        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
-        mailbox.Enqueue(secondHook, Event(secondType, 0x2));
-        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
-        mailbox.Enqueue(firstHook, Event(firstType, 0x2));
-
-        var delivered = mailbox.Dequeue(8);
-
-        Assert.Equal([firstHook, secondHook, firstHook], delivered.Select(entry => entry.Hook));
-        Assert.Equal(1, metrics.Current.EventsCoalesced);
-        Assert.Equal(3, metrics.Current.EventsDelivered);
     }
 
     [Fact]
@@ -151,35 +157,24 @@ public class NpcBrainMailboxTests
     }
 
     [Fact]
-    public void Dequeue_LimitBelowCount_DeliversAtMostLimitAndRetainsRemainder()
+    public void Enqueue_SecondMovementForSameMobile_ReplacesPendingEventAndRecordsCoalesced()
     {
         var metrics = new NpcAiMetrics();
         var mailbox = new NpcBrainMailbox(4, metrics);
-        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
-        mailbox.Enqueue(NpcBrainHookType.Attacked, Event(NpcBrainEventType.Attacked, 0x2));
-        mailbox.Enqueue(NpcBrainHookType.SpeechHeard, Event(NpcBrainEventType.SpeechHeard, 0x3));
+        mailbox.Enqueue(
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x2, new(10, 10, 0), new(11, 10, 0))
+        );
 
-        var first = mailbox.Dequeue(2);
-        var second = mailbox.Dequeue(2);
+        mailbox.Enqueue(
+            NpcBrainHookType.MobileMoved,
+            Event(NpcBrainEventType.MobileMoved, 0x2, new(11, 10, 0), new(12, 10, 0))
+        );
 
-        Assert.Equal(2, first.Count);
-        Assert.Single(second);
-        Assert.Equal(NpcBrainHookType.SpeechHeard, second[0].Hook);
-        Assert.Equal(3, metrics.Current.EventsDelivered);
-    }
-
-    [Fact]
-    public void Clear_QueuedEvents_RemovesAllWithoutRecordingDelivery()
-    {
-        var metrics = new NpcAiMetrics();
-        var mailbox = new NpcBrainMailbox(4, metrics);
-        mailbox.Enqueue(NpcBrainHookType.Activate, Event(NpcBrainEventType.Activate));
-        mailbox.Enqueue(NpcBrainHookType.MobileMoved, Event(NpcBrainEventType.MobileMoved, 0x2));
-
-        mailbox.Clear();
-
-        Assert.Empty(mailbox.Dequeue(4));
-        Assert.Equal(0, metrics.Current.EventsDelivered);
+        var delivered = Assert.Single(mailbox.Dequeue(4));
+        Assert.Equal(new Point3D(12, 10, 0), delivered.Event.ToPosition);
+        Assert.Equal(1, metrics.Current.EventsCoalesced);
+        Assert.Equal(1, metrics.Current.EventsDelivered);
     }
 
     private static NpcBrainEvent Event(
@@ -192,11 +187,11 @@ public class NpcBrainMailboxTests
 
     private static BrainMobileSnapshot Snapshot(uint serial)
         => new(
-            new Serial(serial),
+            new(serial),
             $"mobile-{serial}",
             false,
             0,
-            new Point3D(10, 10, 0),
+            new(10, 10, 0),
             10,
             10,
             false,

--- a/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainSchedulerTests.cs
@@ -1,5 +1,6 @@
+using System.Collections;
+using System.Reflection;
 using Moongate.Core.Extensions;
-using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.AI;
@@ -17,22 +18,151 @@ namespace Moongate.Tests.Server.AI;
 [Collection(GlobalSerilogCollection.Name)]
 public class NpcBrainSchedulerTests
 {
-    [Fact]
-    public void Bind_SleepingSector_BindsAndRetainsRuntimeWithoutInvoking()
+    private sealed class SchedulerFixture
     {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddMobile(0x1);
+        public FakePersistenceService Persistence { get; } = new();
 
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
+        public RecordingNpcBrainRuntime Runtime { get; } = new();
 
-        Assert.Equal([(mobile.Id, "guard")], fixture.Runtime.BindCalls);
-        Assert.Empty(fixture.Runtime.Invocations);
-        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
-        Assert.True(fixture.Scheduler.TryGetDescriptor(mobile.Id, out var descriptor));
-        Assert.Equal("guard", descriptor!.BrainId);
-        Assert.Equal(1, fixture.Metrics.Current.SleepingBrains);
-        Assert.Equal(1, fixture.Metrics.Current.SleepingSectors);
+        public StubAiActionService AiActions { get; } = new();
+
+        public StubNpcMemoryService Memory { get; } = new();
+
+        public StubSectorActivityService Sectors { get; } = new();
+
+        public StubSessionManager Sessions { get; } = new();
+
+        public MutableTimeProvider Time { get; } = new(new(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+
+        public NpcAiMetrics Metrics { get; } = new();
+
+        public StubGameLoopContext Loop { get; } = new();
+
+        public SpatialIndexService Spatial { get; }
+
+        public NpcBrainScheduler Scheduler { get; }
+
+        public SchedulerFixture(
+            int maxBrainsPerLoop = 100,
+            int maxEventsPerWake = 16,
+            int? maxMailboxEvents = null,
+            int minTickMilliseconds = 100,
+            int maxTickMilliseconds = 60_000
+        )
+        {
+            Runtime.Descriptors["guard"] = new("guard", 1000, 10, 15);
+            Spatial = new(Persistence, new StubLoopAffinity(), new StubEventBus());
+            var config = new MoongateConfig
+            {
+                NpcAi = new()
+                {
+                    Advanced = new()
+                    {
+                        MinTickMilliseconds = minTickMilliseconds,
+                        MaxTickMilliseconds = maxTickMilliseconds,
+                        MaxBrainsPerLoop = maxBrainsPerLoop,
+                        MaxEventsPerBrainWake = maxEventsPerWake,
+                        MaxMailboxEvents = maxMailboxEvents ?? Math.Max(16, maxEventsPerWake)
+                    }
+                }
+            };
+            var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
+            Scheduler = new(
+                Loop,
+                Runtime,
+                AiActions,
+                Memory,
+                Sectors,
+                Persistence,
+                contextFactory,
+                Time,
+                config,
+                Metrics
+            );
+        }
+
+        public MobileEntity AddActiveMobile(uint serial)
+        {
+            var mobile = AddMobile(serial);
+            Sectors.SetActive(mobile, true);
+
+            return mobile;
+        }
+
+        public MobileEntity AddMobile(
+            uint serial,
+            string brainId = "guard",
+            int mapId = 0,
+            int x = 10,
+            int y = 10
+        )
+        {
+            var mobile = new MobileEntity
+            {
+                Id = new(serial),
+                Name = $"mobile-{serial}",
+                BrainScriptId = brainId,
+                MapId = mapId,
+                Position = new(x, y, 0),
+                Hits = 10,
+                HitsMax = 10
+            };
+            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            Spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+
+        public void EnqueueSpeech(Serial ownerId, uint speakerId)
+            => Scheduler.EnqueueEvent(
+                ownerId,
+                NpcBrainHookType.SpeechHeard,
+                Event(NpcBrainEventType.SpeechHeard, speakerId)
+            );
+
+        public void Move(MobileEntity mobile, int x, int y)
+        {
+            mobile.Position = new(x, y, mobile.Position.Z);
+            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            Spatial.AddOrUpdate(mobile);
+        }
+
+        public int ThinkCount(Serial mobileId)
+            => Runtime.Invocations.Count(
+                invocation => invocation.MobileId == mobileId && invocation.Hook == NpcBrainHookType.Think
+            );
+    }
+
+    private sealed class StubSectorActivityService : ISectorActivityService
+    {
+        private readonly HashSet<(int MapId, int SectorX, int SectorY)> _active = [];
+
+        public SectorActivitySnapshot Current => new(_active.Count, 0);
+
+        public bool IsActive(int mapId, int sectorX, int sectorY)
+            => _active.Contains((mapId, sectorX, sectorY));
+
+        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY) { }
+
+        public void SetActive(MobileEntity mobile, bool active)
+        {
+            var key = (mobile.MapId, mobile.Position.X >> 4, mobile.Position.Y >> 4);
+
+            if (active)
+            {
+                _active.Add(key);
+
+                return;
+            }
+
+            _active.Remove(key);
+        }
+
+        public void Tick() { }
+
+        public void TrackPlayer(MobileEntity player) { }
+
+        public void UntrackPlayer(Serial playerId) { }
     }
 
     [Fact]
@@ -56,23 +186,201 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
-    public void Tick_HookInvocation_UsesInjectedTimeProviderForDurationMetrics()
+    public void Activate_PendingDeactivation_CancelsSleepWithoutTransitionHooks()
     {
         var fixture = new SchedulerFixture();
         var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Runtime.InvocationHandler = (_, _, _, _) =>
-        {
-            fixture.Time.Advance(TimeSpan.FromMilliseconds(25));
-            return NpcBrainInvocationResult.Succeeded(null);
-        };
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(500));
+
+        fixture.Scheduler.Deactivate(mobile.Id);
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Empty(fixture.Runtime.Invocations);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(499));
+        fixture.Scheduler.Tick();
+        Assert.Empty(fixture.Runtime.Invocations);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(
+            [NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+    }
+
+    [Fact]
+    public void Bind_ChangedBrainUnavailable_DoesNotInvokeStaleRuntimeBindingAndRetriesNewBrain()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        mobile.BrainScriptId = "missing";
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+
+        Assert.Empty(fixture.Runtime.Invocations);
+        Assert.Equal(
+            [(mobile.Id, "guard"), (mobile.Id, "missing"), (mobile.Id, "missing")],
+            fixture.Runtime.BindCalls
+        );
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+    }
+
+    [Fact]
+    public void Bind_ChangedBrain_ClearsMobileThrottleEntriesBeforeBrainCanReturn()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors["scout"] = new("scout", 1000, 20, 25);
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+                                                hook == NpcBrainHookType.Think
+                                                    ? NpcBrainInvocationResult.Failed("think failed")
+                                                    : NpcBrainInvocationResult.Succeeded(null);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        mobile.BrainScriptId = "scout";
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        mobile.BrainScriptId = "guard";
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(3, SchedulerWarnings(logs).Count);
+    }
+
+    [Fact]
+    public void Bind_ChangedBrain_ResetsRebindsAndRecapturesHome()
+    {
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors["wanderer"] = new("wanderer", 500, 7, 9);
+        var mobile = fixture.AddMobile(0x1, x: 10, y: 10);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Move(mobile, 30, 40);
+        mobile.BrainScriptId = "wanderer";
+        fixture.Sectors.SetActive(mobile, true);
 
         fixture.Scheduler.Bind(mobile);
         fixture.Scheduler.Tick();
 
-        Assert.Equal(2, fixture.Metrics.Current.HookInvocations);
-        Assert.Equal(TimeSpan.FromMilliseconds(50).Ticks, fixture.Metrics.Current.TotalHookDurationTicks);
-        Assert.Equal(TimeSpan.FromMilliseconds(25).Ticks, fixture.Metrics.Current.MaxHookDurationTicks);
-        Assert.Equal(TimeSpan.FromMilliseconds(25), fixture.Metrics.Current.AverageHookDuration);
+        Assert.Equal([mobile.Id], fixture.Runtime.ResetCalls);
+        Assert.Equal([(mobile.Id, "guard"), (mobile.Id, "wanderer")], fixture.Runtime.BindCalls);
+        var activation = Assert.Single(
+            fixture.Runtime.Invocations,
+            invocation => invocation.Hook == NpcBrainHookType.Activate
+        );
+        Assert.Equal(new(30, 40, 0), activation.Context.HomePosition);
+        Assert.Equal(0, activation.Context.HomeMapId);
+    }
+
+    [Fact]
+    public void Bind_MissingDescriptor_RetriesBindingWithFaultBackoff()
+    {
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors.Remove("guard");
+        var mobile = fixture.AddActiveMobile(0x1);
+
+        fixture.Scheduler.Bind(mobile);
+        Assert.Single(fixture.Runtime.BindCalls);
+        fixture.Scheduler.Tick();
+        Assert.Single(fixture.Runtime.BindCalls);
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.Runtime.BindCalls.Count);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(4999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.Runtime.BindCalls.Count);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.Runtime.BindCalls.Count);
+
+        fixture.Runtime.Descriptors["guard"] = new("guard", 1000, 10, 15);
+        fixture.Time.Advance(TimeSpan.FromSeconds(30));
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(4, fixture.Runtime.BindCalls.Count);
+        Assert.Equal(
+            [NpcBrainHookType.Activate, NpcBrainHookType.Think],
+            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
+        );
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+    }
+
+    [Fact]
+    public void Bind_RepeatedAfterUnavailableBrainChange_DoesNotRestoreOldDescriptorRangesOrRuntime()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+        mobile.BrainScriptId = "missing";
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Bind(mobile);
+
+        Assert.False(fixture.Scheduler.TryGetDescriptor(mobile.Id, out _));
+        Assert.Equal(0, fixture.Scheduler.MaxPerceptionRange);
+        Assert.Equal(0, fixture.Scheduler.MaxHearingRange);
+
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+
+        Assert.Empty(fixture.Runtime.Invocations);
+    }
+
+    [Fact]
+    public void Bind_SameBrainAfterMove_PreservesOriginalHome()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddMobile(0x1, x: 10, y: 10);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Move(mobile, 30, 40);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        var context = Assert.Single(
+                                fixture.Runtime.Invocations,
+                                invocation => invocation.Hook == NpcBrainHookType.Activate
+                            )
+                            .Context;
+        Assert.Equal(new(10, 10, 0), context.HomePosition);
+        Assert.Single(fixture.Runtime.BindCalls);
+    }
+
+    [Fact]
+    public void Bind_SleepingSector_BindsAndRetainsRuntimeWithoutInvoking()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddMobile(0x1);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal([(mobile.Id, "guard")], fixture.Runtime.BindCalls);
+        Assert.Empty(fixture.Runtime.Invocations);
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.True(fixture.Scheduler.TryGetDescriptor(mobile.Id, out var descriptor));
+        Assert.Equal("guard", descriptor!.BrainId);
+        Assert.Equal(1, fixture.Metrics.Current.SleepingBrains);
+        Assert.Equal(1, fixture.Metrics.Current.SleepingSectors);
     }
 
     [Fact]
@@ -112,9 +420,9 @@ public class NpcBrainSchedulerTests
         var fixture = new SchedulerFixture();
         var mobile = fixture.AddActiveMobile(0x1);
         fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Deactivate
-                ? NpcBrainInvocationResult.Failed("deactivate failed")
-                : NpcBrainInvocationResult.Succeeded(null);
+                                                hook == NpcBrainHookType.Deactivate
+                                                    ? NpcBrainInvocationResult.Failed("deactivate failed")
+                                                    : NpcBrainInvocationResult.Succeeded(null);
         fixture.Scheduler.Bind(mobile);
         fixture.Scheduler.Tick();
         fixture.Runtime.Invocations.Clear();
@@ -129,202 +437,6 @@ public class NpcBrainSchedulerTests
         fixture.Time.Advance(TimeSpan.FromMinutes(2));
         fixture.Scheduler.Tick();
         Assert.Single(fixture.Runtime.Invocations);
-    }
-
-    [Fact]
-    public void Activate_PendingDeactivation_CancelsSleepWithoutTransitionHooks()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        fixture.Runtime.Invocations.Clear();
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(500));
-
-        fixture.Scheduler.Deactivate(mobile.Id);
-        fixture.Scheduler.Activate(mobile.Id);
-        fixture.Scheduler.Tick();
-
-        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
-        Assert.Empty(fixture.Runtime.Invocations);
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(499));
-        fixture.Scheduler.Tick();
-        Assert.Empty(fixture.Runtime.Invocations);
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(
-            [NpcBrainHookType.Think],
-            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
-        );
-        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
-    }
-
-    [Fact]
-    public void SleepWake_Cycle_PreservesBindingAndRuntimeState()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        fixture.Scheduler.Deactivate(mobile.Id);
-        fixture.Scheduler.Tick();
-
-        fixture.Scheduler.Activate(mobile.Id);
-        fixture.Scheduler.Tick();
-
-        Assert.Single(fixture.Runtime.BindCalls);
-        Assert.Empty(fixture.Runtime.ResetCalls);
-        Assert.Empty(fixture.Runtime.UnbindCalls);
-        Assert.Equal(2, fixture.Runtime.Invocations.Count(invocation => invocation.Hook == NpcBrainHookType.Activate));
-        Assert.Single(fixture.Runtime.Invocations, invocation => invocation.Hook == NpcBrainHookType.Deactivate);
-    }
-
-    [Fact]
-    public void Bind_SameBrainAfterMove_PreservesOriginalHome()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddMobile(0x1, x: 10, y: 10);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Move(mobile, 30, 40);
-
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Activate(mobile.Id);
-        fixture.Scheduler.Tick();
-
-        var context = Assert.Single(
-            fixture.Runtime.Invocations,
-            invocation => invocation.Hook == NpcBrainHookType.Activate
-        ).Context;
-        Assert.Equal(new Point3D(10, 10, 0), context.HomePosition);
-        Assert.Single(fixture.Runtime.BindCalls);
-    }
-
-    [Fact]
-    public void Bind_ChangedBrain_ResetsRebindsAndRecapturesHome()
-    {
-        var fixture = new SchedulerFixture();
-        fixture.Runtime.Descriptors["wanderer"] = new("wanderer", 500, 7, 9);
-        var mobile = fixture.AddMobile(0x1, x: 10, y: 10);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Move(mobile, 30, 40);
-        mobile.BrainScriptId = "wanderer";
-        fixture.Sectors.SetActive(mobile, true);
-
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-
-        Assert.Equal([mobile.Id], fixture.Runtime.ResetCalls);
-        Assert.Equal([(mobile.Id, "guard"), (mobile.Id, "wanderer")], fixture.Runtime.BindCalls);
-        var activation = Assert.Single(
-            fixture.Runtime.Invocations,
-            invocation => invocation.Hook == NpcBrainHookType.Activate
-        );
-        Assert.Equal(new Point3D(30, 40, 0), activation.Context.HomePosition);
-        Assert.Equal(0, activation.Context.HomeMapId);
-    }
-
-    [Fact]
-    public void Bind_ChangedBrainUnavailable_DoesNotInvokeStaleRuntimeBindingAndRetriesNewBrain()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        fixture.Runtime.Invocations.Clear();
-        mobile.BrainScriptId = "missing";
-
-        fixture.Scheduler.Bind(mobile);
-        fixture.Time.Advance(TimeSpan.FromSeconds(1));
-        fixture.Scheduler.Tick();
-
-        Assert.Empty(fixture.Runtime.Invocations);
-        Assert.Equal(
-            [(mobile.Id, "guard"), (mobile.Id, "missing"), (mobile.Id, "missing")],
-            fixture.Runtime.BindCalls
-        );
-        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
-    }
-
-    [Fact]
-    public void Bind_RepeatedAfterUnavailableBrainChange_DoesNotRestoreOldDescriptorRangesOrRuntime()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        fixture.Runtime.Invocations.Clear();
-        mobile.BrainScriptId = "missing";
-
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Bind(mobile);
-
-        Assert.False(fixture.Scheduler.TryGetDescriptor(mobile.Id, out _));
-        Assert.Equal(0, fixture.Scheduler.MaxPerceptionRange);
-        Assert.Equal(0, fixture.Scheduler.MaxHearingRange);
-
-        fixture.Time.Advance(TimeSpan.FromSeconds(1));
-        fixture.Scheduler.Tick();
-
-        Assert.Empty(fixture.Runtime.Invocations);
-    }
-
-    [Fact]
-    public void Unbind_BoundBrain_RemovesSchedulerAndRuntimeState()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-
-        fixture.Scheduler.Unbind(mobile.Id);
-        fixture.Scheduler.Tick();
-
-        Assert.Equal([mobile.Id], fixture.Runtime.UnbindCalls);
-        Assert.False(fixture.Scheduler.TryGetDescriptor(mobile.Id, out _));
-        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
-        Assert.Empty(fixture.Runtime.Invocations);
-        Assert.Equal(0, fixture.Metrics.Current.ActiveBrains);
-    }
-
-    [Fact]
-    public void Tick_QueuedEventAndThinkDue_InvokesEventsBeforeThink()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.EnqueueEvent(
-            mobile.Id,
-            NpcBrainHookType.SpeechHeard,
-            Event(NpcBrainEventType.SpeechHeard, 0x2)
-        );
-
-        fixture.Scheduler.Tick();
-
-        Assert.Equal(
-            [NpcBrainHookType.Activate, NpcBrainHookType.SpeechHeard, NpcBrainHookType.Think],
-            fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
-        );
-    }
-
-    [Fact]
-    public void Tick_MoreEventsThanWakeBudget_DefersRemainderToNextWake()
-    {
-        var fixture = new SchedulerFixture(maxEventsPerWake: 2);
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        fixture.Runtime.Invocations.Clear();
-
-        fixture.EnqueueSpeech(mobile.Id, 0x2);
-        fixture.EnqueueSpeech(mobile.Id, 0x3);
-        fixture.EnqueueSpeech(mobile.Id, 0x4);
-        fixture.Scheduler.Tick();
-
-        Assert.Equal(2, fixture.Runtime.Invocations.Count);
-        fixture.Scheduler.Tick();
-        Assert.Equal(3, fixture.Runtime.Invocations.Count);
-        Assert.Equal(4, fixture.Metrics.Current.EventsDelivered);
     }
 
     [Fact]
@@ -386,43 +498,58 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
-    public void Tick_MoreDueBrainsThanLoopBudget_PreservesStableFifoAndCountsEachDeferredBrain()
+    public void RefreshDescriptor_ChangedRanges_RecomputesGlobalMaximums()
     {
-        var fixture = new SchedulerFixture(maxBrainsPerLoop: 1);
-        var first = fixture.AddActiveMobile(0x1);
-        var second = fixture.AddActiveMobile(0x2);
-        var third = fixture.AddActiveMobile(0x3);
-        fixture.Scheduler.Bind(first);
-        fixture.Scheduler.Bind(second);
-        fixture.Scheduler.Bind(third);
+        var fixture = new SchedulerFixture();
+        fixture.Runtime.Descriptors["scout"] = new("scout", 1000, 20, 25);
+        fixture.Scheduler.Bind(fixture.AddMobile(0x1));
+        fixture.Scheduler.Bind(fixture.AddMobile(0x2, "scout"));
+        Assert.Equal(20, fixture.Scheduler.MaxPerceptionRange);
+        Assert.Equal(25, fixture.Scheduler.MaxHearingRange);
 
-        fixture.Scheduler.Tick();
-        fixture.Scheduler.Tick();
-        fixture.Scheduler.Tick();
+        fixture.Scheduler.RefreshDescriptor("scout", new("scout", 1000, 4, 5));
 
-        Assert.Equal(
-            [first.Id, second.Id, third.Id],
-            fixture.Runtime.Invocations
-                .Where(invocation => invocation.Hook == NpcBrainHookType.Activate)
-                .Select(invocation => invocation.MobileId)
-        );
-        Assert.Equal(3, fixture.Metrics.Current.BrainsExecuted);
-        Assert.Equal(3, fixture.Metrics.Current.BrainsDeferred);
+        Assert.Equal(10, fixture.Scheduler.MaxPerceptionRange);
+        Assert.Equal(15, fixture.Scheduler.MaxHearingRange);
+        Assert.True(fixture.Scheduler.TryGetDescriptor(new(0x2), out var descriptor));
+        Assert.Equal(4, descriptor!.PerceptionRange);
     }
 
     [Fact]
-    public void Tick_SuccessfulThink_DoesNotFaultEntry()
+    public void SleepWake_Cycle_PreservesBindingAndRuntimeState()
     {
         var fixture = new SchedulerFixture();
         var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Runtime.InvocationHandler = (_, _, _, _) =>
-            NpcBrainInvocationResult.Succeeded(null);
-
         fixture.Scheduler.Bind(mobile);
         fixture.Scheduler.Tick();
+        fixture.Scheduler.Deactivate(mobile.Id);
+        fixture.Scheduler.Tick();
 
-        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+        fixture.Scheduler.Activate(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.Single(fixture.Runtime.BindCalls);
         Assert.Empty(fixture.Runtime.ResetCalls);
+        Assert.Empty(fixture.Runtime.UnbindCalls);
+        Assert.Equal(2, fixture.Runtime.Invocations.Count(invocation => invocation.Hook == NpcBrainHookType.Activate));
+        Assert.Single(fixture.Runtime.Invocations, invocation => invocation.Hook == NpcBrainHookType.Deactivate);
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistersOneSchedulerTimerAndStopAsyncCancelsIt()
+    {
+        var fixture = new SchedulerFixture(minTickMilliseconds: 125);
+
+        await fixture.Scheduler.StartAsync();
+        await fixture.Scheduler.StartAsync();
+
+        Assert.True(fixture.Loop.Repeating.ContainsKey("npc-brain-scheduler"));
+        Assert.Single(fixture.Loop.Repeating);
+        Assert.Equal(TimeSpan.FromMilliseconds(125), fixture.Loop.RepeatingInterval);
+        Assert.Null(fixture.Loop.RepeatingDelay);
+
+        await fixture.Scheduler.StopAsync();
+        Assert.Empty(fixture.Loop.Repeating);
     }
 
     [Fact]
@@ -431,9 +558,9 @@ public class NpcBrainSchedulerTests
         var fixture = new SchedulerFixture();
         var mobile = fixture.AddActiveMobile(0x1);
         fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Think
-                ? NpcBrainInvocationResult.Failed("think failed")
-                : NpcBrainInvocationResult.Succeeded(null);
+                                                hook == NpcBrainHookType.Think
+                                                    ? NpcBrainInvocationResult.Failed("think failed")
+                                                    : NpcBrainInvocationResult.Succeeded(null);
         fixture.Scheduler.Bind(mobile);
 
         fixture.Scheduler.Tick();
@@ -464,15 +591,59 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
+    public void Tick_ExpiredFaultThrottleEntry_PrunesEntryWithoutAnotherFailure()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        var failThink = true;
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+                                                hook == NpcBrainHookType.Think && failThink
+                                                    ? NpcBrainInvocationResult.Failed("think failed")
+                                                    : NpcBrainInvocationResult.Succeeded(null);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        Assert.Equal(1, FaultLogCount(fixture.Scheduler));
+
+        failThink = false;
+        fixture.Time.Advance(TimeSpan.FromSeconds(61));
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(0, FaultLogCount(fixture.Scheduler));
+        Assert.Single(SchedulerWarnings(logs));
+    }
+
+    [Fact]
+    public void Tick_HookInvocation_UsesInjectedTimeProviderForDurationMetrics()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, _, _, _) =>
+                                            {
+                                                fixture.Time.Advance(TimeSpan.FromMilliseconds(25));
+
+                                                return NpcBrainInvocationResult.Succeeded(null);
+                                            };
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, fixture.Metrics.Current.HookInvocations);
+        Assert.Equal(TimeSpan.FromMilliseconds(50).Ticks, fixture.Metrics.Current.TotalHookDurationTicks);
+        Assert.Equal(TimeSpan.FromMilliseconds(25).Ticks, fixture.Metrics.Current.MaxHookDurationTicks);
+        Assert.Equal(TimeSpan.FromMilliseconds(25), fixture.Metrics.Current.AverageHookDuration);
+    }
+
+    [Fact]
     public void Tick_IdenticalFaults_LogsOneSchedulerWarningPerMinute()
     {
         using var logs = new GlobalSerilogCapture();
         var fixture = new SchedulerFixture();
         var mobile = fixture.AddActiveMobile(0x1);
         fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Think
-                ? NpcBrainInvocationResult.Failed("think failed")
-                : NpcBrainInvocationResult.Succeeded(null);
+                                                hook == NpcBrainHookType.Think
+                                                    ? NpcBrainInvocationResult.Failed("think failed")
+                                                    : NpcBrainInvocationResult.Succeeded(null);
         fixture.Scheduler.Bind(mobile);
 
         fixture.Scheduler.Tick();
@@ -498,191 +669,69 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
-    public void Unbind_AfterFault_ClearsMobileThrottleEntry()
+    public void Tick_MoreDueBrainsThanLoopBudget_PreservesStableFifoAndCountsEachDeferredBrain()
     {
-        using var logs = new GlobalSerilogCapture();
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Think
-                ? NpcBrainInvocationResult.Failed("think failed")
-                : NpcBrainInvocationResult.Succeeded(null);
-        fixture.Scheduler.Bind(mobile);
+        var fixture = new SchedulerFixture(1);
+        var first = fixture.AddActiveMobile(0x1);
+        var second = fixture.AddActiveMobile(0x2);
+        var third = fixture.AddActiveMobile(0x3);
+        fixture.Scheduler.Bind(first);
+        fixture.Scheduler.Bind(second);
+        fixture.Scheduler.Bind(third);
+
+        fixture.Scheduler.Tick();
+        fixture.Scheduler.Tick();
         fixture.Scheduler.Tick();
 
-        fixture.Scheduler.Unbind(mobile.Id);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-
-        Assert.Equal(2, SchedulerWarnings(logs).Count);
-    }
-
-    [Fact]
-    public void Bind_ChangedBrain_ClearsMobileThrottleEntriesBeforeBrainCanReturn()
-    {
-        using var logs = new GlobalSerilogCapture();
-        var fixture = new SchedulerFixture();
-        fixture.Runtime.Descriptors["scout"] = new("scout", 1000, 20, 25);
-        var mobile = fixture.AddActiveMobile(0x1);
-        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Think
-                ? NpcBrainInvocationResult.Failed("think failed")
-                : NpcBrainInvocationResult.Succeeded(null);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-
-        mobile.BrainScriptId = "scout";
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        mobile.BrainScriptId = "guard";
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-
-        Assert.Equal(3, SchedulerWarnings(logs).Count);
-    }
-
-    [Fact]
-    public void Tick_ExpiredFaultThrottleEntry_PrunesEntryWithoutAnotherFailure()
-    {
-        using var logs = new GlobalSerilogCapture();
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        var failThink = true;
-        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Think && failThink
-                ? NpcBrainInvocationResult.Failed("think failed")
-                : NpcBrainInvocationResult.Succeeded(null);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        Assert.Equal(1, FaultLogCount(fixture.Scheduler));
-
-        failThink = false;
-        fixture.Time.Advance(TimeSpan.FromSeconds(61));
-        fixture.Scheduler.Tick();
-
-        Assert.Equal(0, FaultLogCount(fixture.Scheduler));
-        Assert.Single(SchedulerWarnings(logs));
-    }
-
-    [Fact]
-    public void Tick_SuccessAfterFailures_ResetsNextFailureBackoffToOneSecond()
-    {
-        var fixture = new SchedulerFixture();
-        var mobile = fixture.AddActiveMobile(0x1);
-        var attempts = 0;
-        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-        {
-            if (hook != NpcBrainHookType.Think)
-            {
-                return NpcBrainInvocationResult.Succeeded(null);
-            }
-
-            attempts++;
-            return attempts == 3
-                ? NpcBrainInvocationResult.Succeeded(null)
-                : NpcBrainInvocationResult.Failed("think failed");
-        };
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-        fixture.Time.Advance(TimeSpan.FromSeconds(1));
-        fixture.Scheduler.Tick();
-        fixture.Time.Advance(TimeSpan.FromSeconds(5));
-        fixture.Scheduler.Tick();
-        fixture.Time.Advance(TimeSpan.FromSeconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(4, attempts);
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
-        fixture.Scheduler.Tick();
-        Assert.Equal(4, attempts);
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(5, attempts);
-    }
-
-    [Fact]
-    public void Bind_MissingDescriptor_RetriesBindingWithFaultBackoff()
-    {
-        var fixture = new SchedulerFixture();
-        fixture.Runtime.Descriptors.Remove("guard");
-        var mobile = fixture.AddActiveMobile(0x1);
-
-        fixture.Scheduler.Bind(mobile);
-        Assert.Single(fixture.Runtime.BindCalls);
-        fixture.Scheduler.Tick();
-        Assert.Single(fixture.Runtime.BindCalls);
-
-        fixture.Time.Advance(TimeSpan.FromSeconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(2, fixture.Runtime.BindCalls.Count);
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(4999));
-        fixture.Scheduler.Tick();
-        Assert.Equal(2, fixture.Runtime.BindCalls.Count);
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(3, fixture.Runtime.BindCalls.Count);
-
-        fixture.Runtime.Descriptors["guard"] = new("guard", 1000, 10, 15);
-        fixture.Time.Advance(TimeSpan.FromSeconds(30));
-        fixture.Scheduler.Tick();
-
-        Assert.Equal(4, fixture.Runtime.BindCalls.Count);
         Assert.Equal(
-            [NpcBrainHookType.Activate, NpcBrainHookType.Think],
+            [first.Id, second.Id, third.Id],
+            fixture.Runtime
+                   .Invocations
+                   .Where(invocation => invocation.Hook == NpcBrainHookType.Activate)
+                   .Select(invocation => invocation.MobileId)
+        );
+        Assert.Equal(3, fixture.Metrics.Current.BrainsExecuted);
+        Assert.Equal(3, fixture.Metrics.Current.BrainsDeferred);
+    }
+
+    [Fact]
+    public void Tick_MoreEventsThanWakeBudget_DefersRemainderToNextWake()
+    {
+        var fixture = new SchedulerFixture(maxEventsPerWake: 2);
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Runtime.Invocations.Clear();
+
+        fixture.EnqueueSpeech(mobile.Id, 0x2);
+        fixture.EnqueueSpeech(mobile.Id, 0x3);
+        fixture.EnqueueSpeech(mobile.Id, 0x4);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, fixture.Runtime.Invocations.Count);
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.Runtime.Invocations.Count);
+        Assert.Equal(4, fixture.Metrics.Current.EventsDelivered);
+    }
+
+    [Fact]
+    public void Tick_QueuedEventAndThinkDue_InvokesEventsBeforeThink()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.EnqueueEvent(
+            mobile.Id,
+            NpcBrainHookType.SpeechHeard,
+            Event(NpcBrainEventType.SpeechHeard, 0x2)
+        );
+
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(
+            [NpcBrainHookType.Activate, NpcBrainHookType.SpeechHeard, NpcBrainHookType.Think],
             fixture.Runtime.Invocations.Select(invocation => invocation.Hook)
         );
-        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
-    }
-
-    [Fact]
-    public void RefreshDescriptor_ChangedRanges_RecomputesGlobalMaximums()
-    {
-        var fixture = new SchedulerFixture();
-        fixture.Runtime.Descriptors["scout"] = new("scout", 1000, 20, 25);
-        fixture.Scheduler.Bind(fixture.AddMobile(0x1));
-        fixture.Scheduler.Bind(fixture.AddMobile(0x2, brainId: "scout"));
-        Assert.Equal(20, fixture.Scheduler.MaxPerceptionRange);
-        Assert.Equal(25, fixture.Scheduler.MaxHearingRange);
-
-        fixture.Scheduler.RefreshDescriptor("scout", new("scout", 1000, 4, 5));
-
-        Assert.Equal(10, fixture.Scheduler.MaxPerceptionRange);
-        Assert.Equal(15, fixture.Scheduler.MaxHearingRange);
-        Assert.True(fixture.Scheduler.TryGetDescriptor(new Serial(0x2), out var descriptor));
-        Assert.Equal(4, descriptor!.PerceptionRange);
-    }
-
-    [Fact]
-    public void Tick_ThinkOverride_ClampsToConfiguredMinimumAndMaximum()
-    {
-        var fixture = new SchedulerFixture(minTickMilliseconds: 100, maxTickMilliseconds: 1000);
-        var mobile = fixture.AddActiveMobile(0x1);
-        var thinkResults = new Queue<int?>([1, 5000, null]);
-        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
-            hook == NpcBrainHookType.Think
-                ? NpcBrainInvocationResult.Succeeded(thinkResults.Dequeue())
-                : NpcBrainInvocationResult.Succeeded(null);
-        fixture.Scheduler.Bind(mobile);
-        fixture.Scheduler.Tick();
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(99));
-        fixture.Scheduler.Tick();
-        Assert.Equal(1, fixture.ThinkCount(mobile.Id));
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
-        fixture.Scheduler.Tick();
-        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
-
-        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
-        fixture.Scheduler.Tick();
-        Assert.Equal(3, fixture.ThinkCount(mobile.Id));
     }
 
     [Fact]
@@ -707,20 +756,123 @@ public class NpcBrainSchedulerTests
     }
 
     [Fact]
-    public async Task StartAsync_RegistersOneSchedulerTimerAndStopAsyncCancelsIt()
+    public void Tick_SuccessAfterFailures_ResetsNextFailureBackoffToOneSecond()
     {
-        var fixture = new SchedulerFixture(minTickMilliseconds: 125);
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        var attempts = 0;
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+                                            {
+                                                if (hook != NpcBrainHookType.Think)
+                                                {
+                                                    return NpcBrainInvocationResult.Succeeded(null);
+                                                }
 
-        await fixture.Scheduler.StartAsync();
-        await fixture.Scheduler.StartAsync();
+                                                attempts++;
 
-        Assert.True(fixture.Loop.Repeating.ContainsKey("npc-brain-scheduler"));
-        Assert.Single(fixture.Loop.Repeating);
-        Assert.Equal(TimeSpan.FromMilliseconds(125), fixture.Loop.RepeatingInterval);
-        Assert.Null(fixture.Loop.RepeatingDelay);
+                                                return attempts == 3
+                                                           ? NpcBrainInvocationResult.Succeeded(null)
+                                                           : NpcBrainInvocationResult.Failed("think failed");
+                                            };
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(5));
+        fixture.Scheduler.Tick();
+        fixture.Time.Advance(TimeSpan.FromSeconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(4, attempts);
 
-        await fixture.Scheduler.StopAsync();
-        Assert.Empty(fixture.Loop.Repeating);
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(4, attempts);
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(5, attempts);
+    }
+
+    [Fact]
+    public void Tick_SuccessfulThink_DoesNotFaultEntry()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, _, _, _) =>
+                                                NpcBrainInvocationResult.Succeeded(null);
+
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.True(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Empty(fixture.Runtime.ResetCalls);
+    }
+
+    [Fact]
+    public void Tick_ThinkOverride_ClampsToConfiguredMinimumAndMaximum()
+    {
+        var fixture = new SchedulerFixture(minTickMilliseconds: 100, maxTickMilliseconds: 1000);
+        var mobile = fixture.AddActiveMobile(0x1);
+        var thinkResults = new Queue<int?>([1, 5000, null]);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+                                                hook == NpcBrainHookType.Think
+                                                    ? NpcBrainInvocationResult.Succeeded(thinkResults.Dequeue())
+                                                    : NpcBrainInvocationResult.Succeeded(null);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(99));
+        fixture.Scheduler.Tick();
+        Assert.Equal(1, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(999));
+        fixture.Scheduler.Tick();
+        Assert.Equal(2, fixture.ThinkCount(mobile.Id));
+
+        fixture.Time.Advance(TimeSpan.FromMilliseconds(1));
+        fixture.Scheduler.Tick();
+        Assert.Equal(3, fixture.ThinkCount(mobile.Id));
+    }
+
+    [Fact]
+    public void Unbind_AfterFault_ClearsMobileThrottleEntry()
+    {
+        using var logs = new GlobalSerilogCapture();
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Runtime.InvocationHandler = (_, hook, _, _) =>
+                                                hook == NpcBrainHookType.Think
+                                                    ? NpcBrainInvocationResult.Failed("think failed")
+                                                    : NpcBrainInvocationResult.Succeeded(null);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        fixture.Scheduler.Unbind(mobile.Id);
+        fixture.Scheduler.Bind(mobile);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal(2, SchedulerWarnings(logs).Count);
+    }
+
+    [Fact]
+    public void Unbind_BoundBrain_RemovesSchedulerAndRuntimeState()
+    {
+        var fixture = new SchedulerFixture();
+        var mobile = fixture.AddActiveMobile(0x1);
+        fixture.Scheduler.Bind(mobile);
+
+        fixture.Scheduler.Unbind(mobile.Id);
+        fixture.Scheduler.Tick();
+
+        Assert.Equal([mobile.Id], fixture.Runtime.UnbindCalls);
+        Assert.False(fixture.Scheduler.TryGetDescriptor(mobile.Id, out _));
+        Assert.False(fixture.Scheduler.IsActive(mobile.Id));
+        Assert.Empty(fixture.Runtime.Invocations);
+        Assert.Equal(0, fixture.Metrics.Current.ActiveBrains);
     }
 
     private static NpcBrainEvent Event(NpcBrainEventType type, uint subject)
@@ -729,12 +881,11 @@ public class NpcBrainSchedulerTests
     private static int FaultLogCount(NpcBrainScheduler scheduler)
     {
         var field = typeof(NpcBrainScheduler).GetField(
-            "_faultLogs",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
-        ) ?? throw new InvalidOperationException("Scheduler fault throttle storage was not found.");
-        var entries = Assert.IsAssignableFrom<System.Collections.IDictionary>(
-            field.GetValue(scheduler)
-        );
+                        "_faultLogs",
+                        BindingFlags.Instance | BindingFlags.NonPublic
+                    ) ??
+                    throw new InvalidOperationException("Scheduler fault throttle storage was not found.");
+        var entries = Assert.IsAssignableFrom<IDictionary>(field.GetValue(scheduler));
 
         return entries.Count;
     }
@@ -742,9 +893,10 @@ public class NpcBrainSchedulerTests
     private static int ScheduleQueueCount(NpcBrainScheduler scheduler)
     {
         var field = typeof(NpcBrainScheduler).GetField(
-            "_queue",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
-        ) ?? throw new InvalidOperationException("Scheduler queue was not found.");
+                        "_queue",
+                        BindingFlags.Instance | BindingFlags.NonPublic
+                    ) ??
+                    throw new InvalidOperationException("Scheduler queue was not found.");
         var queue = field.GetValue(scheduler) ??
                     throw new InvalidOperationException("Scheduler queue was not initialized.");
         var count = queue.GetType().GetProperty("Count") ??
@@ -755,22 +907,23 @@ public class NpcBrainSchedulerTests
 
     private static IReadOnlyList<LogEvent> SchedulerWarnings(GlobalSerilogCapture logs)
         => logs.Events
-            .Where(logEvent =>
-                logEvent.Level == LogEventLevel.Warning &&
-                logEvent.MessageTemplate.Text.StartsWith(
-                    "NPC brain scheduler fault",
-                    StringComparison.Ordinal
-                )
-            )
-            .ToArray();
+               .Where(
+                   logEvent =>
+                       logEvent.Level == LogEventLevel.Warning &&
+                       logEvent.MessageTemplate.Text.StartsWith(
+                           "NPC brain scheduler fault",
+                           StringComparison.Ordinal
+                       )
+               )
+               .ToArray();
 
     private static BrainMobileSnapshot Snapshot(uint serial)
         => new(
-            new Serial(serial),
+            new(serial),
             $"mobile-{serial}",
             false,
             0,
-            new Point3D(10, 10, 0),
+            new(10, 10, 0),
             10,
             10,
             false,
@@ -778,162 +931,4 @@ public class NpcBrainSchedulerTests
             false,
             0
         );
-
-    private sealed class SchedulerFixture
-    {
-        public FakePersistenceService Persistence { get; } = new();
-
-        public RecordingNpcBrainRuntime Runtime { get; } = new();
-
-        public StubAiActionService AiActions { get; } = new();
-
-        public StubNpcMemoryService Memory { get; } = new();
-
-        public StubSectorActivityService Sectors { get; } = new();
-
-        public StubSessionManager Sessions { get; } = new();
-
-        public MutableTimeProvider Time { get; } = new(
-            new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero)
-        );
-
-        public NpcAiMetrics Metrics { get; } = new();
-
-        public StubGameLoopContext Loop { get; } = new();
-
-        public SpatialIndexService Spatial { get; }
-
-        public NpcBrainScheduler Scheduler { get; }
-
-        public SchedulerFixture(
-            int maxBrainsPerLoop = 100,
-            int maxEventsPerWake = 16,
-            int? maxMailboxEvents = null,
-            int minTickMilliseconds = 100,
-            int maxTickMilliseconds = 60_000
-        )
-        {
-            Runtime.Descriptors["guard"] = new("guard", 1000, 10, 15);
-            Spatial = new(Persistence, new StubLoopAffinity(), new StubEventBus());
-            var config = new MoongateConfig
-            {
-                NpcAi = new()
-                {
-                    Advanced = new()
-                    {
-                        MinTickMilliseconds = minTickMilliseconds,
-                        MaxTickMilliseconds = maxTickMilliseconds,
-                        MaxBrainsPerLoop = maxBrainsPerLoop,
-                        MaxEventsPerBrainWake = maxEventsPerWake,
-                        MaxMailboxEvents = maxMailboxEvents ?? Math.Max(16, maxEventsPerWake)
-                    }
-                }
-            };
-            var contextFactory = new NpcBrainContextFactory(Spatial, Sessions, Time);
-            Scheduler = new(
-                Loop,
-                Runtime,
-                AiActions,
-                Memory,
-                Sectors,
-                Persistence,
-                contextFactory,
-                Time,
-                config,
-                Metrics
-            );
-        }
-
-        public MobileEntity AddMobile(
-            uint serial,
-            string brainId = "guard",
-            int mapId = 0,
-            int x = 10,
-            int y = 10
-        )
-        {
-            var mobile = new MobileEntity
-            {
-                Id = new Serial(serial),
-                Name = $"mobile-{serial}",
-                BrainScriptId = brainId,
-                MapId = mapId,
-                Position = new Point3D(x, y, 0),
-                Hits = 10,
-                HitsMax = 10
-            };
-            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
-            Spatial.AddOrUpdate(mobile);
-
-            return mobile;
-        }
-
-        public MobileEntity AddActiveMobile(uint serial)
-        {
-            var mobile = AddMobile(serial);
-            Sectors.SetActive(mobile, true);
-
-            return mobile;
-        }
-
-        public void Move(MobileEntity mobile, int x, int y)
-        {
-            mobile.Position = new(x, y, mobile.Position.Z);
-            Persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
-            Spatial.AddOrUpdate(mobile);
-        }
-
-        public void EnqueueSpeech(Serial ownerId, uint speakerId)
-        {
-            Scheduler.EnqueueEvent(
-                ownerId,
-                NpcBrainHookType.SpeechHeard,
-                Event(NpcBrainEventType.SpeechHeard, speakerId)
-            );
-        }
-
-        public int ThinkCount(Serial mobileId)
-            => Runtime.Invocations.Count(
-                invocation => invocation.MobileId == mobileId && invocation.Hook == NpcBrainHookType.Think
-            );
-    }
-
-    private sealed class StubSectorActivityService : ISectorActivityService
-    {
-        private readonly HashSet<(int MapId, int SectorX, int SectorY)> _active = [];
-
-        public SectorActivitySnapshot Current => new(_active.Count, 0);
-
-        public bool IsActive(int mapId, int sectorX, int sectorY)
-            => _active.Contains((mapId, sectorX, sectorY));
-
-        public void SetActive(MobileEntity mobile, bool active)
-        {
-            var key = (mobile.MapId, mobile.Position.X >> 4, mobile.Position.Y >> 4);
-
-            if (active)
-            {
-                _active.Add(key);
-                return;
-            }
-
-            _active.Remove(key);
-        }
-
-        public void TrackPlayer(MobileEntity player)
-        {
-        }
-
-        public void MovePlayer(Serial playerId, int mapId, int sectorX, int sectorY)
-        {
-        }
-
-        public void UntrackPlayer(Serial playerId)
-        {
-        }
-
-        public void Tick()
-        {
-        }
-    }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcMemoryLifecycleSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcMemoryLifecycleSubscriberTests.cs
@@ -1,7 +1,6 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.AI;
-using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Server.Subscribers;
 
@@ -9,37 +8,37 @@ namespace Moongate.Tests.Server.AI;
 
 public class NpcMemoryLifecycleSubscriberTests
 {
+    private sealed class RecordingForget : INpcMemoryService
+    {
+        public List<Serial> Forgotten { get; } = [];
+
+        public IReadOnlyDictionary<string, NpcMemoryValue> All()
+            => throw new NotSupportedException();
+
+        public IDisposable Begin(BrainContext context)
+            => throw new NotSupportedException();
+
+        public bool Delete(string key)
+            => throw new NotSupportedException();
+
+        public void Forget(Serial mobileId)
+            => Forgotten.Add(mobileId);
+
+        public NpcMemoryValue? Get(string key)
+            => throw new NotSupportedException();
+
+        public bool Set(string key, NpcMemoryValue value)
+            => throw new NotSupportedException();
+    }
+
     [Fact]
     public async Task OnMobileDeleted_ForgetsThatMobilesMemory()
     {
         var memory = new RecordingForget();
         var subscriber = new NpcMemoryLifecycleSubscriber(memory);
 
-        await subscriber.OnMobileDeleted(new MobileDeletedEvent(new MobileEntity { Id = new(0x7) }), default);
+        await subscriber.OnMobileDeleted(new(new() { Id = new(0x7) }), default);
 
-        Assert.Equal(new Serial(0x7), Assert.Single(memory.Forgotten));
-    }
-
-    private sealed class RecordingForget : INpcMemoryService
-    {
-        public List<Serial> Forgotten { get; } = [];
-
-        public IDisposable Begin(BrainContext context)
-            => throw new NotSupportedException();
-
-        public bool Set(string key, NpcMemoryValue value)
-            => throw new NotSupportedException();
-
-        public NpcMemoryValue? Get(string key)
-            => throw new NotSupportedException();
-
-        public bool Delete(string key)
-            => throw new NotSupportedException();
-
-        public IReadOnlyDictionary<string, NpcMemoryValue> All()
-            => throw new NotSupportedException();
-
-        public void Forget(Serial mobileId)
-            => Forgotten.Add(mobileId);
+        Assert.Equal(new(0x7), Assert.Single(memory.Forgotten));
     }
 }

--- a/tests/Moongate.Tests/Server/AI/NpcMemoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcMemoryServiceTests.cs
@@ -1,4 +1,3 @@
-using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.AI;
 using Moongate.Server.Services.AI;
@@ -8,97 +7,6 @@ namespace Moongate.Tests.Server.AI;
 
 public class NpcMemoryServiceTests
 {
-    [Fact]
-    public void Set_Then_Get_RoundTripsScalarTypes()
-    {
-        var (service, persistence) = Build();
-        var npc = AddMobile(persistence, 0x1);
-
-        using (service.Begin(Context(npc)))
-        {
-            Assert.True(service.Set("name", NpcMemoryValue.FromString("Bob")));
-            Assert.True(service.Set("count", NpcMemoryValue.FromNumber(3)));
-            Assert.True(service.Set("hostile", NpcMemoryValue.FromBoolean(true)));
-
-            Assert.Equal("Bob", service.Get("name")!.ToScalar());
-            Assert.Equal(3d, service.Get("count")!.ToScalar());
-            Assert.Equal(true, service.Get("hostile")!.ToScalar());
-            Assert.Null(service.Get("missing"));
-        }
-
-        var stored = persistence.Store<NpcMemoryEntity>().GetById(npc.Id)!;
-        Assert.Equal(3, stored.Memory.Count);
-    }
-
-    [Fact]
-    public void Set_SurvivesAFreshServiceOverTheSameStore()
-    {
-        var (service, persistence) = Build();
-        var npc = AddMobile(persistence, 0x1);
-        using (service.Begin(Context(npc)))
-        {
-            service.Set("seen", NpcMemoryValue.FromNumber(1));
-        }
-
-        var reopened = new NpcMemoryService(persistence, new StubLoopAffinity());
-        using (reopened.Begin(Context(npc)))
-        {
-            Assert.Equal(1d, reopened.Get("seen")!.ToScalar());
-        }
-    }
-
-    [Fact]
-    public void Set_UnknownMobile_ReturnsFalse()
-    {
-        var (service, persistence) = Build();
-        var ghost = new MobileEntity { Id = new(0x99), Name = "ghost" };
-
-        using (service.Begin(Context(ghost)))
-        {
-            Assert.False(service.Set("k", NpcMemoryValue.FromString("v")));
-        }
-
-        Assert.Null(persistence.Store<NpcMemoryEntity>().GetById(new(0x99)));
-    }
-
-    [Fact]
-    public void Set_ExceedingBounds_ReturnsFalse()
-    {
-        var (service, persistence) = Build();
-        var npc = AddMobile(persistence, 0x1);
-
-        using (service.Begin(Context(npc)))
-        {
-            Assert.False(service.Set(new string('k', 65), NpcMemoryValue.FromString("v")));
-            Assert.False(service.Set("k", NpcMemoryValue.FromString(new string('v', 257))));
-            for (var i = 0; i < 128; i++)
-            {
-                Assert.True(service.Set("k" + i, NpcMemoryValue.FromNumber(i)));
-            }
-
-            Assert.False(service.Set("k128", NpcMemoryValue.FromNumber(0)));
-            Assert.True(service.Set("k0", NpcMemoryValue.FromNumber(99)));
-        }
-    }
-
-    [Fact]
-    public void Delete_And_Forget()
-    {
-        var (service, persistence) = Build();
-        var npc = AddMobile(persistence, 0x1);
-        using (service.Begin(Context(npc)))
-        {
-            service.Set("a", NpcMemoryValue.FromNumber(1));
-            Assert.True(service.Delete("a"));
-            Assert.False(service.Delete("a"));
-            Assert.Null(service.Get("a"));
-            service.Set("b", NpcMemoryValue.FromNumber(2));
-        }
-
-        service.Forget(npc.Id);
-        Assert.Null(persistence.Store<NpcMemoryEntity>().GetById(npc.Id));
-    }
-
     [Fact]
     public void Action_WithoutActiveContext_Throws()
     {
@@ -130,23 +38,120 @@ public class NpcMemoryServiceTests
         Assert.Throws<InvalidOperationException>(() => service.Get("z"));
     }
 
-    private static (NpcMemoryService Service, FakePersistenceService Persistence) Build()
+    [Fact]
+    public void Delete_And_Forget()
     {
-        var persistence = new FakePersistenceService();
-        return (new NpcMemoryService(persistence, new StubLoopAffinity()), persistence);
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+
+        using (service.Begin(Context(npc)))
+        {
+            service.Set("a", NpcMemoryValue.FromNumber(1));
+            Assert.True(service.Delete("a"));
+            Assert.False(service.Delete("a"));
+            Assert.Null(service.Get("a"));
+            service.Set("b", NpcMemoryValue.FromNumber(2));
+        }
+
+        service.Forget(npc.Id);
+        Assert.Null(persistence.Store<NpcMemoryEntity>().GetById(npc.Id));
+    }
+
+    [Fact]
+    public void Set_ExceedingBounds_ReturnsFalse()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+
+        using (service.Begin(Context(npc)))
+        {
+            Assert.False(service.Set(new('k', 65), NpcMemoryValue.FromString("v")));
+            Assert.False(service.Set("k", NpcMemoryValue.FromString(new('v', 257))));
+
+            for (var i = 0; i < 128; i++)
+            {
+                Assert.True(service.Set("k" + i, NpcMemoryValue.FromNumber(i)));
+            }
+
+            Assert.False(service.Set("k128", NpcMemoryValue.FromNumber(0)));
+            Assert.True(service.Set("k0", NpcMemoryValue.FromNumber(99)));
+        }
+    }
+
+    [Fact]
+    public void Set_SurvivesAFreshServiceOverTheSameStore()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+
+        using (service.Begin(Context(npc)))
+        {
+            service.Set("seen", NpcMemoryValue.FromNumber(1));
+        }
+
+        var reopened = new NpcMemoryService(persistence, new StubLoopAffinity());
+
+        using (reopened.Begin(Context(npc)))
+        {
+            Assert.Equal(1d, reopened.Get("seen")!.ToScalar());
+        }
+    }
+
+    [Fact]
+    public void Set_Then_Get_RoundTripsScalarTypes()
+    {
+        var (service, persistence) = Build();
+        var npc = AddMobile(persistence, 0x1);
+
+        using (service.Begin(Context(npc)))
+        {
+            Assert.True(service.Set("name", NpcMemoryValue.FromString("Bob")));
+            Assert.True(service.Set("count", NpcMemoryValue.FromNumber(3)));
+            Assert.True(service.Set("hostile", NpcMemoryValue.FromBoolean(true)));
+
+            Assert.Equal("Bob", service.Get("name")!.ToScalar());
+            Assert.Equal(3d, service.Get("count")!.ToScalar());
+            Assert.Equal(true, service.Get("hostile")!.ToScalar());
+            Assert.Null(service.Get("missing"));
+        }
+
+        var stored = persistence.Store<NpcMemoryEntity>().GetById(npc.Id)!;
+        Assert.Equal(3, stored.Memory.Count);
+    }
+
+    [Fact]
+    public void Set_UnknownMobile_ReturnsFalse()
+    {
+        var (service, persistence) = Build();
+        var ghost = new MobileEntity { Id = new(0x99), Name = "ghost" };
+
+        using (service.Begin(Context(ghost)))
+        {
+            Assert.False(service.Set("k", NpcMemoryValue.FromString("v")));
+        }
+
+        Assert.Null(persistence.Store<NpcMemoryEntity>().GetById(new(0x99)));
     }
 
     private static MobileEntity AddMobile(FakePersistenceService persistence, uint id)
     {
         var mobile = new MobileEntity { Id = new(id), Name = "npc-" + id };
         persistence.Store<MobileEntity>().UpsertAsync(mobile).AsTask().Wait();
+
         return mobile;
+    }
+
+    private static (NpcMemoryService Service, FakePersistenceService Persistence) Build()
+    {
+        var persistence = new FakePersistenceService();
+
+        return (new(persistence, new StubLoopAffinity()), persistence);
     }
 
     private static BrainContext Context(MobileEntity owner)
         => new(
             DateTimeOffset.UtcNow,
-            new BrainMobileSnapshot(
+            new(
                 owner.Id,
                 owner.Name,
                 false,

--- a/tests/Moongate.Tests/Server/AI/SectorActivityServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/SectorActivityServiceTests.cs
@@ -1,7 +1,4 @@
-using Moongate.Core.Geometry;
-using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.AI;
 using Moongate.Tests.Support;
@@ -10,6 +7,105 @@ namespace Moongate.Tests.Server.AI;
 
 public class SectorActivityServiceTests
 {
+    [Fact]
+    public void MovePlayer_OneSectorEast_ActivatesNewColumnAndReleasesOldColumn()
+    {
+        var (service, bus, _, _) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+
+        service.MovePlayer(new(0x1), 0, 11, 10);
+
+        Assert.Equal(new(9, 3), service.Current);
+        Assert.Equal(12, bus.Published.OfType<SectorActivatedEvent>().Count());
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+        Assert.True(service.IsActive(0, 9, 10));
+        Assert.True(service.IsActive(0, 12, 10));
+    }
+
+    [Fact]
+    public async Task StartAsync_RegistersOneGraceTimer_AndStopAsyncCancelsIt()
+    {
+        var (service, _, _, _) = Build();
+        var loop = new StubGameLoopContext();
+        service = Create(loop, new(), new(), MutableTimeProvider.StartingNow());
+
+        await service.StartAsync();
+
+        Assert.True(loop.Repeating.ContainsKey("npc-sector-activity"));
+        Assert.Equal(TimeSpan.FromMilliseconds(100), loop.RepeatingInterval);
+        Assert.Null(loop.RepeatingDelay);
+
+        await service.StopAsync();
+
+        Assert.False(loop.Repeating.ContainsKey("npc-sector-activity"));
+    }
+
+    [Fact]
+    public void Tick_AtGraceExpiry_DeactivatesEachExpiredSectorOnce()
+    {
+        var (service, bus, _, time) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+        service.UntrackPlayer(new(0x1));
+
+        time.Advance(TimeSpan.FromSeconds(60));
+        service.Tick();
+
+        Assert.Equal(9, bus.Published.OfType<SectorDeactivatedEvent>().Count());
+        Assert.False(service.IsActive(0, 10, 10));
+        Assert.Equal(new(0, 0), service.Current);
+
+        service.Tick();
+        Assert.Equal(9, bus.Published.OfType<SectorDeactivatedEvent>().Count());
+    }
+
+    [Fact]
+    public void Tick_BeforeGraceExpires_DoesNotDeactivateSectors()
+    {
+        var (service, bus, _, time) = Build();
+        service.TrackPlayer(Player(0x1, 0, 10, 10));
+        service.UntrackPlayer(new(0x1));
+
+        time.Advance(TimeSpan.FromSeconds(59));
+        service.Tick();
+
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+        Assert.True(service.IsActive(0, 10, 10));
+        Assert.Equal(new(0, 9), service.Current);
+    }
+
+    [Fact]
+    public void TrackPlayer_DuringGrace_CancelsDeactivation()
+    {
+        var (service, bus, _, time) = Build();
+        var player = Player(0x1, 0, 10, 10);
+        service.TrackPlayer(player);
+        service.UntrackPlayer(player.Id);
+
+        time.Advance(TimeSpan.FromSeconds(30));
+        service.TrackPlayer(player);
+        time.Advance(TimeSpan.FromSeconds(60));
+        service.Tick();
+
+        Assert.Equal(new(9, 0), service.Current);
+        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
+        Assert.True(service.IsActive(0, 10, 10));
+    }
+
+    [Fact]
+    public void TrackPlayer_OnAnotherMap_ReleasesOldCoverageAndActivatesNewCoverage()
+    {
+        var (service, bus, _, _) = Build();
+        var player = Player(0x1, 0, 10, 10);
+        service.TrackPlayer(player);
+
+        service.TrackPlayer(Player(player.Id, 1, 20, 20));
+
+        Assert.Equal(new(9, 9), service.Current);
+        Assert.Equal(18, bus.Published.OfType<SectorActivatedEvent>().Count());
+        Assert.True(service.IsActive(0, 10, 10));
+        Assert.True(service.IsActive(1, 20, 20));
+    }
+
     [Fact]
     public void TrackPlayer_OnePlayer_ActivatesNineSectors()
     {
@@ -41,21 +137,6 @@ public class SectorActivityServiceTests
     }
 
     [Fact]
-    public void MovePlayer_OneSectorEast_ActivatesNewColumnAndReleasesOldColumn()
-    {
-        var (service, bus, _, _) = Build();
-        service.TrackPlayer(Player(0x1, 0, 10, 10));
-
-        service.MovePlayer(new(0x1), 0, 11, 10);
-
-        Assert.Equal(new(9, 3), service.Current);
-        Assert.Equal(12, bus.Published.OfType<SectorActivatedEvent>().Count());
-        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
-        Assert.True(service.IsActive(0, 9, 10));
-        Assert.True(service.IsActive(0, 12, 10));
-    }
-
-    [Fact]
     public void UntrackPlayer_LastReferenceReleased_EntersGraceAndRemainsActive()
     {
         var (service, _, metrics, _) = Build();
@@ -66,57 +147,6 @@ public class SectorActivityServiceTests
         Assert.Equal(new(0, 9), service.Current);
         Assert.Equal(0, metrics.Current.ActiveSectors);
         Assert.Equal(9, metrics.Current.GraceSectors);
-        Assert.True(service.IsActive(0, 10, 10));
-    }
-
-    [Fact]
-    public void Tick_BeforeGraceExpires_DoesNotDeactivateSectors()
-    {
-        var (service, bus, _, time) = Build();
-        service.TrackPlayer(Player(0x1, 0, 10, 10));
-        service.UntrackPlayer(new(0x1));
-
-        time.Advance(TimeSpan.FromSeconds(59));
-        service.Tick();
-
-        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
-        Assert.True(service.IsActive(0, 10, 10));
-        Assert.Equal(new(0, 9), service.Current);
-    }
-
-    [Fact]
-    public void Tick_AtGraceExpiry_DeactivatesEachExpiredSectorOnce()
-    {
-        var (service, bus, _, time) = Build();
-        service.TrackPlayer(Player(0x1, 0, 10, 10));
-        service.UntrackPlayer(new(0x1));
-
-        time.Advance(TimeSpan.FromSeconds(60));
-        service.Tick();
-
-        Assert.Equal(9, bus.Published.OfType<SectorDeactivatedEvent>().Count());
-        Assert.False(service.IsActive(0, 10, 10));
-        Assert.Equal(new(0, 0), service.Current);
-
-        service.Tick();
-        Assert.Equal(9, bus.Published.OfType<SectorDeactivatedEvent>().Count());
-    }
-
-    [Fact]
-    public void TrackPlayer_DuringGrace_CancelsDeactivation()
-    {
-        var (service, bus, _, time) = Build();
-        var player = Player(0x1, 0, 10, 10);
-        service.TrackPlayer(player);
-        service.UntrackPlayer(player.Id);
-
-        time.Advance(TimeSpan.FromSeconds(30));
-        service.TrackPlayer(player);
-        time.Advance(TimeSpan.FromSeconds(60));
-        service.Tick();
-
-        Assert.Equal(new(9, 0), service.Current);
-        Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
         Assert.True(service.IsActive(0, 10, 10));
     }
 
@@ -133,45 +163,12 @@ public class SectorActivityServiceTests
         Assert.Empty(bus.Published.OfType<SectorDeactivatedEvent>());
     }
 
-    [Fact]
-    public void TrackPlayer_OnAnotherMap_ReleasesOldCoverageAndActivatesNewCoverage()
-    {
-        var (service, bus, _, _) = Build();
-        var player = Player(0x1, 0, 10, 10);
-        service.TrackPlayer(player);
-
-        service.TrackPlayer(Player(player.Id, 1, 20, 20));
-
-        Assert.Equal(new(9, 9), service.Current);
-        Assert.Equal(18, bus.Published.OfType<SectorActivatedEvent>().Count());
-        Assert.True(service.IsActive(0, 10, 10));
-        Assert.True(service.IsActive(1, 20, 20));
-    }
-
-    [Fact]
-    public async Task StartAsync_RegistersOneGraceTimer_AndStopAsyncCancelsIt()
-    {
-        var (service, _, _, _) = Build();
-        var loop = new StubGameLoopContext();
-        service = Create(loop, new StubEventBus(), new NpcAiMetrics(), MutableTimeProvider.StartingNow());
-
-        await service.StartAsync();
-
-        Assert.True(loop.Repeating.ContainsKey("npc-sector-activity"));
-        Assert.Equal(TimeSpan.FromMilliseconds(100), loop.RepeatingInterval);
-        Assert.Null(loop.RepeatingDelay);
-
-        await service.StopAsync();
-
-        Assert.False(loop.Repeating.ContainsKey("npc-sector-activity"));
-    }
-
     private static (SectorActivityService Service, StubEventBus Bus, NpcAiMetrics Metrics, MutableTimeProvider Time) Build()
     {
         var bus = new StubEventBus();
         var metrics = new NpcAiMetrics();
         var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
-        var service = Create(new StubGameLoopContext(), bus, metrics, time);
+        var service = Create(new(), bus, metrics, time);
 
         return (service, bus, metrics, time);
     }
@@ -182,8 +179,8 @@ public class SectorActivityServiceTests
         NpcAiMetrics metrics,
         MutableTimeProvider time
     )
-        => new(loop, bus, time, new MoongateConfig(), metrics);
+        => new(loop, bus, time, new(), metrics);
 
     private static MobileEntity Player(uint serial, int mapId, int sectorX, int sectorY)
-        => new() { Id = new(serial), MapId = mapId, Position = new Point3D(sectorX << 4, sectorY << 4, 0) };
+        => new() { Id = new(serial), MapId = mapId, Position = new(sectorX << 4, sectorY << 4, 0) };
 }

--- a/tests/Moongate.Tests/Server/Accounts/AccountServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/AccountServiceTests.cs
@@ -72,6 +72,28 @@ public class AccountServiceTests
     }
 
     [Fact]
+    public void Delete_ACharacterIsBeingPlayed_IsRefusedAndNothingIsDeleted()
+    {
+        var persistence = new FakePersistenceService();
+        var sessions = new StubSessionManager();
+        var characters = CharacterServiceFixture.Create(persistence, new EventBusService(), sessions);
+        var service = Service(persistence, characters, sessions);
+
+        service.Create("tom", "secret", null, AccountLevelType.Player);
+        var accountId = service.GetByUsername("tom")!.Id;
+        var played = characters.CreateCharacter(accountId, Packet());
+        var other = characters.CreateCharacter(accountId, Packet());
+        sessions.Played.Add(played.Id);
+
+        Assert.Equal(AccountDeleteResultType.CharacterBeingPlayed, service.Delete("tom"));
+
+        // Refused as a whole: the account keeps every character, not just the one in play.
+        Assert.NotNull(service.GetByUsername("tom"));
+        Assert.NotNull(persistence.Store<MobileEntity>().GetById(played.Id));
+        Assert.NotNull(persistence.Store<MobileEntity>().GetById(other.Id));
+    }
+
+    [Fact]
     public void Delete_AccountWithNoCharacters_StillGoes()
     {
         var service = Service(new());
@@ -97,28 +119,6 @@ public class AccountServiceTests
 
         Assert.Null(persistence.Store<MobileEntity>().GetById(first.Id));
         Assert.Null(persistence.Store<MobileEntity>().GetById(second.Id));
-    }
-
-    [Fact]
-    public void Delete_ACharacterIsBeingPlayed_IsRefusedAndNothingIsDeleted()
-    {
-        var persistence = new FakePersistenceService();
-        var sessions = new StubSessionManager();
-        var characters = CharacterServiceFixture.Create(persistence, new EventBusService(), sessions);
-        var service = Service(persistence, characters, sessions);
-
-        service.Create("tom", "secret", null, AccountLevelType.Player);
-        var accountId = service.GetByUsername("tom")!.Id;
-        var played = characters.CreateCharacter(accountId, Packet());
-        var other = characters.CreateCharacter(accountId, Packet());
-        sessions.Played.Add(played.Id);
-
-        Assert.Equal(AccountDeleteResultType.CharacterBeingPlayed, service.Delete("tom"));
-
-        // Refused as a whole: the account keeps every character, not just the one in play.
-        Assert.NotNull(service.GetByUsername("tom"));
-        Assert.NotNull(persistence.Store<MobileEntity>().GetById(played.Id));
-        Assert.NotNull(persistence.Store<MobileEntity>().GetById(other.Id));
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Accounts/IAccountServiceContractTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/IAccountServiceContractTests.cs
@@ -1,7 +1,6 @@
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Server.Accounts;
 

--- a/tests/Moongate.Tests/Server/CharacterServiceTests.cs
+++ b/tests/Moongate.Tests/Server/CharacterServiceTests.cs
@@ -2,7 +2,6 @@ using Moongate.Core.Primitives;
 using Moongate.Network.Packets.Incoming;
 using Moongate.Network.Types;
 using Moongate.Persistence.Entities;
-using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Services.Accounts;
@@ -81,8 +80,8 @@ public class CharacterServiceTests
     {
         var persistence = new FakePersistenceService();
         var loopAffinity = new LoopAffinity(
-            new StubLoopThread(onLoop: false),
-            new MoongateConfig { StrictLoopAffinity = true }
+            new StubLoopThread(false),
+            new() { StrictLoopAffinity = true }
         );
         var service = CharacterServiceFixture.Create(persistence, new EventBusService(), loopAffinity: loopAffinity);
 
@@ -99,7 +98,8 @@ public class CharacterServiceTests
 
         var eventBus = new EventBusService();
         CharacterCreatedEvent? published = null;
-        eventBus.Subscribe<CharacterCreatedEvent>((evt, _) =>
+        eventBus.Subscribe<CharacterCreatedEvent>(
+            (evt, _) =>
             {
                 published = evt;
 
@@ -138,7 +138,8 @@ public class CharacterServiceTests
         var eventBus = new EventBusService();
 
         CharacterReadyEvent? ready = null;
-        eventBus.Subscribe<CharacterReadyEvent>((evt, _) =>
+        eventBus.Subscribe<CharacterReadyEvent>(
+            (evt, _) =>
             {
                 ready = evt;
 
@@ -203,8 +204,8 @@ public class CharacterServiceTests
         var mobile = service.CreateCharacter(accountId, Packet());
 
         var loopAffinity = new LoopAffinity(
-            new StubLoopThread(onLoop: false),
-            new MoongateConfig { StrictLoopAffinity = true }
+            new StubLoopThread(false),
+            new() { StrictLoopAffinity = true }
         );
         var guardedService = CharacterServiceFixture.Create(
             persistence,
@@ -245,7 +246,8 @@ public class CharacterServiceTests
 
         var eventBus = new EventBusService();
         CharacterDeletedEvent? published = null;
-        eventBus.Subscribe<CharacterDeletedEvent>((evt, _) =>
+        eventBus.Subscribe<CharacterDeletedEvent>(
+            (evt, _) =>
             {
                 published = evt;
 
@@ -277,7 +279,8 @@ public class CharacterServiceTests
 
         var eventBus = new EventBusService();
         var published = 0;
-        eventBus.Subscribe<CharacterDeletedEvent>((_, _) =>
+        eventBus.Subscribe<CharacterDeletedEvent>(
+            (_, _) =>
             {
                 published++;
 

--- a/tests/Moongate.Tests/Server/CommandRestSourceTests.cs
+++ b/tests/Moongate.Tests/Server/CommandRestSourceTests.cs
@@ -6,7 +6,6 @@ using Moongate.Server.Abstractions.Interfaces.Commands;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.Commands;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Server;
 
@@ -17,6 +16,33 @@ public class CommandRestSourceTests
         public void Execute(CommandContext context)
             => context.Reply("ran");
     }
+
+    [Fact]
+    public void Execute_refuses_a_console_only_command_from_the_rest_source()
+    {
+        var lines = new List<string>();
+
+        Build(CommandSourceType.Console)
+            .Execute(new(CommandSourceType.Rest, AccountLevelType.GrandMaster, null, "echo", lines.Add));
+
+        Assert.DoesNotContain("ran", lines);
+        Assert.Contains("Unknown command.", lines);
+    }
+
+    [Fact]
+    public void Execute_runs_a_rest_enabled_command_from_the_rest_source()
+    {
+        var lines = new List<string>();
+
+        Build(CommandSourceType.Console | CommandSourceType.Rest)
+            .Execute(new(CommandSourceType.Rest, AccountLevelType.GrandMaster, null, "echo", lines.Add));
+
+        Assert.Contains("ran", lines);
+    }
+
+    [Fact]
+    public void Rest_flag_is_distinct()
+        => Assert.Equal(4, (byte)CommandSourceType.Rest);
 
     private static ICommandService Build(CommandSourceType sources)
     {
@@ -29,32 +55,5 @@ public class CommandRestSourceTests
         );
 
         return new CommandService([registration], new Container(), new SeededAccountService());
-    }
-
-    [Fact]
-    public void Rest_flag_is_distinct()
-        => Assert.Equal(4, (byte)CommandSourceType.Rest);
-
-    [Fact]
-    public void Execute_runs_a_rest_enabled_command_from_the_rest_source()
-    {
-        var lines = new List<string>();
-
-        Build(CommandSourceType.Console | CommandSourceType.Rest)
-            .Execute(new CommandInvocation(CommandSourceType.Rest, AccountLevelType.GrandMaster, null, "echo", lines.Add));
-
-        Assert.Contains("ran", lines);
-    }
-
-    [Fact]
-    public void Execute_refuses_a_console_only_command_from_the_rest_source()
-    {
-        var lines = new List<string>();
-
-        Build(CommandSourceType.Console)
-            .Execute(new CommandInvocation(CommandSourceType.Rest, AccountLevelType.GrandMaster, null, "echo", lines.Add));
-
-        Assert.DoesNotContain("ran", lines);
-        Assert.Contains("Unknown command.", lines);
     }
 }

--- a/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
@@ -17,9 +17,7 @@ public class BroadcastCommandTests
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
 
-        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
-        {
-        }
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/CommandServiceTests.cs
@@ -19,17 +19,6 @@ public class CommandServiceTests
             => LastContext = context;
     }
 
-    private static CommandRegistration Registration(
-        string name,
-        CommandSourceType sources = CommandSourceType.InGame,
-        AccountLevelType minLevel = AccountLevelType.GrandMaster,
-        RecordingCommand? command = null
-    )
-        => new(name, minLevel, "A recording test command.", sources, _ => command ?? new RecordingCommand());
-
-    private static CommandService Service(params CommandRegistration[] registrations)
-        => new(registrations, new Container(), new StubAccountService());
-
     // ---- BuildRegistry (unchanged behavior) ----
 
     [Fact]
@@ -52,33 +41,84 @@ public class CommandServiceTests
         Assert.Same(registration, registry["t"]);
     }
 
-    // ---- Parse (now prefix-free) ----
+    // ---- Execute(CommandInvocation): gating ----
 
     [Fact]
-    public void Parse_ExtraWhitespaceBetweenTokens_IsIgnored()
+    public void Execute_KnownAllowedAuthorized_DispatchesWithArguments()
     {
-        var (name, arguments) = CommandService.Parse("broadcast   hello    world");
+        var command = new RecordingCommand();
+        var service = Service(Registration("test|t", CommandSourceType.Console, AccountLevelType.GrandMaster, command));
 
-        Assert.Equal("broadcast", name);
-        Assert.Equal(["hello", "world"], arguments);
+        service.Execute(
+            new(
+                CommandSourceType.Console,
+                AccountLevelType.GrandMaster,
+                null,
+                "test a b",
+                _ => { }
+            )
+        );
+
+        Assert.NotNull(command.LastContext);
+        Assert.Equal(["a", "b"], command.LastContext!.Value.Arguments);
+        Assert.Equal(CommandSourceType.Console, command.LastContext!.Value.Source);
     }
 
     [Fact]
-    public void Parse_EmptyLine_ReturnsEmptyNameAndNoArguments()
+    public void Execute_LevelBelowMinimum_RepliesUnknownCommand()
     {
-        var (name, arguments) = CommandService.Parse(string.Empty);
+        var replies = new List<string>();
+        var service = Service(Registration("test", CommandSourceType.Console));
 
-        Assert.Equal(string.Empty, name);
-        Assert.Empty(arguments);
+        service.Execute(
+            new(
+                CommandSourceType.Console,
+                AccountLevelType.Player,
+                null,
+                "test",
+                replies.Add
+            )
+        );
+
+        Assert.Equal("Unknown command.", Assert.Single(replies));
     }
 
     [Fact]
-    public void Parse_NameWithArguments_SplitsOnWhitespace()
+    public void Execute_SourceNotAllowed_RepliesUnknownCommand()
     {
-        var (name, arguments) = CommandService.Parse("broadcast Server restarting soon");
+        var replies = new List<string>();
+        var service = Service(Registration("test")); // in-game only
 
-        Assert.Equal("broadcast", name);
-        Assert.Equal(["Server", "restarting", "soon"], arguments);
+        service.Execute(
+            new(
+                CommandSourceType.Console,
+                AccountLevelType.Administrator,
+                null,
+                "test",
+                replies.Add
+            )
+        );
+
+        Assert.Equal("Unknown command.", Assert.Single(replies));
+    }
+
+    [Fact]
+    public void Execute_UnknownName_RepliesUnknownCommand()
+    {
+        var replies = new List<string>();
+        var service = Service(Registration("test", CommandSourceType.Console));
+
+        service.Execute(
+            new(
+                CommandSourceType.Console,
+                AccountLevelType.Administrator,
+                null,
+                "nope",
+                replies.Add
+            )
+        );
+
+        Assert.Equal("Unknown command.", Assert.Single(replies));
     }
 
     // ---- IsAuthorized ----
@@ -94,86 +134,6 @@ public class CommandServiceTests
     public void IsAuthorized_ActorBelowMinLevel_IsFalse()
         => Assert.False(CommandService.IsAuthorized(AccountLevelType.Player, AccountLevelType.GrandMaster));
 
-    // ---- Execute(CommandInvocation): gating ----
-
-    [Fact]
-    public void Execute_KnownAllowedAuthorized_DispatchesWithArguments()
-    {
-        var command = new RecordingCommand();
-        var service = Service(Registration("test|t", CommandSourceType.Console, AccountLevelType.GrandMaster, command));
-
-        service.Execute(
-            new CommandInvocation(
-                CommandSourceType.Console,
-                AccountLevelType.GrandMaster,
-                null,
-                "test a b",
-                _ => { }
-            )
-        );
-
-        Assert.NotNull(command.LastContext);
-        Assert.Equal(["a", "b"], command.LastContext!.Value.Arguments);
-        Assert.Equal(CommandSourceType.Console, command.LastContext!.Value.Source);
-    }
-
-    [Fact]
-    public void Execute_UnknownName_RepliesUnknownCommand()
-    {
-        var replies = new List<string>();
-        var service = Service(Registration("test", CommandSourceType.Console));
-
-        service.Execute(
-            new CommandInvocation(
-                CommandSourceType.Console,
-                AccountLevelType.Administrator,
-                null,
-                "nope",
-                replies.Add
-            )
-        );
-
-        Assert.Equal("Unknown command.", Assert.Single(replies));
-    }
-
-    [Fact]
-    public void Execute_SourceNotAllowed_RepliesUnknownCommand()
-    {
-        var replies = new List<string>();
-        var service = Service(Registration("test", CommandSourceType.InGame)); // in-game only
-
-        service.Execute(
-            new CommandInvocation(
-                CommandSourceType.Console,
-                AccountLevelType.Administrator,
-                null,
-                "test",
-                replies.Add
-            )
-        );
-
-        Assert.Equal("Unknown command.", Assert.Single(replies));
-    }
-
-    [Fact]
-    public void Execute_LevelBelowMinimum_RepliesUnknownCommand()
-    {
-        var replies = new List<string>();
-        var service = Service(Registration("test", CommandSourceType.Console, AccountLevelType.GrandMaster));
-
-        service.Execute(
-            new CommandInvocation(
-                CommandSourceType.Console,
-                AccountLevelType.Player,
-                null,
-                "test",
-                replies.Add
-            )
-        );
-
-        Assert.Equal("Unknown command.", Assert.Single(replies));
-    }
-
     // ---- ListCommands ----
 
     [Fact]
@@ -181,7 +141,7 @@ public class CommandServiceTests
     {
         var service = Service(
             Registration("broadcast|bc", CommandSourceType.InGame | CommandSourceType.Console),
-            Registration("ingameonly", CommandSourceType.InGame)
+            Registration("ingameonly")
         );
 
         var console = service.ListCommands(CommandSourceType.Console);
@@ -190,4 +150,44 @@ public class CommandServiceTests
         Assert.Equal("broadcast", descriptor.Name);
         Assert.Equal(AccountLevelType.GrandMaster, descriptor.MinLevel);
     }
+
+    [Fact]
+    public void Parse_EmptyLine_ReturnsEmptyNameAndNoArguments()
+    {
+        var (name, arguments) = CommandService.Parse(string.Empty);
+
+        Assert.Equal(string.Empty, name);
+        Assert.Empty(arguments);
+    }
+
+    // ---- Parse (now prefix-free) ----
+
+    [Fact]
+    public void Parse_ExtraWhitespaceBetweenTokens_IsIgnored()
+    {
+        var (name, arguments) = CommandService.Parse("broadcast   hello    world");
+
+        Assert.Equal("broadcast", name);
+        Assert.Equal(["hello", "world"], arguments);
+    }
+
+    [Fact]
+    public void Parse_NameWithArguments_SplitsOnWhitespace()
+    {
+        var (name, arguments) = CommandService.Parse("broadcast Server restarting soon");
+
+        Assert.Equal("broadcast", name);
+        Assert.Equal(["Server", "restarting", "soon"], arguments);
+    }
+
+    private static CommandRegistration Registration(
+        string name,
+        CommandSourceType sources = CommandSourceType.InGame,
+        AccountLevelType minLevel = AccountLevelType.GrandMaster,
+        RecordingCommand? command = null
+    )
+        => new(name, minLevel, "A recording test command.", sources, _ => command ?? new RecordingCommand());
+
+    private static CommandService Service(params CommandRegistration[] registrations)
+        => new(registrations, new Container(), new StubAccountService());
 }

--- a/tests/Moongate.Tests/Server/Events/LoopAffineEventBusTests.cs
+++ b/tests/Moongate.Tests/Server/Events/LoopAffineEventBusTests.cs
@@ -19,6 +19,11 @@ public class LoopAffineEventBusTests
         public List<IEvent> Published { get; } = [];
         public Delegate? LastHandler { get; private set; }
 
+        private sealed class Noop : IDisposable
+        {
+            public void Dispose() { }
+        }
+
         public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent
             => Published.Add(eventData);
 
@@ -26,23 +31,18 @@ public class LoopAffineEventBusTests
             where TEvent : IEvent
         {
             Published.Add(eventData);
-            return Task.CompletedTask;
-        }
 
-        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
-        {
-            LastHandler = handler;
-            return new Noop();
+            return Task.CompletedTask;
         }
 
         public IDisposable RegisterListener<TEvent>(IEventListener<TEvent> listener) where TEvent : IEvent
             => new Noop();
 
-        private sealed class Noop : IDisposable
+        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) where TEvent : IEvent
         {
-            public void Dispose()
-            {
-            }
+            LastHandler = handler;
+
+            return new Noop();
         }
     }
 
@@ -51,7 +51,7 @@ public class LoopAffineEventBusTests
     {
         var inner = new CapturingEventBus();
         var dispatcher = new MainThreadDispatcherService();
-        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: false));
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(false));
 
         bus.Publish(new LoopEvent());
 
@@ -68,7 +68,7 @@ public class LoopAffineEventBusTests
     {
         var inner = new CapturingEventBus();
         var dispatcher = new MainThreadDispatcherService();
-        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(true));
 
         bus.Publish(new LoopEvent());
 
@@ -81,7 +81,7 @@ public class LoopAffineEventBusTests
     {
         var inner = new CapturingEventBus();
         var dispatcher = new MainThreadDispatcherService();
-        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: false));
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(false));
 
         bus.Publish(new PlainEvent());
 
@@ -90,24 +90,11 @@ public class LoopAffineEventBusTests
     }
 
     [Fact]
-    public void Subscribe_LoopAffineHandlerOffLoop_Throws()
-    {
-        var inner = new CapturingEventBus();
-        var dispatcher = new MainThreadDispatcherService();
-        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: false));
-
-        bus.Subscribe<LoopEvent>((_, _) => Task.CompletedTask);
-        var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
-
-        Assert.Throws<InvalidOperationException>(() => wrapped(new LoopEvent(), default).GetAwaiter().GetResult());
-    }
-
-    [Fact]
     public void Subscribe_LoopAffineHandlerGoesAsync_Throws()
     {
         var inner = new CapturingEventBus();
         var dispatcher = new MainThreadDispatcherService();
-        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(true));
 
         // A never-completed task models a handler that did not finish synchronously (it went async),
         // deterministically — unlike Task.Yield(), whose thread-pool continuation can complete before
@@ -120,7 +107,20 @@ public class LoopAffineEventBusTests
         // to Assert.Throws<T>(Action) instead of the xUnit-analyzer-flagged Func<Task> overload. The
         // guard throws synchronously before ever returning a task, so GetResult() is never reached —
         // this is equivalent to a plain synchronous throw, just in a shape the analyzer accepts.
-        Assert.Throws<InvalidOperationException>(() => wrapped(new LoopEvent(), default).GetAwaiter().GetResult());
+        Assert.Throws<InvalidOperationException>(() => wrapped(new(), default).GetAwaiter().GetResult());
+    }
+
+    [Fact]
+    public void Subscribe_LoopAffineHandlerOffLoop_Throws()
+    {
+        var inner = new CapturingEventBus();
+        var dispatcher = new MainThreadDispatcherService();
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(false));
+
+        bus.Subscribe<LoopEvent>((_, _) => Task.CompletedTask);
+        var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
+
+        Assert.Throws<InvalidOperationException>(() => wrapped(new(), default).GetAwaiter().GetResult());
     }
 
     [Fact]
@@ -128,17 +128,19 @@ public class LoopAffineEventBusTests
     {
         var inner = new CapturingEventBus();
         var dispatcher = new MainThreadDispatcherService();
-        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread(onLoop: true));
+        var bus = new LoopAffineEventBus(inner, dispatcher, new StubLoopThread());
         var ran = false;
 
-        bus.Subscribe<LoopEvent>((_, _) =>
+        bus.Subscribe<LoopEvent>(
+            (_, _) =>
             {
                 ran = true;
+
                 return Task.CompletedTask;
             }
         );
         var wrapped = (Func<LoopEvent, CancellationToken, Task>)inner.LastHandler!;
-        wrapped(new LoopEvent(), default).GetAwaiter().GetResult();
+        wrapped(new(), default).GetAwaiter().GetResult();
 
         Assert.True(ran);
     }

--- a/tests/Moongate.Tests/Server/Game/GameLoopContextTests.cs
+++ b/tests/Moongate.Tests/Server/Game/GameLoopContextTests.cs
@@ -7,6 +7,18 @@ namespace Moongate.Tests.Server.Game;
 public class GameLoopContextTests
 {
     [Fact]
+    public async Task InvokeAsync_LoopNeverRuns_TimesOut()
+    {
+        var dispatcher = new MainThreadDispatcherService();
+        var timers = new FakeTimerServiceForContext();
+        var loop = new GameLoopContext(dispatcher, timers);
+
+        var task = loop.InvokeAsync(() => 1, TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAsync<TimeoutException>(async () => await task);
+    }
+
+    [Fact]
     public async Task InvokeAsync_RunsWorkOnLoop_ReturnsResult()
     {
         var dispatcher = new MainThreadDispatcherService();
@@ -17,17 +29,5 @@ public class GameLoopContextTests
         dispatcher.DrainPending();
 
         Assert.Equal(42, await task);
-    }
-
-    [Fact]
-    public async Task InvokeAsync_LoopNeverRuns_TimesOut()
-    {
-        var dispatcher = new MainThreadDispatcherService();
-        var timers = new FakeTimerServiceForContext();
-        var loop = new GameLoopContext(dispatcher, timers);
-
-        var task = loop.InvokeAsync(() => 1, TimeSpan.FromMilliseconds(50));
-
-        await Assert.ThrowsAsync<TimeoutException>(async () => await task);
     }
 }

--- a/tests/Moongate.Tests/Server/Game/LoopAffinityTests.cs
+++ b/tests/Moongate.Tests/Server/Game/LoopAffinityTests.cs
@@ -1,4 +1,3 @@
-using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Services.Game;
 using Moongate.Tests.Support;
 using Serilog;
@@ -22,8 +21,8 @@ public class LoopAffinityTests
     {
         var sink = new ListSink();
         var affinity = new LoopAffinity(
-            new StubLoopThread(onLoop: false),
-            new MoongateConfig { StrictLoopAffinity = false },
+            new StubLoopThread(false),
+            new() { StrictLoopAffinity = false },
             LoggerFor(sink)
         );
 
@@ -36,8 +35,8 @@ public class LoopAffinityTests
     public void AssertOnLoop_OffLoopStrict_Throws()
     {
         var affinity = new LoopAffinity(
-            new StubLoopThread(onLoop: false),
-            new MoongateConfig { StrictLoopAffinity = true }
+            new StubLoopThread(false),
+            new() { StrictLoopAffinity = true }
         );
 
         Assert.Throws<InvalidOperationException>(() => affinity.AssertOnLoop("item.create"));
@@ -48,8 +47,8 @@ public class LoopAffinityTests
     {
         var sink = new ListSink();
         var affinity = new LoopAffinity(
-            new StubLoopThread(onLoop: true),
-            new MoongateConfig { StrictLoopAffinity = true },
+            new StubLoopThread(),
+            new() { StrictLoopAffinity = true },
             LoggerFor(sink)
         );
 

--- a/tests/Moongate.Tests/Server/Handlers/MegaClilocHandlerTests.cs
+++ b/tests/Moongate.Tests/Server/Handlers/MegaClilocHandlerTests.cs
@@ -30,8 +30,8 @@ public class MegaClilocHandlerTests
         var second = NewItem(items, "a katana");
 
         var responses = MegaClilocHandler
-            .BuildResponses([first.Id, new(0x40009999), second.Id], opl)
-            .ToList();
+                        .BuildResponses([first.Id, new(0x40009999), second.Id], opl)
+                        .ToList();
 
         Assert.Equal(2, responses.Count);
         Assert.Equal(first.Id, responses[0].Serial);

--- a/tests/Moongate.Tests/Server/ItemFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/ItemFactoryServiceTests.cs
@@ -8,14 +8,6 @@ namespace Moongate.Tests.Server;
 public class ItemFactoryServiceTests
 {
     [Fact]
-    public void Create_ClampsCountAndAmountToMinimumOne()
-    {
-        var items = Factory().CreateFromTemplate("dagger", 0, 0);
-        var item = Assert.Single(items);
-        Assert.Equal(1, item.Amount);
-    }
-
-    [Fact]
     public void CreateByCategory_ReturnsItemInCategory()
     {
         var item = Assert.Single(Factory().CreateByCategory("Clothing"));
@@ -119,6 +111,14 @@ public class ItemFactoryServiceTests
     [Fact]
     public void CreateFromTemplate_UnknownId_ReturnsEmpty()
         => Assert.Empty(Factory().CreateFromTemplate("does_not_exist"));
+
+    [Fact]
+    public void Create_ClampsCountAndAmountToMinimumOne()
+    {
+        var items = Factory().CreateFromTemplate("dagger", 0, 0);
+        var item = Assert.Single(items);
+        Assert.Equal(1, item.Amount);
+    }
 
     private static ItemFactoryService Factory(int seed = 1)
         => new(Templates(), new(seed));

--- a/tests/Moongate.Tests/Server/ItemTemplateSeedingCollection.cs
+++ b/tests/Moongate.Tests/Server/ItemTemplateSeedingCollection.cs
@@ -1,6 +1,4 @@
 namespace Moongate.Tests.Server;
 
 [CollectionDefinition("ItemTemplateSeeding", DisableParallelization = true)]
-public sealed class ItemTemplateSeedingCollection
-{
-}
+public sealed class ItemTemplateSeedingCollection { }

--- a/tests/Moongate.Tests/Server/ItemTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/ItemTemplatesLoaderTests.cs
@@ -140,9 +140,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("collections.yaml", exception.Message);
             Assert.Contains("'item'", exception.Message);
@@ -167,13 +168,36 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("b.yaml", exception.Message);
             Assert.Contains("DUPLICATE", exception.Message);
             Assert.Contains("Duplicate", exception.Message);
+            Assert.Equal(0, service.Count);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenExistingDirectoryIsEmpty_DoesNotSeed()
+    {
+        var root = NewRoot();
+        var directories = new DirectoriesConfig(root, Array.Empty<string>());
+        var itemsDirectory = Path.Combine(directories.RegisterDirectory("templates"), "items");
+        Directory.CreateDirectory(itemsDirectory);
+        var service = new ItemTemplateService();
+
+        try
+        {
+            await new ItemTemplatesLoader(service, directories).LoadAsync();
+
+            Assert.Empty(Directory.EnumerateFiles(itemsDirectory, "*", SearchOption.AllDirectories));
             Assert.Equal(0, service.Count);
         }
         finally
@@ -205,28 +229,6 @@ public class ItemTemplatesLoaderTests
         }
     }
 
-    [Fact]
-    public async Task LoadAsync_WhenExistingDirectoryIsEmpty_DoesNotSeed()
-    {
-        var root = NewRoot();
-        var directories = new DirectoriesConfig(root, Array.Empty<string>());
-        var itemsDirectory = Path.Combine(directories.RegisterDirectory("templates"), "items");
-        Directory.CreateDirectory(itemsDirectory);
-        var service = new ItemTemplateService();
-
-        try
-        {
-            await new ItemTemplatesLoader(service, directories).LoadAsync();
-
-            Assert.Empty(Directory.EnumerateFiles(itemsDirectory, "*", SearchOption.AllDirectories));
-            Assert.Equal(0, service.Count);
-        }
-        finally
-        {
-            Directory.Delete(root, true);
-        }
-    }
-
     [Theory, MemberData(nameof(StrictNullDocuments))]
     public async Task LoadAsync_WhenGuardedPropertyIsNull_ReportsPropertyAndLeavesRegistryEmpty(
         string yaml,
@@ -240,9 +242,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("strict-null.yaml", exception.Message);
             Assert.Contains("'item'", exception.Message);
@@ -270,9 +273,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("validation.yaml", exception.Message);
             Assert.Contains(templateId, exception.Message);
@@ -323,9 +327,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("b-invalid.yaml", exception.Message);
             Assert.Contains("invalid", exception.Message);
@@ -357,9 +362,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("params.yaml", exception.Message);
             Assert.Contains("Params[broken]", exception.Message);
@@ -383,9 +389,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains("non-finite-weight.yaml", exception.Message);
             Assert.Contains("'item'", exception.Message);
@@ -409,9 +416,10 @@ public class ItemTemplatesLoaderTests
 
         try
         {
-            var exception = await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                await new ItemTemplatesLoader(service, directories).LoadAsync()
-            );
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                                async () =>
+                                    await new ItemTemplatesLoader(service, directories).LoadAsync()
+                            );
 
             Assert.Contains(Path.Combine("nested", "schema.yaml"), exception.Message);
             Assert.NotNull(exception.InnerException);

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -12,7 +12,6 @@ using Moongate.Network.Packets.Outgoing;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
-using Moongate.Server.Abstractions.Data.Internal;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.Commands;
@@ -76,12 +75,18 @@ public class LoginFlowIntegrationTests
 
         public LoopThreadDispatcher()
         {
-            _thread = new Thread(Run) { IsBackground = true, Name = "test-game-loop" };
+            _thread = new(Run) { IsBackground = true, Name = "test-game-loop" };
             _thread.Start();
             _ready.Wait();
         }
 
         public int PendingCount => _queue.Count;
+
+        public void Dispose()
+        {
+            _queue.CompleteAdding();
+            _thread.Join(TimeSpan.FromSeconds(2));
+        }
 
         public int DrainPending(double? budgetMs = null)
             => 0;
@@ -98,12 +103,6 @@ public class LoginFlowIntegrationTests
             {
                 action();
             }
-        }
-
-        public void Dispose()
-        {
-            _queue.CompleteAdding();
-            _thread.Join(TimeSpan.FromSeconds(2));
         }
     }
 
@@ -161,7 +160,8 @@ public class LoginFlowIntegrationTests
 
         using var aliceEntered = new ManualResetEventSlim();
         using var bobEntered = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(
+            (e, _) =>
             {
                 if (e.Mobile.Name == "Alice")
                 {
@@ -277,27 +277,27 @@ public class LoginFlowIntegrationTests
         var config = LoopbackConfig();
         var persistence = new FakePersistenceService();
         await persistence.Store<AccountEntity>()
-            .UpsertAsync(
-                new()
-                {
-                    Id = (Serial)1,
-                    Username = "gm",
-                    PasswordHash = HashUtils.HashPassword("secret"),
-                    IsActive = true,
-                    AccountLevel = AccountLevelType.GrandMaster
-                }
-            );
+                         .UpsertAsync(
+                             new()
+                             {
+                                 Id = (Serial)1,
+                                 Username = "gm",
+                                 PasswordHash = HashUtils.HashPassword("secret"),
+                                 IsActive = true,
+                                 AccountLevel = AccountLevelType.GrandMaster
+                             }
+                         );
         await persistence.Store<AccountEntity>()
-            .UpsertAsync(
-                new()
-                {
-                    Id = (Serial)2,
-                    Username = "player",
-                    PasswordHash = HashUtils.HashPassword("secret"),
-                    IsActive = true,
-                    AccountLevel = AccountLevelType.Player
-                }
-            );
+                         .UpsertAsync(
+                             new()
+                             {
+                                 Id = (Serial)2,
+                                 Username = "player",
+                                 PasswordHash = HashUtils.HashPassword("secret"),
+                                 IsActive = true,
+                                 AccountLevel = AccountLevelType.Player
+                             }
+                         );
 
         var eventBus = new EventBusService();
         var opl = new OplService(persistence, new ItemTemplateService());
@@ -329,12 +329,13 @@ public class LoginFlowIntegrationTests
         );
         var characters = CharacterServiceFixture.Create(persistence, eventBus, sessions, testCities);
         var accounts = new AccountService(persistence, characters, sessions, eventBus, TimeProvider.System);
+
         // Mirrors the runtime path: register the command declaratively (name/level/help) instead of
         // scanning an attribute. The resolver is a throwaway container — the registration below closes
         // over an already-built instance, so it never actually resolves through it.
         var commands = new CommandService(
             [
-                new CommandRegistration(
+                new(
                     "broadcast|bc",
                     AccountLevelType.GrandMaster,
                     "Sends a server-wide system message.",
@@ -348,7 +349,8 @@ public class LoginFlowIntegrationTests
 
         using var gmEntered = new ManualResetEventSlim();
         using var playerEntered = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(
+            (e, _) =>
             {
                 if (e.Mobile.Name == "GM")
                 {
@@ -364,16 +366,16 @@ public class LoginFlowIntegrationTests
         );
 
         var network = await StartServerWithCommandsAsync(
-            config,
-            eventBus,
-            characters,
-            world,
-            chat,
-            commands,
-            accounts,
-            opl,
-            sessions
-        );
+                          config,
+                          eventBus,
+                          characters,
+                          world,
+                          chat,
+                          commands,
+                          accounts,
+                          opl,
+                          sessions
+                      );
 
         try
         {
@@ -436,7 +438,8 @@ public class LoginFlowIntegrationTests
         var eventBus = new EventBusService();
 
         using var dispatched = new ManualResetEventSlim();
-        eventBus.Subscribe<PacketDispatchedEvent>((e, _) =>
+        eventBus.Subscribe<PacketDispatchedEvent>(
+            (e, _) =>
             {
                 if (e.OpCode == 0x80)
                 {
@@ -478,7 +481,8 @@ public class LoginFlowIntegrationTests
 
         var eventBus = new EventBusService();
         using var enteredWorld = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>((_, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(
+            (_, _) =>
             {
                 enteredWorld.Set();
 
@@ -538,8 +542,8 @@ public class LoginFlowIntegrationTests
             // The response holds the 1050045 name line with "Freydis" in the UTF-16LE arguments.
             var nameArgs = Encoding.Unicode.GetBytes(" \tFreydis\t ");
             var megaClilocPattern = new byte[] { 0x00, 0x10, 0x05, 0xBD, 0x00, (byte)nameArgs.Length }
-                .Concat(nameArgs)
-                .ToArray();
+                                    .Concat(nameArgs)
+                                    .ToArray();
             Assert.True(
                 PollUntil(socket, compressed, megaClilocPattern),
                 "No MegaCliloc (0xD6) response carrying the name line arrived."
@@ -642,7 +646,8 @@ public class LoginFlowIntegrationTests
 
         var eventBus = new EventBusService();
         using var enteredWorld = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>((_, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(
+            (_, _) =>
             {
                 enteredWorld.Set();
 
@@ -776,7 +781,8 @@ public class LoginFlowIntegrationTests
                 opl,
                 sessions
             );
-            var movement = new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System, eventBus);
+            var movement =
+                new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System, eventBus);
 
             // CharacterServiceFixture.Create wires its own MobileFactoryService, whose starting-city
             // lookup is independent of the city StartServerWithMovementAsync registers for the
@@ -799,7 +805,8 @@ public class LoginFlowIntegrationTests
 
             using var aliceEntered = new ManualResetEventSlim();
             using var bobEntered = new ManualResetEventSlim();
-            eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
+            eventBus.Subscribe<PlayerEnteredWorldEvent>(
+                (e, _) =>
                 {
                     if (e.Mobile.Name == "Alice")
                     {
@@ -894,6 +901,48 @@ public class LoginFlowIntegrationTests
         }
     }
 
+    // A client disconnect is raised on the transport thread, but its SessionDestroyedEvent subscribers
+    // mutate world state (SpatialSubscriber removes the character from the spatial index), so they must
+    // run on the game loop — never on the transport thread. NetworkService now publishes directly and
+    // relies on LoopAffineEventBus to marshal the event onto the loop, exactly as production wires it
+    // (Program.cs registers the decorator around the raw bus), so this test wraps the bus the same way.
+    [Fact]
+    public async Task SessionDestroyed_IsPublishedOnTheGameLoopThread_NotTheTransportThread()
+    {
+        var config = LoopbackConfig();
+        var inner = new EventBusService();
+        using var loop = new LoopThreadDispatcher();
+        IEventBus eventBus = new LoopAffineEventBus(inner, loop, new LoopThreadDispatcherAdapter(loop.LoopThreadId));
+
+        using var destroyed = new ManualResetEventSlim();
+        var subscriberThreadId = 0;
+        eventBus.Subscribe<SessionDestroyedEvent>(
+            (_, _) =>
+            {
+                subscriberThreadId = Environment.CurrentManagedThreadId;
+                destroyed.Set();
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var network = await StartServerAsync(config, eventBus, loop);
+
+        try
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket.Connect(IPAddress.Loopback, network.Port);
+            socket.Close();
+
+            Assert.True(destroyed.Wait(TimeSpan.FromSeconds(2)), "SessionDestroyedEvent was not published.");
+            Assert.Equal(loop.LoopThreadId, subscriberThreadId);
+        }
+        finally
+        {
+            await network.StopAsync(CancellationToken.None);
+        }
+    }
+
     [Fact]
     public async Task SessionLifecycle_ConnectAndDisconnect_PublishesEvents()
     {
@@ -902,14 +951,16 @@ public class LoginFlowIntegrationTests
 
         using var created = new ManualResetEventSlim();
         using var destroyed = new ManualResetEventSlim();
-        eventBus.Subscribe<SessionCreatedEvent>((_, _) =>
+        eventBus.Subscribe<SessionCreatedEvent>(
+            (_, _) =>
             {
                 created.Set();
 
                 return Task.CompletedTask;
             }
         );
-        eventBus.Subscribe<SessionDestroyedEvent>((_, _) =>
+        eventBus.Subscribe<SessionDestroyedEvent>(
+            (_, _) =>
             {
                 destroyed.Set();
 
@@ -929,47 +980,6 @@ public class LoginFlowIntegrationTests
             socket.Close();
 
             Assert.True(destroyed.Wait(TimeSpan.FromSeconds(2)), "SessionDestroyedEvent was not published.");
-        }
-        finally
-        {
-            await network.StopAsync(CancellationToken.None);
-        }
-    }
-
-    // A client disconnect is raised on the transport thread, but its SessionDestroyedEvent subscribers
-    // mutate world state (SpatialSubscriber removes the character from the spatial index), so they must
-    // run on the game loop — never on the transport thread. NetworkService now publishes directly and
-    // relies on LoopAffineEventBus to marshal the event onto the loop, exactly as production wires it
-    // (Program.cs registers the decorator around the raw bus), so this test wraps the bus the same way.
-    [Fact]
-    public async Task SessionDestroyed_IsPublishedOnTheGameLoopThread_NotTheTransportThread()
-    {
-        var config = LoopbackConfig();
-        var inner = new EventBusService();
-        using var loop = new LoopThreadDispatcher();
-        IEventBus eventBus = new LoopAffineEventBus(inner, loop, new LoopThreadDispatcherAdapter(loop.LoopThreadId));
-
-        using var destroyed = new ManualResetEventSlim();
-        var subscriberThreadId = 0;
-        eventBus.Subscribe<SessionDestroyedEvent>((_, _) =>
-            {
-                subscriberThreadId = Environment.CurrentManagedThreadId;
-                destroyed.Set();
-
-                return Task.CompletedTask;
-            }
-        );
-
-        var network = await StartServerAsync(config, eventBus, loop);
-
-        try
-        {
-            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            socket.Connect(IPAddress.Loopback, network.Port);
-            socket.Close();
-
-            Assert.True(destroyed.Wait(TimeSpan.FromSeconds(2)), "SessionDestroyedEvent was not published.");
-            Assert.Equal(loop.LoopThreadId, subscriberThreadId);
         }
         finally
         {
@@ -1015,7 +1025,8 @@ public class LoginFlowIntegrationTests
 
         using var aliceEntered = new ManualResetEventSlim();
         using var bobEntered = new ManualResetEventSlim();
-        eventBus.Subscribe<PlayerEnteredWorldEvent>((e, _) =>
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(
+            (e, _) =>
             {
                 if (e.Mobile.Name == "Alice")
                 {

--- a/tests/Moongate.Tests/Server/LootTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/LootTemplatesLoaderTests.cs
@@ -28,7 +28,8 @@ public class LootTemplatesLoaderTests
             var seedAtomic = seederType.GetMethod("SeedAtomic");
             Assert.NotNull(seedAtomic);
 
-            var exception = Assert.Throws<TargetInvocationException>(() => seedAtomic.Invoke(
+            var exception = Assert.Throws<TargetInvocationException>(
+                () => seedAtomic.Invoke(
                     null,
                     [
                         typeof(LootTemplatesLoader).Assembly,

--- a/tests/Moongate.Tests/Server/MobileFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/MobileFactoryServiceTests.cs
@@ -10,17 +10,6 @@ namespace Moongate.Tests.Server;
 public class MobileFactoryServiceTests
 {
     [Fact]
-    public void Create_BuildsBareMobileWithNameMapAndPosition()
-    {
-        var mobile = Factory().Create("Town Guard", 1, new(1420, 1690, 5));
-
-        Assert.Equal("Town Guard", mobile.Name);
-        Assert.Equal(1, mobile.MapId);
-        Assert.Equal(new(1420, 1690, 5), mobile.Position);
-        Assert.Equal(Serial.Zero, mobile.Id);
-    }
-
-    [Fact]
     public void CreateFromTemplate_AppliesBodyStatsHuesAndSkills()
     {
         var templates = new MobileTemplateService();
@@ -83,8 +72,8 @@ public class MobileFactoryServiceTests
         var factory = Factory(templates);
 
         var genders = Enumerable.Range(0, 40)
-            .Select(_ => factory.CreateFromTemplate("any", 1, new(0, 0, 0))!.Mobile.Gender)
-            .ToHashSet();
+                                .Select(_ => factory.CreateFromTemplate("any", 1, new(0, 0, 0))!.Mobile.Gender)
+                                .ToHashSet();
 
         Assert.Contains(GenderType.Male, genders);
         Assert.Contains(GenderType.Female, genders);
@@ -180,8 +169,8 @@ public class MobileFactoryServiceTests
         var factory = Factory(templates);
 
         var loots = Enumerable.Range(0, 40)
-            .Select(_ => factory.CreateFromTemplate("guard", 1, new(0, 0, 0))!.Mobile.LootTableId)
-            .ToHashSet();
+                              .Select(_ => factory.CreateFromTemplate("guard", 1, new(0, 0, 0))!.Mobile.LootTableId)
+                              .ToHashSet();
 
         Assert.Contains("guard.rich", loots); // variant override wins
         Assert.Contains("guard.base", loots); // variant without loot inherits the template
@@ -273,6 +262,17 @@ public class MobileFactoryServiceTests
         Assert.Equal(dexterity, character.Dexterity);
         Assert.Equal(intelligence, character.Intelligence);
         Assert.Equal(expectedHits, character.HitsMax);
+    }
+
+    [Fact]
+    public void Create_BuildsBareMobileWithNameMapAndPosition()
+    {
+        var mobile = Factory().Create("Town Guard", 1, new(1420, 1690, 5));
+
+        Assert.Equal("Town Guard", mobile.Name);
+        Assert.Equal(1, mobile.MapId);
+        Assert.Equal(new(1420, 1690, 5), mobile.Position);
+        Assert.Equal(Serial.Zero, mobile.Id);
     }
 
     private static StartingCityService Cities()

--- a/tests/Moongate.Tests/Server/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/MobileModuleTests.cs
@@ -16,36 +16,6 @@ namespace Moongate.Tests.Server;
 public class MobileModuleTests
 {
     [Fact]
-    public void Create_PersistsAndReturnsSerial()
-    {
-        var (module, persistence) = Build();
-
-        var serial = module.Create("Guard", 1, 100, 200, 5);
-
-        Assert.NotNull(serial);
-        var stored = persistence.Store<MobileEntity>().GetById((Serial)serial!.Value)!;
-        Assert.Equal("Guard", stored.Name);
-        Assert.Equal(1, stored.MapId);
-        Assert.Equal(100, stored.Position.X);
-        Assert.Equal(5, stored.Position.Z);
-    }
-
-    [Fact]
-    public void Create_PublishesCreatedEventAndIndexesMobile()
-    {
-        var (module, persistence, spatial, bus) = BuildWithObserved();
-
-        var serial = module.Create("Guard", 1, 100, 200, 5);
-
-        Assert.NotNull(serial);
-        var stored = persistence.Store<MobileEntity>().GetById((Serial)serial!.Value)!;
-        var created = Assert.Single(bus.Published.OfType<MobileCreatedEvent>());
-        Assert.Equal(stored.Id, created.Mobile.Id);
-        Assert.Equal(stored.Position, created.Mobile.Position);
-        Assert.Single(spatial.GetMobilesInSector(1, 6, 12));
-    }
-
-    [Fact]
     public void CreateFromTemplate_PersistsMobileAndEquipsItems()
     {
         var (module, persistence, templates, _, bus) = BuildWithTemplates();
@@ -82,13 +52,33 @@ public class MobileModuleTests
     }
 
     [Fact]
-    public void Delete_RemovesMobile()
+    public void Create_PersistsAndReturnsSerial()
     {
         var (module, persistence) = Build();
-        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
 
-        Assert.True(module.Delete(serial));
-        Assert.Null(persistence.Store<MobileEntity>().GetById((Serial)serial));
+        var serial = module.Create("Guard", 1, 100, 200, 5);
+
+        Assert.NotNull(serial);
+        var stored = persistence.Store<MobileEntity>().GetById((Serial)serial!.Value)!;
+        Assert.Equal("Guard", stored.Name);
+        Assert.Equal(1, stored.MapId);
+        Assert.Equal(100, stored.Position.X);
+        Assert.Equal(5, stored.Position.Z);
+    }
+
+    [Fact]
+    public void Create_PublishesCreatedEventAndIndexesMobile()
+    {
+        var (module, persistence, spatial, bus) = BuildWithObserved();
+
+        var serial = module.Create("Guard", 1, 100, 200, 5);
+
+        Assert.NotNull(serial);
+        var stored = persistence.Store<MobileEntity>().GetById((Serial)serial!.Value)!;
+        var created = Assert.Single(bus.Published.OfType<MobileCreatedEvent>());
+        Assert.Equal(stored.Id, created.Mobile.Id);
+        Assert.Equal(stored.Position, created.Mobile.Position);
+        Assert.Single(spatial.GetMobilesInSector(1, 6, 12));
     }
 
     [Fact]
@@ -104,6 +94,16 @@ public class MobileModuleTests
         Assert.Equal(new(100, 200, 5), deleted.Mobile.Position);
         Assert.Null(persistence.Store<MobileEntity>().GetById((Serial)serial));
         Assert.Empty(spatial.GetMobilesInSector(1, 6, 12));
+    }
+
+    [Fact]
+    public void Delete_RemovesMobile()
+    {
+        var (module, persistence) = Build();
+        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
+
+        Assert.True(module.Delete(serial));
+        Assert.Null(persistence.Store<MobileEntity>().GetById((Serial)serial));
     }
 
     [Fact]
@@ -125,20 +125,6 @@ public class MobileModuleTests
     {
         var (module, _) = Build();
         Assert.Null(module.Get(999999u));
-    }
-
-    [Fact]
-    public void Move_UpdatesPosition()
-    {
-        var (module, persistence) = Build();
-        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
-
-        Assert.True(module.Move(serial, 10, 20, 0));
-
-        var m = persistence.Store<MobileEntity>().GetById((Serial)serial)!;
-        Assert.Equal(10, m.Position.X);
-        Assert.Equal(20, m.Position.Y);
-        Assert.Equal(1, m.MapId);
     }
 
     [Fact]
@@ -172,20 +158,50 @@ public class MobileModuleTests
     }
 
     [Fact]
-    public void Set_MapChange_PublishesMovedEventAndRelocatesMobileInSpatialIndex()
+    public void Move_UpdatesPosition()
     {
-        var (module, _, spatial, bus) = BuildWithObserved();
+        var (module, persistence) = Build();
         var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
-        var fields = new Table(new());
-        fields["map"] = 2;
 
-        Assert.True(module.Set(serial, fields));
+        Assert.True(module.Move(serial, 10, 20, 0));
 
-        var moved = Assert.Single(bus.Published.OfType<MobileMovedEvent>());
-        Assert.Equal((1, new Point3D(100, 200, 5)), (moved.FromMapId, moved.FromPosition));
-        Assert.Equal((2, new Point3D(100, 200, 5)), (moved.ToMapId, moved.ToPosition));
-        Assert.Empty(spatial.GetMobilesInSector(1, 6, 12));
-        Assert.Single(spatial.GetMobilesInSector(2, 6, 12));
+        var m = persistence.Store<MobileEntity>().GetById((Serial)serial)!;
+        Assert.Equal(10, m.Position.X);
+        Assert.Equal(20, m.Position.Y);
+        Assert.Equal(1, m.MapId);
+    }
+
+    [Fact]
+    public void SetSkill_AcceptsDisplayNameWithSpaces()
+    {
+        var (module, _) = Build();
+        var serial = module.Create("Tamer", 1, 0, 0, 0)!.Value;
+
+        Assert.True(module.SetSkill(serial, "Animal Lore", 300));
+        Assert.Equal(300, module.GetSkill(serial, "AnimalLore"));
+    }
+
+    [Fact]
+    public void SetSkill_AcceptsNumericId_AndUnifiesWithName()
+    {
+        var (module, _) = Build();
+        var serial = module.Create("Guard", 1, 0, 0, 0)!.Value;
+
+        // Lua passes an exposed SkillName constant as a number (double). 40 == Swordsmanship.
+        Assert.True(module.SetSkill(serial, 40d, 700));
+
+        Assert.Equal(700, module.GetSkill(serial, 40d));
+        Assert.Equal(700, module.GetSkill(serial, "Swordsmanship"));
+    }
+
+    [Fact]
+    public void SetSkill_UnknownSkillName_ReturnsFalse()
+    {
+        var (module, _) = Build();
+        var serial = module.Create("Guard", 1, 0, 0, 0)!.Value;
+
+        Assert.False(module.SetSkill(serial, "Jumping", 100));
+        Assert.Equal(0, module.GetSkill(serial, "Jumping"));
     }
 
     [Fact]
@@ -243,36 +259,20 @@ public class MobileModuleTests
     }
 
     [Fact]
-    public void SetSkill_AcceptsDisplayNameWithSpaces()
+    public void Set_MapChange_PublishesMovedEventAndRelocatesMobileInSpatialIndex()
     {
-        var (module, _) = Build();
-        var serial = module.Create("Tamer", 1, 0, 0, 0)!.Value;
+        var (module, _, spatial, bus) = BuildWithObserved();
+        var serial = module.Create("Guard", 1, 100, 200, 5)!.Value;
+        var fields = new Table(new());
+        fields["map"] = 2;
 
-        Assert.True(module.SetSkill(serial, "Animal Lore", 300));
-        Assert.Equal(300, module.GetSkill(serial, "AnimalLore"));
-    }
+        Assert.True(module.Set(serial, fields));
 
-    [Fact]
-    public void SetSkill_AcceptsNumericId_AndUnifiesWithName()
-    {
-        var (module, _) = Build();
-        var serial = module.Create("Guard", 1, 0, 0, 0)!.Value;
-
-        // Lua passes an exposed SkillName constant as a number (double). 40 == Swordsmanship.
-        Assert.True(module.SetSkill(serial, 40d, 700));
-
-        Assert.Equal(700, module.GetSkill(serial, 40d));
-        Assert.Equal(700, module.GetSkill(serial, "Swordsmanship"));
-    }
-
-    [Fact]
-    public void SetSkill_UnknownSkillName_ReturnsFalse()
-    {
-        var (module, _) = Build();
-        var serial = module.Create("Guard", 1, 0, 0, 0)!.Value;
-
-        Assert.False(module.SetSkill(serial, "Jumping", 100));
-        Assert.Equal(0, module.GetSkill(serial, "Jumping"));
+        var moved = Assert.Single(bus.Published.OfType<MobileMovedEvent>());
+        Assert.Equal((1, new Point3D(100, 200, 5)), (moved.FromMapId, moved.FromPosition));
+        Assert.Equal((2, new Point3D(100, 200, 5)), (moved.ToMapId, moved.ToPosition));
+        Assert.Empty(spatial.GetMobilesInSector(1, 6, 12));
+        Assert.Single(spatial.GetMobilesInSector(2, 6, 12));
     }
 
     [Fact]
@@ -299,7 +299,7 @@ public class MobileModuleTests
         FakePersistenceService Persistence,
         SpatialIndexService Spatial,
         StubEventBus Bus
-    ) BuildWith(MobileTemplateService mobileTemplates)
+        ) BuildWith(MobileTemplateService mobileTemplates)
     {
         var persistence = new FakePersistenceService();
         var random = new Random(1);
@@ -326,7 +326,7 @@ public class MobileModuleTests
         MobileTemplateService Templates,
         SpatialIndexService Spatial,
         StubEventBus Bus
-    )
+        )
         BuildWithTemplates()
     {
         var templates = new MobileTemplateService();

--- a/tests/Moongate.Tests/Server/MoongateConfigTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateConfigTests.cs
@@ -32,14 +32,14 @@ public class MoongateConfigTests
     }
 
     [Fact]
-    public void Validate_NonPositiveLimit_ThrowsWithPropertyName()
+    public void Validate_MailboxSmallerThanWakeBudget_ThrowsWithPropertyName()
     {
         var config = new NpcAiConfig();
-        config.Advanced.MaxBrainsPerLoop = 0;
+        config.Advanced.MaxMailboxEvents = config.Advanced.MaxEventsPerBrainWake - 1;
 
         var exception = Assert.Throws<InvalidOperationException>(() => NpcAiConfigValidator.Validate(config));
 
-        Assert.Contains(nameof(NpcAiAdvancedConfig.MaxBrainsPerLoop), exception.Message);
+        Assert.Contains(nameof(NpcAiAdvancedConfig.MaxMailboxEvents), exception.Message);
     }
 
     [Fact]
@@ -54,13 +54,13 @@ public class MoongateConfigTests
     }
 
     [Fact]
-    public void Validate_MailboxSmallerThanWakeBudget_ThrowsWithPropertyName()
+    public void Validate_NonPositiveLimit_ThrowsWithPropertyName()
     {
         var config = new NpcAiConfig();
-        config.Advanced.MaxMailboxEvents = config.Advanced.MaxEventsPerBrainWake - 1;
+        config.Advanced.MaxBrainsPerLoop = 0;
 
         var exception = Assert.Throws<InvalidOperationException>(() => NpcAiConfigValidator.Validate(config));
 
-        Assert.Contains(nameof(NpcAiAdvancedConfig.MaxMailboxEvents), exception.Message);
+        Assert.Contains(nameof(NpcAiAdvancedConfig.MaxBrainsPerLoop), exception.Message);
     }
 }

--- a/tests/Moongate.Tests/Server/MoongateDataLoaderPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateDataLoaderPluginTests.cs
@@ -1,5 +1,4 @@
 using DryIoc;
-using Moongate.Server;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Loading;
 using Moongate.Server.Loaders;

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -2,6 +2,7 @@ using DryIoc;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
 using Moongate.Scripting;
 using Moongate.Scripting.AI;
 using Moongate.Server.Abstractions.Data.Config;
@@ -21,39 +22,25 @@ using Moongate.UO.Data.Types;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Directories;
 using SquidStd.Core.Interfaces.Events;
-using SquidStd.Plugin.Abstractions.Data;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.Tests.Server;
 
 public sealed class MoongateNpcAiPluginTests
 {
-    [Fact]
-    public void Configure_RegistersAiServicesAndSubscribers()
+    private sealed class StubMovementService : IMovementService
     {
-        using var container = new Container();
+        public void TryMove(PlayerSession session, DirectionType direction, byte sequence) { }
 
-        new MoongateNpcAiPlugin().Configure(container, new PluginContext());
+        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
+            => true;
+    }
 
-        Assert.IsType<NpcAiMetrics>(container.Resolve<INpcAiMetrics>());
-        Assert.True(container.IsRegistered<ISectorActivityService>());
-        Assert.True(container.IsRegistered<IAiActionService>());
-        Assert.True(container.IsRegistered<INpcMemoryService>());
-        Assert.True(container.IsRegistered<NpcBrainContextFactory>());
-        Assert.True(container.IsRegistered<INpcBrainScheduler>());
-        var subscribers = container.GetServiceRegistrations()
-            .Where(registration => registration.ServiceType == typeof(IEventSubscriberRegistration))
-            .Select(registration => registration.ImplementationType)
-            .ToArray();
-        Assert.Equal(
-            [
-                typeof(SectorActivitySubscriber),
-                typeof(NpcBrainLifecycleSubscriber),
-                typeof(NpcBrainEventRouter),
-                typeof(NpcMemoryLifecycleSubscriber)
-            ],
-            subscribers
-        );
+    private sealed class StubChatService : IChatService
+    {
+        public void Broadcast(string text, Hue? hue = null) { }
+
+        public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
     }
 
     [Fact]
@@ -68,9 +55,7 @@ public sealed class MoongateNpcAiPluginTests
             var persistence = new FakePersistenceService();
             var eventBus = new StubEventBus();
             var loopAffinity = new StubLoopAffinity();
-            container.RegisterInstance(
-                new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" }
-            );
+            container.RegisterInstance(new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" });
             container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
             container.RegisterInstance(new MoongateConfig());
             container.RegisterInstance<IPersistenceService>(persistence);
@@ -78,16 +63,14 @@ public sealed class MoongateNpcAiPluginTests
             container.RegisterInstance<IGameLoopContext>(new StubGameLoopContext());
             container.RegisterInstance<ILoopAffinity>(loopAffinity);
             container.RegisterInstance<ISessionManager>(new StubSessionManager());
-            container.RegisterInstance<ISpatialIndexService>(
-                new SpatialIndexService(persistence, loopAffinity, eventBus)
-            );
+            container.RegisterInstance<ISpatialIndexService>(new SpatialIndexService(persistence, loopAffinity, eventBus));
             container.RegisterInstance<IMovementService>(new StubMovementService());
             container.RegisterInstance<IChatService>(new StubChatService());
             container.RegisterInstance(Random.Shared);
-            container.RegisterInstance<TimeProvider>(TimeProvider.System);
+            container.RegisterInstance(TimeProvider.System);
 
-            new MoongateScriptingPlugin().Configure(container, new PluginContext());
-            new MoongateNpcAiPlugin().Configure(container, new PluginContext());
+            new MoongateScriptingPlugin().Configure(container, new());
+            new MoongateNpcAiPlugin().Configure(container, new());
 
             Assert.IsType<LuaNpcBrainRuntime>(container.Resolve<INpcBrainRuntime>());
             Assert.IsType<SectorActivityService>(container.Resolve<ISectorActivityService>());
@@ -101,24 +84,31 @@ public sealed class MoongateNpcAiPluginTests
         }
     }
 
-    private sealed class StubMovementService : IMovementService
+    [Fact]
+    public void Configure_RegistersAiServicesAndSubscribers()
     {
-        public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
-        {
-        }
+        using var container = new Container();
 
-        public bool TryMoveNpc(Serial mobileId, DirectionType direction)
-            => true;
-    }
+        new MoongateNpcAiPlugin().Configure(container, new());
 
-    private sealed class StubChatService : IChatService
-    {
-        public void Broadcast(string text, Hue? hue = null)
-        {
-        }
-
-        public void Say(Moongate.Persistence.Entities.MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
-        {
-        }
+        Assert.IsType<NpcAiMetrics>(container.Resolve<INpcAiMetrics>());
+        Assert.True(container.IsRegistered<ISectorActivityService>());
+        Assert.True(container.IsRegistered<IAiActionService>());
+        Assert.True(container.IsRegistered<INpcMemoryService>());
+        Assert.True(container.IsRegistered<NpcBrainContextFactory>());
+        Assert.True(container.IsRegistered<INpcBrainScheduler>());
+        var subscribers = container.GetServiceRegistrations()
+                                   .Where(registration => registration.ServiceType == typeof(IEventSubscriberRegistration))
+                                   .Select(registration => registration.ImplementationType)
+                                   .ToArray();
+        Assert.Equal(
+            [
+                typeof(SectorActivitySubscriber),
+                typeof(NpcBrainLifecycleSubscriber),
+                typeof(NpcBrainEventRouter),
+                typeof(NpcMemoryLifecycleSubscriber)
+            ],
+            subscribers
+        );
     }
 }

--- a/tests/Moongate.Tests/Server/MoongateScriptModulesPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateScriptModulesPluginTests.cs
@@ -1,6 +1,5 @@
 using DryIoc;
 using Moongate.Core.Types;
-using Moongate.Server;
 using Moongate.Server.Plugins;
 using Moongate.Server.Scripting;
 using Moongate.Ultima.Types;

--- a/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/AccountRegistrationSubscriberTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.Notifications;
 using Moongate.Server.Services.Server;
@@ -11,24 +10,25 @@ namespace Moongate.Tests.Server.Notifications;
 
 public sealed class AccountRegistrationSubscriberTests
 {
-    [Fact]
-    public async Task RegistrationEvent_SendsCanonicalVerificationUrlAndPreservesCustomTemplateFields()
+    [Theory, InlineData("http:/portal"), InlineData("https:/portal"), InlineData("http:portal"),
+     InlineData("http:///portal")]
+    public void BuildVerificationUrl_HostlessHttpWebsite_ThrowsArgumentException(string website)
     {
-        var channel = new RecordingNotificationChannel("log");
-        var bus = Wire(channel, "log");
-
-        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc+123"));
-
-        var (recipient, content) = Assert.Single(channel.Sent);
-        Assert.Equal("tom@example.com", recipient.Address);
-        Assert.Equal("log", recipient.ChannelId);
-        Assert.Contains(
-            "https://shard.example/moongate/verify?token=abc%2B123",
-            content.Body,
-            StringComparison.Ordinal
+        var method = typeof(AccountRegistrationSubscriber).GetMethod(
+            "BuildVerificationUrl",
+            BindingFlags.Static | BindingFlags.NonPublic
         );
-        Assert.Contains("tom/abc+123/https://shard.example/moongate/", content.Body, StringComparison.Ordinal);
-        Assert.Contains("/Britannia", content.Body, StringComparison.Ordinal);
+
+        if (method is null)
+        {
+            throw new InvalidOperationException("BuildVerificationUrl was not found.");
+        }
+
+        var invocationException = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, [website, "abc123"]));
+        var exception = Assert.IsType<ArgumentException>(invocationException.InnerException);
+
+        Assert.Equal("website", exception.ParamName);
+        Assert.Contains("absolute HTTP(S) URI", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -59,30 +59,24 @@ public sealed class AccountRegistrationSubscriberTests
         );
     }
 
-    [Theory]
-    [InlineData("http:/portal")]
-    [InlineData("https:/portal")]
-    [InlineData("http:portal")]
-    [InlineData("http:///portal")]
-    public void BuildVerificationUrl_HostlessHttpWebsite_ThrowsArgumentException(string website)
+    [Fact]
+    public async Task RegistrationEvent_SendsCanonicalVerificationUrlAndPreservesCustomTemplateFields()
     {
-        var method = typeof(AccountRegistrationSubscriber).GetMethod(
-            "BuildVerificationUrl",
-            BindingFlags.Static | BindingFlags.NonPublic
+        var channel = new RecordingNotificationChannel("log");
+        var bus = Wire(channel, "log");
+
+        await bus.PublishAsync(new AccountRegistrationRequestedEvent(new(1), "tom", "tom@example.com", "abc+123"));
+
+        var (recipient, content) = Assert.Single(channel.Sent);
+        Assert.Equal("tom@example.com", recipient.Address);
+        Assert.Equal("log", recipient.ChannelId);
+        Assert.Contains(
+            "https://shard.example/moongate/verify?token=abc%2B123",
+            content.Body,
+            StringComparison.Ordinal
         );
-
-        if (method is null)
-        {
-            throw new InvalidOperationException("BuildVerificationUrl was not found.");
-        }
-
-        var invocationException = Assert.Throws<TargetInvocationException>(
-            () => method.Invoke(null, [website, "abc123"])
-        );
-        var exception = Assert.IsType<ArgumentException>(invocationException.InnerException);
-
-        Assert.Equal("website", exception.ParamName);
-        Assert.Contains("absolute HTTP(S) URI", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("tom/abc+123/https://shard.example/moongate/", content.Body, StringComparison.Ordinal);
+        Assert.Contains("/Britannia", content.Body, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Notifications/NotificationServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationServiceTests.cs
@@ -7,6 +7,43 @@ namespace Moongate.Tests.Server.Notifications;
 public sealed class NotificationServiceTests
 {
     [Fact]
+    public void LogChannel_IdentifiesItselfAsLog()
+        => Assert.Equal("log", new LogNotificationChannel().Id);
+
+    [Fact]
+    public void Notify_GivesUpAfterMaxAttempts_WithoutThrowing()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register("test", "greet", "hi");
+        var channel = new RecordingNotificationChannel(failuresBeforeSuccess: 99);
+        var service = new NotificationService(
+            templates,
+            [channel],
+            new StubJobSystem(),
+            new() { MaxAttempts = 2, RetryDelaySeconds = 0 }
+        );
+
+        // The job runs inline here, so an escaping exception would fail this test — which is the point:
+        // on a real worker thread it would be an unobserved crash.
+        service.Notify("greet", new("test", "somewhere"), new { });
+
+        Assert.Equal(2, channel.Attempts);
+        Assert.Empty(channel.Sent);
+    }
+
+    [Fact]
+    public void Notify_MissingTemplate_DropsWithoutSending()
+    {
+        var templates = new NotificationTemplateService();
+        var channel = new RecordingNotificationChannel();
+        var service = new NotificationService(templates, [channel], new StubJobSystem(), new());
+
+        service.Notify("absent", new("test", "somewhere"), new { });
+
+        Assert.Equal(0, channel.Attempts);
+    }
+
+    [Fact]
     public void Notify_RendersTheTemplateAndSendsItOnTheNamedChannel()
     {
         var templates = new NotificationTemplateService();
@@ -21,6 +58,25 @@ public sealed class NotificationServiceTests
         var (recipient, content) = Assert.Single(channel.Sent);
         Assert.Equal("tom@example.com", recipient.Address);
         Assert.Equal("Hello tom", content.Body.Trim());
+    }
+
+    [Fact]
+    public void Notify_RetriesUntilTheChannelSucceeds()
+    {
+        var templates = new NotificationTemplateService();
+        templates.Register("test", "greet", "hi");
+        var channel = new RecordingNotificationChannel(failuresBeforeSuccess: 2);
+        var service = new NotificationService(
+            templates,
+            [channel],
+            new StubJobSystem(),
+            new() { MaxAttempts = 3, RetryDelaySeconds = 0 }
+        );
+
+        service.Notify("greet", new("test", "somewhere"), new { });
+
+        Assert.Equal(3, channel.Attempts);
+        Assert.Single(channel.Sent);
     }
 
     [Fact]
@@ -52,60 +108,4 @@ public sealed class NotificationServiceTests
         Assert.Equal(0, jobs.Scheduled);
         Assert.Empty(channel.Sent);
     }
-
-    [Fact]
-    public void Notify_MissingTemplate_DropsWithoutSending()
-    {
-        var templates = new NotificationTemplateService();
-        var channel = new RecordingNotificationChannel();
-        var service = new NotificationService(templates, [channel], new StubJobSystem(), new());
-
-        service.Notify("absent", new("test", "somewhere"), new { });
-
-        Assert.Equal(0, channel.Attempts);
-    }
-
-    [Fact]
-    public void Notify_RetriesUntilTheChannelSucceeds()
-    {
-        var templates = new NotificationTemplateService();
-        templates.Register("test", "greet", "hi");
-        var channel = new RecordingNotificationChannel(failuresBeforeSuccess: 2);
-        var service = new NotificationService(
-            templates,
-            [channel],
-            new StubJobSystem(),
-            new() { MaxAttempts = 3, RetryDelaySeconds = 0 }
-        );
-
-        service.Notify("greet", new("test", "somewhere"), new { });
-
-        Assert.Equal(3, channel.Attempts);
-        Assert.Single(channel.Sent);
-    }
-
-    [Fact]
-    public void Notify_GivesUpAfterMaxAttempts_WithoutThrowing()
-    {
-        var templates = new NotificationTemplateService();
-        templates.Register("test", "greet", "hi");
-        var channel = new RecordingNotificationChannel(failuresBeforeSuccess: 99);
-        var service = new NotificationService(
-            templates,
-            [channel],
-            new StubJobSystem(),
-            new() { MaxAttempts = 2, RetryDelaySeconds = 0 }
-        );
-
-        // The job runs inline here, so an escaping exception would fail this test — which is the point:
-        // on a real worker thread it would be an unobserved crash.
-        service.Notify("greet", new("test", "somewhere"), new { });
-
-        Assert.Equal(2, channel.Attempts);
-        Assert.Empty(channel.Sent);
-    }
-
-    [Fact]
-    public void LogChannel_IdentifiesItselfAsLog()
-        => Assert.Equal("log", new LogNotificationChannel().Id);
 }

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplateServiceTests.cs
@@ -6,6 +6,61 @@ namespace Moongate.Tests.Server.Notifications;
 public sealed class NotificationTemplateServiceTests
 {
     [Fact]
+    public void Count_ReportsRegisteredTemplates()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "one", "a");
+        service.Register("email", "one", "b");
+
+        Assert.Equal(2, service.Count);
+    }
+
+    [Fact]
+    public void Register_BrokenSyntax_ThrowsNamingTheTemplate()
+    {
+        var service = new NotificationTemplateService();
+
+        // Compiling at registration is the whole point: a broken template must fail at load, not on the
+        // first notification months later.
+        var exception = Assert.Throws<InvalidDataException>(() => service.Register("log", "broken", "{{ if }}"));
+
+        Assert.Contains("broken", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, service.Count);
+    }
+
+    [Fact]
+    public void Register_ExposesModelMembersInSnakeCase()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "greet", "{{ shard_name }}");
+
+        var content = service.Render("log", "greet", new { ShardName = "Britannia" });
+
+        Assert.Equal("Britannia", content!.Body.Trim());
+    }
+
+    [Fact]
+    public void Render_FrontMatterContentTypeHtml_MarksTheContentAsHtml()
+    {
+        var service = new NotificationTemplateService();
+        service.Register(
+            "email",
+            "fancy",
+            """
+            +++
+            content_type = "html"
+            +++
+            <p>Hello {{ username }}</p>
+            """
+        );
+
+        var content = service.Render("email", "fancy", new { Username = "tom" });
+
+        Assert.Equal(NotificationContentType.Html, content!.ContentType);
+        Assert.Equal("<p>Hello tom</p>", content.Body.Trim());
+    }
+
+    [Fact]
     public void Render_TakesTheSubjectFromFrontMatterAndTheBodyFromTheContent()
     {
         var service = new NotificationTemplateService();
@@ -34,93 +89,6 @@ public sealed class NotificationTemplateServiceTests
     }
 
     [Fact]
-    public void Render_WithoutFrontMatter_HasNoSubject()
-    {
-        var service = new NotificationTemplateService();
-        service.Register("log", "account_verification", "Token for {{ username }}: {{ token }}");
-
-        var content = service.Render("log", "account_verification", new { Username = "tom", Token = "abc" });
-
-        Assert.Null(content!.Subject);
-        Assert.Equal("Token for tom: abc", content.Body.Trim());
-    }
-
-    [Fact]
-    public void Register_ExposesModelMembersInSnakeCase()
-    {
-        var service = new NotificationTemplateService();
-        service.Register("log", "greet", "{{ shard_name }}");
-
-        var content = service.Render("log", "greet", new { ShardName = "Britannia" });
-
-        Assert.Equal("Britannia", content!.Body.Trim());
-    }
-
-    [Fact]
-    public void Render_UnknownTemplateOrChannel_IsNull()
-    {
-        var service = new NotificationTemplateService();
-        service.Register("log", "account_verification", "hello");
-
-        Assert.Null(service.Render("log", "nope", new { }));
-        Assert.Null(service.Render("email", "account_verification", new { }));
-    }
-
-    [Fact]
-    public void Register_BrokenSyntax_ThrowsNamingTheTemplate()
-    {
-        var service = new NotificationTemplateService();
-
-        // Compiling at registration is the whole point: a broken template must fail at load, not on the
-        // first notification months later.
-        var exception = Assert.Throws<InvalidDataException>(() => service.Register("log", "broken", "{{ if }}")
-        );
-
-        Assert.Contains("broken", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(0, service.Count);
-    }
-
-    [Fact]
-    public void Count_ReportsRegisteredTemplates()
-    {
-        var service = new NotificationTemplateService();
-        service.Register("log", "one", "a");
-        service.Register("email", "one", "b");
-
-        Assert.Equal(2, service.Count);
-    }
-
-    [Fact]
-    public void Render_FrontMatterContentTypeHtml_MarksTheContentAsHtml()
-    {
-        var service = new NotificationTemplateService();
-        service.Register(
-            "email",
-            "fancy",
-            """
-            +++
-            content_type = "html"
-            +++
-            <p>Hello {{ username }}</p>
-            """
-        );
-
-        var content = service.Render("email", "fancy", new { Username = "tom" });
-
-        Assert.Equal(NotificationContentType.Html, content!.ContentType);
-        Assert.Equal("<p>Hello tom</p>", content.Body.Trim());
-    }
-
-    [Fact]
-    public void Render_WithoutContentType_IsText()
-    {
-        var service = new NotificationTemplateService();
-        service.Register("log", "plain", "hello");
-
-        Assert.Equal(NotificationContentType.Text, service.Render("log", "plain", new { })!.ContentType);
-    }
-
-    [Fact]
     public void Render_UnknownContentType_FallsBackToText()
     {
         var service = new NotificationTemplateService();
@@ -138,5 +106,36 @@ public sealed class NotificationTemplateServiceTests
         // Deliberately forgiving: a mistyped content type must not cost the notification. Anything that
         // is not "html" is text.
         Assert.Equal(NotificationContentType.Text, service.Render("email", "typo", new { })!.ContentType);
+    }
+
+    [Fact]
+    public void Render_UnknownTemplateOrChannel_IsNull()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "account_verification", "hello");
+
+        Assert.Null(service.Render("log", "nope", new { }));
+        Assert.Null(service.Render("email", "account_verification", new { }));
+    }
+
+    [Fact]
+    public void Render_WithoutContentType_IsText()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "plain", "hello");
+
+        Assert.Equal(NotificationContentType.Text, service.Render("log", "plain", new { })!.ContentType);
+    }
+
+    [Fact]
+    public void Render_WithoutFrontMatter_HasNoSubject()
+    {
+        var service = new NotificationTemplateService();
+        service.Register("log", "account_verification", "Token for {{ username }}: {{ token }}");
+
+        var content = service.Render("log", "account_verification", new { Username = "tom", Token = "abc" });
+
+        Assert.Null(content!.Subject);
+        Assert.Equal("Token for tom: abc", content.Body.Trim());
     }
 }

--- a/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/Notifications/NotificationTemplatesLoaderTests.cs
@@ -7,41 +7,26 @@ namespace Moongate.Tests.Server.Notifications;
 public sealed class NotificationTemplatesLoaderTests
 {
     [Fact]
-    public async Task LoadAsync_WhenMissing_SeedsTheDefaultsAndRegistersThem()
+    public async Task LoadAsync_BrokenTemplate_IsReportedAndTheRestStillLoad()
     {
         var root = NewRoot();
         var directories = new DirectoriesConfig(root, Array.Empty<string>());
+        var log = Path.Combine(directories.RegisterDirectory("notification"), "templates", "log");
+        Directory.CreateDirectory(log);
+        File.WriteAllText(Path.Combine(log, "broken.mgtmpl"), "{{ if }}");
+        File.WriteAllText(Path.Combine(log, "fine.mgtmpl"), "ok");
+
         var templates = new NotificationTemplateService();
         var loader = new NotificationTemplatesLoader(templates, directories);
 
         try
         {
+            // One bad file must not stop the shard from booting, nor hide the good templates.
             await loader.LoadAsync();
 
-            var templatesDirectory = Path.Combine(directories.GetPath("notification"), "templates");
-
-            // Seeded as directories-per-channel, with the dot-free id intact.
-            Assert.True(File.Exists(Path.Combine(templatesDirectory, "log", "account_verification.mgtmpl")));
-            Assert.True(File.Exists(Path.Combine(templatesDirectory, "email", "account_verification.mgtmpl")));
-
-            Assert.Equal(2, templates.Count);
-            var model = new
-            {
-                Username = "tom",
-                Email = "t@x",
-                Token = "abc+123",
-                Website = "https://shard.example/moongate/",
-                VerificationUrl = "https://shard.example/moongate/verify?token=abc%2B123",
-                ShardName = "Britannia"
-            };
-
-            var log = templates.Render("log", "account_verification", model);
-            var email = templates.Render("email", "account_verification", model);
-
-            Assert.NotNull(log);
-            Assert.NotNull(email);
-            Assert.Contains(model.VerificationUrl, log.Body, StringComparison.Ordinal);
-            Assert.Contains(model.VerificationUrl, email.Body, StringComparison.Ordinal);
+            Assert.Equal(1, templates.Count);
+            Assert.NotNull(templates.Render("log", "fine", new { }));
+            Assert.Null(templates.Render("log", "broken", new { }));
         }
         finally
         {
@@ -78,26 +63,41 @@ public sealed class NotificationTemplatesLoaderTests
     }
 
     [Fact]
-    public async Task LoadAsync_BrokenTemplate_IsReportedAndTheRestStillLoad()
+    public async Task LoadAsync_WhenMissing_SeedsTheDefaultsAndRegistersThem()
     {
         var root = NewRoot();
         var directories = new DirectoriesConfig(root, Array.Empty<string>());
-        var log = Path.Combine(directories.RegisterDirectory("notification"), "templates", "log");
-        Directory.CreateDirectory(log);
-        File.WriteAllText(Path.Combine(log, "broken.mgtmpl"), "{{ if }}");
-        File.WriteAllText(Path.Combine(log, "fine.mgtmpl"), "ok");
-
         var templates = new NotificationTemplateService();
         var loader = new NotificationTemplatesLoader(templates, directories);
 
         try
         {
-            // One bad file must not stop the shard from booting, nor hide the good templates.
             await loader.LoadAsync();
 
-            Assert.Equal(1, templates.Count);
-            Assert.NotNull(templates.Render("log", "fine", new { }));
-            Assert.Null(templates.Render("log", "broken", new { }));
+            var templatesDirectory = Path.Combine(directories.GetPath("notification"), "templates");
+
+            // Seeded as directories-per-channel, with the dot-free id intact.
+            Assert.True(File.Exists(Path.Combine(templatesDirectory, "log", "account_verification.mgtmpl")));
+            Assert.True(File.Exists(Path.Combine(templatesDirectory, "email", "account_verification.mgtmpl")));
+
+            Assert.Equal(2, templates.Count);
+            var model = new
+            {
+                Username = "tom",
+                Email = "t@x",
+                Token = "abc+123",
+                Website = "https://shard.example/moongate/",
+                VerificationUrl = "https://shard.example/moongate/verify?token=abc%2B123",
+                ShardName = "Britannia"
+            };
+
+            var log = templates.Render("log", "account_verification", model);
+            var email = templates.Render("email", "account_verification", model);
+
+            Assert.NotNull(log);
+            Assert.NotNull(email);
+            Assert.Contains(model.VerificationUrl, log.Body, StringComparison.Ordinal);
+            Assert.Contains(model.VerificationUrl, email.Body, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/Moongate.Tests/Server/OplServiceTests.cs
+++ b/tests/Moongate.Tests/Server/OplServiceTests.cs
@@ -45,6 +45,37 @@ public class OplServiceTests
     }
 
     [Fact]
+    public void ItemServiceDelete_DropsTheCachedList()
+    {
+        var persistence = new FakePersistenceService();
+        var opl = new OplService(persistence, new ItemTemplateService());
+        var items = new ItemService(persistence, opl);
+        var item = new ItemEntity { Name = "a dagger", ItemId = 3921 };
+        items.Create(item);
+        Assert.True(opl.GetOrBuild(item.Id).HasEntries);
+
+        items.Delete(item.Id);
+
+        Assert.False(opl.GetOrBuild(item.Id).HasEntries);
+    }
+
+    [Fact]
+    public void ItemServiceSave_InvalidatesTheCachedList()
+    {
+        var persistence = new FakePersistenceService();
+        var opl = new OplService(persistence, new ItemTemplateService());
+        var items = new ItemService(persistence, opl);
+        var item = new ItemEntity { Name = "a dagger", ItemId = 3921 };
+        items.Create(item);
+        Assert.Equal("a dagger", opl.GetOrBuild(item.Id).Entries[0].Arguments);
+
+        item.Name = "a katana";
+        items.Save(item);
+
+        Assert.Equal("a katana", opl.GetOrBuild(item.Id).Entries[0].Arguments);
+    }
+
+    [Fact]
     public void Item_CommonRarity_HasNoRarityLine()
     {
         var (opl, items, _) = Build();
@@ -108,37 +139,6 @@ public class OplServiceTests
 
         Assert.Contains(new(1072789, "5"), opl.GetOrBuild(heavy.Id).Entries);
         Assert.Contains(new(1072788, "1"), opl.GetOrBuild(light.Id).Entries);
-    }
-
-    [Fact]
-    public void ItemServiceDelete_DropsTheCachedList()
-    {
-        var persistence = new FakePersistenceService();
-        var opl = new OplService(persistence, new ItemTemplateService());
-        var items = new ItemService(persistence, opl);
-        var item = new ItemEntity { Name = "a dagger", ItemId = 3921 };
-        items.Create(item);
-        Assert.True(opl.GetOrBuild(item.Id).HasEntries);
-
-        items.Delete(item.Id);
-
-        Assert.False(opl.GetOrBuild(item.Id).HasEntries);
-    }
-
-    [Fact]
-    public void ItemServiceSave_InvalidatesTheCachedList()
-    {
-        var persistence = new FakePersistenceService();
-        var opl = new OplService(persistence, new ItemTemplateService());
-        var items = new ItemService(persistence, opl);
-        var item = new ItemEntity { Name = "a dagger", ItemId = 3921 };
-        items.Create(item);
-        Assert.Equal("a dagger", opl.GetOrBuild(item.Id).Entries[0].Arguments);
-
-        item.Name = "a katana";
-        items.Save(item);
-
-        Assert.Equal("a katana", opl.GetOrBuild(item.Id).Entries[0].Arguments);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Plugins/DiscoverablePlugin.cs
+++ b/tests/Moongate.Tests/Server/Plugins/DiscoverablePlugin.cs
@@ -17,7 +17,5 @@ public sealed class DiscoverablePlugin : ISquidStdPlugin
             Description = "found by elimination"
         };
 
-    public void Configure(IContainer container, PluginContext context)
-    {
-    }
+    public void Configure(IContainer container, PluginContext context) { }
 }

--- a/tests/Moongate.Tests/Server/Plugins/PluginCatalogTests.cs
+++ b/tests/Moongate.Tests/Server/Plugins/PluginCatalogTests.cs
@@ -7,18 +7,64 @@ namespace Moongate.Tests.Server.Plugins;
 
 public class PluginCatalogTests
 {
+    private sealed class FakePlugin : ISquidStdPlugin
+    {
+        public FakePlugin(string id, string name)
+        {
+            Metadata = new()
+            {
+                Id = id,
+                Name = name,
+                Version = new(2, 3, 4),
+                Author = "squid",
+                Description = "a fake"
+            };
+        }
+
+        public PluginMetadata Metadata { get; }
+
+        public void Configure(IContainer container, PluginContext context) { }
+    }
+
+    [Fact]
+    public void Plugins_KeepsTheOrderTheyWereRecordedIn()
+    {
+        var catalog = new PluginCatalog();
+
+        catalog.Record(new FakePlugin("fake.one", "One"), false);
+        catalog.Record(new FakePlugin("fake.two", "Two"), false);
+
+        Assert.Equal(["fake.one", "fake.two"], catalog.Plugins.Select(plugin => plugin.Id));
+    }
+
+    [Fact]
+    public void Record_IgnoresASecondRecordOfTheSameId()
+    {
+        // FromDirectory-loaded plugins are found by elimination after the explicit ones are recorded, so
+        // the same plugin reaching Record twice is a real path, not a hypothetical.
+        var catalog = new PluginCatalog();
+
+        catalog.Record(new FakePlugin("fake.one", "First"), false);
+        catalog.Record(new FakePlugin("fake.one", "Second"), true);
+
+        var plugin = Assert.Single(catalog.Plugins);
+
+        Assert.Equal("First", plugin.Name);
+        Assert.False(plugin.IsExternal);
+    }
+
     [Fact]
     public void Record_KeepsTheMetadataAndTheDeclaringAssembly()
     {
         var catalog = new PluginCatalog();
 
-        catalog.Record(new FakePlugin("fake.one", "Fake One"), isExternal: false);
+        catalog.Record(new FakePlugin("fake.one", "Fake One"), false);
 
         var plugin = Assert.Single(catalog.Plugins);
 
         Assert.Equal("fake.one", plugin.Id);
         Assert.Equal("Fake One", plugin.Name);
-        Assert.Equal(new Version(2, 3, 4), plugin.Version);
+        Assert.Equal(new(2, 3, 4), plugin.Version);
         Assert.Equal("squid", plugin.Author);
         Assert.Equal("a fake", plugin.Description);
         Assert.False(plugin.IsExternal);
@@ -33,58 +79,8 @@ public class PluginCatalogTests
     {
         var catalog = new PluginCatalog();
 
-        catalog.Record(new FakePlugin("fake.external", "External"), isExternal: true);
+        catalog.Record(new FakePlugin("fake.external", "External"), true);
 
         Assert.True(Assert.Single(catalog.Plugins).IsExternal);
-    }
-
-    [Fact]
-    public void Record_IgnoresASecondRecordOfTheSameId()
-    {
-        // FromDirectory-loaded plugins are found by elimination after the explicit ones are recorded, so
-        // the same plugin reaching Record twice is a real path, not a hypothetical.
-        var catalog = new PluginCatalog();
-
-        catalog.Record(new FakePlugin("fake.one", "First"), isExternal: false);
-        catalog.Record(new FakePlugin("fake.one", "Second"), isExternal: true);
-
-        var plugin = Assert.Single(catalog.Plugins);
-
-        Assert.Equal("First", plugin.Name);
-        Assert.False(plugin.IsExternal);
-    }
-
-    [Fact]
-    public void Plugins_KeepsTheOrderTheyWereRecordedIn()
-    {
-        var catalog = new PluginCatalog();
-
-        catalog.Record(new FakePlugin("fake.one", "One"), isExternal: false);
-        catalog.Record(new FakePlugin("fake.two", "Two"), isExternal: false);
-
-        Assert.Equal(["fake.one", "fake.two"], catalog.Plugins.Select(plugin => plugin.Id));
-    }
-
-    private sealed class FakePlugin : ISquidStdPlugin
-    {
-        private readonly PluginMetadata _metadata;
-
-        public FakePlugin(string id, string name)
-        {
-            _metadata = new()
-            {
-                Id = id,
-                Name = name,
-                Version = new(2, 3, 4),
-                Author = "squid",
-                Description = "a fake"
-            };
-        }
-
-        public PluginMetadata Metadata => _metadata;
-
-        public void Configure(IContainer container, PluginContext context)
-        {
-        }
     }
 }

--- a/tests/Moongate.Tests/Server/Plugins/PluginDiscoveryTests.cs
+++ b/tests/Moongate.Tests/Server/Plugins/PluginDiscoveryTests.cs
@@ -10,42 +10,11 @@ public class PluginDiscoveryTests
     private static readonly Assembly Abstractions = typeof(IPluginCatalog).Assembly;
 
     [Fact]
-    public void IsExternal_IsFalseForTheHostItself()
-    {
-        Assert.False(PluginDiscovery.IsExternal(Tests, Tests));
-    }
-
-    [Fact]
-    public void IsExternal_IsFalseForAnAssemblyTheHostReferences()
-    {
-        // Moongate.Tests references Moongate.Server.Abstractions transitively and directly enough to appear
-        // in its reference list: anything in the compile-time graph was shipped with the server.
-        Assert.False(PluginDiscovery.IsExternal(Tests, Abstractions));
-    }
-
-    [Fact]
-    public void IsExternal_IsTrueForAnAssemblyOutsideTheHostGraph()
-    {
-        // Reversing the roles gives a genuine outsider: Moongate.Server.Abstractions cannot reference the
-        // test project, so from its point of view the tests are an externally loaded assembly. This is the
-        // same shape as a DLL dropped into plugins/.
-        Assert.True(PluginDiscovery.IsExternal(Abstractions, Tests));
-    }
-
-    [Fact]
     public void ExternalPluginTypes_FindsPluginTypesOnlyOutsideTheHostGraph()
     {
         var found = PluginDiscovery.ExternalPluginTypes(Abstractions, [Tests]).ToList();
 
         Assert.Contains(typeof(DiscoverablePlugin), found);
-    }
-
-    [Fact]
-    public void ExternalPluginTypes_SkipsAssembliesInsideTheHostGraph()
-    {
-        // The host's own plugins are recorded explicitly at activation; sweeping them up here would
-        // resurrect the very plugin a configuration flag switched off.
-        Assert.Empty(PluginDiscovery.ExternalPluginTypes(Tests, [Tests]));
     }
 
     [Fact]
@@ -55,4 +24,30 @@ public class PluginDiscoveryTests
 
         Assert.DoesNotContain(typeof(AbstractPlugin), found);
     }
+
+    [Fact]
+    public void ExternalPluginTypes_SkipsAssembliesInsideTheHostGraph()
+
+        // The host's own plugins are recorded explicitly at activation; sweeping them up here would
+        // resurrect the very plugin a configuration flag switched off.
+        => Assert.Empty(PluginDiscovery.ExternalPluginTypes(Tests, [Tests]));
+
+    [Fact]
+    public void IsExternal_IsFalseForAnAssemblyTheHostReferences()
+
+        // Moongate.Tests references Moongate.Server.Abstractions transitively and directly enough to appear
+        // in its reference list: anything in the compile-time graph was shipped with the server.
+        => Assert.False(PluginDiscovery.IsExternal(Tests, Abstractions));
+
+    [Fact]
+    public void IsExternal_IsFalseForTheHostItself()
+        => Assert.False(PluginDiscovery.IsExternal(Tests, Tests));
+
+    [Fact]
+    public void IsExternal_IsTrueForAnAssemblyOutsideTheHostGraph()
+
+        // Reversing the roles gives a genuine outsider: Moongate.Server.Abstractions cannot reference the
+        // test project, so from its point of view the tests are an externally loaded assembly. This is the
+        // same shape as a DLL dropped into plugins/.
+        => Assert.True(PluginDiscovery.IsExternal(Abstractions, Tests));
 }

--- a/tests/Moongate.Tests/Server/Scripting/AiModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/AiModuleTests.cs
@@ -8,14 +8,90 @@ namespace Moongate.Tests.Server.Scripting;
 
 public class AiModuleTests
 {
-    [Fact]
-    public void Say_RoutesTextToService()
+    private sealed class RecordingAiActionService : IAiActionService
     {
-        var actions = new RecordingAiActionService { Result = true };
-        var module = new AiModule(actions);
+        public bool Result { get; set; }
 
-        Assert.True(module.Say("hello"));
-        Assert.Equal("hello", Assert.Single(actions.Said));
+        public List<string> Said { get; } = [];
+        public List<Serial> Engaged { get; } = [];
+        public List<Serial> MovedToward { get; } = [];
+        public List<Serial> MovedAway { get; } = [];
+        public List<DirectionType> Stepped { get; } = [];
+        public List<(int X, int Y)> MovedTo { get; } = [];
+        public int Patrols { get; private set; }
+        public int ReturnsHome { get; private set; }
+        public int ClearsTarget { get; private set; }
+
+        private sealed class NoopScope : IDisposable
+        {
+            public void Dispose() { }
+        }
+
+        public IDisposable Begin(BrainContext context)
+            => new NoopScope();
+
+        public bool ClearTarget()
+        {
+            ClearsTarget++;
+
+            return Result;
+        }
+
+        public bool Engage(Serial targetId)
+        {
+            Engaged.Add(targetId);
+
+            return Result;
+        }
+
+        public bool MoveAway(Serial targetId)
+        {
+            MovedAway.Add(targetId);
+
+            return Result;
+        }
+
+        public bool MoveTo(int x, int y)
+        {
+            MovedTo.Add((x, y));
+
+            return Result;
+        }
+
+        public bool MoveToward(Serial targetId)
+        {
+            MovedToward.Add(targetId);
+
+            return Result;
+        }
+
+        public bool Patrol()
+        {
+            Patrols++;
+
+            return Result;
+        }
+
+        public bool ReturnHome()
+        {
+            ReturnsHome++;
+
+            return Result;
+        }
+
+        public bool Say(string text)
+        {
+            Said.Add(text);
+
+            return Result;
+        }
+
+        public bool Step(DirectionType direction)
+        {
+            Stepped.Add(direction);
+
+            return Result;
+        }
     }
 
     [Fact]
@@ -25,7 +101,17 @@ public class AiModuleTests
         var module = new AiModule(actions);
 
         Assert.True(module.Engage(0x2A));
-        Assert.Equal(new Serial(0x2A), Assert.Single(actions.Engaged));
+        Assert.Equal(new(0x2A), Assert.Single(actions.Engaged));
+    }
+
+    [Fact]
+    public void MoveTo_RoutesCoordinatesToService()
+    {
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
+
+        Assert.True(module.MoveTo(42, 7));
+        Assert.Equal((42, 7), Assert.Single(actions.MovedTo));
     }
 
     [Fact]
@@ -37,46 +123,8 @@ public class AiModuleTests
         Assert.True(module.MoveToward(0x3));
         Assert.True(module.MoveAway(0x4));
 
-        Assert.Equal(new Serial(0x3), Assert.Single(actions.MovedToward));
-        Assert.Equal(new Serial(0x4), Assert.Single(actions.MovedAway));
-    }
-
-    [Theory]
-    [InlineData("north", DirectionType.North)]
-    [InlineData("N", DirectionType.North)]
-    [InlineData("ne", DirectionType.NorthEast)]
-    [InlineData("southwest", DirectionType.SouthWest)]
-    [InlineData(" NW ", DirectionType.NorthWest)]
-    public void Step_ParsesDirectionAndRoutesToService(string direction, DirectionType expected)
-    {
-        var actions = new RecordingAiActionService { Result = true };
-        var module = new AiModule(actions);
-
-        Assert.True(module.Step(direction));
-        Assert.Equal(expected, Assert.Single(actions.Stepped));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("up")]
-    [InlineData("nne")]
-    public void Step_UnknownDirection_ReturnsFalseWithoutCallingService(string direction)
-    {
-        var actions = new RecordingAiActionService { Result = true };
-        var module = new AiModule(actions);
-
-        Assert.False(module.Step(direction));
-        Assert.Empty(actions.Stepped);
-    }
-
-    [Fact]
-    public void MoveTo_RoutesCoordinatesToService()
-    {
-        var actions = new RecordingAiActionService { Result = true };
-        var module = new AiModule(actions);
-
-        Assert.True(module.MoveTo(42, 7));
-        Assert.Equal((42, 7), Assert.Single(actions.MovedTo));
+        Assert.Equal(new(0x3), Assert.Single(actions.MovedToward));
+        Assert.Equal(new(0x4), Assert.Single(actions.MovedAway));
     }
 
     [Fact]
@@ -94,82 +142,35 @@ public class AiModuleTests
         Assert.Equal(1, actions.ClearsTarget);
     }
 
-    private sealed class RecordingAiActionService : IAiActionService
+    [Fact]
+    public void Say_RoutesTextToService()
     {
-        public bool Result { get; set; }
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
 
-        public List<string> Said { get; } = [];
-        public List<Serial> Engaged { get; } = [];
-        public List<Serial> MovedToward { get; } = [];
-        public List<Serial> MovedAway { get; } = [];
-        public List<DirectionType> Stepped { get; } = [];
-        public List<(int X, int Y)> MovedTo { get; } = [];
-        public int Patrols { get; private set; }
-        public int ReturnsHome { get; private set; }
-        public int ClearsTarget { get; private set; }
+        Assert.True(module.Say("hello"));
+        Assert.Equal("hello", Assert.Single(actions.Said));
+    }
 
-        public IDisposable Begin(BrainContext context)
-            => new NoopScope();
+    [Theory, InlineData("north", DirectionType.North), InlineData("N", DirectionType.North),
+     InlineData("ne", DirectionType.NorthEast), InlineData("southwest", DirectionType.SouthWest),
+     InlineData(" NW ", DirectionType.NorthWest)]
+    public void Step_ParsesDirectionAndRoutesToService(string direction, DirectionType expected)
+    {
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
 
-        public bool Say(string text)
-        {
-            Said.Add(text);
-            return Result;
-        }
+        Assert.True(module.Step(direction));
+        Assert.Equal(expected, Assert.Single(actions.Stepped));
+    }
 
-        public bool Patrol()
-        {
-            Patrols++;
-            return Result;
-        }
+    [Theory, InlineData(""), InlineData("up"), InlineData("nne")]
+    public void Step_UnknownDirection_ReturnsFalseWithoutCallingService(string direction)
+    {
+        var actions = new RecordingAiActionService { Result = true };
+        var module = new AiModule(actions);
 
-        public bool ReturnHome()
-        {
-            ReturnsHome++;
-            return Result;
-        }
-
-        public bool MoveToward(Serial targetId)
-        {
-            MovedToward.Add(targetId);
-            return Result;
-        }
-
-        public bool MoveAway(Serial targetId)
-        {
-            MovedAway.Add(targetId);
-            return Result;
-        }
-
-        public bool Engage(Serial targetId)
-        {
-            Engaged.Add(targetId);
-            return Result;
-        }
-
-        public bool ClearTarget()
-        {
-            ClearsTarget++;
-            return Result;
-        }
-
-        public bool Step(DirectionType direction)
-        {
-            Stepped.Add(direction);
-            return Result;
-        }
-
-        public bool MoveTo(int x, int y)
-        {
-            MovedTo.Add((x, y));
-            return Result;
-        }
-
-        private sealed class NoopScope : IDisposable
-        {
-            public void Dispose()
-            {
-            }
-        }
+        Assert.False(module.Step(direction));
+        Assert.Empty(actions.Stepped);
     }
 }

--- a/tests/Moongate.Tests/Server/Scripting/LoopAffineInvokeMarshallerTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/LoopAffineInvokeMarshallerTests.cs
@@ -20,28 +20,12 @@ public class LoopAffineInvokeMarshallerTests
         public bool IsOnLoopThread { get; }
     }
 
-    [Fact]
-    public void OffLoopThread_PostsToDispatcher_AndReturnsNil()
+    private sealed class ListSink : ILogEventSink
     {
-        var dispatcher = new MainThreadDispatcherService();
-        var marshaller = new LoopAffineInvokeMarshaller(new StubLoopThread(false), dispatcher);
-        var ran = false;
+        public List<LogEvent> Events { get; } = [];
 
-        var result = marshaller.Invoke(() =>
-            {
-                ran = true;
-
-                return DynValue.NewNumber(42);
-            }
-        );
-
-        Assert.False(ran);
-        Assert.True(result.IsNil());
-        Assert.Equal(1, dispatcher.PendingCount);
-
-        dispatcher.DrainPending();
-
-        Assert.True(ran);
+        public void Emit(LogEvent logEvent)
+            => Events.Add(logEvent);
     }
 
     [Fact]
@@ -62,12 +46,29 @@ public class LoopAffineInvokeMarshallerTests
         Assert.Contains(sink.Events, e => e.Level == LogEventLevel.Warning);
     }
 
-    private sealed class ListSink : ILogEventSink
+    [Fact]
+    public void OffLoopThread_PostsToDispatcher_AndReturnsNil()
     {
-        public List<LogEvent> Events { get; } = [];
+        var dispatcher = new MainThreadDispatcherService();
+        var marshaller = new LoopAffineInvokeMarshaller(new StubLoopThread(false), dispatcher);
+        var ran = false;
 
-        public void Emit(LogEvent logEvent)
-            => Events.Add(logEvent);
+        var result = marshaller.Invoke(
+            () =>
+            {
+                ran = true;
+
+                return DynValue.NewNumber(42);
+            }
+        );
+
+        Assert.False(ran);
+        Assert.True(result.IsNil());
+        Assert.Equal(1, dispatcher.PendingCount);
+
+        dispatcher.DrainPending();
+
+        Assert.True(ran);
     }
 
     [Fact]
@@ -77,7 +78,8 @@ public class LoopAffineInvokeMarshallerTests
         var marshaller = new LoopAffineInvokeMarshaller(new StubLoopThread(true), dispatcher);
         var ran = false;
 
-        var result = marshaller.Invoke(() =>
+        var result = marshaller.Invoke(
+            () =>
             {
                 ran = true;
 

--- a/tests/Moongate.Tests/Server/Scripting/MemoryModuleTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MemoryModuleTests.cs
@@ -8,6 +8,65 @@ namespace Moongate.Tests.Server.Scripting;
 
 public class MemoryModuleTests
 {
+    private sealed class RecordingMemoryService : INpcMemoryService
+    {
+        public bool Result { get; set; }
+
+        public Dictionary<string, NpcMemoryValue> Stored { get; } = new(StringComparer.Ordinal);
+
+        private sealed class Noop : IDisposable
+        {
+            public void Dispose() { }
+        }
+
+        public IReadOnlyDictionary<string, NpcMemoryValue> All()
+            => Stored;
+
+        public IDisposable Begin(BrainContext context)
+            => new Noop();
+
+        public bool Delete(string key)
+            => Stored.Remove(key);
+
+        public void Forget(Serial mobileId)
+            => Stored.Clear();
+
+        public NpcMemoryValue? Get(string key)
+            => Stored.TryGetValue(key, out var value) ? value : null;
+
+        public bool Set(string key, NpcMemoryValue value)
+        {
+            Stored[key] = value;
+
+            return Result;
+        }
+    }
+
+    [Fact]
+    public void All_ProjectsScalarsByKey()
+    {
+        var svc = new RecordingMemoryService();
+        svc.Stored["s"] = NpcMemoryValue.FromString("x");
+        svc.Stored["b"] = NpcMemoryValue.FromBoolean(false);
+        var module = new MemoryModule(svc);
+
+        var dict = module.All().ToDictionary();
+
+        Assert.Equal("x", dict["s"]);
+        Assert.Equal(false, dict["b"]);
+    }
+
+    [Fact]
+    public void Get_ReturnsUnderlyingScalarOrNull()
+    {
+        var svc = new RecordingMemoryService();
+        svc.Stored["n"] = NpcMemoryValue.FromNumber(7);
+        var module = new MemoryModule(svc);
+
+        Assert.Equal(7d, module.Get("n"));
+        Assert.Null(module.Get("missing"));
+    }
+
     [Fact]
     public void Set_ConvertsLuaScalarsToTypedValues()
     {
@@ -29,67 +88,7 @@ public class MemoryModuleTests
         var svc = new RecordingMemoryService { Result = true };
         var module = new MemoryModule(svc);
 
-        Assert.False(module.Set("t", new object()));
+        Assert.False(module.Set("t", new()));
         Assert.Empty(svc.Stored);
-    }
-
-    [Fact]
-    public void Get_ReturnsUnderlyingScalarOrNull()
-    {
-        var svc = new RecordingMemoryService();
-        svc.Stored["n"] = NpcMemoryValue.FromNumber(7);
-        var module = new MemoryModule(svc);
-
-        Assert.Equal(7d, module.Get("n"));
-        Assert.Null(module.Get("missing"));
-    }
-
-    [Fact]
-    public void All_ProjectsScalarsByKey()
-    {
-        var svc = new RecordingMemoryService();
-        svc.Stored["s"] = NpcMemoryValue.FromString("x");
-        svc.Stored["b"] = NpcMemoryValue.FromBoolean(false);
-        var module = new MemoryModule(svc);
-
-        var dict = module.All().ToDictionary();
-
-        Assert.Equal("x", dict["s"]);
-        Assert.Equal(false, dict["b"]);
-    }
-
-    private sealed class RecordingMemoryService : INpcMemoryService
-    {
-        public bool Result { get; set; }
-
-        public Dictionary<string, NpcMemoryValue> Stored { get; } = new(StringComparer.Ordinal);
-
-        public IDisposable Begin(BrainContext context)
-            => new Noop();
-
-        public bool Set(string key, NpcMemoryValue value)
-        {
-            Stored[key] = value;
-            return Result;
-        }
-
-        public NpcMemoryValue? Get(string key)
-            => Stored.TryGetValue(key, out var value) ? value : null;
-
-        public bool Delete(string key)
-            => Stored.Remove(key);
-
-        public IReadOnlyDictionary<string, NpcMemoryValue> All()
-            => Stored;
-
-        public void Forget(Serial mobileId)
-            => Stored.Clear();
-
-        private sealed class Noop : IDisposable
-        {
-            public void Dispose()
-            {
-            }
-        }
     }
 }

--- a/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/MoongateScriptingPluginTests.cs
@@ -5,7 +5,6 @@ using Moongate.Server.Abstractions.Interfaces.AI;
 using Moongate.Tests.Support;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Directories;
-using SquidStd.Plugin.Abstractions.Data;
 
 namespace Moongate.Tests.Server.Scripting;
 
@@ -20,19 +19,17 @@ public sealed class MoongateScriptingPluginTests
         {
             Directory.CreateDirectory(Path.Combine(root, "scripts"));
             using var container = new Container();
-            container.RegisterInstance(
-                new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" }
-            );
+            container.RegisterInstance(new SquidStdOptions { AppName = "MoongateTests", AppVersion = "1.0.0" });
             container.RegisterInstance(new DirectoriesConfig(root, ["scripts"]));
 
-            new MoongateScriptingPlugin().Configure(container, new PluginContext());
+            new MoongateScriptingPlugin().Configure(container, new());
 
             Assert.True(container.IsRegistered<INpcBrainRuntime>());
             Assert.Equal(
                 typeof(LuaNpcBrainRuntime),
                 container.GetServiceRegistrations()
-                    .Single(registration => registration.ServiceType == typeof(INpcBrainRuntime))
-                    .ImplementationType
+                         .Single(registration => registration.ServiceType == typeof(INpcBrainRuntime))
+                         .ImplementationType
             );
         }
         finally

--- a/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Accounts/AccountRegistrationTests.cs
@@ -8,7 +8,6 @@ using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.Accounts;
 using Moongate.Tests.Support;
 using SquidStd.Services.Core.Services;
-using Xunit;
 
 namespace Moongate.Tests.Server.Services.Accounts;
 
@@ -16,293 +15,178 @@ public sealed class AccountRegistrationTests
 {
     private static readonly DateTimeOffset Now = new(2026, 7, 25, 12, 0, 0, TimeSpan.Zero);
 
+    [Fact]
+    public void LegacyPlaintextToken_PrivilegedAccountCannotMigrateOrVerify()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
+        accounts.SetActive("staff", false);
+        var staff = accounts.GetByUsername("staff")!;
+        staff.ActivationToken = "legacy-staff-token";
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (_, _) =>
+            {
+                eventCount++;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        Assert.Equal(AccountResendResultType.Ignored, accounts.ResendVerification("staff", "staff@bie.test"));
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("legacy-staff-token"));
+        Assert.Equal("legacy-staff-token", staff.ActivationToken);
+        Assert.False(staff.IsActive);
+        Assert.Equal(0, eventCount);
+    }
+
     public static TheoryData<string, string, string, AccountRegisterResultType> PublicRegistrationInputs()
         => new()
         {
             { "ab", "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
             { "abc", "secret99", "new@bie.test", AccountRegisterResultType.Created },
-            { new string('a', 30), "secret99", "new@bie.test", AccountRegisterResultType.Created },
-            { new string('a', 31), "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
+            { new('a', 30), "secret99", "new@bie.test", AccountRegisterResultType.Created },
+            { new('a', 31), "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
             { "naïve", "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
             { "new!bie", "secret99", "new@bie.test", AccountRegisterResultType.UsernameInvalid },
             { "newbie", "1234567", "new@bie.test", AccountRegisterResultType.PasswordInvalid },
             { "newbie", "12345678", "new@bie.test", AccountRegisterResultType.Created },
-            { "newbie", new string('p', 30), "new@bie.test", AccountRegisterResultType.Created },
-            { "newbie", new string('p', 31), "new@bie.test", AccountRegisterResultType.PasswordInvalid },
+            { "newbie", new('p', 30), "new@bie.test", AccountRegisterResultType.Created },
+            { "newbie", new('p', 31), "new@bie.test", AccountRegisterResultType.PasswordInvalid },
             { "newbie", "secret\n9", "new@bie.test", AccountRegisterResultType.PasswordInvalid },
             { "newbie", "pässword", "new@bie.test", AccountRegisterResultType.PasswordInvalid }
         };
 
-    private static (
-        AccountService Accounts,
-        EventBusService Bus,
-        FakePersistenceService Persistence,
-        CharacterService Characters,
-        StubSessionManager Sessions
-    ) Create(TimeProvider? timeProvider = null)
-    {
-        var persistence = new FakePersistenceService();
-        var sessions = new StubSessionManager();
-        var bus = new EventBusService();
-        var characters = CharacterServiceFixture.Create(persistence, bus, sessions);
-
-        return (
-            new AccountService(persistence, characters, sessions, bus, timeProvider ?? new FixedTimeProvider(Now)),
-            bus,
-            persistence,
-            characters,
-            sessions
-        );
-    }
-
-    private static string Hash(string token)
-        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
-
-    private static async Task<TResult[]> RunConcurrently<TResult>(params Func<TResult>[] actions)
-    {
-        using var start = new Barrier(actions.Length + 1);
-        var tasks = actions
-            .Select(action =>
-                Task.Factory.StartNew(
-                    () =>
-                    {
-                        start.SignalAndWait();
-                        return action();
-                    },
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default
-                )
-            )
-            .ToArray();
-
-        start.SignalAndWait();
-
-        return await Task.WhenAll(tasks);
-    }
-
     [Fact]
-    public void ResendVerification_RotatesTokenAndPublishesOneEvent()
+    public async Task RegisterPending_ConcurrentDuplicateEmail_CreatesOnlyOneAccount()
     {
-        var (accounts, bus, persistence, _, _) = Create();
-        var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-        var accountStore = persistence.Store<AccountEntity>();
-        var upsertsBefore = accountStore.UpsertCount;
-        AccountRegistrationRequestedEvent? resent = null;
-        var eventCount = 0;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+        var (accounts, bus, _, _, _) = Create();
+        var events = new ConcurrentQueue<AccountRegistrationRequestedEvent>();
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
             {
-                resent = message;
-                eventCount++;
+                events.Enqueue(message);
+
                 return Task.CompletedTask;
             }
         );
 
-        var result = accounts.ResendVerification("newbie", "NEW@BIE.TEST");
+        var results = await RunConcurrently(
+                          () => accounts.RegisterPending("first", "secret99", "same@bie.test").Result,
+                          () => accounts.RegisterPending("second", "secret99", "SAME@BIE.TEST").Result
+                      );
 
-        Assert.Equal(AccountResendResultType.Sent, result);
-        Assert.NotNull(resent);
-        Assert.Equal(1, eventCount);
-        Assert.Equal(upsertsBefore + 1, accountStore.UpsertCount);
-        Assert.NotEqual(first, resent!.Token);
-        Assert.Equal(Hash(resent.Token), accounts.GetByUsername("newbie")!.ActivationTokenHash);
-        Assert.True(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.Created));
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.EmailTaken));
+        Assert.Single(accounts.GetAll());
+        Assert.Single(events);
     }
 
     [Fact]
-    public void ResendVerification_MissingAccount_IsIgnoredWithoutPublishingAnEvent()
+    public async Task RegisterPending_ConcurrentDuplicateUsername_CreatesOnlyOneAccount()
     {
-        var (accounts, bus, persistence, _, _) = Create();
-        var accountStore = persistence.Store<AccountEntity>();
-        var upsertsBefore = accountStore.UpsertCount;
-        AccountRegistrationRequestedEvent? resent = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+        var (accounts, bus, _, _, _) = Create();
+        var events = new ConcurrentQueue<AccountRegistrationRequestedEvent>();
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
             {
-                resent = message;
+                events.Enqueue(message);
+
                 return Task.CompletedTask;
             }
         );
 
-        var result = accounts.ResendVerification("newbie", "new@bie.test");
+        var results = await RunConcurrently(
+                          () => accounts.RegisterPending("newbie", "secret99", "one@bie.test").Result,
+                          () => accounts.RegisterPending("newbie", "secret99", "two@bie.test").Result
+                      );
 
-        Assert.Equal(AccountResendResultType.Ignored, result);
-        Assert.Null(resent);
-        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
-        Assert.Null(accounts.GetByUsername("newbie"));
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.Created));
+        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.UsernameTaken));
+        Assert.Single(accounts.GetAll());
+        Assert.Single(events);
     }
 
     [Fact]
-    public void ResendVerification_ActiveAccount_IsIgnoredWithoutPublishingAnEvent()
+    public void RegisterPending_EmailTakenForActiveAndInactiveAccounts()
     {
-        var (accounts, bus, persistence, _, _) = Create();
-        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
-        var accountStore = persistence.Store<AccountEntity>();
-        var upsertsBefore = accountStore.UpsertCount;
-        AccountRegistrationRequestedEvent? resent = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
-            {
-                resent = message;
-                return Task.CompletedTask;
-            }
+        var (accounts, _, _, _, _) = Create();
+        accounts.Create("active", "pw", "taken@example.test", AccountLevelType.Player);
+        Assert.Equal(
+            AccountRegisterResultType.EmailTaken,
+            accounts.RegisterPending("another", "secret99", "TAKEN@example.test").Result
         );
 
-        var result = accounts.ResendVerification("newbie", "new@bie.test");
-
-        Assert.Equal(AccountResendResultType.Ignored, result);
-        Assert.Null(resent);
-        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
-        Assert.True(accounts.GetByUsername("newbie")!.IsActive);
-    }
-
-    [Fact]
-    public void ResendVerification_BlockedPlayer_IsIgnoredWithoutRotatingOrPublishingAnEvent()
-    {
-        var (accounts, bus, persistence, _, _) = Create();
-        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
-        accounts.SetActive("newbie", false);
-        var account = accounts.GetByUsername("newbie")!;
-        account.ActivationTokenHash = Hash("blocked-token");
-        account.ActivationTokenExpiresAtUtc = Now.AddHours(1);
-        var originalHash = account.ActivationTokenHash;
-        var accountStore = persistence.Store<AccountEntity>();
-        var upsertsBefore = accountStore.UpsertCount;
-        var eventCount = 0;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
-            {
-                eventCount++;
-                return Task.CompletedTask;
-            }
+        Assert.Equal(
+            AccountRegisterResultType.Created,
+            accounts.RegisterPending("inactive", "secret99", "inactive@example.test").Result
         );
-
-        var result = accounts.ResendVerification("newbie", "new@bie.test");
-
-        Assert.Equal(AccountResendResultType.Ignored, result);
-        Assert.Equal(0, eventCount);
-        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
-        Assert.Equal(originalHash, account.ActivationTokenHash);
-        Assert.False(account.IsActive);
-    }
-
-    [Fact]
-    public void ResendVerification_PrivilegedAccount_IsIgnoredEvenWithPendingMarker()
-    {
-        var (accounts, bus, persistence, _, _) = Create();
-        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
-        accounts.SetActive("staff", false);
-        var account = accounts.GetByUsername("staff")!;
-        account.IsPublicRegistrationPending = true;
-        account.ActivationTokenHash = Hash("staff-token");
-        account.ActivationTokenExpiresAtUtc = Now.AddHours(1);
-        var originalHash = account.ActivationTokenHash;
-        var accountStore = persistence.Store<AccountEntity>();
-        var upsertsBefore = accountStore.UpsertCount;
-        var eventCount = 0;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
-            {
-                eventCount++;
-                return Task.CompletedTask;
-            }
+        Assert.Equal(
+            AccountRegisterResultType.EmailTaken,
+            accounts.RegisterPending("other", "secret99", "INACTIVE@example.test").Result
         );
-
-        var result = accounts.ResendVerification("staff", "staff@bie.test");
-
-        Assert.Equal(AccountResendResultType.Ignored, result);
-        Assert.Equal(0, eventCount);
-        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
-        Assert.Equal(originalHash, account.ActivationTokenHash);
-        Assert.False(account.IsActive);
     }
 
-    [Fact]
-    public void ResendVerification_MismatchedEmail_IsIgnoredWithoutChangingTokenOrPublishingAnEvent()
-    {
-        var (accounts, bus, persistence, _, _) = Create();
-        var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-        var accountStore = persistence.Store<AccountEntity>();
-        var upsertsBefore = accountStore.UpsertCount;
-        AccountRegistrationRequestedEvent? resent = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
-            {
-                resent = message;
-                return Task.CompletedTask;
-            }
-        );
-
-        var result = accounts.ResendVerification("newbie", "other@bie.test");
-
-        Assert.Equal(AccountResendResultType.Ignored, result);
-        Assert.Null(resent);
-        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
-        Assert.Equal(Hash(first), accounts.GetByUsername("newbie")!.ActivationTokenHash);
-    }
-
-    [Theory]
-    [InlineData("ab", "new@bie.test", AccountResendResultType.UsernameInvalid)]
-    [InlineData("newbie", "not-an-email", AccountResendResultType.EmailInvalid)]
-    public void ResendVerification_InvalidInput_ReturnsValidationResultWithoutPublishingAnEvent(
+    [Theory, InlineData("", "secret99", "new@bie.test", AccountRegisterResultType.UsernameEmpty),
+     InlineData("newbie", "", "new@bie.test", AccountRegisterResultType.PasswordEmpty),
+     InlineData("newbie", "secret99", "", AccountRegisterResultType.EmailEmpty),
+     InlineData("newbie", "secret99", "not-an-email", AccountRegisterResultType.EmailInvalid)]
+    public void RegisterPending_MissingOrInvalidInputs_ReturnsExpectedResult(
         string username,
+        string password,
         string email,
-        AccountResendResultType expected
+        AccountRegisterResultType expected
     )
     {
+        var (accounts, _, _, _, _) = Create();
+
+        Assert.Equal(expected, accounts.RegisterPending(username, password, email).Result);
+    }
+
+    [Fact]
+    public void RegisterPending_PreservesPasswordWhitespace()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var password = " secret99 ";
+        var token = accounts.RegisterPending("newbie", password, "new@bie.test").Token!;
+
+        Assert.Equal(AccountVerifyResultType.Verified, accounts.VerifyEmail(token));
+        Assert.True(accounts.Authenticate("newbie", password).Success);
+        Assert.False(accounts.Authenticate("newbie", password.Trim()).Success);
+    }
+
+    [Theory, MemberData(nameof(PublicRegistrationInputs))]
+    public void RegisterPending_PublicCredentialRules_ReturnsExpectedResult(
+        string username,
+        string password,
+        string email,
+        AccountRegisterResultType expected
+    )
+    {
+        var (accounts, _, _, _, _) = Create();
+
+        Assert.Equal(expected, accounts.RegisterPending(username, password, email).Result);
+    }
+
+    [Fact]
+    public void RegisterPending_PublishesEvent()
+    {
         var (accounts, bus, _, _, _) = Create();
-        AccountRegistrationRequestedEvent? resent = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
+        AccountRegistrationRequestedEvent? seen = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (e, _) =>
             {
-                resent = message;
+                seen = e;
+
                 return Task.CompletedTask;
             }
         );
 
-        var result = accounts.ResendVerification(username, email);
+        var result = accounts.RegisterPending("newbie", "secret99", "new@bie.test");
 
-        Assert.Equal(expected, result);
-        Assert.Null(resent);
-    }
-
-    [Fact]
-    public void ResendVerification_LegacyPendingAccount_MigratesToHashedToken()
-    {
-        var (accounts, bus, _, _, _) = Create();
-        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
-        var account = accounts.GetByUsername("newbie")!;
-        account.IsActive = false;
-        account.ActivationToken = "legacy-token";
-        AccountRegistrationRequestedEvent? resent = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
-            {
-                resent = message;
-                return Task.CompletedTask;
-            }
-        );
-
-        var result = accounts.ResendVerification("newbie", "new@bie.test");
-
-        Assert.Equal(AccountResendResultType.Sent, result);
-        Assert.NotNull(resent);
-        Assert.Empty(account.ActivationToken);
-        Assert.Equal(Hash(resent!.Token), account.ActivationTokenHash);
-        Assert.True(account.IsPublicRegistrationPending);
-    }
-
-    [Fact]
-    public void ResendVerification_ResetsExpiryToTwentyFourHoursFromCurrentTime()
-    {
-        var (accounts, bus, persistence, characters, sessions) = Create();
-        accounts.RegisterPending("newbie", "secret99", "new@bie.test");
-        var later = Now.AddHours(1);
-        var resendingAccounts = new AccountService(
-            persistence,
-            characters,
-            sessions,
-            bus,
-            new FixedTimeProvider(later)
-        );
-
-        var result = resendingAccounts.ResendVerification("newbie", "new@bie.test");
-
-        Assert.Equal(AccountResendResultType.Sent, result);
-        Assert.Equal(later.AddHours(24), resendingAccounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
+        Assert.NotNull(seen);
+        Assert.Equal("newbie", seen!.Username);
+        Assert.Equal(result.Token, seen.Token);
     }
 
     [Fact]
@@ -330,56 +214,6 @@ public sealed class AccountRegistrationTests
     }
 
     [Fact]
-    public void RegisterPending_PublishesEvent()
-    {
-        var (accounts, bus, _, _, _) = Create();
-        AccountRegistrationRequestedEvent? seen = null;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((e, _) =>
-            {
-                seen = e;
-
-                return Task.CompletedTask;
-            }
-        );
-
-        var result = accounts.RegisterPending("newbie", "secret99", "new@bie.test");
-
-        Assert.NotNull(seen);
-        Assert.Equal("newbie", seen!.Username);
-        Assert.Equal(result.Token, seen.Token);
-    }
-
-    [Theory, MemberData(nameof(PublicRegistrationInputs))]
-    public void RegisterPending_PublicCredentialRules_ReturnsExpectedResult(
-        string username,
-        string password,
-        string email,
-        AccountRegisterResultType expected
-    )
-    {
-        var (accounts, _, _, _, _) = Create();
-
-        Assert.Equal(expected, accounts.RegisterPending(username, password, email).Result);
-    }
-
-    [Theory]
-    [InlineData("", "secret99", "new@bie.test", AccountRegisterResultType.UsernameEmpty)]
-    [InlineData("newbie", "", "new@bie.test", AccountRegisterResultType.PasswordEmpty)]
-    [InlineData("newbie", "secret99", "", AccountRegisterResultType.EmailEmpty)]
-    [InlineData("newbie", "secret99", "not-an-email", AccountRegisterResultType.EmailInvalid)]
-    public void RegisterPending_MissingOrInvalidInputs_ReturnsExpectedResult(
-        string username,
-        string password,
-        string email,
-        AccountRegisterResultType expected
-    )
-    {
-        var (accounts, _, _, _, _) = Create();
-
-        Assert.Equal(expected, accounts.RegisterPending(username, password, email).Result);
-    }
-
-    [Fact]
     public void RegisterPending_TrimmedUsernameAndEmail_StoresNormalizedValues()
     {
         var (accounts, _, _, _, _) = Create();
@@ -391,18 +225,6 @@ public sealed class AccountRegistrationTests
         Assert.NotNull(account);
         Assert.Equal("newbie", account!.Username);
         Assert.Equal("new@bie.test", account.Email);
-    }
-
-    [Fact]
-    public void RegisterPending_PreservesPasswordWhitespace()
-    {
-        var (accounts, _, _, _, _) = Create();
-        var password = " secret99 ";
-        var token = accounts.RegisterPending("newbie", password, "new@bie.test").Token!;
-
-        Assert.Equal(AccountVerifyResultType.Verified, accounts.VerifyEmail(token));
-        Assert.True(accounts.Authenticate("newbie", password).Success);
-        Assert.False(accounts.Authenticate("newbie", password.Trim()).Success);
     }
 
     [Fact]
@@ -418,103 +240,242 @@ public sealed class AccountRegistrationTests
     }
 
     [Fact]
-    public void RegisterPending_EmailTakenForActiveAndInactiveAccounts()
+    public void ResendVerification_ActiveAccount_IsIgnoredWithoutPublishingAnEvent()
     {
-        var (accounts, _, _, _, _) = Create();
-        accounts.Create("active", "pw", "taken@example.test", AccountLevelType.Player);
-        Assert.Equal(
-            AccountRegisterResultType.EmailTaken,
-            accounts.RegisterPending("another", "secret99", "TAKEN@example.test").Result
+        var (accounts, bus, persistence, _, _) = Create();
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
+            {
+                resent = message;
+
+                return Task.CompletedTask;
+            }
         );
 
-        Assert.Equal(
-            AccountRegisterResultType.Created,
-            accounts.RegisterPending("inactive", "secret99", "inactive@example.test").Result
-        );
-        Assert.Equal(
-            AccountRegisterResultType.EmailTaken,
-            accounts.RegisterPending("other", "secret99", "INACTIVE@example.test").Result
-        );
-    }
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
 
-    [Fact]
-    public void VerifyEmail_BeforeExpiry_ActivatesAndIsSingleUse()
-    {
-        var (accounts, _, _, _, _) = Create();
-        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-
-        Assert.Equal(AccountVerifyResultType.Verified, accounts.VerifyEmail(token));
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Null(resent);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
         Assert.True(accounts.GetByUsername("newbie")!.IsActive);
-        Assert.Empty(accounts.GetByUsername("newbie")!.ActivationTokenHash);
-        Assert.Null(accounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
-        Assert.False(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
-
-        // consumed token no longer matches
-        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail(token));
     }
 
     [Fact]
-    public void VerifyEmail_AtExpiry_ReturnsExpiredTokenAndClearsTokenState()
+    public void ResendVerification_BlockedPlayer_IsIgnoredWithoutRotatingOrPublishingAnEvent()
     {
-        var (accounts, bus, persistence, characters, sessions) = Create();
-        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-        var atExpiry = new AccountService(
-            persistence,
-            characters,
-            sessions,
-            bus,
-            new FixedTimeProvider(Now.AddHours(24))
+        var (accounts, bus, persistence, _, _) = Create();
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        accounts.SetActive("newbie", false);
+        var account = accounts.GetByUsername("newbie")!;
+        account.ActivationTokenHash = Hash("blocked-token");
+        account.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+        var originalHash = account.ActivationTokenHash;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (_, _) =>
+            {
+                eventCount++;
+
+                return Task.CompletedTask;
+            }
         );
 
-        Assert.Equal(AccountVerifyResultType.ExpiredToken, atExpiry.VerifyEmail(token));
-        var account = atExpiry.GetByUsername("newbie")!;
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Equal(0, eventCount);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
+        Assert.Equal(originalHash, account.ActivationTokenHash);
         Assert.False(account.IsActive);
+    }
+
+    [Theory, InlineData("ab", "new@bie.test", AccountResendResultType.UsernameInvalid),
+     InlineData("newbie", "not-an-email", AccountResendResultType.EmailInvalid)]
+    public void ResendVerification_InvalidInput_ReturnsValidationResultWithoutPublishingAnEvent(
+        string username,
+        string email,
+        AccountResendResultType expected
+    )
+    {
+        var (accounts, bus, _, _, _) = Create();
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
+            {
+                resent = message;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification(username, email);
+
+        Assert.Equal(expected, result);
+        Assert.Null(resent);
+    }
+
+    [Fact]
+    public void ResendVerification_LegacyPendingAccount_MigratesToHashedToken()
+    {
+        var (accounts, bus, _, _, _) = Create();
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        var account = accounts.GetByUsername("newbie")!;
+        account.IsActive = false;
+        account.ActivationToken = "legacy-token";
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
+            {
+                resent = message;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Sent, result);
+        Assert.NotNull(resent);
         Assert.Empty(account.ActivationToken);
-        Assert.Empty(account.ActivationTokenHash);
-        Assert.Null(account.ActivationTokenExpiresAtUtc);
+        Assert.Equal(Hash(resent!.Token), account.ActivationTokenHash);
         Assert.True(account.IsPublicRegistrationPending);
     }
 
     [Fact]
-    public void VerifyEmail_LegacyPlaintextToken_ReturnsExpiredTokenAndClearsLegacyState()
+    public void ResendVerification_MismatchedEmail_IsIgnoredWithoutChangingTokenOrPublishingAnEvent()
     {
-        var (accounts, _, _, _, _) = Create();
-        var account = accounts.GetByUsername("newbie");
-        Assert.Null(account);
-        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
-        account = accounts.GetByUsername("newbie")!;
-        account.IsActive = false;
-        account.ActivationToken = "legacy-token";
+        var (accounts, bus, persistence, _, _) = Create();
+        var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
+            {
+                resent = message;
 
-        Assert.Equal(AccountVerifyResultType.ExpiredToken, accounts.VerifyEmail("legacy-token"));
-        Assert.False(accounts.GetByUsername("newbie")!.IsActive);
-        Assert.Empty(accounts.GetByUsername("newbie")!.ActivationToken);
-        Assert.True(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "other@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Null(resent);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
+        Assert.Equal(Hash(first), accounts.GetByUsername("newbie")!.ActivationTokenHash);
     }
 
     [Fact]
-    public void VerifyEmail_BlockedPlayerAndPrivilegedAccount_CannotBeReactivated()
+    public void ResendVerification_MissingAccount_IsIgnoredWithoutPublishingAnEvent()
     {
-        var (accounts, _, _, _, _) = Create();
-        accounts.Create("blocked", "secret99", "blocked@bie.test", AccountLevelType.Player);
-        accounts.SetActive("blocked", false);
-        var blocked = accounts.GetByUsername("blocked")!;
-        blocked.ActivationTokenHash = Hash("blocked-token");
-        blocked.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+        var (accounts, bus, persistence, _, _) = Create();
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        AccountRegistrationRequestedEvent? resent = null;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
+            {
+                resent = message;
 
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Null(resent);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
+        Assert.Null(accounts.GetByUsername("newbie"));
+    }
+
+    [Fact]
+    public void ResendVerification_PrivilegedAccount_IsIgnoredEvenWithPendingMarker()
+    {
+        var (accounts, bus, persistence, _, _) = Create();
         accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
         accounts.SetActive("staff", false);
-        var staff = accounts.GetByUsername("staff")!;
-        staff.IsPublicRegistrationPending = true;
-        staff.ActivationTokenHash = Hash("staff-token");
-        staff.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+        var account = accounts.GetByUsername("staff")!;
+        account.IsPublicRegistrationPending = true;
+        account.ActivationTokenHash = Hash("staff-token");
+        account.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+        var originalHash = account.ActivationTokenHash;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (_, _) =>
+            {
+                eventCount++;
 
-        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("blocked-token"));
-        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("staff-token"));
-        Assert.False(blocked.IsActive);
-        Assert.False(staff.IsActive);
-        Assert.Equal(Hash("blocked-token"), blocked.ActivationTokenHash);
-        Assert.Equal(Hash("staff-token"), staff.ActivationTokenHash);
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("staff", "staff@bie.test");
+
+        Assert.Equal(AccountResendResultType.Ignored, result);
+        Assert.Equal(0, eventCount);
+        Assert.Equal(upsertsBefore, accountStore.UpsertCount);
+        Assert.Equal(originalHash, account.ActivationTokenHash);
+        Assert.False(account.IsActive);
+    }
+
+    [Fact]
+    public void ResendVerification_ResetsExpiryToTwentyFourHoursFromCurrentTime()
+    {
+        var (accounts, bus, persistence, characters, sessions) = Create();
+        accounts.RegisterPending("newbie", "secret99", "new@bie.test");
+        var later = Now.AddHours(1);
+        var resendingAccounts = new AccountService(
+            persistence,
+            characters,
+            sessions,
+            bus,
+            new FixedTimeProvider(later)
+        );
+
+        var result = resendingAccounts.ResendVerification("newbie", "new@bie.test");
+
+        Assert.Equal(AccountResendResultType.Sent, result);
+        Assert.Equal(later.AddHours(24), resendingAccounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
+    }
+
+    [Fact]
+    public void ResendVerification_RotatesTokenAndPublishesOneEvent()
+    {
+        var (accounts, bus, persistence, _, _) = Create();
+        var first = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var accountStore = persistence.Store<AccountEntity>();
+        var upsertsBefore = accountStore.UpsertCount;
+        AccountRegistrationRequestedEvent? resent = null;
+        var eventCount = 0;
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (message, _) =>
+            {
+                resent = message;
+                eventCount++;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var result = accounts.ResendVerification("newbie", "NEW@BIE.TEST");
+
+        Assert.Equal(AccountResendResultType.Sent, result);
+        Assert.NotNull(resent);
+        Assert.Equal(1, eventCount);
+        Assert.Equal(upsertsBefore + 1, accountStore.UpsertCount);
+        Assert.NotEqual(first, resent!.Token);
+        Assert.Equal(Hash(resent.Token), accounts.GetByUsername("newbie")!.ActivationTokenHash);
+        Assert.True(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
     }
 
     [Fact]
@@ -549,108 +510,24 @@ public sealed class AccountRegistrationTests
     }
 
     [Fact]
-    public void LegacyPlaintextToken_PrivilegedAccountCannotMigrateOrVerify()
-    {
-        var (accounts, bus, _, _, _) = Create();
-        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
-        accounts.SetActive("staff", false);
-        var staff = accounts.GetByUsername("staff")!;
-        staff.ActivationToken = "legacy-staff-token";
-        var eventCount = 0;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
-            {
-                eventCount++;
-                return Task.CompletedTask;
-            }
-        );
-
-        Assert.Equal(AccountResendResultType.Ignored, accounts.ResendVerification("staff", "staff@bie.test"));
-        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("legacy-staff-token"));
-        Assert.Equal("legacy-staff-token", staff.ActivationToken);
-        Assert.False(staff.IsActive);
-        Assert.Equal(0, eventCount);
-    }
-
-    [Fact]
-    public async Task RegisterPending_ConcurrentDuplicateUsername_CreatesOnlyOneAccount()
-    {
-        var (accounts, bus, _, _, _) = Create();
-        var events = new ConcurrentQueue<AccountRegistrationRequestedEvent>();
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
-            {
-                events.Enqueue(message);
-                return Task.CompletedTask;
-            }
-        );
-
-        var results = await RunConcurrently(
-            () => accounts.RegisterPending("newbie", "secret99", "one@bie.test").Result,
-            () => accounts.RegisterPending("newbie", "secret99", "two@bie.test").Result
-        );
-
-        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.Created));
-        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.UsernameTaken));
-        Assert.Single(accounts.GetAll());
-        Assert.Single(events);
-    }
-
-    [Fact]
-    public async Task RegisterPending_ConcurrentDuplicateEmail_CreatesOnlyOneAccount()
-    {
-        var (accounts, bus, _, _, _) = Create();
-        var events = new ConcurrentQueue<AccountRegistrationRequestedEvent>();
-        bus.Subscribe<AccountRegistrationRequestedEvent>((message, _) =>
-            {
-                events.Enqueue(message);
-                return Task.CompletedTask;
-            }
-        );
-
-        var results = await RunConcurrently(
-            () => accounts.RegisterPending("first", "secret99", "same@bie.test").Result,
-            () => accounts.RegisterPending("second", "secret99", "SAME@BIE.TEST").Result
-        );
-
-        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.Created));
-        Assert.Equal(1, results.Count(result => result == AccountRegisterResultType.EmailTaken));
-        Assert.Single(accounts.GetAll());
-        Assert.Single(events);
-    }
-
-    [Fact]
-    public async Task VerifyEmail_ConcurrentRequests_ConsumeTokenExactlyOnce()
-    {
-        var (accounts, _, _, _, _) = Create();
-        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
-        var actions = Enumerable
-            .Range(0, 16)
-            .Select(_ => (Func<AccountVerifyResultType>)(() => accounts.VerifyEmail(token)))
-            .ToArray();
-
-        var results = await RunConcurrently(actions);
-
-        Assert.Equal(1, results.Count(result => result == AccountVerifyResultType.Verified));
-        Assert.Equal(15, results.Count(result => result == AccountVerifyResultType.InvalidToken));
-        Assert.True(accounts.GetByUsername("newbie")!.IsActive);
-    }
-
-    [Fact]
     public async Task VerifyAndResend_ConcurrentRequests_LeaveOneConsistentTransition()
     {
         var (accounts, bus, _, _, _) = Create();
         var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
         var resendEvents = 0;
-        bus.Subscribe<AccountRegistrationRequestedEvent>((_, _) =>
+        bus.Subscribe<AccountRegistrationRequestedEvent>(
+            (_, _) =>
             {
                 Interlocked.Increment(ref resendEvents);
+
                 return Task.CompletedTask;
             }
         );
 
         var results = await RunConcurrently(
-            () => $"verify:{accounts.VerifyEmail(token)}",
-            () => $"resend:{accounts.ResendVerification("newbie", "new@bie.test")}"
-        );
+                          () => $"verify:{accounts.VerifyEmail(token)}",
+                          () => $"resend:{accounts.ResendVerification("newbie", "new@bie.test")}"
+                      );
         var account = accounts.GetByUsername("newbie")!;
 
         var verifiedFirst = results.Contains("verify:Verified") && results.Contains("resend:Ignored");
@@ -673,11 +550,158 @@ public sealed class AccountRegistrationTests
     }
 
     [Fact]
+    public void VerifyEmail_AtExpiry_ReturnsExpiredTokenAndClearsTokenState()
+    {
+        var (accounts, bus, persistence, characters, sessions) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var atExpiry = new AccountService(
+            persistence,
+            characters,
+            sessions,
+            bus,
+            new FixedTimeProvider(Now.AddHours(24))
+        );
+
+        Assert.Equal(AccountVerifyResultType.ExpiredToken, atExpiry.VerifyEmail(token));
+        var account = atExpiry.GetByUsername("newbie")!;
+        Assert.False(account.IsActive);
+        Assert.Empty(account.ActivationToken);
+        Assert.Empty(account.ActivationTokenHash);
+        Assert.Null(account.ActivationTokenExpiresAtUtc);
+        Assert.True(account.IsPublicRegistrationPending);
+    }
+
+    [Fact]
+    public void VerifyEmail_BeforeExpiry_ActivatesAndIsSingleUse()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+
+        Assert.Equal(AccountVerifyResultType.Verified, accounts.VerifyEmail(token));
+        Assert.True(accounts.GetByUsername("newbie")!.IsActive);
+        Assert.Empty(accounts.GetByUsername("newbie")!.ActivationTokenHash);
+        Assert.Null(accounts.GetByUsername("newbie")!.ActivationTokenExpiresAtUtc);
+        Assert.False(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
+
+        // consumed token no longer matches
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail(token));
+    }
+
+    [Fact]
+    public void VerifyEmail_BlockedPlayerAndPrivilegedAccount_CannotBeReactivated()
+    {
+        var (accounts, _, _, _, _) = Create();
+        accounts.Create("blocked", "secret99", "blocked@bie.test", AccountLevelType.Player);
+        accounts.SetActive("blocked", false);
+        var blocked = accounts.GetByUsername("blocked")!;
+        blocked.ActivationTokenHash = Hash("blocked-token");
+        blocked.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+
+        accounts.Create("staff", "secret99", "staff@bie.test", AccountLevelType.Administrator);
+        accounts.SetActive("staff", false);
+        var staff = accounts.GetByUsername("staff")!;
+        staff.IsPublicRegistrationPending = true;
+        staff.ActivationTokenHash = Hash("staff-token");
+        staff.ActivationTokenExpiresAtUtc = Now.AddHours(1);
+
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("blocked-token"));
+        Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("staff-token"));
+        Assert.False(blocked.IsActive);
+        Assert.False(staff.IsActive);
+        Assert.Equal(Hash("blocked-token"), blocked.ActivationTokenHash);
+        Assert.Equal(Hash("staff-token"), staff.ActivationTokenHash);
+    }
+
+    [Fact]
+    public async Task VerifyEmail_ConcurrentRequests_ConsumeTokenExactlyOnce()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var token = accounts.RegisterPending("newbie", "secret99", "new@bie.test").Token!;
+        var actions = Enumerable
+                      .Range(0, 16)
+                      .Select(_ => (Func<AccountVerifyResultType>)(() => accounts.VerifyEmail(token)))
+                      .ToArray();
+
+        var results = await RunConcurrently(actions);
+
+        Assert.Equal(1, results.Count(result => result == AccountVerifyResultType.Verified));
+        Assert.Equal(15, results.Count(result => result == AccountVerifyResultType.InvalidToken));
+        Assert.True(accounts.GetByUsername("newbie")!.IsActive);
+    }
+
+    [Fact]
+    public void VerifyEmail_LegacyPlaintextToken_ReturnsExpiredTokenAndClearsLegacyState()
+    {
+        var (accounts, _, _, _, _) = Create();
+        var account = accounts.GetByUsername("newbie");
+        Assert.Null(account);
+        accounts.Create("newbie", "secret99", "new@bie.test", AccountLevelType.Player);
+        account = accounts.GetByUsername("newbie")!;
+        account.IsActive = false;
+        account.ActivationToken = "legacy-token";
+
+        Assert.Equal(AccountVerifyResultType.ExpiredToken, accounts.VerifyEmail("legacy-token"));
+        Assert.False(accounts.GetByUsername("newbie")!.IsActive);
+        Assert.Empty(accounts.GetByUsername("newbie")!.ActivationToken);
+        Assert.True(accounts.GetByUsername("newbie")!.IsPublicRegistrationPending);
+    }
+
+    [Fact]
     public void VerifyEmail_UnknownOrBlankToken_IsInvalid()
     {
         var (accounts, _, _, _, _) = Create();
 
         Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("nope"));
         Assert.Equal(AccountVerifyResultType.InvalidToken, accounts.VerifyEmail("  "));
+    }
+
+    private static (
+        AccountService Accounts,
+        EventBusService Bus,
+        FakePersistenceService Persistence,
+        CharacterService Characters,
+        StubSessionManager Sessions
+        ) Create(TimeProvider? timeProvider = null)
+    {
+        var persistence = new FakePersistenceService();
+        var sessions = new StubSessionManager();
+        var bus = new EventBusService();
+        var characters = CharacterServiceFixture.Create(persistence, bus, sessions);
+
+        return (
+                   new(persistence, characters, sessions, bus, timeProvider ?? new FixedTimeProvider(Now)),
+                   bus,
+                   persistence,
+                   characters,
+                   sessions
+               );
+    }
+
+    private static string Hash(string token)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token)));
+
+    private static async Task<TResult[]> RunConcurrently<TResult>(params Func<TResult>[] actions)
+    {
+        using var start = new Barrier(actions.Length + 1);
+        var tasks = actions
+                    .Select(
+                        action =>
+                            Task.Factory.StartNew(
+                                () =>
+                                {
+                                    start.SignalAndWait();
+
+                                    return action();
+                                },
+                                CancellationToken.None,
+                                TaskCreationOptions.LongRunning,
+                                TaskScheduler.Default
+                            )
+                    )
+                    .ToArray();
+
+        start.SignalAndWait();
+
+        return await Task.WhenAll(tasks);
     }
 }

--- a/tests/Moongate.Tests/Server/Services/Server/ServerSettingsServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Services/Server/ServerSettingsServiceTests.cs
@@ -1,15 +1,11 @@
 using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Services.Server;
 using Moongate.Tests.Support;
-using Xunit;
 
 namespace Moongate.Tests.Server.Services.Server;
 
 public sealed class ServerSettingsServiceTests
 {
-    private static ServerSettingsService Create()
-        => new(new FakePersistenceService());
-
     [Fact]
     public void Get_FirstAccess_CreatesDisabledDefault()
     {
@@ -30,6 +26,18 @@ public sealed class ServerSettingsServiceTests
         var second = service.Get();
 
         Assert.Equal(first.Id, second.Id);
+    }
+
+    [Fact]
+    public void SetAsset_ThenClear_RoundTrips()
+    {
+        var service = Create();
+
+        service.SetAsset(ServerAssetSlotType.Logo, new() { FileName = "logo.png", ContentType = "image/png" });
+        Assert.Equal("logo.png", service.Get().Assets[nameof(ServerAssetSlotType.Logo)].FileName);
+
+        service.ClearAsset(ServerAssetSlotType.Logo);
+        Assert.DoesNotContain(nameof(ServerAssetSlotType.Logo), service.Get().Assets.Keys);
     }
 
     [Fact]
@@ -55,15 +63,6 @@ public sealed class ServerSettingsServiceTests
         Assert.Equal("Sosaria never sleeps.", service.Get().Tagline);
     }
 
-    [Fact]
-    public void SetAsset_ThenClear_RoundTrips()
-    {
-        var service = Create();
-
-        service.SetAsset(ServerAssetSlotType.Logo, new() { FileName = "logo.png", ContentType = "image/png" });
-        Assert.Equal("logo.png", service.Get().Assets[nameof(ServerAssetSlotType.Logo)].FileName);
-
-        service.ClearAsset(ServerAssetSlotType.Logo);
-        Assert.DoesNotContain(nameof(ServerAssetSlotType.Logo), service.Get().Assets.Keys);
-    }
+    private static ServerSettingsService Create()
+        => new(new FakePersistenceService());
 }

--- a/tests/Moongate.Tests/Server/Stats/ServerStatsServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Stats/ServerStatsServiceTests.cs
@@ -1,8 +1,6 @@
 using Moongate.Core.Extensions;
 using Moongate.Core.Interfaces;
-using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
-using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Stats;
 using Moongate.Server.Services.Items;
@@ -29,8 +27,8 @@ public sealed class ServerStatsServiceTests
     public void Refresh_CountsAccountsCharactersAndTemplates()
     {
         var (service, persistence, _) = Build();
-        SeedAccount(persistence, "tom", isActive: true, characters: 2);
-        SeedAccount(persistence, "ann", isActive: false, characters: 1);
+        SeedAccount(persistence, "tom", true, 2);
+        SeedAccount(persistence, "ann", false, 1);
 
         service.Refresh();
 
@@ -45,7 +43,7 @@ public sealed class ServerStatsServiceTests
     public void Refresh_CountsNpcsAsMobilesThatNoAccountOwns()
     {
         var (service, persistence, _) = Build();
-        SeedAccount(persistence, "tom", isActive: true, characters: 2);
+        SeedAccount(persistence, "tom", true, 2);
 
         // Two more mobiles owned by nobody: what an NPC looks like in the store.
         persistence.Store<MobileEntity>().UpsertAsync(new() { Name = "orc" }).WaitSync();
@@ -54,6 +52,18 @@ public sealed class ServerStatsServiceTests
         service.Refresh();
 
         Assert.Equal(2, service.Current.Npcs);
+    }
+
+    [Fact]
+    public void Refresh_CountsWorldItems()
+    {
+        var (service, persistence, _) = Build();
+        persistence.Store<ItemEntity>().UpsertAsync(new() { Name = "sword" }).WaitSync();
+        persistence.Store<ItemEntity>().UpsertAsync(new() { Name = "shield" }).WaitSync();
+
+        service.Refresh();
+
+        Assert.Equal(2, service.Current.WorldItems);
     }
 
     [Fact]
@@ -79,22 +89,10 @@ public sealed class ServerStatsServiceTests
     }
 
     [Fact]
-    public void Refresh_CountsWorldItems()
-    {
-        var (service, persistence, _) = Build();
-        persistence.Store<ItemEntity>().UpsertAsync(new() { Name = "sword" }).WaitSync();
-        persistence.Store<ItemEntity>().UpsertAsync(new() { Name = "shield" }).WaitSync();
-
-        service.Refresh();
-
-        Assert.Equal(2, service.Current.WorldItems);
-    }
-
-    [Fact]
     public void Refresh_OnlinePlayers_CountsOnlyCharactersASessionIsPlaying()
     {
         var (service, persistence, sessions) = Build();
-        var account = SeedAccount(persistence, "tom", isActive: true, characters: 2);
+        var account = SeedAccount(persistence, "tom", true, 2);
         sessions.Played.Add(account.MobileIds[0]);
         sessions.Count = 5;
 
@@ -124,7 +122,7 @@ public sealed class ServerStatsServiceTests
     public async Task StartAsync_RegistersTheRepeatingRefreshTimer_AndStopAsyncCancelsIt()
     {
         var loop = new StubGameLoopContext();
-        var service = Started(loop, new EventBusService(), refreshSeconds: 45);
+        var service = Started(loop, new EventBusService(), 45);
 
         await service.StartAsync();
 
@@ -147,7 +145,7 @@ public sealed class ServerStatsServiceTests
     public async Task StartAsync_TakesTheFirstSnapshotOnWorldReady()
     {
         var bus = new EventBusService();
-        var service = Started(new StubGameLoopContext(), bus, refreshSeconds: 30);
+        var service = Started(new StubGameLoopContext(), bus, 30);
 
         await service.StartAsync();
         Assert.Same(ServerStatsSnapshot.Empty, service.Current);
@@ -171,10 +169,6 @@ public sealed class ServerStatsServiceTests
 
         return (service, persistence, sessions);
     }
-
-    /// <summary>The same service, when the test drives the loop or the bus rather than the stores.</summary>
-    private static ServerStatsService Started(IGameLoopContext loop, IEventBus eventBus, int refreshSeconds)
-        => Create(new FakePersistenceService(), new StubSessionManager(), loop, eventBus, refreshSeconds);
 
     private static ServerStatsService Create(
         FakePersistenceService persistence,
@@ -229,4 +223,8 @@ public sealed class ServerStatsServiceTests
 
         return account;
     }
+
+    /// <summary>The same service, when the test drives the loop or the bus rather than the stores.</summary>
+    private static ServerStatsService Started(IGameLoopContext loop, IEventBus eventBus, int refreshSeconds)
+        => Create(new(), new(), loop, eventBus, refreshSeconds);
 }

--- a/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Subscribers/SpatialSubscriberTests.cs
@@ -31,8 +31,8 @@ public class SpatialSubscriberTests
         persistence.Store<MobileEntity>().UpsertAsync(npc).WaitSync();
         persistence.Store<MobileEntity>().UpsertAsync(character).WaitSync();
         persistence.Store<AccountEntity>()
-            .UpsertAsync(new() { Id = new(0x999), Username = "bob", MobileIds = [character.Id] })
-            .WaitSync();
+                   .UpsertAsync(new() { Id = new(0x999), Username = "bob", MobileIds = [character.Id] })
+                   .WaitSync();
 
         // A ground item and a contained item: only the ground one must be indexed.
         var ground = new ItemEntity { Id = new(0x40000001), MapId = 0, Position = new(100, 100, 0) };

--- a/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/SpatialIndexServiceTests.cs
@@ -1,5 +1,4 @@
 using Moongate.Core.Extensions;
-using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.World;
@@ -40,6 +39,44 @@ public class SpatialIndexServiceTests
     }
 
     [Fact]
+    public void AddOrUpdate_MoveAcrossSectors_PublishesLeftEnteredAndChanged()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var mobile = SeedMobile(persistence, 0x1, 0, 15, 0); // sector (0, 0)
+        index.AddOrUpdate(mobile);
+
+        mobile.Position = new(400, 400, 0); // sector (25, 25)
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+        index.AddOrUpdate(mobile);
+
+        // Left and Changed are unique to the move; Entered also fired once on the initial spawn, so the
+        // move's entry is the later of the two.
+        var left = Assert.Single(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Equal((0, 0, 0), (left.MapId, left.SectorX, left.SectorY));
+
+        var entered = bus.Published.OfType<MobileEnteredSectorEvent>().Last();
+        Assert.Equal((0, 25, 25), (entered.MapId, entered.SectorX, entered.SectorY));
+
+        var changed = Assert.Single(bus.Published.OfType<MobileChangedSectorEvent>());
+        Assert.Equal((0, 0, 0), (changed.FromMapId, changed.FromSectorX, changed.FromSectorY));
+        Assert.Equal((0, 25, 25), (changed.ToMapId, changed.ToSectorX, changed.ToSectorY));
+    }
+
+    [Fact]
+    public void AddOrUpdate_NewMobile_PublishesEnteredSectorOnly()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+
+        index.AddOrUpdate(SeedMobile(persistence, 0x1, 0, 100, 100)); // sector (6, 6)
+
+        var entered = Assert.Single(bus.Published.OfType<MobileEnteredSectorEvent>());
+        Assert.Equal(new(0x1), entered.Mobile);
+        Assert.Equal((0, 6, 6), (entered.MapId, entered.SectorX, entered.SectorY));
+        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
+    }
+
+    [Fact]
     public void AddOrUpdate_SameSectorTwice_DoesNotDuplicate()
     {
         var (index, persistence) = Build();
@@ -49,6 +86,20 @@ public class SpatialIndexServiceTests
         index.AddOrUpdate(mobile);
 
         Assert.Single(index.GetMobilesInRange(0, new(100, 100, 0), 5));
+    }
+
+    [Fact]
+    public void AddOrUpdate_SameSector_PublishesNoFurtherSectorEvents()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var mobile = SeedMobile(persistence, 0x1, 0, 100, 100);
+
+        index.AddOrUpdate(mobile);
+        index.AddOrUpdate(mobile); // same tile, same sector
+
+        Assert.Single(bus.Published.OfType<MobileEnteredSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
     }
 
     [Fact]
@@ -91,8 +142,22 @@ public class SpatialIndexServiceTests
         var sectorSix = index.GetMobilesInSector(0, 6, 6);
 
         Assert.Single(sectorSix);
-        Assert.Equal(new Serial(0x1), sectorSix[0].Id);
+        Assert.Equal(new(0x1), sectorSix[0].Id);
         Assert.Empty(index.GetMobilesInSector(1, 6, 6));
+    }
+
+    [Fact]
+    public void Items_ProduceNoSectorEvents()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var item = SeedItem(persistence, 0x40000001, 0, 50, 50);
+
+        index.AddOrUpdate(item);
+        index.Remove(item.Id);
+
+        Assert.Empty(bus.Published.OfType<MobileEnteredSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
     }
 
     [Fact]
@@ -131,6 +196,20 @@ public class SpatialIndexServiceTests
     }
 
     [Fact]
+    public void Remove_Mobile_PublishesLeftSector()
+    {
+        var (index, persistence, bus) = BuildWithBus();
+        var mobile = SeedMobile(persistence, 0x1, 0, 100, 100);
+        index.AddOrUpdate(mobile);
+
+        index.Remove(mobile.Id);
+
+        var left = Assert.Single(bus.Published.OfType<MobileLeftSectorEvent>());
+        Assert.Equal(new(0x1), left.Mobile);
+        Assert.Equal((0, 6, 6), (left.MapId, left.SectorX, left.SectorY));
+    }
+
+    [Fact]
     public void Remove_ThenQuery_ReturnsEmpty()
     {
         var (index, persistence) = Build();
@@ -148,86 +227,6 @@ public class SpatialIndexServiceTests
         var (index, _) = Build();
 
         index.Remove(new(0xDEAD));
-    }
-
-    [Fact]
-    public void AddOrUpdate_NewMobile_PublishesEnteredSectorOnly()
-    {
-        var (index, persistence, bus) = BuildWithBus();
-
-        index.AddOrUpdate(SeedMobile(persistence, 0x1, 0, 100, 100)); // sector (6, 6)
-
-        var entered = Assert.Single(bus.Published.OfType<MobileEnteredSectorEvent>());
-        Assert.Equal(new(0x1), entered.Mobile);
-        Assert.Equal((0, 6, 6), (entered.MapId, entered.SectorX, entered.SectorY));
-        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
-        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
-    }
-
-    [Fact]
-    public void AddOrUpdate_MoveAcrossSectors_PublishesLeftEnteredAndChanged()
-    {
-        var (index, persistence, bus) = BuildWithBus();
-        var mobile = SeedMobile(persistence, 0x1, 0, 15, 0); // sector (0, 0)
-        index.AddOrUpdate(mobile);
-
-        mobile.Position = new(400, 400, 0); // sector (25, 25)
-        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
-        index.AddOrUpdate(mobile);
-
-        // Left and Changed are unique to the move; Entered also fired once on the initial spawn, so the
-        // move's entry is the later of the two.
-        var left = Assert.Single(bus.Published.OfType<MobileLeftSectorEvent>());
-        Assert.Equal((0, 0, 0), (left.MapId, left.SectorX, left.SectorY));
-
-        var entered = bus.Published.OfType<MobileEnteredSectorEvent>().Last();
-        Assert.Equal((0, 25, 25), (entered.MapId, entered.SectorX, entered.SectorY));
-
-        var changed = Assert.Single(bus.Published.OfType<MobileChangedSectorEvent>());
-        Assert.Equal((0, 0, 0), (changed.FromMapId, changed.FromSectorX, changed.FromSectorY));
-        Assert.Equal((0, 25, 25), (changed.ToMapId, changed.ToSectorX, changed.ToSectorY));
-    }
-
-    [Fact]
-    public void AddOrUpdate_SameSector_PublishesNoFurtherSectorEvents()
-    {
-        var (index, persistence, bus) = BuildWithBus();
-        var mobile = SeedMobile(persistence, 0x1, 0, 100, 100);
-
-        index.AddOrUpdate(mobile);
-        index.AddOrUpdate(mobile); // same tile, same sector
-
-        Assert.Single(bus.Published.OfType<MobileEnteredSectorEvent>());
-        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
-        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
-    }
-
-    [Fact]
-    public void Remove_Mobile_PublishesLeftSector()
-    {
-        var (index, persistence, bus) = BuildWithBus();
-        var mobile = SeedMobile(persistence, 0x1, 0, 100, 100);
-        index.AddOrUpdate(mobile);
-
-        index.Remove(mobile.Id);
-
-        var left = Assert.Single(bus.Published.OfType<MobileLeftSectorEvent>());
-        Assert.Equal(new(0x1), left.Mobile);
-        Assert.Equal((0, 6, 6), (left.MapId, left.SectorX, left.SectorY));
-    }
-
-    [Fact]
-    public void Items_ProduceNoSectorEvents()
-    {
-        var (index, persistence, bus) = BuildWithBus();
-        var item = SeedItem(persistence, 0x40000001, 0, 50, 50);
-
-        index.AddOrUpdate(item);
-        index.Remove(item.Id);
-
-        Assert.Empty(bus.Published.OfType<MobileEnteredSectorEvent>());
-        Assert.Empty(bus.Published.OfType<MobileLeftSectorEvent>());
-        Assert.Empty(bus.Published.OfType<MobileChangedSectorEvent>());
     }
 
     private static (SpatialIndexService Index, FakePersistenceService Persistence) Build()

--- a/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
@@ -23,9 +23,7 @@ public class WorldServiceTests
     // because there are no sessions.
     private sealed class NoopPacket : IOutgoingPacket
     {
-        public void Write(ref SpanWriter writer)
-        {
-        }
+        public void Write(ref SpanWriter writer) { }
     }
 
     [Fact]
@@ -40,11 +38,12 @@ public class WorldServiceTests
     public void BuildSequence_EmitsExpectedOrderedOpcodes()
     {
         var opcodes = Service(new([]))
-            .BuildSequence(Player())
-            .Select(packet => Serialize(packet)[0])
-            .ToArray();
+                      .BuildSequence(Player())
+                      .Select(packet => Serialize(packet)[0])
+                      .ToArray();
 
         Assert.Equal(
+
             // The second 0x11 neighbour is 0xBF/0x19, the stat lock state paired with the status.
             new byte[] { 0x1B, 0xBF, 0xBF, 0xBC, 0xB9, 0x20, 0x4F, 0x4E, 0x78, 0x11, 0xBF, 0x3A, 0x72, 0x55, 0x5B },
             opcodes

--- a/tests/Moongate.Tests/Smtp/MoongateSmtpPluginTests.cs
+++ b/tests/Moongate.Tests/Smtp/MoongateSmtpPluginTests.cs
@@ -4,15 +4,18 @@ using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Smtp.Plugin;
 using SquidStd.Core.Config;
 using SquidStd.Core.Directories;
-using SquidStd.Plugin.Abstractions.Data;
 
 namespace Moongate.Tests.Smtp;
 
 public sealed class MoongateSmtpPluginTests
 {
     [Fact]
-    public void Metadata_IdentifiesThePlugin()
-        => Assert.Equal("moongate.smtp.plugin", new MoongateSmtpPlugin().Metadata.Id);
+    public void Configure_WhenConfigured_RegistersTheEmailChannel()
+    {
+        var container = Configured("localhost", "shard@example.com");
+
+        Assert.Equal("email", Assert.Single(container.ResolveMany<INotificationChannel>()).Id);
+    }
 
     [Fact]
     public void Configure_WithoutHost_RegistersNoChannel()
@@ -24,12 +27,8 @@ public sealed class MoongateSmtpPluginTests
     }
 
     [Fact]
-    public void Configure_WhenConfigured_RegistersTheEmailChannel()
-    {
-        var container = Configured(host: "localhost", from: "shard@example.com");
-
-        Assert.Equal("email", Assert.Single(container.ResolveMany<INotificationChannel>()).Id);
-    }
+    public void Metadata_IdentifiesThePlugin()
+        => Assert.Equal("moongate.smtp.plugin", new MoongateSmtpPlugin().Metadata.Id);
 
     /// <summary>A container carrying what the real bootstrap supplies around the plugin.</summary>
     private static IContainer Configured(string host = "", string from = "")
@@ -52,7 +51,7 @@ public sealed class MoongateSmtpPluginTests
         container.RegisterInstance(directories);
         container.RegisterInstance(new MoongateConfig { ShardName = "Britannia", UltimaDirectory = "/tmp" });
 
-        new MoongateSmtpPlugin().Configure(container, new PluginContext());
+        new MoongateSmtpPlugin().Configure(container, new());
 
         return container;
     }

--- a/tests/Moongate.Tests/Smtp/SmtpCredentialGuardTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpCredentialGuardTests.cs
@@ -6,25 +6,27 @@ namespace Moongate.Tests.Smtp;
 public sealed class SmtpCredentialGuardTests
 {
     [Fact]
+    public void CredentialsOnAnEncryptedConnection_IsAllowed()
+        => SmtpCredentialGuard.EnsureCredentialsAreProtected(true, true);
+
+    [Fact]
     public void CredentialsOnAnUnencryptedConnection_Throws()
     {
         // Security: Auto resolves to StartTlsWhenAvailable on any port but the implicit-TLS one, and that
         // proceeds in the clear when the server does not advertise STARTTLS. Authenticating there puts the
         // password on the wire.
-        var exception = Assert.Throws<SmtpInsecureConnectionException>(() =>
-            SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: true, isSecure: false)
+        var exception = Assert.Throws<SmtpInsecureConnectionException>(
+            () =>
+                SmtpCredentialGuard.EnsureCredentialsAreProtected(true, false)
         );
 
         Assert.Contains("unencrypted", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void CredentialsOnAnEncryptedConnection_IsAllowed()
-        => SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: true, isSecure: true);
-
-    [Fact]
     public void NoCredentialsOnAnUnencryptedConnection_IsAllowed()
+
         // A local relay with no authentication is a legitimate setup, and nothing secret crosses the
         // socket. Blocking it would be a broader change than the leak requires.
-        => SmtpCredentialGuard.EnsureCredentialsAreProtected(hasCredentials: false, isSecure: false);
+        => SmtpCredentialGuard.EnsureCredentialsAreProtected(false, false);
 }

--- a/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpNotificationChannelTests.cs
@@ -1,9 +1,7 @@
 using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
-using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Types;
-using Moongate.Smtp.Plugin.Data.Config;
 using Moongate.Smtp.Plugin.Data.Exceptions;
 using Moongate.Smtp.Plugin.Services;
 using Moongate.Tests.Support;
@@ -14,7 +12,14 @@ public sealed class SmtpNotificationChannelTests
 {
     [Fact]
     public void Id_IsEmail()
-        => Assert.Equal("email", Channel(new RecordingSmtpTransport()).Id);
+        => Assert.Equal("email", Channel(new()).Id);
+
+    [Fact]
+    public async Task SendAsync_AuthenticationFailure_DoesNotRethrow()
+
+        // Retrying bad credentials can trip a provider's rate limits.
+        => await Channel(new(new AuthenticationException("bad credentials")))
+               .SendAsync(new("email", "tom@example.com"), new("s", "b"));
 
     [Fact]
     public async Task SendAsync_BuildsTheMessageFromConfigAndContent()
@@ -28,17 +33,6 @@ public sealed class SmtpNotificationChannelTests
         Assert.Equal("shard@example.com", Assert.IsType<MailboxAddress>(Assert.Single(message.From)).Address);
         Assert.Equal("tom@example.com", Assert.IsType<MailboxAddress>(Assert.Single(message.To)).Address);
         Assert.Equal("hello", message.TextBody!.Trim());
-    }
-
-    [Fact]
-    public async Task SendAsync_WithoutFromName_UsesTheShardName()
-    {
-        var transport = new RecordingSmtpTransport();
-
-        await Channel(transport, fromName: string.Empty).SendAsync(new("email", "tom@example.com"), new("s", "b"));
-
-        var from = Assert.IsType<MailboxAddress>(Assert.Single(Assert.Single(transport.Sent).From));
-        Assert.Equal("Britannia", from.Name);
     }
 
     [Fact]
@@ -58,6 +52,14 @@ public sealed class SmtpNotificationChannelTests
     }
 
     [Fact]
+    public async Task SendAsync_InsecureConnection_DoesNotRethrow()
+
+        // A misconfiguration will not fix itself between attempts, so retrying it three times only
+        // delays the error in the log.
+        => await Channel(new(new SmtpInsecureConnectionException("unencrypted")))
+               .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+
+    [Fact]
     public async Task SendAsync_NullSubject_SendsAnEmptySubject()
     {
         var transport = new RecordingSmtpTransport();
@@ -65,21 +67,6 @@ public sealed class SmtpNotificationChannelTests
         await Channel(transport).SendAsync(new("email", "tom@example.com"), new(null, "body"));
 
         Assert.Equal(string.Empty, Assert.Single(transport.Sent).Subject);
-    }
-
-    [Fact]
-    public async Task SendAsync_TransientFailure_Rethrows()
-    {
-        // A 4xx is the server saying "not now": the pipeline's retry is exactly the right response.
-        var transient = new SmtpCommandException(
-            SmtpErrorCode.MessageNotAccepted,
-            SmtpStatusCode.MailboxBusy,
-            "try later"
-        );
-
-        await Assert.ThrowsAsync<SmtpCommandException>(async () => await Channel(new RecordingSmtpTransport(transient))
-            .SendAsync(new("email", "tom@example.com"), new("s", "b"))
-        );
     }
 
     [Fact]
@@ -92,31 +79,41 @@ public sealed class SmtpNotificationChannelTests
             "no such user"
         );
 
-        await Channel(new RecordingSmtpTransport(permanent))
+        await Channel(new(permanent))
             .SendAsync(new("email", "tom@example.com"), new("s", "b"));
     }
 
     [Fact]
-    public async Task SendAsync_InsecureConnection_DoesNotRethrow()
+    public async Task SendAsync_TransientFailure_Rethrows()
     {
-        // A misconfiguration will not fix itself between attempts, so retrying it three times only
-        // delays the error in the log.
-        await Channel(new RecordingSmtpTransport(new SmtpInsecureConnectionException("unencrypted")))
-            .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+        // A 4xx is the server saying "not now": the pipeline's retry is exactly the right response.
+        var transient = new SmtpCommandException(
+            SmtpErrorCode.MessageNotAccepted,
+            SmtpStatusCode.MailboxBusy,
+            "try later"
+        );
+
+        await Assert.ThrowsAsync<SmtpCommandException>(
+            async () => await Channel(new(transient))
+                            .SendAsync(new("email", "tom@example.com"), new("s", "b"))
+        );
     }
 
     [Fact]
-    public async Task SendAsync_AuthenticationFailure_DoesNotRethrow()
+    public async Task SendAsync_WithoutFromName_UsesTheShardName()
     {
-        // Retrying bad credentials can trip a provider's rate limits.
-        await Channel(new RecordingSmtpTransport(new AuthenticationException("bad credentials")))
-            .SendAsync(new("email", "tom@example.com"), new("s", "b"));
+        var transport = new RecordingSmtpTransport();
+
+        await Channel(transport, string.Empty).SendAsync(new("email", "tom@example.com"), new("s", "b"));
+
+        var from = Assert.IsType<MailboxAddress>(Assert.Single(Assert.Single(transport.Sent).From));
+        Assert.Equal("Britannia", from.Name);
     }
 
     private static SmtpNotificationChannel Channel(RecordingSmtpTransport transport, string fromName = "Shard Mail")
         => new(
             transport,
-            new MoongateSmtpConfig
+            new()
             {
                 Host = "localhost",
                 FromAddress = "shard@example.com",

--- a/tests/Moongate.Tests/Smtp/SmtpSecurityTypeExtensionsTests.cs
+++ b/tests/Moongate.Tests/Smtp/SmtpSecurityTypeExtensionsTests.cs
@@ -6,21 +6,21 @@ namespace Moongate.Tests.Smtp;
 
 public sealed class SmtpSecurityTypeExtensionsTests
 {
-    [Theory]
-    [InlineData(SmtpSecurityType.None, SecureSocketOptions.None)]
-    [InlineData(SmtpSecurityType.StartTls, SecureSocketOptions.StartTls)]
-    [InlineData(SmtpSecurityType.SslOnConnect, SecureSocketOptions.SslOnConnect)]
-    [InlineData(SmtpSecurityType.Auto, SecureSocketOptions.Auto)]
-    public void ToSocketOptions_MapsEveryDeclaredValue(SmtpSecurityType security, SecureSocketOptions expected)
-        => Assert.Equal(expected, security.ToSocketOptions());
+    [Fact]
+    public void ToSocketOptions_AnUnrecognisedValue_FallsBackToAuto()
+        => Assert.Equal(SecureSocketOptions.Auto, ((SmtpSecurityType)99).ToSocketOptions());
 
     [Fact]
     public void ToSocketOptions_EveryEnumValueIsCovered()
+
         // The mapping falls through to Auto, so a value added later would silently pick it up rather
         // than being noticed. This fails the moment the enum grows without the theory above growing too.
         => Assert.Equal(4, Enum.GetValues<SmtpSecurityType>().Length);
 
-    [Fact]
-    public void ToSocketOptions_AnUnrecognisedValue_FallsBackToAuto()
-        => Assert.Equal(SecureSocketOptions.Auto, ((SmtpSecurityType)99).ToSocketOptions());
+    [Theory, InlineData(SmtpSecurityType.None, SecureSocketOptions.None),
+     InlineData(SmtpSecurityType.StartTls, SecureSocketOptions.StartTls),
+     InlineData(SmtpSecurityType.SslOnConnect, SecureSocketOptions.SslOnConnect),
+     InlineData(SmtpSecurityType.Auto, SecureSocketOptions.Auto)]
+    public void ToSocketOptions_MapsEveryDeclaredValue(SmtpSecurityType security, SecureSocketOptions expected)
+        => Assert.Equal(expected, security.ToSocketOptions());
 }

--- a/tests/Moongate.Tests/Support/FakeTimerServiceForContext.cs
+++ b/tests/Moongate.Tests/Support/FakeTimerServiceForContext.cs
@@ -18,9 +18,7 @@ public sealed class FakeTimerServiceForContext : ITimerService
     )
         => name;
 
-    public void UnregisterAllTimers()
-    {
-    }
+    public void UnregisterAllTimers() { }
 
     public bool UnregisterTimer(string timerId)
         => true;

--- a/tests/Moongate.Tests/Support/GlobalSerilogCapture.cs
+++ b/tests/Moongate.Tests/Support/GlobalSerilogCapture.cs
@@ -19,26 +19,12 @@ public sealed class GlobalSerilogCapture : IDisposable
     {
         _previous = Log.Logger;
         _logger = new LoggerConfiguration()
-            .MinimumLevel.Verbose()
-            .WriteTo.Sink(_sink)
-            .CreateLogger();
+                  .MinimumLevel
+                  .Verbose()
+                  .WriteTo
+                  .Sink(_sink)
+                  .CreateLogger();
         Log.Logger = _logger;
-    }
-
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        Log.Logger = _previous;
-        if (_logger is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
-
-        _disposed = true;
     }
 
     private sealed class CaptureSink : ILogEventSink
@@ -64,5 +50,22 @@ public sealed class GlobalSerilogCapture : IDisposable
                 _events.Add(logEvent);
             }
         }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Log.Logger = _previous;
+
+        if (_logger is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        _disposed = true;
     }
 }

--- a/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
+++ b/tests/Moongate.Tests/Support/InMemoryEntityStore.cs
@@ -58,8 +58,8 @@ public sealed class InMemoryEntityStore<TEntity> : IEntityStore<TEntity, Serial>
         var matched = filter is null ? _items.Values.ToList() : _items.Values.Where(filter).ToList();
 
         var ordered = descending
-            ? matched.OrderByDescending(orderBy).ThenByDescending(entity => entity.Id)
-            : matched.OrderBy(orderBy).ThenBy(entity => entity.Id);
+                          ? matched.OrderByDescending(orderBy).ThenByDescending(entity => entity.Id)
+                          : matched.OrderBy(orderBy).ThenBy(entity => entity.Id);
 
         IReadOnlyList<TEntity> page = [.. ordered.Skip(skip).Take(take)];
 

--- a/tests/Moongate.Tests/Support/MutableTimeProvider.cs
+++ b/tests/Moongate.Tests/Support/MutableTimeProvider.cs
@@ -17,19 +17,6 @@ public sealed class MutableTimeProvider : TimeProvider
         _now = now;
     }
 
-    /// <summary>
-    /// A clock starting at the real instant, which is what any test involving a JWT needs.
-    /// <para>
-    /// The API issues tokens from the injected provider but validates their lifetime against the system
-    /// clock, because <c>TokenValidationParameters</c> offers no way to supply one. In production both are
-    /// the system clock and the two agree; in a test they only agree if this clock starts near the real
-    /// instant. A hardcoded date makes the suite pass or fail depending on the hour it is run — which is
-    /// exactly what it did before this existed.
-    /// </para>
-    /// </summary>
-    public static MutableTimeProvider StartingNow()
-        => new(DateTimeOffset.UtcNow);
-
     public DateTimeOffset Now
     {
         get
@@ -52,14 +39,80 @@ public sealed class MutableTimeProvider : TimeProvider
 
     public override long TimestampFrequency => TimeSpan.TicksPerSecond;
 
-    public override DateTimeOffset GetUtcNow()
-        => Now;
-
-    public override long GetTimestamp()
+    private sealed class MutableTimer : ITimer
     {
-        lock (_sync)
+        private readonly TimerCallback _callback;
+        private readonly MutableTimeProvider _owner;
+        private readonly object? _state;
+
+        public bool IsDisposed { get; set; }
+
+        public DateTimeOffset? NextDue { get; set; }
+
+        public TimeSpan Period { get; set; }
+
+        public MutableTimer(MutableTimeProvider owner, TimerCallback callback, object? state)
         {
-            return _timestamp;
+            _callback = callback;
+            _owner = owner;
+            _state = state;
+        }
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+            => _owner.ChangeTimer(this, dueTime, period);
+
+        public void Dispose()
+            => _owner.DisposeTimer(this);
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+
+            return ValueTask.CompletedTask;
+        }
+
+        public void InvokeCallback()
+            => _callback(_state);
+
+        public void PrepareCallback()
+        {
+            if (Period > TimeSpan.Zero)
+            {
+                NextDue += Period;
+
+                return;
+            }
+
+            NextDue = null;
+        }
+    }
+
+    public void Advance(TimeSpan delta)
+    {
+        var target = Now + delta;
+
+        while (true)
+        {
+            MutableTimer? timer;
+
+            lock (_sync)
+            {
+                timer = _timers
+                        .Where(candidate => candidate.NextDue is { } due && due <= target)
+                        .MinBy(candidate => candidate.NextDue);
+
+                if (timer is null)
+                {
+                    SetNow(target);
+
+                    return;
+                }
+
+                SetNow(timer.NextDue!.Value);
+                timer.PrepareCallback();
+            }
+
+            timer.InvokeCallback();
         }
     }
 
@@ -83,47 +136,29 @@ public sealed class MutableTimeProvider : TimeProvider
         return timer;
     }
 
-    public void Advance(TimeSpan delta)
+    public override long GetTimestamp()
     {
-        var target = Now + delta;
-
-        while (true)
+        lock (_sync)
         {
-            MutableTimer? timer;
-
-            lock (_sync)
-            {
-                timer = _timers
-                    .Where(candidate => candidate.NextDue is { } due && due <= target)
-                    .MinBy(candidate => candidate.NextDue);
-
-                if (timer is null)
-                {
-                    SetNow(target);
-                    return;
-                }
-
-                SetNow(timer.NextDue!.Value);
-                timer.PrepareCallback();
-            }
-
-            timer.InvokeCallback();
+            return _timestamp;
         }
     }
 
-    private void SetNow(DateTimeOffset value)
-    {
-        _timestamp += (value - _now).Ticks;
-        _now = value;
-    }
+    public override DateTimeOffset GetUtcNow()
+        => Now;
 
-    private static void ValidateTimerDuration(TimeSpan value, string parameterName)
-    {
-        if (value < Timeout.InfiniteTimeSpan || value.TotalMilliseconds > uint.MaxValue - 1)
-        {
-            throw new ArgumentOutOfRangeException(parameterName);
-        }
-    }
+    /// <summary>
+    /// A clock starting at the real instant, which is what any test involving a JWT needs.
+    /// <para>
+    /// The API issues tokens from the injected provider but validates their lifetime against the system
+    /// clock, because <c>TokenValidationParameters</c> offers no way to supply one. In production both are
+    /// the system clock and the two agree; in a test they only agree if this clock starts near the real
+    /// instant. A hardcoded date makes the suite pass or fail depending on the hour it is run — which is
+    /// exactly what it did before this existed.
+    /// </para>
+    /// </summary>
+    public static MutableTimeProvider StartingNow()
+        => new(DateTimeOffset.UtcNow);
 
     private bool ChangeTimer(MutableTimer timer, TimeSpan dueTime, TimeSpan period)
     {
@@ -154,52 +189,17 @@ public sealed class MutableTimeProvider : TimeProvider
         }
     }
 
-    private sealed class MutableTimer : ITimer
+    private void SetNow(DateTimeOffset value)
     {
-        private readonly TimerCallback _callback;
-        private readonly MutableTimeProvider _owner;
-        private readonly object? _state;
+        _timestamp += (value - _now).Ticks;
+        _now = value;
+    }
 
-        public bool IsDisposed { get; set; }
-
-        public DateTimeOffset? NextDue { get; set; }
-
-        public TimeSpan Period { get; set; }
-
-        public MutableTimer(MutableTimeProvider owner, TimerCallback callback, object? state)
+    private static void ValidateTimerDuration(TimeSpan value, string parameterName)
+    {
+        if (value < Timeout.InfiniteTimeSpan || value.TotalMilliseconds > uint.MaxValue - 1)
         {
-            _callback = callback;
-            _owner = owner;
-            _state = state;
-        }
-
-        public bool Change(TimeSpan dueTime, TimeSpan period)
-            => _owner.ChangeTimer(this, dueTime, period);
-
-        public void InvokeCallback()
-            => _callback(_state);
-
-        public void PrepareCallback()
-        {
-            if (Period > TimeSpan.Zero)
-            {
-                NextDue += Period;
-                return;
-            }
-
-            NextDue = null;
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            Dispose();
-
-            return ValueTask.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            _owner.DisposeTimer(this);
+            throw new ArgumentOutOfRangeException(parameterName);
         }
     }
 }

--- a/tests/Moongate.Tests/Support/MutableTimeProviderTests.cs
+++ b/tests/Moongate.Tests/Support/MutableTimeProviderTests.cs
@@ -3,17 +3,6 @@ namespace Moongate.Tests.Support;
 public class MutableTimeProviderTests
 {
     [Fact]
-    public void GetElapsedTime_AfterAdvance_ReportsDeterministicDuration()
-    {
-        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
-        var started = time.GetTimestamp();
-
-        time.Advance(TimeSpan.FromMilliseconds(25));
-
-        Assert.Equal(TimeSpan.FromMilliseconds(25), time.GetElapsedTime(started));
-    }
-
-    [Fact]
     public void Advance_OneShotTimer_FiresAtDueTimeOnce()
     {
         var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
@@ -76,5 +65,16 @@ public class MutableTimeProviderTests
 
         Assert.Equal(0, callbackCount);
         Assert.False(timer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan));
+    }
+
+    [Fact]
+    public void GetElapsedTime_AfterAdvance_ReportsDeterministicDuration()
+    {
+        var time = new MutableTimeProvider(new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var started = time.GetTimestamp();
+
+        time.Advance(TimeSpan.FromMilliseconds(25));
+
+        Assert.Equal(TimeSpan.FromMilliseconds(25), time.GetElapsedTime(started));
     }
 }

--- a/tests/Moongate.Tests/Support/RecordingChatService.cs
+++ b/tests/Moongate.Tests/Support/RecordingChatService.cs
@@ -17,12 +17,8 @@ public sealed class RecordingChatService : IChatService
     public IReadOnlyList<(Serial Speaker, ChatMessageType Type, string Text, Hue Hue, int Range)> Messages => _messages;
 
     public void Broadcast(string text, Hue? hue = null)
-    {
-        _broadcasts.Add((text, hue));
-    }
+        => _broadcasts.Add((text, hue));
 
     public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
-    {
-        _messages.Add((speaker.Id, type, text, hue, range));
-    }
+        => _messages.Add((speaker.Id, type, text, hue, range));
 }

--- a/tests/Moongate.Tests/Support/RecordingNpcBrainRuntime.cs
+++ b/tests/Moongate.Tests/Support/RecordingNpcBrainRuntime.cs
@@ -18,15 +18,37 @@ public sealed class RecordingNpcBrainRuntime : INpcBrainRuntime
 
     public List<(Serial MobileId, string BrainId)> BindCalls { get; } = [];
 
-    public List<(Serial MobileId, NpcBrainHookType Hook, BrainContext Context, NpcBrainEvent? Event)> Invocations { get; } = [];
+    public List<(Serial MobileId, NpcBrainHookType Hook, BrainContext Context, NpcBrainEvent? Event)> Invocations { get; } =
+        [];
 
     public List<Serial> ResetCalls { get; } = [];
 
     public List<Serial> UnbindCalls { get; } = [];
 
     public Func<Serial, NpcBrainHookType, BrainContext, NpcBrainEvent?, NpcBrainInvocationResult>?
-        InvocationHandler
-    { get; set; }
+        InvocationHandler { get; set; }
+
+    public NpcBrainInvocationResult Invoke(
+        Serial mobileId,
+        NpcBrainHookType hook,
+        BrainContext context,
+        NpcBrainEvent? brainEvent = null
+    )
+    {
+        Invocations.Add((mobileId, hook, context, brainEvent));
+
+        if (InvocationHandler is not null)
+        {
+            return InvocationHandler(mobileId, hook, context, brainEvent);
+        }
+
+        return Results.TryDequeue(out var result)
+                   ? result
+                   : NpcBrainInvocationResult.Succeeded(null);
+    }
+
+    public void Reset(Serial mobileId)
+        => ResetCalls.Add(mobileId);
 
     public bool TryBind(Serial mobileId, string brainId, out BrainDescriptor? descriptor, out string? error)
     {
@@ -36,6 +58,7 @@ public sealed class RecordingNpcBrainRuntime : INpcBrainRuntime
         {
             descriptor = null;
             error = $"Brain '{brainId}' is unavailable.";
+
             return false;
         }
 
@@ -53,40 +76,18 @@ public sealed class RecordingNpcBrainRuntime : INpcBrainRuntime
                Descriptors.TryGetValue(brainId, out descriptor);
     }
 
-    public NpcBrainInvocationResult Invoke(
-        Serial mobileId,
-        NpcBrainHookType hook,
-        BrainContext context,
-        NpcBrainEvent? brainEvent = null
-    )
-    {
-        Invocations.Add((mobileId, hook, context, brainEvent));
-
-        if (InvocationHandler is not null)
-        {
-            return InvocationHandler(mobileId, hook, context, brainEvent);
-        }
-
-        return Results.TryDequeue(out var result)
-            ? result
-            : NpcBrainInvocationResult.Succeeded(null);
-    }
-
     public bool TryReload(string brainId, out BrainDescriptor? descriptor, out string? error)
     {
         if (Descriptors.TryGetValue(brainId, out descriptor))
         {
             error = null;
+
             return true;
         }
 
         error = $"Brain '{brainId}' is unavailable.";
-        return false;
-    }
 
-    public void Reset(Serial mobileId)
-    {
-        ResetCalls.Add(mobileId);
+        return false;
     }
 
     public void Unbind(Serial mobileId)

--- a/tests/Moongate.Tests/Support/SeededAccountService.cs
+++ b/tests/Moongate.Tests/Support/SeededAccountService.cs
@@ -18,18 +18,22 @@ public sealed class SeededAccountService : IAccountService
     private readonly Dictionary<string, (string Password, AccountLevelType Level, Serial Id)> _accounts =
         new(StringComparer.OrdinalIgnoreCase);
 
-    public void Seed(string username, string password, AccountLevelType level)
-        => _accounts[username] = (password, level, (Serial)(uint)(_accounts.Count + 1));
-
     public AccountAuthResult Authenticate(string username, string password)
         => _accounts.TryGetValue(username, out var account) && account.Password == password
-            ? AccountAuthResult.Ok(username)
-            : AccountAuthResult.Denied(LoginDeniedReasonType.IncorrectCredentials);
+               ? AccountAuthResult.Ok(username)
+               : AccountAuthResult.Denied(LoginDeniedReasonType.IncorrectCredentials);
 
-    public AccountEntity? GetByUsername(string username)
-        => _accounts.TryGetValue(username, out var account)
-            ? new AccountEntity { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true }
-            : null;
+    public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
+        => throw new NotSupportedException();
+
+    public AccountDeleteResultType Delete(string username)
+        => throw new NotSupportedException();
+
+    public Serial? GetAccountIdByUsername(string username)
+        => _accounts.TryGetValue(username, out var account) ? account.Id : null;
+
+    public IReadOnlyList<AccountEntity> GetAll()
+        => throw new NotSupportedException();
 
     public AccountEntity? GetById(Serial accountId)
     {
@@ -37,18 +41,19 @@ public sealed class SeededAccountService : IAccountService
         {
             if (account.Id == accountId)
             {
-                return new AccountEntity
-                    { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true };
+                return new() { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true };
             }
         }
 
         return null;
     }
 
-    public Serial? GetAccountIdByUsername(string username)
-        => _accounts.TryGetValue(username, out var account) ? account.Id : null;
+    public AccountEntity? GetByUsername(string username)
+        => _accounts.TryGetValue(username, out var account)
+               ? new AccountEntity { Id = account.Id, Username = username, AccountLevel = account.Level, IsActive = true }
+               : null;
 
-    public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
+    public IReadOnlyList<string> GetUsernames()
         => throw new NotSupportedException();
 
     public AccountRegisterResult RegisterPending(string username, string password, string email)
@@ -57,17 +62,8 @@ public sealed class SeededAccountService : IAccountService
     public AccountResendResultType ResendVerification(string username, string email)
         => throw new NotSupportedException();
 
-    public AccountVerifyResultType VerifyEmail(string token)
-        => throw new NotSupportedException();
-
-    public AccountDeleteResultType Delete(string username)
-        => throw new NotSupportedException();
-
-    public IReadOnlyList<AccountEntity> GetAll()
-        => throw new NotSupportedException();
-
-    public IReadOnlyList<string> GetUsernames()
-        => throw new NotSupportedException();
+    public void Seed(string username, string password, AccountLevelType level)
+        => _accounts[username] = (password, level, (Serial)(uint)(_accounts.Count + 1));
 
     public bool SetActive(string username, bool isActive)
         => throw new NotSupportedException();
@@ -76,5 +72,8 @@ public sealed class SeededAccountService : IAccountService
         => throw new NotSupportedException();
 
     public bool SetPassword(string username, string password)
+        => throw new NotSupportedException();
+
+    public AccountVerifyResultType VerifyEmail(string token)
         => throw new NotSupportedException();
 }

--- a/tests/Moongate.Tests/Support/StubAccountService.cs
+++ b/tests/Moongate.Tests/Support/StubAccountService.cs
@@ -29,12 +29,6 @@ public sealed class StubAccountService : IAccountService
     public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
         => throw new NotSupportedException();
 
-    public AccountRegisterResult RegisterPending(string username, string password, string email)
-        => throw new NotSupportedException();
-
-    public AccountVerifyResultType VerifyEmail(string token)
-        => throw new NotSupportedException();
-
     public AccountDeleteResultType Delete(string username)
         => throw new NotSupportedException();
 
@@ -55,6 +49,9 @@ public sealed class StubAccountService : IAccountService
     public IReadOnlyList<string> GetUsernames()
         => throw new NotSupportedException();
 
+    public AccountRegisterResult RegisterPending(string username, string password, string email)
+        => throw new NotSupportedException();
+
     public bool SetActive(string username, bool isActive)
         => throw new NotSupportedException();
 
@@ -62,5 +59,8 @@ public sealed class StubAccountService : IAccountService
         => throw new NotSupportedException();
 
     public bool SetPassword(string username, string password)
+        => throw new NotSupportedException();
+
+    public AccountVerifyResultType VerifyEmail(string token)
         => throw new NotSupportedException();
 }

--- a/tests/Moongate.Tests/Support/StubAiActionService.cs
+++ b/tests/Moongate.Tests/Support/StubAiActionService.cs
@@ -8,19 +8,21 @@ namespace Moongate.Tests.Support;
 /// <summary>No-op AI action service for scheduler tests, where brain effects are simulated by the runtime double.</summary>
 public sealed class StubAiActionService : IAiActionService
 {
+    private sealed class NoopScope : IDisposable
+    {
+        public void Dispose() { }
+    }
+
     public IDisposable Begin(BrainContext context)
         => new NoopScope();
 
-    public bool Say(string text)
+    public bool ClearTarget()
         => true;
 
-    public bool Patrol()
+    public bool Engage(Serial targetId)
         => true;
 
-    public bool ReturnHome()
-        => true;
-
-    public bool Step(DirectionType direction)
+    public bool MoveAway(Serial targetId)
         => true;
 
     public bool MoveTo(int x, int y)
@@ -29,19 +31,15 @@ public sealed class StubAiActionService : IAiActionService
     public bool MoveToward(Serial targetId)
         => true;
 
-    public bool MoveAway(Serial targetId)
+    public bool Patrol()
         => true;
 
-    public bool Engage(Serial targetId)
+    public bool ReturnHome()
         => true;
 
-    public bool ClearTarget()
+    public bool Say(string text)
         => true;
 
-    private sealed class NoopScope : IDisposable
-    {
-        public void Dispose()
-        {
-        }
-    }
+    public bool Step(DirectionType direction)
+        => true;
 }

--- a/tests/Moongate.Tests/Support/StubConfigManagerService.cs
+++ b/tests/Moongate.Tests/Support/StubConfigManagerService.cs
@@ -23,6 +23,9 @@ public sealed class StubConfigManagerService : IConfigManagerService
     public string Compose()
         => throw new NotSupportedException();
 
+    public void EnsureFiles()
+        => throw new NotSupportedException();
+
     public TConfig GetConfig<TConfig>()
         where TConfig : class
         => throw new NotSupportedException();
@@ -32,7 +35,4 @@ public sealed class StubConfigManagerService : IConfigManagerService
 
     public void Save()
         => SaveCount++;
-
-    public void EnsureFiles()
-        => throw new NotSupportedException();
 }

--- a/tests/Moongate.Tests/Support/StubEventBus.cs
+++ b/tests/Moongate.Tests/Support/StubEventBus.cs
@@ -16,9 +16,7 @@ public sealed class StubEventBus : IEventBus
     {
         public static readonly NoopDisposable Instance = new();
 
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
     }
 
     public void Publish<TEvent>(TEvent eventData) where TEvent : IEvent

--- a/tests/Moongate.Tests/Support/StubGameLoopContext.cs
+++ b/tests/Moongate.Tests/Support/StubGameLoopContext.cs
@@ -37,6 +37,18 @@ public sealed class StubGameLoopContext : IGameLoopContext
     public bool Cancel(string timerId)
         => Repeating.Remove(timerId);
 
+    public Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null)
+    {
+        PostCount++;
+
+        if (_answers)
+        {
+            return Task.FromResult(work());
+        }
+
+        return Task.FromException<T>(new TimeoutException("Stub game loop is not answering."));
+    }
+
     public void Post(Action action)
     {
         PostCount++;
@@ -57,17 +69,5 @@ public sealed class StubGameLoopContext : IGameLoopContext
         RepeatingDelay = delay;
 
         return name;
-    }
-
-    public Task<T> InvokeAsync<T>(Func<T> work, TimeSpan? timeout = null)
-    {
-        PostCount++;
-
-        if (_answers)
-        {
-            return Task.FromResult(work());
-        }
-
-        return Task.FromException<T>(new TimeoutException("Stub game loop is not answering."));
     }
 }

--- a/tests/Moongate.Tests/Support/StubJobSystem.cs
+++ b/tests/Moongate.Tests/Support/StubJobSystem.cs
@@ -19,6 +19,8 @@ public sealed class StubJobSystem : IJobSystem
 
     public long CompletedCount => Scheduled;
 
+    public void Dispose() { }
+
     public Task ScheduleAsync(Action work, CancellationToken cancellationToken = default)
     {
         Scheduled++;
@@ -32,9 +34,5 @@ public sealed class StubJobSystem : IJobSystem
         Scheduled++;
 
         return Task.FromResult(work());
-    }
-
-    public void Dispose()
-    {
     }
 }

--- a/tests/Moongate.Tests/Support/StubLoopAffinity.cs
+++ b/tests/Moongate.Tests/Support/StubLoopAffinity.cs
@@ -5,7 +5,5 @@ namespace Moongate.Tests.Support;
 /// <summary>Test double for <see cref="ILoopAffinity" /> that never trips — the loop is assumed present.</summary>
 public sealed class StubLoopAffinity : ILoopAffinity
 {
-    public void AssertOnLoop(string operation)
-    {
-    }
+    public void AssertOnLoop(string operation) { }
 }

--- a/tests/Moongate.Tests/Support/StubNpcMemoryService.cs
+++ b/tests/Moongate.Tests/Support/StubNpcMemoryService.cs
@@ -10,29 +10,25 @@ public sealed class StubNpcMemoryService : INpcMemoryService
 {
     private static readonly IReadOnlyDictionary<string, NpcMemoryValue> Empty = new Dictionary<string, NpcMemoryValue>();
 
-    public IDisposable Begin(BrainContext context)
-        => new NoopScope();
-
-    public bool Set(string key, NpcMemoryValue value)
-        => true;
-
-    public NpcMemoryValue? Get(string key)
-        => null;
-
-    public bool Delete(string key)
-        => false;
+    private sealed class NoopScope : IDisposable
+    {
+        public void Dispose() { }
+    }
 
     public IReadOnlyDictionary<string, NpcMemoryValue> All()
         => Empty;
 
-    public void Forget(Serial mobileId)
-    {
-    }
+    public IDisposable Begin(BrainContext context)
+        => new NoopScope();
 
-    private sealed class NoopScope : IDisposable
-    {
-        public void Dispose()
-        {
-        }
-    }
+    public bool Delete(string key)
+        => false;
+
+    public void Forget(Serial mobileId) { }
+
+    public NpcMemoryValue? Get(string key)
+        => null;
+
+    public bool Set(string key, NpcMemoryValue value)
+        => true;
 }

--- a/tests/Moongate.Tests/Support/StubServerStatsService.cs
+++ b/tests/Moongate.Tests/Support/StubServerStatsService.cs
@@ -11,7 +11,5 @@ public sealed class StubServerStatsService : IServerStatsService
 {
     public ServerStatsSnapshot Current { get; set; } = ServerStatsSnapshot.Empty;
 
-    public void Refresh()
-    {
-    }
+    public void Refresh() { }
 }

--- a/tests/Moongate.Tests/Support/StubSessionManager.cs
+++ b/tests/Moongate.Tests/Support/StubSessionManager.cs
@@ -37,9 +37,7 @@ public sealed class StubSessionManager : ISessionManager
     public bool IsCharacterPlayed(Serial mobileId)
         => Played.Contains(mobileId);
 
-    public void Remove(long sessionId)
-    {
-    }
+    public void Remove(long sessionId) { }
 
     public bool TryGet(long sessionId, out PlayerSession session)
     {

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -24,9 +24,9 @@ using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Services.Plugins;
 using Moongate.Http.Plugin.Services.Registration;
 using Moongate.Server.Abstractions.Data.Config;
-using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
+using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Abstractions.Interfaces.Server;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Plugins;
@@ -96,9 +96,9 @@ public sealed class TestApiServer : IAsyncDisposable
     public async Task AuthenticateAsync()
     {
         var response = await Client.PostAsJsonAsync(
-            "/api/v1/auth/login",
-            new { username = "tom", password = "secret" }
-        );
+                           "/api/v1/auth/login",
+                           new { username = "tom", password = "secret" }
+                       );
         var token = await response.Content.ReadFromJsonAsync<ApiTokenResult>();
 
         Client.DefaultRequestHeaders.Authorization = new("Bearer", token!.Token);
@@ -187,7 +187,7 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterInstance<IServerAssetFileStore>(assetStore);
         INotificationChannel[] channels = emailChannelReady ? [new RecordingNotificationChannel("email")] : [];
         var registrationReadiness = new RegistrationReadinessService(
-            new NotificationConfig { AccountVerificationChannel = accountVerificationChannel },
+            new() { AccountVerificationChannel = accountVerificationChannel },
             channels
         );
         container.RegisterInstance<IRegistrationReadinessService>(registrationReadiness);
@@ -200,12 +200,12 @@ public sealed class TestApiServer : IAsyncDisposable
 
         // The default is deliberately low so a test can prove the throttle without flooding; callers can
         // inject a recording limiter when exact budget keys or independent budgets are the behavior at stake.
-        var rateLimiter = registrationRateLimiter
-            ?? new RegistrationRateLimiter(
-                TimeProvider.System,
-                permitPerWindow: 2,
-                window: TimeSpan.FromMinutes(10)
-            );
+        var rateLimiter = registrationRateLimiter ??
+                          new RegistrationRateLimiter(
+                              TimeProvider.System,
+                              2,
+                              TimeSpan.FromMinutes(10)
+                          );
         container.RegisterApiEndpointInstance(
             new RegistrationEndpoints(accounts, serverSettings, registrationReadiness, rateLimiter)
         );
@@ -217,12 +217,10 @@ public sealed class TestApiServer : IAsyncDisposable
         // The fixture's endpoints all live in Moongate.Http.Plugin, so recording that plugin is what makes
         // their routes attributable — the same join the real bootstrap makes.
         var pluginCatalog = new PluginCatalog();
-        pluginCatalog.Record(new MoongateHttpPlugin(), isExternal: false);
+        pluginCatalog.Record(new MoongateHttpPlugin(), false);
 
         container.RegisterInstance<IPluginCatalog>(pluginCatalog);
-        container.RegisterApiEndpointInstance(
-            new PluginAdminEndpoints(pluginCatalog, new EndpointPluginRouteInspector())
-        );
+        container.RegisterApiEndpointInstance(new PluginAdminEndpoints(pluginCatalog, new EndpointPluginRouteInspector()));
 
         // Lets a test add endpoint groups this fixture cannot know about — the ones the HTTP plugin owns.
         configure?.Invoke(container);

--- a/tests/Moongate.Tests/Support/TestDirectoryCleanup.cs
+++ b/tests/Moongate.Tests/Support/TestDirectoryCleanup.cs
@@ -8,11 +8,7 @@ internal static class TestDirectoryCleanup
         {
             Directory.Delete(path, true);
         }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
-        {
-        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 }

--- a/tests/Moongate.Tests/Support/UltimaClientDataCollection.cs
+++ b/tests/Moongate.Tests/Support/UltimaClientDataCollection.cs
@@ -6,6 +6,4 @@ namespace Moongate.Tests.Support;
 /// these tests would race on the shared client-file paths.
 /// </summary>
 [CollectionDefinition("UltimaClientData", DisableParallelization = true)]
-public sealed class UltimaClientDataCollection
-{
-}
+public sealed class UltimaClientDataCollection { }

--- a/tests/Moongate.Tests/Ultima/ClientVersionReaderTests.cs
+++ b/tests/Moongate.Tests/Ultima/ClientVersionReaderTests.cs
@@ -51,6 +51,15 @@ public class ClientVersionReaderTests
     }
 
     [Fact]
+    public void TryRead_WithVersionResource_ParsesVersion()
+    {
+        var ok = ClientVersionReader.TryRead(BuildClientExe(), out var version);
+
+        Assert.True(ok);
+        Assert.Equal(new(7, 0, 95, 3), version);
+    }
+
+    [Fact]
     public void TryRead_WithoutSignature_ReturnsFalse()
     {
         var buffer = new byte[128];
@@ -59,15 +68,6 @@ public class ClientVersionReaderTests
 
         Assert.False(ok);
         Assert.Equal(new(0, 0), version);
-    }
-
-    [Fact]
-    public void TryRead_WithVersionResource_ParsesVersion()
-    {
-        var ok = ClientVersionReader.TryRead(BuildClientExe(), out var version);
-
-        Assert.True(ok);
-        Assert.Equal(new(7, 0, 95, 3), version);
     }
 
     // A minimal client.exe: prefix + VS_VERSION_INFO signature(30) + filler(12) + version fields

--- a/tests/Moongate.Tests/Ultima/ItemCatalogTests.cs
+++ b/tests/Moongate.Tests/Ultima/ItemCatalogTests.cs
@@ -15,52 +15,6 @@ public class ItemCatalogTests
     private const int ItemId = 0x10;
 
     [Fact]
-    public void GetItem_KnownId_ReturnsEnrichedInfo()
-    {
-        var dir = CreateFixtureDirectory();
-
-        try
-        {
-            Files.SetDirectory(dir);
-            InitializeReaders();
-
-            var catalog = new ItemCatalog();
-            var info = catalog.GetItem(ItemId);
-
-            Assert.NotNull(info);
-            Assert.Equal((uint)ItemId, info.ItemId);
-            Assert.Equal("test tunic", info.Name);
-            Assert.Equal(4, info.Height);
-            Assert.True((info.Flags & TileFlagType.Wearable) != 0);
-            Assert.True(info.HasArt);
-            Assert.Equal(2, info.ArtWidth);
-            Assert.Equal(2, info.ArtHeight);
-        }
-        finally
-        {
-            Directory.Delete(dir, true);
-        }
-    }
-
-    [Fact]
-    public void GetItem_OutOfRange_ReturnsNull()
-    {
-        var dir = CreateFixtureDirectory();
-
-        try
-        {
-            Files.SetDirectory(dir);
-            InitializeReaders();
-
-            Assert.Null(new ItemCatalog().GetItem(uint.MaxValue));
-        }
-        finally
-        {
-            Directory.Delete(dir, true);
-        }
-    }
-
-    [Fact]
     public void GetItemImage_MissingArt_ReturnsNull()
     {
         var dir = CreateFixtureDirectory();
@@ -126,6 +80,52 @@ public class ItemCatalogTests
             using var huedImage = Image.Load<Bgra32>(hued);
 
             Assert.NotEqual(plainImage[0, 0], huedImage[0, 0]);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void GetItem_KnownId_ReturnsEnrichedInfo()
+    {
+        var dir = CreateFixtureDirectory();
+
+        try
+        {
+            Files.SetDirectory(dir);
+            InitializeReaders();
+
+            var catalog = new ItemCatalog();
+            var info = catalog.GetItem(ItemId);
+
+            Assert.NotNull(info);
+            Assert.Equal((uint)ItemId, info.ItemId);
+            Assert.Equal("test tunic", info.Name);
+            Assert.Equal(4, info.Height);
+            Assert.True((info.Flags & TileFlagType.Wearable) != 0);
+            Assert.True(info.HasArt);
+            Assert.Equal(2, info.ArtWidth);
+            Assert.Equal(2, info.ArtHeight);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void GetItem_OutOfRange_ReturnsNull()
+    {
+        var dir = CreateFixtureDirectory();
+
+        try
+        {
+            Files.SetDirectory(dir);
+            InitializeReaders();
+
+            Assert.Null(new ItemCatalog().GetItem(uint.MaxValue));
         }
         finally
         {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -307,7 +307,7 @@
           "console"
         ],
         "summary": "Opens a per-connection SSE feed; its first event carries the connection id to POST with.",
-        "description": "Emits `ready` (data = the connection id), then a `line` per command reply and a\n            `done` when a command finishes. The connection is closed when the client disconnects.",
+        "description": "Emits `ready` (data = the connection id), then a `line` per command reply and a\n`done` when a command finishes. The connection is closed when the client disconnects.",
         "operationId": "StreamConsole",
         "responses": {
           "200": {
@@ -329,7 +329,7 @@
           "console"
         ],
         "summary": "Runs a console command; its reply lines stream to the given connection's SSE feed.",
-        "description": "Returns 202 immediately — the command is dispatched onto the game loop and its output\n            arrives asynchronously on `GET /api/v1/admin/console/stream`.",
+        "description": "Returns 202 immediately — the command is dispatched onto the game loop and its output\narrives asynchronously on `GET /api/v1/admin/console/stream`.",
         "operationId": "SendConsoleCommand",
         "requestBody": {
           "content": {
@@ -3080,7 +3080,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "The public server profile a website or launcher reads: identity, contacts, assets, and effective registration availability."
+        "description": "The public server profile a website or launcher reads: identity, contacts, assets, and effective registration\navailability."
       },
       "ServerSettingsResponse": {
         "required": [

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -183,7 +183,7 @@ export interface paths {
         /**
          * Opens a per-connection SSE feed; its first event carries the connection id to POST with.
          * @description Emits `ready` (data = the connection id), then a `line` per command reply and a
-         *                 `done` when a command finishes. The connection is closed when the client disconnects.
+         *     `done` when a command finishes. The connection is closed when the client disconnects.
          */
         get: operations["StreamConsole"];
         put?: never;
@@ -206,7 +206,7 @@ export interface paths {
         /**
          * Runs a console command; its reply lines stream to the given connection's SSE feed.
          * @description Returns 202 immediately — the command is dispatched onto the game loop and its output
-         *                 arrives asynchronously on `GET /api/v1/admin/console/stream`.
+         *     arrives asynchronously on `GET /api/v1/admin/console/stream`.
          */
         post: operations["SendConsoleCommand"];
         delete?: never;
@@ -1453,7 +1453,10 @@ export interface components {
             email?: string | null;
             discord?: string | null;
         };
-        /** @description The public server profile a website or launcher reads: identity, contacts, assets, and effective registration availability. */
+        /**
+         * @description The public server profile a website or launcher reads: identity, contacts, assets, and effective registration
+         *     availability.
+         */
         ServerInfoResponse: {
             shardName: string;
             description?: string | null;


### PR DESCRIPTION
Commits the reformat that had been sitting uncommitted in the working tree.

It goes beyond the 2026-07-14 pass in `30f1d89`: besides layout and line wrapping it **reorders type members alphabetically** and aligns switch arms in columns, plus normalises self-closing XML tags in `Moongate.slnx` and the Http plugin csproj.

272 files, no behaviour change — the tree builds and the full suite passes at 1777. It had in fact been building and passing all day, since `dotnet test` compiles the working tree rather than HEAD.

**Not included:** the pending `global.json` deletion, which removes the 10.0.301 SDK pin. That is not a formatting decision and is left in the working tree for a deliberate call.