### PR TITLE
feat(items): repaint an item when its fields change

### DIFF
--- a/docs/scripting/reference/item.md
+++ b/docs/scripting/reference/item.md
@@ -102,6 +102,11 @@ Mutates the item from a `fields` table and saves it. Recognised keys are read
 and applied; anything else is ignored. Returns `true` on success, `false` when
 the serial is unknown or `fields` is missing.
 
+The change is **redrawn on every client that can see the item** — on the ground,
+on a paperdoll, or inside a container someone has open. That is what makes a
+graphic swap visible: setting `item_id` to a lit torch lights it up on screen
+straight away, rather than the next time the item comes back into view.
+
 Recognised keys: `amount` (number), `hue` (number), `item_id` (number),
 `name` (string).
 

--- a/src/Moongate.Server.Abstractions/Data/Events/ItemChangedEvent.cs
+++ b/src/Moongate.Server.Abstractions/Data/Events/ItemChangedEvent.cs
@@ -1,0 +1,10 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Events;
+
+namespace Moongate.Server.Abstractions.Data.Events;
+
+/// <summary>
+/// Raised when an item's own fields change — its graphic, hue, name or amount. Not raised when it
+/// merely moves: equipping, containing and dropping have their own events and send their own packets.
+/// </summary>
+public sealed record ItemChangedEvent(Serial Item) : ILoopAffineEvent;

--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IContainerOpenerRegistry.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IContainerOpenerRegistry.cs
@@ -1,0 +1,23 @@
+using Moongate.Core.Primitives;
+
+namespace Moongate.Server.Abstractions.Interfaces.Items;
+
+/// <summary>
+/// Remembers which mobiles have which containers open, so an item inside one can be redrawn for the
+/// players actually looking at it. There is no close packet worth trusting, so entries are dropped
+/// when the opener walks out of range — the same lazy pruning ModernUO does.
+/// </summary>
+public interface IContainerOpenerRegistry
+{
+    /// <summary>Drops <paramref name="mobile" /> from <paramref name="container" />'s openers.</summary>
+    void Closed(Serial container, Serial mobile);
+
+    /// <summary>Drops <paramref name="mobile" /> from every container it had open.</summary>
+    void ForgetMobile(Serial mobile);
+
+    /// <summary>Records that <paramref name="mobile" /> is looking inside <paramref name="container" />.</summary>
+    void Opened(Serial container, Serial mobile);
+
+    /// <summary>The mobiles believed to have <paramref name="container" /> open. Never null.</summary>
+    IReadOnlyCollection<Serial> OpenersOf(Serial container);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IItemService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IItemService.cs
@@ -48,6 +48,12 @@ public interface IItemService
 
     void RemoveFromContainer(ItemEntity container, ItemEntity item);
 
+    /// <summary>
+    /// Walks up the container chain to the item that is actually somewhere — lying on a map or worn by
+    /// a mobile. Returns <paramref name="item" /> itself when it is already that item.
+    /// </summary>
+    ItemEntity RootOf(ItemEntity item);
+
     /// <summary>Persists changes to an existing item.</summary>
     void Save(ItemEntity item);
 

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -31,6 +31,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
         container.RegisterEventSubscriber<HeldItemBounceSubscriber>();
         container.RegisterEventSubscriber<ItemScriptSubscriber>();
+        container.RegisterEventSubscriber<ItemRefreshSubscriber>();
 
         container.RegisterStdService<IEventSubscriberService, EventSubscriberService>();
     }

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -195,6 +195,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IItemFactoryService, ItemFactoryService>(Reuse.Singleton);
                 container.Register<IItemService, ItemService>(Reuse.Singleton);
                 container.Register<IDragDropService, DragDropService>(Reuse.Singleton);
+                container.Register<IContainerOpenerRegistry, ContainerOpenerRegistry>(Reuse.Singleton);
                 container.Register<ILootService, LootService>(Reuse.Singleton);
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Items/ContainerOpenerRegistry.cs
+++ b/src/Moongate.Server/Services/Items/ContainerOpenerRegistry.cs
@@ -1,0 +1,44 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Interfaces.Items;
+
+namespace Moongate.Server.Services.Items;
+
+/// <summary>
+/// In-memory <see cref="IContainerOpenerRegistry" />. Deliberately not persisted: an open gump is a
+/// property of a live connection, and every session starts with nothing open.
+/// </summary>
+public sealed class ContainerOpenerRegistry : IContainerOpenerRegistry
+{
+    private readonly Dictionary<Serial, HashSet<Serial>> _openers = new();
+
+    public void Closed(Serial container, Serial mobile)
+    {
+        if (_openers.TryGetValue(container, out var mobiles) && mobiles.Remove(mobile) && mobiles.Count == 0)
+        {
+            _openers.Remove(container);
+        }
+    }
+
+    public void ForgetMobile(Serial mobile)
+    {
+        foreach (var container in _openers.Keys.ToList())
+        {
+            Closed(container, mobile);
+        }
+    }
+
+    public void Opened(Serial container, Serial mobile)
+    {
+        if (!_openers.TryGetValue(container, out var mobiles))
+        {
+            mobiles = [];
+            _openers[container] = mobiles;
+        }
+
+        mobiles.Add(mobile);
+    }
+
+    // Returns a copy on purpose: the refresh subscriber prunes while iterating it.
+    public IReadOnlyCollection<Serial> OpenersOf(Serial container)
+        => _openers.TryGetValue(container, out var mobiles) ? [.. mobiles] : [];
+}

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -371,27 +371,6 @@ public sealed class DragDropService : IDragDropService
         => new(item.Id, (ushort)item.ItemId, (ushort)item.Amount, position, containerId, item.Hue);
 
     /// <summary>
-    /// Walks up the container chain to the item that is actually somewhere — on the ground or on a
-    /// mobile. The guard stops a corrupted cycle from hanging the loop thread.
-    /// </summary>
-    private ItemEntity Root(ItemEntity item)
-    {
-        var current = item;
-
-        for (var depth = 0; current.ParentContainerId != Serial.Zero && depth < 32; depth++)
-        {
-            if (_items.GetById(current.ParentContainerId) is not { } parent)
-            {
-                break;
-            }
-
-            current = parent;
-        }
-
-        return current;
-    }
-
-    /// <summary>
     /// Where an item is in the world, for the range check: its own position when it lies on the
     /// ground, its root's otherwise. An item worn by the actor is wherever the actor is; one worn by
     /// somebody else keeps the stale coordinates of an equipped entity, which fails the range check —
@@ -399,7 +378,7 @@ public sealed class DragDropService : IDragDropService
     /// </summary>
     private (int MapId, Point3D Position) WorldLocation(ItemEntity item, MobileEntity actor)
     {
-        var root = Root(item);
+        var root = _items.RootOf(item);
 
         return root.EquippedMobileId == actor.Id
             ? (actor.MapId, actor.Position)
@@ -413,7 +392,7 @@ public sealed class DragDropService : IDragDropService
     /// </summary>
     private bool Reachable(ItemEntity item, MobileEntity actor)
     {
-        var root = Root(item);
+        var root = _items.RootOf(item);
 
         if (root.EquippedMobileId == actor.Id)
         {

--- a/src/Moongate.Server/Services/Items/ItemService.cs
+++ b/src/Moongate.Server/Services/Items/ItemService.cs
@@ -183,12 +183,32 @@ public sealed class ItemService : IItemService
         _spatial?.AddOrUpdate(item);
     }
 
+    public ItemEntity RootOf(ItemEntity item)
+    {
+        var current = item;
+
+        // The depth guard stops a corrupted cycle from hanging the loop thread.
+        for (var depth = 0; current.ParentContainerId != Serial.Zero && depth < 32; depth++)
+        {
+            if (_items.GetById(current.ParentContainerId) is not { } parent)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return current;
+    }
+
     public void Save(ItemEntity item)
     {
         _loopAffinity?.AssertOnLoop("item.save");
         _items.UpsertAsync(item).WaitSync();
         _opl?.Invalidate(item.Id);
         _spatial?.AddOrUpdate(item);
+
+        _eventBus?.Publish(new ItemChangedEvent(item.Id));
     }
 
     public ItemEntity? Unequip(MobileEntity mobile, LayerType layer)

--- a/src/Moongate.Server/Subscribers/ContainerSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/ContainerSubscriber.cs
@@ -23,13 +23,15 @@ public sealed class ContainerSubscriber : IEventSubscriberRegistration
     private readonly IItemTemplateService _templates;
     private readonly IContainerGumpService _gumps;
     private readonly IOplService _opl;
+    private readonly IContainerOpenerRegistry _openers;
 
     public ContainerSubscriber(
         ISessionManager sessions,
         IItemService items,
         IItemTemplateService templates,
         IContainerGumpService gumps,
-        IOplService opl
+        IOplService opl,
+        IContainerOpenerRegistry openers
     )
     {
         _sessions = sessions;
@@ -37,6 +39,7 @@ public sealed class ContainerSubscriber : IEventSubscriberRegistration
         _templates = templates;
         _gumps = gumps;
         _opl = opl;
+        _openers = openers;
     }
 
     /// <summary>
@@ -99,6 +102,12 @@ public sealed class ContainerSubscriber : IEventSubscriberRegistration
 
         session.Send(new DrawContainerPacket(item.Id, (ushort)gumpId));
         session.Send(new ContainerContentPacket(item.Id, BuildContents(contents)));
+
+        // Remembered so a change to anything inside can be redrawn for whoever is looking at it.
+        if (session.Character is { } character)
+        {
+            _openers.Opened(item.Id, character.Id);
+        }
 
         // Prime the client's tooltip cache for what it can now see.
         foreach (var contained in contents)

--- a/src/Moongate.Server/Subscribers/ContainerSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/ContainerSubscriber.cs
@@ -83,10 +83,24 @@ public sealed class ContainerSubscriber : IEventSubscriberRegistration
         return container.GumpId ?? _gumps.GetByItemId(item.ItemId)?.GumpId ?? ContainerGumpLayout.DefaultGumpId;
     }
 
-    public void Subscribe(IEventBus eventBus)
-        => eventBus.Subscribe<ItemDoubleClickEvent>(OnDoubleClick);
+    /// <summary>A departing player has nothing open any more; their entries would otherwise linger.</summary>
+    public Task OnSessionDestroyed(SessionDestroyedEvent message, CancellationToken cancellationToken)
+    {
+        if (message.Session.Character is { } character)
+        {
+            _openers.ForgetMobile(character.Id);
+        }
 
-    private Task OnDoubleClick(ItemDoubleClickEvent message, CancellationToken cancellationToken)
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<ItemDoubleClickEvent>(OnDoubleClick);
+        eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+    }
+
+    public Task OnDoubleClick(ItemDoubleClickEvent message, CancellationToken cancellationToken)
     {
         if (!_sessions.TryGet(message.SessionId, out var session) || _items.GetById(message.Serial) is not { } item)
         {

--- a/src/Moongate.Server/Subscribers/ItemRefreshSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/ItemRefreshSubscriber.cs
@@ -1,0 +1,151 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Redraws an item on the clients that can see it after its fields change. Which packet to send is
+/// decided by where the item's root sits — loose on a map, worn by a mobile, or inside a container —
+/// the same three-way split ModernUO's Item.ProcessDelta makes.
+/// </summary>
+public sealed class ItemRefreshSubscriber : IEventSubscriberRegistration
+{
+    private readonly IItemService _items;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IContainerOpenerRegistry _openers;
+    private readonly IWorldService _world;
+
+    public ItemRefreshSubscriber(
+        IItemService items,
+        IPersistenceService persistenceService,
+        IContainerOpenerRegistry openers,
+        IWorldService world
+    )
+    {
+        _items = items;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _openers = openers;
+        _world = world;
+    }
+
+    public Task OnItemChanged(ItemChangedEvent message, CancellationToken cancellationToken)
+    {
+        if (_items.GetById(message.Item) is not { } item)
+        {
+            return Task.CompletedTask;
+        }
+
+        var root = _items.RootOf(item);
+
+        if (item.ParentContainerId != Serial.Zero)
+        {
+            RefreshInContainer(item, root);
+        }
+        else if (item.EquippedMobileId != Serial.Zero)
+        {
+            RefreshOnMobile(item);
+        }
+        else
+        {
+            RefreshOnGround(item);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<ItemChangedEvent>(OnItemChanged);
+
+    /// <summary>
+    /// Whoever is looking inside: the mobile carrying the root container, plus everyone the registry
+    /// believes has it open. Openers that have wandered out of range are dropped as they are found,
+    /// which is why no close packet is needed.
+    /// </summary>
+    private void RefreshInContainer(ItemEntity item, ItemEntity root)
+    {
+        var packet = new AddItemToContainerPacket(
+            item.Id,
+            (ushort)item.ItemId,
+            (ushort)item.Amount,
+            item.ContainerPosition,
+            item.ParentContainerId,
+            item.Hue
+        );
+
+        var owner = root.EquippedMobileId;
+
+        if (owner != Serial.Zero)
+        {
+            _world.SendToPlayer(owner, packet);
+        }
+
+        var (mapId, position) = RootLocation(root, owner);
+
+        foreach (var opener in _openers.OpenersOf(item.ParentContainerId))
+        {
+            if (opener == owner)
+            {
+                continue;
+            }
+
+            if (_mobiles.GetById(opener) is not { } mobile ||
+                mobile.MapId != mapId ||
+                !mobile.Position.InRange(position, PlayerSession.MaxViewRange))
+            {
+                _openers.Closed(item.ParentContainerId, opener);
+
+                continue;
+            }
+
+            _world.SendToPlayer(opener, packet);
+        }
+    }
+
+    private void RefreshOnGround(ItemEntity item)
+        => _world.SendToPlayersInRange(
+            item.MapId,
+            item.Position,
+            PlayerSession.MaxViewRange,
+            new WorldItemPacket(
+                item.Id,
+                (ushort)item.ItemId,
+                (ushort)item.Amount,
+                item.Position,
+                item.Hue
+            )
+        );
+
+    /// <summary>The item is worn: its layer redraws on the paperdoll for everyone watching the wearer.</summary>
+    private void RefreshOnMobile(ItemEntity item)
+    {
+        if (item.EquippedLayer is not { } layer || _mobiles.GetById(item.EquippedMobileId) is not { } wearer)
+        {
+            return;
+        }
+
+        _world.SendToPlayersInRange(
+            wearer.MapId,
+            wearer.Position,
+            PlayerSession.MaxViewRange,
+            new WornItemPacket(item.Id, (ushort)item.ItemId, layer, wearer.Id, item.Hue)
+        );
+    }
+
+    /// <summary>
+    /// Where the root container is in the world: on its wearer when it is worn, otherwise its own
+    /// spot on the map. This is what an opener's distance is measured against.
+    /// </summary>
+    private (int MapId, Point3D Position) RootLocation(ItemEntity root, Serial owner)
+        => owner != Serial.Zero && _mobiles.GetById(owner) is { } wearer
+               ? (wearer.MapId, wearer.Position)
+               : (root.MapId, root.Position);
+}

--- a/tests/Moongate.Tests/Data/ContainerTemplatesTests.cs
+++ b/tests/Moongate.Tests/Data/ContainerTemplatesTests.cs
@@ -60,7 +60,8 @@ public class ContainerTemplatesTests
                 new StubItemService([]),
                 templates,
                 gumps,
-                new OplService(new FakePersistenceService(), templates)
+                new OplService(new FakePersistenceService(), templates),
+                new ContainerOpenerRegistry()
             );
 
             return new(root, templates, subscriber);

--- a/tests/Moongate.Tests/Server/ItemServiceTests.cs
+++ b/tests/Moongate.Tests/Server/ItemServiceTests.cs
@@ -2,10 +2,12 @@ using Moongate.Core.Extensions;
 using Moongate.Core.Geometry;
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
 using Moongate.Ultima.Types;
+using SquidStd.Services.Core.Services;
 
 namespace Moongate.Tests.Server;
 
@@ -369,6 +371,61 @@ public class ItemServiceTests
         Assert.Equal(1, item.MapId);
         Assert.Equal(new Point3D(100, 200, 5), item.Position);
         Assert.DoesNotContain(item.Id, persistence.Store<ItemEntity>().GetById(backpack.Id)!.ContainedItemIds);
+    }
+
+    [Fact]
+    public void RootOf_LooseItem_ReturnsItself()
+    {
+        var persistence = new FakePersistenceService();
+        var service = new ItemService(persistence);
+
+        var coin = new ItemEntity { ItemId = 3821, MapId = 1, Position = new(10, 20, 0) };
+        service.Create(coin);
+
+        Assert.Equal(coin.Id, service.RootOf(coin).Id);
+    }
+
+    [Fact]
+    public void RootOf_NestedItem_ReturnsTheOutermostContainer()
+    {
+        var persistence = new FakePersistenceService();
+        var service = new ItemService(persistence);
+
+        var backpack = new ItemEntity { ItemId = 3701 };
+        var bag = new ItemEntity { ItemId = 3702 };
+        var coin = new ItemEntity { ItemId = 3821 };
+        service.Create(backpack);
+        service.Create(bag);
+        service.Create(coin);
+        service.AddToContainer(backpack, bag, new(10, 10));
+        service.AddToContainer(bag, coin, new(20, 20));
+
+        Assert.Equal(backpack.Id, service.RootOf(coin).Id);
+    }
+
+    [Fact]
+    public void Save_PublishesItemChanged()
+    {
+        var persistence = new FakePersistenceService();
+        var bus = new EventBusService();
+        ItemChangedEvent? published = null;
+        bus.Subscribe<ItemChangedEvent>(
+            (evt, _) =>
+            {
+                published = evt;
+
+                return Task.CompletedTask;
+            }
+        );
+
+        var service = new ItemService(persistence, eventBus: bus);
+        var coin = new ItemEntity { ItemId = 3821 };
+        service.Create(coin);
+
+        service.Save(coin);
+
+        Assert.NotNull(published);
+        Assert.Equal(coin.Id, published!.Item);
     }
 
     private static ItemEntity Item(string name = "Dagger", int itemId = 3921)

--- a/tests/Moongate.Tests/Server/Items/ContainerOpenerRegistryTests.cs
+++ b/tests/Moongate.Tests/Server/Items/ContainerOpenerRegistryTests.cs
@@ -1,0 +1,58 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Services.Items;
+
+namespace Moongate.Tests.Server.Items;
+
+public class ContainerOpenerRegistryTests
+{
+    [Fact]
+    public void Closed_DropsOnlyThatOpener()
+    {
+        var registry = new ContainerOpenerRegistry();
+        registry.Opened((Serial)10, (Serial)1);
+        registry.Opened((Serial)10, (Serial)2);
+
+        registry.Closed((Serial)10, (Serial)1);
+
+        Assert.Equal([(Serial)2], registry.OpenersOf((Serial)10));
+    }
+
+    [Fact]
+    public void ForgetMobile_DropsItFromEveryContainer()
+    {
+        var registry = new ContainerOpenerRegistry();
+        registry.Opened((Serial)10, (Serial)1);
+        registry.Opened((Serial)11, (Serial)1);
+        registry.Opened((Serial)11, (Serial)2);
+
+        registry.ForgetMobile((Serial)1);
+
+        Assert.Empty(registry.OpenersOf((Serial)10));
+        Assert.Equal([(Serial)2], registry.OpenersOf((Serial)11));
+    }
+
+    [Fact]
+    public void Opened_RecordsTheOpener()
+    {
+        var registry = new ContainerOpenerRegistry();
+
+        registry.Opened((Serial)10, (Serial)1);
+
+        Assert.Equal([(Serial)1], registry.OpenersOf((Serial)10));
+    }
+
+    [Fact]
+    public void Opened_Twice_RecordsTheOpenerOnce()
+    {
+        var registry = new ContainerOpenerRegistry();
+
+        registry.Opened((Serial)10, (Serial)1);
+        registry.Opened((Serial)10, (Serial)1);
+
+        Assert.Single(registry.OpenersOf((Serial)10));
+    }
+
+    [Fact]
+    public void OpenersOf_UnknownContainer_IsEmpty()
+        => Assert.Empty(new ContainerOpenerRegistry().OpenersOf((Serial)10));
+}

--- a/tests/Moongate.Tests/Server/Items/ItemRefreshSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Items/ItemRefreshSubscriberTests.cs
@@ -1,0 +1,124 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Server.Items;
+
+public class ItemRefreshSubscriberTests
+{
+    [Fact]
+    public async Task OnItemChanged_ContainedItem_SendsToTheOwnerAndTheOpeners()
+    {
+        var (subscriber, world, items, persistence) = Build(out var openers);
+        var mobile = new MobileEntity { MapId = 1, Position = new(10, 20, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var backpack = new ItemEntity { ItemId = 3701 };
+        items.Create(backpack);
+        items.Equip(mobile, backpack, LayerType.Backpack);
+
+        var coin = new ItemEntity { ItemId = 3821 };
+        items.Create(coin);
+        items.AddToContainer(backpack, coin, new(10, 10));
+
+        var opener = new MobileEntity { MapId = 1, Position = new(11, 20, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(opener).WaitSync();
+        openers.Opened(backpack.Id, opener.Id);
+
+        await subscriber.OnItemChanged(new(coin.Id), CancellationToken.None);
+
+        // The wearer and the registered opener, one packet each.
+        Assert.Equal(2, world.ToPlayer.Count);
+        Assert.All(world.ToPlayer, sent => Assert.IsType<AddItemToContainerPacket>(sent.Packet));
+        Assert.Contains(world.ToPlayer, sent => sent.MobileId == mobile.Id);
+        Assert.Contains(world.ToPlayer, sent => sent.MobileId == opener.Id);
+    }
+
+    [Fact]
+    public async Task OnItemChanged_GroundItem_SendsWorldItemToPlayersInRange()
+    {
+        var (subscriber, world, items, _) = Build();
+        var coin = new ItemEntity { ItemId = 3821, MapId = 1, Position = new(10, 20, 0) };
+        items.Create(coin);
+
+        await subscriber.OnItemChanged(new(coin.Id), CancellationToken.None);
+
+        var sent = Assert.Single(world.InRange);
+        Assert.IsType<WorldItemPacket>(sent.Packet);
+        Assert.Equal(1, sent.MapId);
+    }
+
+    [Fact]
+    public async Task OnItemChanged_OpenerOutOfRange_IsDroppedAndNotSentTo()
+    {
+        var (subscriber, world, items, persistence) = Build(out var openers);
+        var mobile = new MobileEntity { MapId = 1, Position = new(10, 20, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var backpack = new ItemEntity { ItemId = 3701 };
+        items.Create(backpack);
+        items.Equip(mobile, backpack, LayerType.Backpack);
+
+        var coin = new ItemEntity { ItemId = 3821 };
+        items.Create(coin);
+        items.AddToContainer(backpack, coin, new(10, 10));
+
+        // Walked far away with the gump still notionally open.
+        var wanderer = new MobileEntity { MapId = 1, Position = new(500, 500, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(wanderer).WaitSync();
+        openers.Opened(backpack.Id, wanderer.Id);
+
+        await subscriber.OnItemChanged(new(coin.Id), CancellationToken.None);
+
+        Assert.DoesNotContain(world.ToPlayer, sent => sent.MobileId == wanderer.Id);
+        Assert.Empty(openers.OpenersOf(backpack.Id));
+    }
+
+    [Fact]
+    public async Task OnItemChanged_UnknownItem_SendsNothing()
+    {
+        var (subscriber, world, _, _) = Build();
+
+        await subscriber.OnItemChanged(new((Serial)0xDEAD), CancellationToken.None);
+
+        Assert.Empty(world.InRange);
+        Assert.Empty(world.ToPlayer);
+    }
+
+    [Fact]
+    public async Task OnItemChanged_WornItem_SendsWornItemToPlayersInRange()
+    {
+        var (subscriber, world, items, persistence) = Build();
+        var mobile = new MobileEntity { MapId = 1, Position = new(10, 20, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var shirt = new ItemEntity { ItemId = 5399 };
+        items.Create(shirt);
+        items.Equip(mobile, shirt, LayerType.Shirt);
+
+        await subscriber.OnItemChanged(new(shirt.Id), CancellationToken.None);
+
+        var sent = Assert.Single(world.InRange);
+        Assert.IsType<WornItemPacket>(sent.Packet);
+    }
+
+    private static (ItemRefreshSubscriber Subscriber, RecordingWorldService World, ItemService Items,
+        FakePersistenceService Persistence) Build()
+        => Build(out _);
+
+    private static (ItemRefreshSubscriber Subscriber, RecordingWorldService World, ItemService Items,
+        FakePersistenceService Persistence) Build(out ContainerOpenerRegistry openers)
+    {
+        var persistence = new FakePersistenceService();
+        var items = new ItemService(persistence);
+        var world = new RecordingWorldService();
+        openers = new();
+
+        return (new(items, persistence, openers, world), world, items, persistence);
+    }
+}

--- a/tests/Moongate.Tests/Server/Subscribers/ContainerSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Subscribers/ContainerSubscriberTests.cs
@@ -126,7 +126,8 @@ public class ContainerSubscriberTests
             new StubItemService([]),
             templates,
             gumps,
-            new OplService(new FakePersistenceService(), templates)
+            new OplService(new FakePersistenceService(), templates),
+            new ContainerOpenerRegistry()
         );
     }
 }

--- a/tests/Moongate.Tests/Support/RecordingWorldService.cs
+++ b/tests/Moongate.Tests/Support/RecordingWorldService.cs
@@ -1,0 +1,50 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Interfaces;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Records what would have gone out instead of sending it, so a test can assert which packet reached
+/// whom. The counterpart of <see cref="StubWorldService" />, which swallows everything silently.
+/// </summary>
+public sealed class RecordingWorldService : IWorldService
+{
+    public List<(int MapId, Point3D Center, int Range, IOutgoingPacket Packet)> InRange { get; } = [];
+
+    public List<(Serial MobileId, IOutgoingPacket Packet)> ToPlayer { get; } = [];
+
+    public List<IOutgoingPacket> Broadcasts { get; } = [];
+
+    public int Broadcast<TPacket>(TPacket packet) where TPacket : IOutgoingPacket
+    {
+        Broadcasts.Add(packet);
+
+        return 1;
+    }
+
+    public void SendEnterWorld(PlayerSession session, MobileEntity mobile) { }
+
+    public int SendToPlayer<TPacket>(Serial mobileId, TPacket packet) where TPacket : IOutgoingPacket
+    {
+        ToPlayer.Add((mobileId, packet));
+
+        return 1;
+    }
+
+    public int SendToPlayersInRange<TPacket>(
+        int mapId,
+        Point3D center,
+        int range,
+        TPacket packet,
+        Serial? exclude = null
+    ) where TPacket : IOutgoingPacket
+    {
+        InRange.Add((mapId, center, range, packet));
+
+        return 1;
+    }
+}

--- a/tests/Moongate.Tests/Support/StubItemService.cs
+++ b/tests/Moongate.Tests/Support/StubItemService.cs
@@ -52,6 +52,9 @@ public sealed class StubItemService : IItemService
     public void RemoveFromContainer(ItemEntity container, ItemEntity item)
         => throw new NotSupportedException();
 
+    public ItemEntity RootOf(ItemEntity item)
+        => throw new NotSupportedException();
+
     public void Save(ItemEntity item)
         => throw new NotSupportedException();
 


### PR DESCRIPTION
Fixes #130. `item.set` and every other call into `IItemService.Save` wrote the new value and sent nothing, so the client kept drawing the old graphic until the item left and re-entered view. That made every appearance-changing script silently useless — including the shipped torch, whose template carries lit and unlit graphics precisely so a script can swap them.

`Save` now publishes `ItemChangedEvent`, and `ItemRefreshSubscriber` sends the packet that fits where the item is: `WorldItemPacket` on the ground, `WornItemPacket` on a paperdoll — **a packet nothing had ever sent** — and `AddItemToContainerPacket` inside a container. That three-way split is the one ModernUO's `Item.ProcessDelta` makes.

The container case needs to know who is looking. `IContainerOpenerRegistry` records an opener when the gump goes out and **drops it when they walk out of range**, which is how ModernUO avoids depending on a close packet the client does not reliably send. A disconnecting player's entries are dropped too.

`IItemService.RootOf` is new and shared: `DragDropService` had a private copy of the same container-chain walk.

`Save` publishes; `Equip`, `AddToContainer` and `MoveToWorld` deliberately do not — they already have their own events and send their own packets, and publishing from them too would double every drag.

Full suite green (1814), docfx at 0 warnings, real boot clean.