### PR TITLE
fix(scripting): resolve dotted item script ids as namespaced paths

### DIFF
--- a/docs/scripting/data/item-templates.md
+++ b/docs/scripting/data/item-templates.md
@@ -63,7 +63,7 @@ of templates.
 | `Hue` | `int` | optional, default `0` | Default hue index, used unless the caller passes an explicit hue (e.g. `item.create`'s hue argument). |
 | `GoldValue` | `int` | optional, default `0` | Declared gold value. **Reserved** — not read by `ItemFactoryService` or copied onto the spawned item today. |
 | `Weight` | `double` | optional, default `0.0` | Item weight. Must be finite and non-negative. |
-| `ScriptId` | `string` | optional, default `""` | Names the Lua script that runs when players interact with the item — `magic_torch` means `scripts/items/magic_torch.lua`. Must match `^[a-z0-9_]+$`. `none` or empty means no script. See [Item scripts](../reference/item-scripts.md). |
+| `ScriptId` | `string` | optional, default `""` | Names the Lua script that runs when players interact with the item; the dot is a namespace, so `items.magic_torch` means `scripts/items/magic_torch.lua`. Must match `^[a-z0-9_]+(\.[a-z0-9_]+)*$`. `none` or empty means no script. See [Item scripts](../reference/item-scripts.md). |
 | `IsMovable` | `bool` | optional, default `false` | Whether the item can be picked up. `false` refuses the lift with `CannotLift` (0x27). Not read by `ItemFactoryService` — it is enforced at drag time by `DragDropService`. |
 | `Rarity` | `ItemRarityType` enum | optional, default `Common` | One of `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`, `Artifact`. Must be a defined member. Copied onto the spawned item's `Rarity`. |
 | `Tags` | `List<string>` | optional, default `[]` | Free-form labels. Drives `item.create_by_tag` / `CreateByTag`, and is the pool loot entries' `ItemTag` matches against. Cannot be an explicit YAML null. |

--- a/docs/scripting/reference/item-scripts.md
+++ b/docs/scripting/reference/item-scripts.md
@@ -1,7 +1,9 @@
 # Item scripts
 
-An item template's `ScriptId` names a Lua script that runs when players interact with the item.
-`ScriptId: magic_torch` means `<root>/scripts/items/magic_torch.lua`.
+An item template's `ScriptId` names a Lua script that runs when players interact with the item. The
+dot is a namespace separator, so `ScriptId: items.magic_torch` means
+`<root>/scripts/items/magic_torch.lua`, and every shipped template that has a script uses the
+`items.` namespace.
 
 | Concern | Type |
 |---|---|
@@ -17,7 +19,7 @@ the hooks. Item scripts are simpler — no per-instance state, no tick, no bindi
 
 ```lua
 local magic_torch = {
-    id = "magic_torch",
+    id = "items.magic_torch",
 }
 
 function magic_torch.on_double_click(ctx)
@@ -91,8 +93,10 @@ Hooks run **on the game-loop thread**, so they may touch world state directly �
 
 The runtime is deliberately unforgiving, so a content mistake cannot take the server with it:
 
-- **A script id must match `^[a-z0-9_]+$`.** Anything else is refused, which is what stops a
-  `ScriptId` from resolving outside the items directory.
+- **A script id is dot-separated lowercase segments** — `^[a-z0-9_]+(\.[a-z0-9_]+)*$`. No path
+  separator and no empty segment can match, so no id can name a parent directory and nothing resolves
+  outside `scripts/`. A bare id with no dot, like `magic_torch`, is a script at the root of
+  `scripts/`.
 - **A file may not exceed 256 KiB**, and may not be a symbolic link.
 - **A hook gets 50 000 VM instructions.** Exceeding the budget aborts that call with a warning.
 - **A hook may not yield.**

--- a/src/Moongate.Scripting/Assets/Items/magic_torch.lua
+++ b/src/Moongate.Scripting/Assets/Items/magic_torch.lua
@@ -1,8 +1,9 @@
--- Example item script. An item template with `ScriptId: magic_torch` runs these hooks.
+-- Example item script. An item template with `ScriptId: items.magic_torch` runs these hooks —
+-- the dot is a namespace, so that id is this file, scripts/items/magic_torch.lua.
 -- Every hook is optional: define only the ones you need.
 
 local magic_torch = {
-    id = "magic_torch",
+    id = "items.magic_torch",
 }
 
 function magic_torch.on_double_click(ctx)

--- a/src/Moongate.Scripting/Items/LuaItemScriptRuntime.cs
+++ b/src/Moongate.Scripting/Items/LuaItemScriptRuntime.cs
@@ -24,14 +24,16 @@ public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
 
     private readonly ILogger _logger = Log.ForContext<LuaItemScriptRuntime>();
     private readonly Script _script;
-    private readonly string _itemsDirectory;
+    private readonly string _scriptsDirectory;
+    private readonly string _seedDirectory;
     private readonly Dictionary<string, Table?> _definitions = new(StringComparer.Ordinal);
     private bool _seeded;
 
     public LuaItemScriptRuntime(Script script, DirectoriesConfig directoriesConfig)
     {
         _script = script;
-        _itemsDirectory = Path.Combine(directoriesConfig.GetPath("scripts"), "items");
+        _scriptsDirectory = directoriesConfig.GetPath("scripts");
+        _seedDirectory = Path.Combine(_scriptsDirectory, "items");
     }
 
     public bool HasHook(string scriptId, ItemScriptHookType hook)
@@ -144,12 +146,16 @@ public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
     private static bool IsCallable(DynValue value)
         => value.Type is DataType.Function or DataType.ClrFunction;
 
-    [GeneratedRegex("^[a-z0-9_]+$")]
+    /// <summary>
+    /// Dot-separated lowercase segments: <c>items.light_source</c>, or a bare <c>magic_torch</c>. No
+    /// separator and no empty segment can match, so no id can name a parent directory.
+    /// </summary>
+    [GeneratedRegex(@"^[a-z0-9_]+(\.[a-z0-9_]+)*$")]
     private static partial Regex ValidScriptIdPattern();
 
     private Table? Load(string scriptId)
     {
-        // The pattern is what keeps a ScriptId from walking out of the items directory.
+        // The pattern is what keeps a ScriptId from walking out of the scripts directory.
         if (!ValidScriptIdPattern().IsMatch(scriptId))
         {
             _logger.Warning("Item script id '{ScriptId}' is not a valid name; ignored", scriptId);
@@ -157,7 +163,10 @@ public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
             return null;
         }
 
-        var path = Path.Combine(_itemsDirectory, scriptId + ".lua");
+        // The dot is a namespace separator, which is how the shipped templates read: the 129 that
+        // carry a script all say items.<something>, and that is the file scripts/items/<something>.lua.
+        var relativePath = Path.Combine(scriptId.Split('.')) + ".lua";
+        var path = Path.Combine(_scriptsDirectory, relativePath);
 
         if (!File.Exists(path))
         {
@@ -223,7 +232,7 @@ public sealed partial class LuaItemScriptRuntime : IItemScriptRuntime
         if (!_seeded)
         {
             _seeded = true;
-            ItemScriptAssetSeeder.SeedMissing(_itemsDirectory);
+            ItemScriptAssetSeeder.SeedMissing(_seedDirectory);
         }
 
         if (_definitions.TryGetValue(scriptId, out var cached))

--- a/tests/Moongate.Tests/Scripting/LuaItemScriptRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaItemScriptRuntimeTests.cs
@@ -93,12 +93,42 @@ public class LuaItemScriptRuntimeTests
     }
 
     [Fact]
-    public void Invoke_InvalidScriptId_IsRefused()
+    public void Invoke_DottedScriptId_ResolvesAsAPathUnderScripts()
     {
-        // Path traversal must not resolve outside the items directory.
+        // Every shipped template uses this shape: items.light_source, items.food, items.beverage.
+        using var fixture = new Fixture();
+        fixture.WriteScript(
+            "items/light_source",
+            """
+            local light = { id = "items.light_source" }
+
+            function light.on_double_click(ctx)
+                _G.lit = true
+            end
+
+            return light
+            """
+        );
+
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = "items.light_source" };
+
+        Assert.True(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
+        Assert.True(fixture.Script.Globals.Get("lit").Boolean);
+    }
+
+    [Theory]
+    [InlineData("../brains/guard")]  // a separator is never allowed
+    [InlineData("..")]               // nor a bare parent
+    [InlineData("items..food")]      // nor an empty segment
+    [InlineData(".items")]           // nor a leading dot
+    [InlineData("items.")]           // nor a trailing one
+    [InlineData("Items.Food")]       // nor uppercase
+    public void Invoke_InvalidScriptId_IsRefused(string scriptId)
+    {
+        // Nothing may resolve outside the scripts directory.
         using var fixture = new Fixture();
 
-        var item = new ItemEntity { Id = (Serial)11, ScriptId = "../brains/guard" };
+        var item = new ItemEntity { Id = (Serial)11, ScriptId = scriptId };
 
         Assert.False(fixture.Runtime.Invoke(ItemScriptHookType.DoubleClick, ItemScriptContext.For(item, null)));
     }
@@ -140,7 +170,7 @@ public class LuaItemScriptRuntimeTests
         using var fixture = new Fixture();
 
         // Nothing was written by the test: the runtime seeds the shipped scripts on first use.
-        Assert.True(fixture.Runtime.HasHook("magic_torch", ItemScriptHookType.DoubleClick));
+        Assert.True(fixture.Runtime.HasHook("items.magic_torch", ItemScriptHookType.DoubleClick));
     }
 
     [Fact]
@@ -183,8 +213,13 @@ public class LuaItemScriptRuntimeTests
             Runtime = new LuaItemScriptRuntime(Script, new DirectoriesConfig(_root, ["scripts"]));
         }
 
-        public void WriteScript(string id, string body)
-            => File.WriteAllText(Path.Combine(_root, "scripts", "items", id + ".lua"), body);
+        /// <summary>Writes a script at a path relative to the scripts directory, without the extension.</summary>
+        public void WriteScript(string relativePath, string body)
+        {
+            var path = Path.Combine(_root, "scripts", relativePath.Replace('/', Path.DirectorySeparatorChar) + ".lua");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, body);
+        }
 
         public void Dispose()
             => Directory.Delete(_root, true);


### PR DESCRIPTION
Fixes #128, a defect in #127 from earlier today.

`LuaItemScriptRuntime` validated script ids with `^[a-z0-9_]+$`, which refuses a dot — but every one of the **129 shipped templates** that carries a script uses a dotted id: `items.food` (78), `items.light_source` (21), `items.beverage` (15), and so on. All of them were rejected with a warning, so no shipped item could ever have run a script. Nothing looked broken only because none of those script files exist yet.

The dot reads as a namespace separator, and moongatev2's file layout agrees: `ScriptId: items.light_source` was the script at `scripts/items/light_source.lua`. So an id is now dot-separated lowercase segments — `^[a-z0-9_]+(\.[a-z0-9_]+)*$` — resolved as a path under `scripts/`.

Traversal stays impossible by construction: no path separator and no empty segment can match, so no id can name a parent directory. Six refusal cases cover it — `../brains/guard`, `..`, `items..food`, `.items`, `items.`, `Items.Food`.

The shipped example is now `items.magic_torch`, which is the same file in the same place, and matches the namespace every real template uses.

Full suite green (1801), docfx at 0 warnings.