### PR TITLE
feat(items): run Lua hooks on item click, drop, equip and unequip

### DIFF
--- a/docs/scripting/data/item-templates.md
+++ b/docs/scripting/data/item-templates.md
@@ -63,7 +63,7 @@ of templates.
 | `Hue` | `int` | optional, default `0` | Default hue index, used unless the caller passes an explicit hue (e.g. `item.create`'s hue argument). |
 | `GoldValue` | `int` | optional, default `0` | Declared gold value. **Reserved** — not read by `ItemFactoryService` or copied onto the spawned item today. |
 | `Weight` | `double` | optional, default `0.0` | Item weight. Must be finite and non-negative. |
-| `ScriptId` | `string` | optional, default `""` | Free-form script identifier, copied onto the spawned item's `ScriptId`. **Reserved** — no loader in this codebase currently dispatches on it. |
+| `ScriptId` | `string` | optional, default `""` | Names the Lua script that runs when players interact with the item — `magic_torch` means `scripts/items/magic_torch.lua`. Must match `^[a-z0-9_]+$`. `none` or empty means no script. See [Item scripts](../reference/item-scripts.md). |
 | `IsMovable` | `bool` | optional, default `false` | Whether the item can be picked up. `false` refuses the lift with `CannotLift` (0x27). Not read by `ItemFactoryService` — it is enforced at drag time by `DragDropService`. |
 | `Rarity` | `ItemRarityType` enum | optional, default `Common` | One of `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`, `Artifact`. Must be a defined member. Copied onto the spawned item's `Rarity`. |
 | `Tags` | `List<string>` | optional, default `[]` | Free-form labels. Drives `item.create_by_tag` / `CreateByTag`, and is the pool loot entries' `ItemTag` matches against. Cannot be an explicit YAML null. |
@@ -181,7 +181,7 @@ equips):
     Hue: 0
     GoldValue: 0                # declared, not consumed
     Weight: 16.0
-    ScriptId: none              # copied onto the item; nothing dispatches on it yet
+    ScriptId: none              # or the name of a script under scripts/items/
     IsMovable: true              # false would refuse the lift
     Rarity: Common               # must be a defined ItemRarityType member
     Tags:

--- a/docs/scripting/reference/events.md
+++ b/docs/scripting/reference/events.md
@@ -56,6 +56,15 @@ end)
 | `mobile_entered_sector` | When a mobile enters a spatial sector — appearing in the world, or crossing into it from another sector. Boundary-only (never per tile), mobiles only. | `mobile`, `map_id`, `sector_x`, `sector_y` |
 | `mobile_left_sector` | When a mobile leaves a spatial sector — being removed from the world, or crossing out of it into another. Boundary-only, mobiles only. | `mobile`, `map_id`, `sector_x`, `sector_y` |
 | `mobile_changed_sector` | When a mobile moves from one sector to another. Fires alongside `mobile_left_sector` (old) and `mobile_entered_sector` (new); never on spawn or removal. | `mobile`, `from_map_id`, `from_sector_x`, `from_sector_y`, `to_map_id`, `to_sector_x`, `to_sector_y` |
+| `item_single_click` | A player single-clicks an item. | `session_id`, `serial` |
+| `item_double_click` | A player double-clicks an item. | `session_id`, `serial` |
+| `item_dropped` | A held item is put down — `container_id` is `0` for a ground drop. | `item`, `actor`, `container_id` |
+| `item_equipped` | An item is placed on a paperdoll layer, including when a new character is dressed in its starting kit. | `item`, `mobile`, `layer` |
+| `item_unequipped` | An item is taken off a layer. | `item`, `mobile`, `layer` |
+
+For per-item behaviour keyed to a template's `ScriptId`, prefer
+[item scripts](item-scripts.md) over these events: an `events.on("item_double_click", …)` handler
+fires for *every* item in the world and has to filter for itself.
 
 `world_ready` is the recommended hook for bootstrap spawns: the handler runs on
 the loop, so it can create and place mobiles and items directly without

--- a/docs/scripting/reference/item-scripts.md
+++ b/docs/scripting/reference/item-scripts.md
@@ -1,0 +1,109 @@
+# Item scripts
+
+An item template's `ScriptId` names a Lua script that runs when players interact with the item.
+`ScriptId: magic_torch` means `<root>/scripts/items/magic_torch.lua`.
+
+| Concern | Type |
+|---|---|
+| Runtime | `Moongate.Scripting.Items.LuaItemScriptRuntime` (`IItemScriptRuntime`) |
+| Dispatcher | `Moongate.Server.Subscribers.ItemScriptSubscriber` |
+| Hooks enum | `ItemScriptHookType` (`Moongate.Server.Abstractions.Types.Items`) |
+| Seeder | `Moongate.Scripting.Items.ItemScriptAssetSeeder` |
+
+This is the same shape as [NPC brains](ai.md): a file that returns a table whose `on_*` functions are
+the hooks. Item scripts are simpler — no per-instance state, no tick, no binding.
+
+## The shape of a script
+
+```lua
+local magic_torch = {
+    id = "magic_torch",
+}
+
+function magic_torch.on_double_click(ctx)
+    log.info("torch " .. ctx.item.serial .. " was double-clicked")
+end
+
+return magic_torch
+```
+
+The file **must return a table**; one that returns anything else is ignored with a warning. Every
+hook is optional — define only what you need, and an item whose script defines none simply does
+nothing.
+
+`ScriptId: none`, which every shipped item template carries, means no script. So does an empty
+value. Neither reaches the disk.
+
+## The hooks
+
+| Function | Fires when |
+|---|---|
+| `on_single_click(ctx)` | the item is single-clicked |
+| `on_double_click(ctx)` | the item is double-clicked |
+| `on_drop(ctx)` | the item is put down, on the ground or into a container |
+| `on_equip(ctx)` | the item is placed on a paperdoll layer |
+| `on_unequip(ctx)` | the item is taken off a layer |
+
+One name per hook. There are no alternative spellings and no fallback on the item's name.
+
+`on_equip` and `on_unequip` fire for **every** equip, not just player-driven ones — the starting kit
+a new character is dressed in raises them too.
+
+## The context table
+
+Every hook receives one argument.
+
+| Field | Always present | Meaning |
+|---|---|---|
+| `ctx.hook` | yes | The hook's own name, e.g. `"on_double_click"`. |
+| `ctx.item` | yes | The item — see below. |
+| `ctx.container_id` | yes | Serial of the container it was dropped into; `0` for a ground drop, and `0` in every hook other than `on_drop`. |
+| `ctx.actor` | **no** | Who caused it. |
+| `ctx.layer` | **no** | Layer name as a string. Only in `on_equip` / `on_unequip`. |
+
+`ctx.item` carries `serial`, `item_id`, `template_id`, `script_id`, `name`, `amount`, `hue`,
+`map_id`, `x`, `y`, `z`.
+
+`ctx.actor`, when present, carries `serial`, `name`, `map_id`, `x`, `y`, `z`.
+
+> [!IMPORTANT]
+> **Always check `ctx.actor` before using it.** It is absent whenever nothing player-driven caused
+> the hook — a character being dressed in its starting kit raises `on_equip` with no actor — and
+> also when the clicking session has gone away between the click and the dispatch.
+
+```lua
+function magic_torch.on_equip(ctx)
+    if ctx.actor == nil then
+        return
+    end
+
+    log.info(ctx.actor.name .. " equipped a torch on " .. ctx.layer)
+end
+```
+
+## What a hook may do
+
+Hooks run **on the game-loop thread**, so they may touch world state directly — call `item.*`,
+`mobile.*` and the rest of the [scripting API](../index.md) without wrapping anything in
+`game.post`.
+
+## Limits
+
+The runtime is deliberately unforgiving, so a content mistake cannot take the server with it:
+
+- **A script id must match `^[a-z0-9_]+$`.** Anything else is refused, which is what stops a
+  `ScriptId` from resolving outside the items directory.
+- **A file may not exceed 256 KiB**, and may not be a symbolic link.
+- **A hook gets 50 000 VM instructions.** Exceeding the budget aborts that call with a warning.
+- **A hook may not yield.**
+- **Errors are logged, never thrown.** A hook that raises leaves the item inert rather than faulting
+  the game loop.
+
+A script is loaded the first time its id is needed and then kept, misses included — a typo in a
+template does not re-hit the disk on every click. There is **no hot reload**: unlike brains, changing
+an item script needs a restart.
+
+## Shipped example
+
+`magic_torch.lua` ships with the server and is copied into `<root>/scripts/items/` on first use, if
+it is not already there. An existing file is never overwritten, so your edits survive upgrades.

--- a/docs/scripting/toc.yml
+++ b/docs/scripting/toc.yml
@@ -20,6 +20,8 @@
       href: reference/ai.md
     - name: memory
       href: reference/memory.md
+    - name: item scripts
+      href: reference/item-scripts.md
     - name: game
       href: reference/game.md
     - name: events

--- a/src/Moongate.Scripting/Assets/Items/magic_torch.lua
+++ b/src/Moongate.Scripting/Assets/Items/magic_torch.lua
@@ -1,0 +1,16 @@
+-- Example item script. An item template with `ScriptId: magic_torch` runs these hooks.
+-- Every hook is optional: define only the ones you need.
+
+local magic_torch = {
+    id = "magic_torch",
+}
+
+function magic_torch.on_double_click(ctx)
+    log.info("magic torch " .. ctx.item.serial .. " was double-clicked")
+end
+
+function magic_torch.on_equip(ctx)
+    log.info("magic torch equipped on layer " .. ctx.layer)
+end
+
+return magic_torch

--- a/src/Moongate.Scripting/Items/ItemScriptAssetSeeder.cs
+++ b/src/Moongate.Scripting/Items/ItemScriptAssetSeeder.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+
+namespace Moongate.Scripting.Items;
+
+/// <summary>
+/// Copies the shipped item scripts into the runtime directory, skipping any that already exist so a
+/// server owner's edits are never overwritten. The sibling of <c>BrainAssetSeeder</c>.
+/// </summary>
+public static class ItemScriptAssetSeeder
+{
+    private const string ResourcePrefix = "Moongate.Scripting.Assets.Items.";
+
+    public static void SeedMissing(string itemsDirectory)
+    {
+        Directory.CreateDirectory(itemsDirectory);
+
+        var assembly = typeof(ItemScriptAssetSeeder).Assembly;
+        var resources = assembly
+                        .GetManifestResourceNames()
+                        .Where(name => name.StartsWith(ResourcePrefix, StringComparison.Ordinal))
+                        .Where(name => name.EndsWith(".lua", StringComparison.Ordinal))
+                        .Order(StringComparer.Ordinal);
+
+        foreach (var resourceName in resources)
+        {
+            SeedMissing(assembly, resourceName, itemsDirectory);
+        }
+    }
+
+    private static void SeedMissing(Assembly assembly, string resourceName, string itemsDirectory)
+    {
+        var fileName = resourceName[ResourcePrefix.Length..];
+        var destination = Path.Combine(itemsDirectory, fileName);
+
+        if (File.Exists(destination))
+        {
+            return;
+        }
+
+        // Write beside the target and move into place, so a reader never sees a half-written script.
+        var temporaryPath = destination + "." + Guid.NewGuid().ToString("N") + ".tmp";
+
+        try
+        {
+            using (var source = assembly.GetManifestResourceStream(resourceName) ??
+                                throw new InvalidOperationException(
+                                    $"Embedded item script resource was not found: {resourceName}"
+                                ))
+            {
+                using (var temporary = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    source.CopyTo(temporary);
+                }
+            }
+
+            try
+            {
+                File.Move(temporaryPath, destination);
+            }
+            catch (IOException) when (File.Exists(destination)) { }
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+    }
+}

--- a/src/Moongate.Scripting/Items/LuaItemScriptRuntime.cs
+++ b/src/Moongate.Scripting/Items/LuaItemScriptRuntime.cs
@@ -26,6 +26,7 @@ public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
     private readonly Script _script;
     private readonly string _itemsDirectory;
     private readonly Dictionary<string, Table?> _definitions = new(StringComparer.Ordinal);
+    private bool _seeded;
 
     public LuaItemScriptRuntime(Script script, DirectoriesConfig directoriesConfig)
     {
@@ -216,6 +217,13 @@ public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
             string.Equals(scriptId, NoScript, StringComparison.OrdinalIgnoreCase))
         {
             return null;
+        }
+
+        // Seeded lazily rather than in the constructor: construction must not touch the disk.
+        if (!_seeded)
+        {
+            _seeded = true;
+            ItemScriptAssetSeeder.SeedMissing(_itemsDirectory);
         }
 
         if (_definitions.TryGetValue(scriptId, out var cached))

--- a/src/Moongate.Scripting/Items/LuaItemScriptRuntime.cs
+++ b/src/Moongate.Scripting/Items/LuaItemScriptRuntime.cs
@@ -1,0 +1,231 @@
+using System.Text.RegularExpressions;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Types.Items;
+using MoonSharp.Interpreter;
+using Serilog;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Scripting.Items;
+
+/// <summary>
+/// Runs item scripts: <c>&lt;scripts&gt;/items/&lt;ScriptId&gt;.lua</c> returns a table whose
+/// <c>on_*</c> functions are the hooks. A smaller sibling of <c>LuaNpcBrainRuntime</c> — same lazy
+/// load-by-id and the same guards, but no per-instance state and no bindings, because an item script
+/// belongs to the id rather than to any one item.
+/// </summary>
+public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
+{
+    private const int MaximumScriptFileBytes = 256 * 1024;
+    private const int InstructionBudget = 50_000;
+
+    /// <summary>What every shipped template carries when it has no script at all.</summary>
+    private const string NoScript = "none";
+
+    private readonly ILogger _logger = Log.ForContext<LuaItemScriptRuntime>();
+    private readonly Script _script;
+    private readonly string _itemsDirectory;
+    private readonly Dictionary<string, Table?> _definitions = new(StringComparer.Ordinal);
+
+    public LuaItemScriptRuntime(Script script, DirectoriesConfig directoriesConfig)
+    {
+        _script = script;
+        _itemsDirectory = Path.Combine(directoriesConfig.GetPath("scripts"), "items");
+    }
+
+    public bool HasHook(string scriptId, ItemScriptHookType hook)
+        => TryGetDefinition(scriptId) is { } table && IsCallable(table.Get(GetHookName(hook)));
+
+    public bool Invoke(ItemScriptHookType hook, ItemScriptContext context)
+    {
+        if (TryGetDefinition(context.Item.ScriptId) is not { } table)
+        {
+            return false;
+        }
+
+        var hookValue = table.Get(GetHookName(hook));
+
+        if (!IsCallable(hookValue))
+        {
+            return false;
+        }
+
+        try
+        {
+            var coroutine = _script.CreateCoroutine(hookValue).Coroutine;
+            coroutine.AutoYieldCounter = InstructionBudget;
+
+            coroutine.Resume(DynValue.NewTable(BuildContextTable(hook, context)));
+
+            if (coroutine.State == CoroutineState.ForceSuspended)
+            {
+                _logger.Warning(
+                    "Item script '{ScriptId}' hook '{Hook}' exceeded its instruction budget",
+                    context.Item.ScriptId,
+                    GetHookName(hook)
+                );
+
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception exception)
+        {
+            // A content author's mistake must never reach the game loop.
+            _logger.Error(
+                exception,
+                "Item script '{ScriptId}' hook '{Hook}' failed",
+                context.Item.ScriptId,
+                GetHookName(hook)
+            );
+
+            return false;
+        }
+    }
+
+    private Table BuildContextTable(ItemScriptHookType hook, ItemScriptContext context)
+    {
+        var item = new Table(_script)
+        {
+            ["serial"] = (double)(uint)context.Item.Id,
+            ["item_id"] = context.Item.ItemId,
+            ["template_id"] = context.Item.TemplateId,
+            ["script_id"] = context.Item.ScriptId,
+            ["name"] = context.Item.Name,
+            ["amount"] = context.Item.Amount,
+            ["hue"] = (double)context.Item.Hue.Value,
+            ["map_id"] = context.Item.MapId,
+            ["x"] = context.Item.Position.X,
+            ["y"] = context.Item.Position.Y,
+            ["z"] = context.Item.Position.Z
+        };
+
+        var table = new Table(_script)
+        {
+            ["hook"] = GetHookName(hook),
+            ["item"] = item,
+            ["container_id"] = (double)(uint)context.ContainerId
+        };
+
+        if (context.Actor is { } actor)
+        {
+            table["actor"] = new Table(_script)
+            {
+                ["serial"] = (double)(uint)actor.Id,
+                ["name"] = actor.Name,
+                ["map_id"] = actor.MapId,
+                ["x"] = actor.Position.X,
+                ["y"] = actor.Position.Y,
+                ["z"] = actor.Position.Z
+            };
+        }
+
+        if (context.Layer is { } layer)
+        {
+            table["layer"] = layer.ToString();
+        }
+
+        return table;
+    }
+
+    private static string GetHookName(ItemScriptHookType hook)
+        => hook switch
+        {
+            ItemScriptHookType.SingleClick => "on_single_click",
+            ItemScriptHookType.DoubleClick => "on_double_click",
+            ItemScriptHookType.Dropped     => "on_drop",
+            ItemScriptHookType.Equipped    => "on_equip",
+            ItemScriptHookType.Unequipped  => "on_unequip",
+            _                              => $"unknown({(int)hook})"
+        };
+
+    private static bool IsCallable(DynValue value)
+        => value.Type is DataType.Function or DataType.ClrFunction;
+
+    [GeneratedRegex("^[a-z0-9_]+$")]
+    private static partial Regex ValidScriptIdPattern();
+
+    private Table? Load(string scriptId)
+    {
+        // The pattern is what keeps a ScriptId from walking out of the items directory.
+        if (!ValidScriptIdPattern().IsMatch(scriptId))
+        {
+            _logger.Warning("Item script id '{ScriptId}' is not a valid name; ignored", scriptId);
+
+            return null;
+        }
+
+        var path = Path.Combine(_itemsDirectory, scriptId + ".lua");
+
+        if (!File.Exists(path))
+        {
+            _logger.Warning("Item script '{ScriptId}' was not found at {Path}", scriptId, path);
+
+            return null;
+        }
+
+        try
+        {
+            var fileInfo = new FileInfo(path);
+
+            if ((fileInfo.Attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                _logger.Warning("Item script '{ScriptId}' is a link; refused", scriptId);
+
+                return null;
+            }
+
+            if (fileInfo.Length > MaximumScriptFileBytes)
+            {
+                _logger.Warning("Item script '{ScriptId}' exceeds 256 KiB; refused", scriptId);
+
+                return null;
+            }
+
+            var chunk = _script.LoadFile(path, _script.Globals, path);
+            var coroutine = _script.CreateCoroutine(chunk).Coroutine;
+            coroutine.AutoYieldCounter = InstructionBudget;
+
+            var result = coroutine.Resume();
+
+            if (result.Type != DataType.Table)
+            {
+                _logger.Warning("Item script '{ScriptId}' did not return a table; ignored", scriptId);
+
+                return null;
+            }
+
+            return result.Table;
+        }
+        catch (Exception exception)
+        {
+            _logger.Error(exception, "Item script '{ScriptId}' failed to load", scriptId);
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Loads a script the first time its id is asked for and remembers the outcome, misses included,
+    /// so a template with a typo does not hit the disk on every click.
+    /// </summary>
+    private Table? TryGetDefinition(string? scriptId)
+    {
+        if (string.IsNullOrWhiteSpace(scriptId) ||
+            string.Equals(scriptId, NoScript, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        if (_definitions.TryGetValue(scriptId, out var cached))
+        {
+            return cached;
+        }
+
+        var definition = Load(scriptId);
+        _definitions[scriptId] = definition;
+
+        return definition;
+    }
+}

--- a/src/Moongate.Scripting/Moongate.Scripting.csproj
+++ b/src/Moongate.Scripting/Moongate.Scripting.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
         <EmbeddedResource Include="Assets\Brains\**\*.lua"/>
+        <EmbeddedResource Include="Assets\Items\**\*.lua"/>
     </ItemGroup>
 
 </Project>

--- a/src/Moongate.Scripting/MoongateScriptingPlugin.cs
+++ b/src/Moongate.Scripting/MoongateScriptingPlugin.cs
@@ -1,7 +1,9 @@
 using DryIoc;
 using Moongate.Scripting.AI;
+using Moongate.Scripting.Items;
 using Moongate.Scripting.Modules;
 using Moongate.Server.Abstractions.Interfaces.AI;
+using Moongate.Server.Abstractions.Interfaces.Items;
 using SquidStd.Abstractions.Extensions.Services;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Directories;
@@ -10,6 +12,8 @@ using SquidStd.Plugin.Abstractions.Data;
 using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
 using SquidStd.Scripting.Lua.Extensions.Scripts;
 using SquidStd.Scripting.Lua.Interfaces.Events;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+using SquidStd.Scripting.Lua.Services;
 
 namespace Moongate.Scripting;
 
@@ -40,6 +44,20 @@ public class MoongateScriptingPlugin : ISquidStdPlugin
         );
 
         container.RegisterStdService<INpcBrainRuntime, LuaNpcBrainRuntime>();
+
+        // The MoonSharp Script itself is not in the container: the Lua engine owns it. Resolve the
+        // engine and unwrap it here, so the cast lives in one place instead of in every consumer.
+        container.RegisterDelegate<IItemScriptRuntime>(
+            resolver => new LuaItemScriptRuntime(
+                resolver.Resolve<IScriptEngineService>() is LuaScriptEngineService lua
+                    ? lua.LuaScript
+                    : throw new InvalidOperationException(
+                        "LuaItemScriptRuntime requires the SquidStd Lua engine implementation."
+                    ),
+                resolver.Resolve<DirectoriesConfig>()
+            ),
+            Reuse.Singleton
+        );
 
         container.Register<ILuaInvokeMarshaller, LoopAffineInvokeMarshaller>(Reuse.Singleton);
 

--- a/src/Moongate.Server.Abstractions/Data/Events/ItemDroppedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/ItemDroppedEvent.cs
@@ -1,0 +1,10 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>
+/// Raised when a player puts down an item they were holding. <paramref name="ContainerId" /> is the
+/// container it went into, or <see cref="Serial.Zero" /> when it was dropped on the ground.
+/// </summary>
+public sealed record ItemDroppedEvent(Serial Item, Serial Actor, Serial ContainerId) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/ItemEquippedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/ItemEquippedEvent.cs
@@ -1,0 +1,8 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>Raised when an item is placed on a mobile's paperdoll layer.</summary>
+public sealed record ItemEquippedEvent(Serial Item, Serial Mobile, LayerType Layer) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Events/ItemUnequippedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/ItemUnequippedEvent.cs
@@ -1,0 +1,8 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>Raised when an item is taken off a mobile's paperdoll layer.</summary>
+public sealed record ItemUnequippedEvent(Serial Item, Serial Mobile, LayerType Layer) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Data/Internal/ItemScriptContext.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/ItemScriptContext.cs
@@ -1,0 +1,22 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// What an item-script hook is told: the item it fired for, who caused it, and the two fields that
+/// only some hooks carry. <see cref="Actor" /> is null when nobody caused it — a script fired by the
+/// world rather than by a player.
+/// </summary>
+public sealed record ItemScriptContext(
+    ItemEntity Item,
+    MobileEntity? Actor,
+    Serial ContainerId,
+    LayerType? Layer
+)
+{
+    /// <summary>The shape for the three hooks that carry neither a container nor a layer.</summary>
+    public static ItemScriptContext For(ItemEntity item, MobileEntity? actor)
+        => new(item, actor, Serial.Zero, null);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IItemScriptRuntime.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IItemScriptRuntime.cs
@@ -1,0 +1,25 @@
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Types.Items;
+
+namespace Moongate.Server.Abstractions.Interfaces.Items;
+
+/// <summary>
+/// Runs the Lua hooks an item's <c>ScriptId</c> points at. Resolution is by id alone: an item with
+/// <c>ScriptId: magic_torch</c> runs <c>&lt;scripts&gt;/items/magic_torch.lua</c>, which returns a
+/// table whose <c>on_*</c> functions are the hooks.
+/// </summary>
+public interface IItemScriptRuntime
+{
+    /// <summary>
+    /// True when the script named <paramref name="scriptId" /> exists and defines
+    /// <paramref name="hook" />. Answers without running anything.
+    /// </summary>
+    bool HasHook(string scriptId, ItemScriptHookType hook);
+
+    /// <summary>
+    /// Runs <paramref name="hook" /> for the item in <paramref name="context" />. Returns false when
+    /// the item has no script, the script has no such hook, or the call failed — a script error is
+    /// logged and swallowed, never propagated into the game loop.
+    /// </summary>
+    bool Invoke(ItemScriptHookType hook, ItemScriptContext context);
+}

--- a/src/Moongate.Server.Abstractions/Types/Items/ItemScriptHookType.cs
+++ b/src/Moongate.Server.Abstractions/Types/Items/ItemScriptHookType.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Server.Abstractions.Types.Items;
+
+/// <summary>
+/// The moments an item script can react to. Each maps to one Lua function name on the script's
+/// table — see <c>LuaItemScriptRuntime.GetHookName</c>.
+/// </summary>
+public enum ItemScriptHookType
+{
+    SingleClick,
+    DoubleClick,
+    Dropped,
+    Equipped,
+    Unequipped
+}

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -30,6 +30,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<SpatialSubscriber>();
         container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
         container.RegisterEventSubscriber<HeldItemBounceSubscriber>();
+        container.RegisterEventSubscriber<ItemScriptSubscriber>();
 
         container.RegisterStdService<IEventSubscriberService, EventSubscriberService>();
     }

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -4,11 +4,13 @@ using Moongate.Core.Primitives;
 using Moongate.Network.Packets.Outgoing;
 using Moongate.Network.Types;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Internal;
 using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.UO.Data.Items;
+using SquidStd.Core.Interfaces.Events;
 
 namespace Moongate.Server.Services.Items;
 
@@ -33,13 +35,15 @@ public sealed class DragDropService : IDragDropService
     private readonly IItemTemplateService _templates;
     private readonly IWorldService _world;
     private readonly ILoopAffinity? _loopAffinity;
+    private readonly IEventBus? _eventBus;
 
     public DragDropService(
         IItemService items,
         IItemFactoryService itemFactory,
         IItemTemplateService templates,
         IWorldService world,
-        ILoopAffinity? loopAffinity = null
+        ILoopAffinity? loopAffinity = null,
+        IEventBus? eventBus = null
     )
     {
         _items = items;
@@ -47,6 +51,7 @@ public sealed class DragDropService : IDragDropService
         _templates = templates;
         _world = world;
         _loopAffinity = loopAffinity;
+        _eventBus = eventBus;
     }
 
     /// <summary>
@@ -258,6 +263,8 @@ public sealed class DragDropService : IDragDropService
 
         PlaceOnGround(item, actor.MapId, position);
 
+        _eventBus?.Publish(new ItemDroppedEvent(item.Id, actor.Id, Serial.Zero));
+
         return new(true, LiftRejectReasonType.Inspecific);
     }
 
@@ -296,12 +303,16 @@ public sealed class DragDropService : IDragDropService
 
             _world.SendToPlayer(actor.Id, ContainerPacket(stack, container.Id, stack.ContainerPosition));
 
+            _eventBus?.Publish(new ItemDroppedEvent(stack.Id, actor.Id, container.Id));
+
             return new(true, LiftRejectReasonType.Inspecific);
         }
 
         _items.AddToContainer(container, item, position);
 
         _world.SendToPlayer(actor.Id, ContainerPacket(item, container.Id, position));
+
+        _eventBus?.Publish(new ItemDroppedEvent(item.Id, actor.Id, container.Id));
 
         return new(true, LiftRejectReasonType.Inspecific);
     }

--- a/src/Moongate.Server/Services/Items/ItemService.cs
+++ b/src/Moongate.Server/Services/Items/ItemService.cs
@@ -3,9 +3,11 @@ using Moongate.Core.Geometry;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Ultima.Types;
+using SquidStd.Core.Interfaces.Events;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.Server.Services.Items;
@@ -18,6 +20,7 @@ public sealed class ItemService : IItemService
     private readonly IOplService? _opl;
     private readonly ISpatialIndexService? _spatial;
     private readonly ILoopAffinity? _loopAffinity;
+    private readonly IEventBus? _eventBus;
 
     // The property-list cache and the spatial index are optional on purpose: tests build a bare
     // ItemService, and both are concerns the item flows only need to keep in sync, not require.
@@ -25,7 +28,8 @@ public sealed class ItemService : IItemService
         IPersistenceService persistenceService,
         IOplService? opl = null,
         ISpatialIndexService? spatial = null,
-        ILoopAffinity? loopAffinity = null
+        ILoopAffinity? loopAffinity = null,
+        IEventBus? eventBus = null
     )
     {
         _items = persistenceService.GetStore<ItemEntity, Serial>();
@@ -33,6 +37,7 @@ public sealed class ItemService : IItemService
         _opl = opl;
         _spatial = spatial;
         _loopAffinity = loopAffinity;
+        _eventBus = eventBus;
     }
 
     public void AddToContainer(ItemEntity container, ItemEntity item, Point2D position)
@@ -115,6 +120,8 @@ public sealed class ItemService : IItemService
         }
 
         _mobiles.UpsertAsync(mobile).WaitSync();
+
+        _eventBus?.Publish(new ItemEquippedEvent(item.Id, mobile.Id, layer));
     }
 
     public bool Flip(ItemEntity item)
@@ -208,6 +215,8 @@ public sealed class ItemService : IItemService
             item.EquippedLayer = null;
             _items.UpsertAsync(item).WaitSync();
             _spatial?.AddOrUpdate(item);
+
+            _eventBus?.Publish(new ItemUnequippedEvent(item.Id, mobile.Id, layer));
         }
 
         return item;

--- a/src/Moongate.Server/Subscribers/ItemScriptSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/ItemScriptSubscriber.cs
@@ -1,0 +1,101 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Types.Items;
+using Moongate.Ultima.Types;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Turns the five item events into item-script hook calls. Every event it listens to is loop-affine,
+/// so the hooks run on the game loop and a script may touch world state directly. Handlers are public
+/// so tests can drive them without a dispatching event bus.
+/// </summary>
+public sealed class ItemScriptSubscriber : IEventSubscriberRegistration
+{
+    private readonly IItemService _items;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IItemScriptRuntime _scripts;
+    private readonly ISessionManager _sessions;
+
+    public ItemScriptSubscriber(
+        IItemService items,
+        IPersistenceService persistenceService,
+        IItemScriptRuntime scripts,
+        ISessionManager sessions
+    )
+    {
+        _items = items;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _scripts = scripts;
+        _sessions = sessions;
+    }
+
+    public Task OnItemDoubleClick(ItemDoubleClickEvent message, CancellationToken cancellationToken)
+        => Dispatch(ItemScriptHookType.DoubleClick, message.Serial, Clicker(message.SessionId), Serial.Zero, null);
+
+    public Task OnItemDropped(ItemDroppedEvent message, CancellationToken cancellationToken)
+        => Dispatch(
+            ItemScriptHookType.Dropped,
+            message.Item,
+            _mobiles.GetById(message.Actor),
+            message.ContainerId,
+            null
+        );
+
+    public Task OnItemEquipped(ItemEquippedEvent message, CancellationToken cancellationToken)
+        => Dispatch(
+            ItemScriptHookType.Equipped,
+            message.Item,
+            _mobiles.GetById(message.Mobile),
+            Serial.Zero,
+            message.Layer
+        );
+
+    public Task OnItemSingleClick(ItemSingleClickEvent message, CancellationToken cancellationToken)
+        => Dispatch(ItemScriptHookType.SingleClick, message.Serial, Clicker(message.SessionId), Serial.Zero, null);
+
+    public Task OnItemUnequipped(ItemUnequippedEvent message, CancellationToken cancellationToken)
+        => Dispatch(
+            ItemScriptHookType.Unequipped,
+            message.Item,
+            _mobiles.GetById(message.Mobile),
+            Serial.Zero,
+            message.Layer
+        );
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<ItemSingleClickEvent>(OnItemSingleClick);
+        eventBus.Subscribe<ItemDoubleClickEvent>(OnItemDoubleClick);
+        eventBus.Subscribe<ItemDroppedEvent>(OnItemDropped);
+        eventBus.Subscribe<ItemEquippedEvent>(OnItemEquipped);
+        eventBus.Subscribe<ItemUnequippedEvent>(OnItemUnequipped);
+    }
+
+    /// <summary>The character behind a click, or null when the session is gone or has none.</summary>
+    private MobileEntity? Clicker(long sessionId)
+        => _sessions.TryGet(sessionId, out var session) ? session.Character : null;
+
+    private Task Dispatch(
+        ItemScriptHookType hook,
+        Serial itemId,
+        MobileEntity? actor,
+        Serial containerId,
+        LayerType? layer
+    )
+    {
+        // A deleted item, or one whose script does not exist, is not an error: most items have none.
+        if (_items.GetById(itemId) is { } item)
+        {
+            _scripts.Invoke(hook, new(item, actor, containerId, layer));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Moongate.Tests/Scripting/LuaItemScriptRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaItemScriptRuntimeTests.cs
@@ -1,0 +1,183 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Scripting.Items;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Types.Items;
+using MoonSharp.Interpreter;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Scripting;
+
+public class LuaItemScriptRuntimeTests
+{
+    [Fact]
+    public void HasHook_ReportsWhatTheScriptDefines()
+    {
+        using var fixture = new Fixture();
+        fixture.WriteScript(
+            "magic_torch",
+            """
+            local torch = { id = "magic_torch" }
+
+            function torch.on_equip(ctx) end
+
+            return torch
+            """
+        );
+
+        Assert.True(fixture.Runtime.HasHook("magic_torch", ItemScriptHookType.Equipped));
+        Assert.False(fixture.Runtime.HasHook("magic_torch", ItemScriptHookType.Unequipped));
+    }
+
+    [Fact]
+    public void Invoke_CallsTheMatchingHookAndSeesTheItem()
+    {
+        using var fixture = new Fixture();
+        fixture.WriteScript(
+            "magic_torch",
+            """
+            local torch = { id = "magic_torch" }
+
+            function torch.on_double_click(ctx)
+                _G.seen_serial = ctx.item.serial
+                _G.seen_name = ctx.item.name
+                _G.seen_actor = ctx.actor.serial
+            end
+
+            return torch
+            """
+        );
+
+        var item = new ItemEntity { Id = (Serial)11, TemplateId = "torch", ScriptId = "magic_torch", Name = "Torch" };
+        var actor = new MobileEntity { Id = (Serial)7 };
+
+        Assert.True(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, actor)));
+        Assert.Equal(11d, fixture.Script.Globals.Get("seen_serial").Number);
+        Assert.Equal("Torch", fixture.Script.Globals.Get("seen_name").String);
+        Assert.Equal(7d, fixture.Script.Globals.Get("seen_actor").Number);
+    }
+
+    [Fact]
+    public void Invoke_DroppedHook_CarriesTheContainer()
+    {
+        using var fixture = new Fixture();
+        fixture.WriteScript(
+            "magic_torch",
+            """
+            local torch = { id = "magic_torch" }
+
+            function torch.on_drop(ctx)
+                _G.seen_container = ctx.container_id
+            end
+
+            return torch
+            """
+        );
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "magic_torch" };
+        var context = new ItemScriptContext(item, null, (Serial)99, null);
+
+        Assert.True(fixture.Runtime.Invoke(ItemScriptHookType.Dropped, context));
+        Assert.Equal(99d, fixture.Script.Globals.Get("seen_container").Number);
+    }
+
+    [Fact]
+    public void Invoke_HookNotDefined_ReturnsFalse()
+    {
+        using var fixture = new Fixture();
+        fixture.WriteScript("magic_torch", "return { id = \"magic_torch\" }");
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "magic_torch" };
+
+        Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+    }
+
+    [Fact]
+    public void Invoke_InvalidScriptId_IsRefused()
+    {
+        // Path traversal must not resolve outside the items directory.
+        using var fixture = new Fixture();
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "../brains/guard" };
+
+        Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+    }
+
+    [Fact]
+    public void Invoke_MissingFile_ReturnsFalse()
+    {
+        using var fixture = new Fixture();
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "does_not_exist" };
+
+        Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+    }
+
+    [Fact]
+    public void Invoke_NoScriptId_ReturnsFalseWithoutTouchingTheDisk()
+    {
+        using var fixture = new Fixture();
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "" };
+
+        Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+    }
+
+    [Fact]
+    public void Invoke_ScriptIdNone_IsTreatedAsNoScript()
+    {
+        // "none" is what the shipped item templates carry, and it is not a script.
+        using var fixture = new Fixture();
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "none" };
+
+        Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+    }
+
+    [Fact]
+    public void Invoke_ScriptThatThrows_IsSwallowed()
+    {
+        using var fixture = new Fixture();
+        fixture.WriteScript(
+            "broken",
+            """
+            local broken = { id = "broken" }
+
+            function broken.on_double_click(ctx)
+                error("boom")
+            end
+
+            return broken
+            """
+        );
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "broken" };
+
+        // A content author's mistake must not take down the game loop.
+        Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _root;
+
+        public Script Script { get; }
+
+        public LuaItemScriptRuntime Runtime { get; }
+
+        public Fixture()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "mg-item-scripts-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(_root, "scripts", "items"));
+
+            Script = new Script();
+            Runtime = new LuaItemScriptRuntime(Script, new DirectoriesConfig(_root, ["scripts"]));
+        }
+
+        public void WriteScript(string id, string body)
+            => File.WriteAllText(Path.Combine(_root, "scripts", "items", id + ".lua"), body);
+
+        public void Dispose()
+            => Directory.Delete(_root, true);
+    }
+}

--- a/tests/Moongate.Tests/Scripting/LuaItemScriptRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaItemScriptRuntimeTests.cs
@@ -135,6 +135,15 @@ public class LuaItemScriptRuntimeTests
     }
 
     [Fact]
+    public void Invoke_ShippedExample_IsSeededAndLoads()
+    {
+        using var fixture = new Fixture();
+
+        // Nothing was written by the test: the runtime seeds the shipped scripts on first use.
+        Assert.True(fixture.Runtime.HasHook("magic_torch", ItemScriptHookType.DoubleClick));
+    }
+
+    [Fact]
     public void Invoke_ScriptThatThrows_IsSwallowed()
     {
         using var fixture = new Fixture();

--- a/tests/Moongate.Tests/Server/Items/DragDropServiceDropTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropServiceDropTests.cs
@@ -1,6 +1,7 @@
 using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Network.Types;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Tests.Support;
 
 namespace Moongate.Tests.Server.Items;
@@ -73,6 +74,28 @@ public class DragDropServiceDropTests
         Assert.Equal(1, fixture.Gold.MapId);
         Assert.Equal(new Point3D(101, 100, 0), fixture.Gold.Position);
         Assert.Equal(Serial.Zero, fixture.Gold.ParentContainerId);
+    }
+
+    [Fact]
+    public void Drop_OnTheGround_PublishesItemDropped()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(amount: 1);
+        ItemDroppedEvent? published = null;
+        fixture.EventBus.Subscribe<ItemDroppedEvent>(
+            (evt, _) =>
+            {
+                published = evt;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 1, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, Serial.Zero, new(101, 100, 0), Point2D.Zero);
+
+        Assert.NotNull(published);
+        Assert.Equal(fixture.Gold.Id, published!.Item);
+        Assert.Equal(Serial.Zero, published.ContainerId);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Items/ItemLifecycleEventsTests.cs
+++ b/tests/Moongate.Tests/Server/Items/ItemLifecycleEventsTests.cs
@@ -1,0 +1,94 @@
+using Moongate.Core.Extensions;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Services.Items;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Items;
+
+public class ItemLifecycleEventsTests
+{
+    [Fact]
+    public void Equip_PublishesItemEquipped()
+    {
+        var persistence = new FakePersistenceService();
+        var bus = new EventBusService();
+        ItemEquippedEvent? published = null;
+        bus.Subscribe<ItemEquippedEvent>(
+            (evt, _) =>
+            {
+                published = evt;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var service = new ItemService(persistence, eventBus: bus);
+        var mobile = new MobileEntity { MapId = 1, Position = new(100, 100, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var shirt = new ItemEntity { TemplateId = "shirt", ItemId = 5399 };
+        service.Create(shirt);
+        service.Equip(mobile, shirt, LayerType.Shirt);
+
+        Assert.NotNull(published);
+        Assert.Equal(shirt.Id, published!.Item);
+        Assert.Equal(mobile.Id, published.Mobile);
+        Assert.Equal(LayerType.Shirt, published.Layer);
+    }
+
+    [Fact]
+    public void Unequip_PublishesItemUnequipped()
+    {
+        var persistence = new FakePersistenceService();
+        var bus = new EventBusService();
+        ItemUnequippedEvent? published = null;
+        bus.Subscribe<ItemUnequippedEvent>(
+            (evt, _) =>
+            {
+                published = evt;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var service = new ItemService(persistence, eventBus: bus);
+        var mobile = new MobileEntity { MapId = 1, Position = new(100, 100, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var shirt = new ItemEntity { TemplateId = "shirt", ItemId = 5399 };
+        service.Create(shirt);
+        service.Equip(mobile, shirt, LayerType.Shirt);
+        service.Unequip(mobile, LayerType.Shirt);
+
+        Assert.NotNull(published);
+        Assert.Equal(shirt.Id, published!.Item);
+        Assert.Equal(LayerType.Shirt, published.Layer);
+    }
+
+    [Fact]
+    public void Unequip_OfAnEmptyLayer_PublishesNothing()
+    {
+        var persistence = new FakePersistenceService();
+        var bus = new EventBusService();
+        var published = 0;
+        bus.Subscribe<ItemUnequippedEvent>(
+            (_, _) =>
+            {
+                published++;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var service = new ItemService(persistence, eventBus: bus);
+        var mobile = new MobileEntity { MapId = 1, Position = new(100, 100, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        service.Unequip(mobile, LayerType.Shirt);
+
+        Assert.Equal(0, published);
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/ItemScriptSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Items/ItemScriptSubscriberTests.cs
@@ -1,0 +1,76 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Types.Items;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Server.Items;
+
+public class ItemScriptSubscriberTests
+{
+    [Fact]
+    public async Task OnItemDoubleClick_InvokesTheDoubleClickHook()
+    {
+        var (subscriber, runtime, item, _) = Build();
+
+        await subscriber.OnItemDoubleClick(new(SessionId: 1, item.Id), CancellationToken.None);
+
+        var call = Assert.Single(runtime.Calls);
+        Assert.Equal(ItemScriptHookType.DoubleClick, call.Hook);
+        Assert.Equal(item.Id, call.Context.Item.Id);
+    }
+
+    [Fact]
+    public async Task OnItemDoubleClick_UnknownItem_InvokesNothing()
+    {
+        var (subscriber, runtime, _, _) = Build();
+
+        await subscriber.OnItemDoubleClick(new(SessionId: 1, (Serial)0xDEAD), CancellationToken.None);
+
+        Assert.Empty(runtime.Calls);
+    }
+
+    [Fact]
+    public async Task OnItemDropped_CarriesTheContainer()
+    {
+        var (subscriber, runtime, item, mobile) = Build();
+
+        await subscriber.OnItemDropped(new(item.Id, mobile.Id, (Serial)99), CancellationToken.None);
+
+        var call = Assert.Single(runtime.Calls);
+        Assert.Equal(ItemScriptHookType.Dropped, call.Hook);
+        Assert.Equal((Serial)99, call.Context.ContainerId);
+    }
+
+    [Fact]
+    public async Task OnItemEquipped_CarriesTheLayer()
+    {
+        var (subscriber, runtime, item, mobile) = Build();
+
+        await subscriber.OnItemEquipped(new(item.Id, mobile.Id, LayerType.Shirt), CancellationToken.None);
+
+        var call = Assert.Single(runtime.Calls);
+        Assert.Equal(ItemScriptHookType.Equipped, call.Hook);
+        Assert.Equal(LayerType.Shirt, call.Context.Layer);
+        Assert.Equal(mobile.Id, call.Context.Actor?.Id);
+    }
+
+    private static (ItemScriptSubscriber Subscriber, RecordingItemScriptRuntime Runtime, ItemEntity Item,
+        MobileEntity Mobile) Build()
+    {
+        var persistence = new FakePersistenceService();
+        var items = new Moongate.Server.Services.Items.ItemService(persistence);
+
+        var item = new ItemEntity { TemplateId = "torch", ScriptId = "magic_torch", Name = "Torch" };
+        items.Create(item);
+
+        var mobile = new MobileEntity { MapId = 1, Position = new(100, 100, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var runtime = new RecordingItemScriptRuntime();
+
+        return (new(items, persistence, runtime, new StubSessionManager()), runtime, item, mobile);
+    }
+}

--- a/tests/Moongate.Tests/Support/DragDropFixture.cs
+++ b/tests/Moongate.Tests/Support/DragDropFixture.cs
@@ -4,6 +4,7 @@ using Moongate.Persistence.Entities;
 using Moongate.Server.Services.Items;
 using Moongate.Ultima.Types;
 using Moongate.UO.Data.Hues;
+using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Support;
 
@@ -16,6 +17,8 @@ namespace Moongate.Tests.Support;
 public sealed class DragDropFixture
 {
     public FakePersistenceService Persistence { get; }
+
+    public EventBusService EventBus { get; } = new();
 
     public ItemService Items { get; }
 
@@ -49,7 +52,13 @@ public sealed class DragDropFixture
             new() { Id = "bag", Name = "Bag", Category = "Container", ItemId = 3702, IsMovable = true }
         );
 
-        Service = new(Items, new ItemFactoryService(templates, new Random(1)), templates, new StubWorldService());
+        Service = new(
+            Items,
+            new ItemFactoryService(templates, new Random(1)),
+            templates,
+            new StubWorldService(),
+            eventBus: EventBus
+        );
 
         Actor = new() { MapId = 1, Position = new(100, 100, 0) };
         Persistence.Store<MobileEntity>().UpsertAsync(Actor).WaitSync();

--- a/tests/Moongate.Tests/Support/RecordingItemScriptRuntime.cs
+++ b/tests/Moongate.Tests/Support/RecordingItemScriptRuntime.cs
@@ -1,0 +1,21 @@
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Types.Items;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Records the hook calls a subscriber makes, without running any Lua.</summary>
+public sealed class RecordingItemScriptRuntime : IItemScriptRuntime
+{
+    public List<(ItemScriptHookType Hook, ItemScriptContext Context)> Calls { get; } = [];
+
+    public bool HasHook(string scriptId, ItemScriptHookType hook)
+        => true;
+
+    public bool Invoke(ItemScriptHookType hook, ItemScriptContext context)
+    {
+        Calls.Add((hook, context));
+
+        return true;
+    }
+}


### PR DESCRIPTION
Closes the gap from #126: `ItemTemplate.ScriptId` was copied onto every item and read by nothing. Now an item with `ScriptId: magic_torch` runs `<scripts>/items/magic_torch.lua`, which returns a table with any of `on_single_click`, `on_double_click`, `on_drop`, `on_equip`, `on_unequip`.

Modelled on the NPC brain runtime rather than on the old Moongate dispatcher: same lazy load-by-id, the same guards (name pattern that cannot escape the directory, no symlinks, 256 KiB ceiling, instruction-budgeted coroutine), and the same file-returns-a-table convention brains already use — so contributors learn one shape, not two. The old implementation resolved a script through three candidate tables and four candidate function names per hook, with a fallback on the item's *name*; none of that is here.

- Three new bus events, which did not exist: `ItemDroppedEvent`, `ItemEquippedEvent`, `ItemUnequippedEvent`. Equip and unequip are raised from `ItemService`, the single writer of the item-to-mobile links, so the starting kit and a drag both produce them.
- `ItemScriptSubscriber` turns all five events into hook calls. Every one is loop-affine, so hooks run on the game loop and may touch world state directly.
- A script error is logged and swallowed: a content author's mistake never reaches the game loop. Same for a blown instruction budget.
- Ships `magic_torch.lua` as a seeded example, the way brains are shipped — an existing file is never overwritten.

Also documents `item_single_click` and `item_double_click`, which the SquidStd event forwarder had been bridging to Lua all along without anyone writing it down, and corrects the item-template page, which called `ScriptId` reserved.

Out of scope: an `on_use` hook (Moongate has no notion of 'use' distinct from double-click) and hooks on mobiles (the brains cover those).

Full suite green (1795), docfx at 0 warnings, real boot clean.