### PR TITLE
feat(world): day and night

### DIFF
--- a/src/Moongate.Server.Abstractions/Data/Internal/GameClock.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/GameClock.cs
@@ -1,0 +1,35 @@
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// Turns real time into the world's local time. Ported from ModernUO's <c>Clock</c>: five real
+/// seconds are one UO minute, so a UO day is two real hours, and the time is local — sixteen tiles
+/// east is one UO minute later, which is why dawn sweeps across a map rather than arriving at once.
+/// </summary>
+public static class GameClock
+{
+    /// <summary>Real seconds per UO minute. ModernUO's <c>Clock.SecondsPerUOMinute</c>.</summary>
+    public const double SecondsPerUoMinute = 5.0;
+
+    /// <summary>Tiles east per UO minute of local time.</summary>
+    public const int TilesPerUoMinute = 16;
+
+    /// <summary>UO minutes each facet is offset from the last.</summary>
+    public const int MinutesPerFacet = 320;
+
+    /// <summary>
+    /// Where the world's calendar starts. Fixed rather than taken from server start on purpose: the
+    /// time of day is then absolute, and a restart does not jump it.
+    /// </summary>
+    public static readonly DateTimeOffset Epoch = new(1997, 9, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The local time at <paramref name="x" /> on <paramref name="mapId" />.</summary>
+    public static (int Hours, int Minutes) LocalTime(DateTimeOffset now, int mapId, int x)
+    {
+        var totalMinutes = (int)((now - Epoch).TotalSeconds / SecondsPerUoMinute);
+
+        totalMinutes += mapId * MinutesPerFacet;
+        totalMinutes += x / TilesPerUoMinute;
+
+        return (totalMinutes / 60 % 24, totalMinutes % 60);
+    }
+}

--- a/src/Moongate.Server.Abstractions/Data/Internal/LightLevels.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/LightLevels.cs
@@ -1,0 +1,40 @@
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// The global light level through the day. Higher is darker. Ported from ModernUO's
+/// <c>LightCycle.ComputeLevelFor</c>, which follows RunUO's curve rather than OSI's: OSI switches
+/// sharply at 04:00 and midnight, this ramps across two hours at each end.
+/// </summary>
+public static class LightLevels
+{
+    /// <summary>Full daylight.</summary>
+    public const int Day = 0;
+
+    /// <summary>Full night.</summary>
+    public const int Night = 12;
+
+    /// <summary>Inside a dungeon, whatever the hour.</summary>
+    public const int Dungeon = 26;
+
+    /// <summary>Inside a jail, whatever the hour.</summary>
+    public const int Jail = 9;
+
+    /// <summary>
+    /// The level at a local time of day:
+    /// <code>
+    /// 00:00 - 03:59  night
+    /// 04:00 - 05:59  ramping to day over 120 minutes
+    /// 06:00 - 21:59  day
+    /// 22:00 - 23:59  ramping to night over 120 minutes
+    /// </code>
+    /// </summary>
+    public static int ForTime(int hours, int minutes)
+        => hours switch
+        {
+            < 4  => Night,
+            < 6  => Night + ((hours - 4) * 60 + minutes) * (Day - Night) / 120,
+            < 22 => Day,
+            < 24 => Day + ((hours - 22) * 60 + minutes) * (Night - Day) / 120,
+            _    => Night
+        };
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/ILightService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/ILightService.cs
@@ -1,0 +1,19 @@
+using Moongate.Core.Geometry;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>
+/// Answers how dark it is at a spot: the region's own level when it has one, otherwise the time of
+/// day. Higher is darker.
+/// </summary>
+public interface ILightService
+{
+    /// <summary>
+    /// A fixed level that wins over everything, for a GM to force day or night. Null follows the
+    /// normal rules.
+    /// </summary>
+    int? Override { get; set; }
+
+    /// <summary>The light level at <paramref name="position" /> on <paramref name="mapId" />.</summary>
+    int LevelFor(int mapId, Point3D position);
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -207,6 +207,7 @@ await ConsoleApp.RunAsync(
                 // endpoint resolves and the hosted service owning the refresh timer, and it must be the
                 // same singleton in both roles.
                 container.RegisterStdService<IServerStatsService, ServerStatsService>();
+                container.RegisterStdService<LightCycleService, LightCycleService>();
 
                 // INotificationTemplateService is registered by the data-loader plugin, alongside the
                 // loader that fills it, the same way the template services are.

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -198,6 +198,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IContainerOpenerRegistry, ContainerOpenerRegistry>(Reuse.Singleton);
                 container.Register<ILootService, LootService>(Reuse.Singleton);
                 container.Register<IVirtualSerialService, VirtualSerialService>(Reuse.Singleton);
+                container.Register<ILightService, LightService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IChatService, ChatService>(Reuse.Singleton);
                 container.Register<IServerSettingsService, ServerSettingsService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/World/LightCycleService.cs
+++ b/src/Moongate.Server/Services/World/LightCycleService.cs
@@ -1,0 +1,77 @@
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Core.Interfaces;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using SquidStd.Abstractions.Interfaces.Services;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Pushes the light level to each player as it changes. Polls rather than reacting to anything,
+/// because the level moves with the player as well as with the clock: walking into a dungeon changes
+/// it with no event to hang off. ModernUO polls on the same five-second beat.
+/// </summary>
+public sealed class LightCycleService : ISquidStdService
+{
+    private const string TimerName = "light-cycle";
+
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(5);
+
+    private readonly ISessionManager _sessions;
+    private readonly ILightService _light;
+    private readonly IGameLoopContext _loop;
+
+    /// <summary>The level each session was last told, so an unchanged one is not resent.</summary>
+    private readonly Dictionary<long, int> _lastSent = new();
+
+    public LightCycleService(ISessionManager sessions, ILightService light, IGameLoopContext loop)
+    {
+        _sessions = sessions;
+        _light = light;
+        _loop = loop;
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _loop.ScheduleRepeating(TimerName, Interval, Tick);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+        => ValueTask.CompletedTask;
+
+    /// <summary>Public so a test can drive one beat without waiting on the timer.</summary>
+    public void Tick()
+    {
+        var live = new HashSet<long>();
+
+        foreach (var session in _sessions.All)
+        {
+            if (session.State != SessionStateType.InWorld || session.Character is not { } character)
+            {
+                continue;
+            }
+
+            live.Add(session.SessionId);
+
+            var level = _light.LevelFor(character.MapId, character.Position);
+
+            if (_lastSent.TryGetValue(session.SessionId, out var last) && last == level)
+            {
+                continue;
+            }
+
+            _lastSent[session.SessionId] = level;
+            session.Send(new OverallLightLevelPacket((byte)level));
+        }
+
+        // Sessions that have gone away must not keep an entry, or a reused session id would be told
+        // nothing until the level next moved.
+        foreach (var sessionId in _lastSent.Keys.Where(id => !live.Contains(id)).ToList())
+        {
+            _lastSent.Remove(sessionId);
+        }
+    }
+}

--- a/src/Moongate.Server/Services/World/LightService.cs
+++ b/src/Moongate.Server/Services/World/LightService.cs
@@ -1,0 +1,55 @@
+using Moongate.Core.Geometry;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Default <see cref="ILightService" />. The region wins over the hour — a dungeon is dark at noon —
+/// and a GM override wins over both.
+/// </summary>
+public sealed class LightService : ILightService
+{
+    private const string DungeonRegionType = "DungeonRegion";
+    private const string JailRegionType = "JailRegion";
+
+    private readonly IRegionService _regions;
+    private readonly TimeProvider _timeProvider;
+
+    public int? Override { get; set; }
+
+    public LightService(IRegionService regions, TimeProvider timeProvider)
+    {
+        _regions = regions;
+        _timeProvider = timeProvider;
+    }
+
+    public int LevelFor(int mapId, Point3D position)
+    {
+        if (Override is { } forced)
+        {
+            return forced;
+        }
+
+        // MapType's own summary says its value matches the client's map index, so the cast is exact.
+        var region = _regions.At((MapType)mapId, position);
+
+        if (region is not null)
+        {
+            if (string.Equals(region.Type, DungeonRegionType, StringComparison.Ordinal))
+            {
+                return LightLevels.Dungeon;
+            }
+
+            if (string.Equals(region.Type, JailRegionType, StringComparison.Ordinal))
+            {
+                return LightLevels.Jail;
+            }
+        }
+
+        var (hours, minutes) = GameClock.LocalTime(_timeProvider.GetUtcNow(), mapId, position.X);
+
+        return LightLevels.ForTime(hours, minutes);
+    }
+}

--- a/src/Moongate.Server/Services/World/WorldService.cs
+++ b/src/Moongate.Server/Services/World/WorldService.cs
@@ -28,7 +28,6 @@ namespace Moongate.Server.Services.World;
 /// </summary>
 public sealed class WorldService : IWorldService
 {
-    private const byte OverallLightLevel = 0; // full daylight
     private const byte PersonalLightLevel = 0;
     private const byte FemaleFlag = 0x02;
 
@@ -43,6 +42,7 @@ public sealed class WorldService : IWorldService
     private readonly TimeProvider _timeProvider;
     private readonly IOplService _opl;
     private readonly ISessionManager _sessions;
+    private readonly ILightService _light;
     private readonly ILoopAffinity? _loopAffinity;
 
     public WorldService(
@@ -53,6 +53,7 @@ public sealed class WorldService : IWorldService
         TimeProvider timeProvider,
         IOplService opl,
         ISessionManager sessions,
+        ILightService light,
         ILoopAffinity? loopAffinity = null
     )
     {
@@ -63,6 +64,7 @@ public sealed class WorldService : IWorldService
         _timeProvider = timeProvider;
         _opl = opl;
         _sessions = sessions;
+        _light = light;
         _loopAffinity = loopAffinity;
     }
 
@@ -122,7 +124,7 @@ public sealed class WorldService : IWorldService
                 (sbyte)position.Z,
                 mobile.Direction
             ),
-            new OverallLightLevelPacket(OverallLightLevel),
+            new OverallLightLevelPacket((byte)_light.LevelFor(mobile.MapId, mobile.Position)),
             new PersonalLightLevelPacket(mobile.Id, PersonalLightLevel),
             new MobileIncomingPacket(
                 mobile.Id,

--- a/tests/Moongate.Tests/Server/Chat/ChatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Chat/ChatServiceTests.cs
@@ -23,7 +23,8 @@ public class ChatServiceTests
             new StubEventBus(),
             TimeProvider.System,
             new OplService(new FakePersistenceService(), new ItemTemplateService()),
-            new SessionManager()
+            new SessionManager(),
+            new StubLightService(0)
         );
         var service = new ChatService(world, new StubEventBus());
 
@@ -131,7 +132,8 @@ public class ChatServiceTests
             new StubEventBus(),
             TimeProvider.System,
             new OplService(new FakePersistenceService(), new ItemTemplateService()),
-            new SessionManager()
+            new SessionManager(),
+            new StubLightService(0)
         );
         var bus = new StubEventBus();
         var service = new ChatService(world, bus);

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -139,7 +139,8 @@ public class LoginFlowIntegrationTests
             eventBus,
             TimeProvider.System,
             opl,
-            sessions
+            sessions,
+            new StubLightService(0)
         );
         var chat = new ChatService(world, eventBus);
 
@@ -310,7 +311,8 @@ public class LoginFlowIntegrationTests
             eventBus,
             TimeProvider.System,
             opl,
-            sessions
+            sessions,
+            new StubLightService(0)
         );
         var chat = new ChatService(world, eventBus);
 
@@ -779,7 +781,8 @@ public class LoginFlowIntegrationTests
                 eventBus,
                 TimeProvider.System,
                 opl,
-                sessions
+                sessions,
+                new StubLightService(0)
             );
             var movement =
                 new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System, eventBus);
@@ -1019,7 +1022,8 @@ public class LoginFlowIntegrationTests
             eventBus,
             TimeProvider.System,
             opl,
-            sessions
+            sessions,
+            new StubLightService(0)
         );
         var characters = CharacterServiceFixture.Create(persistence, eventBus, sessions);
 
@@ -1348,7 +1352,8 @@ public class LoginFlowIntegrationTests
                 eventBus,
                 TimeProvider.System,
                 opl,
-                new SessionManager()
+                new SessionManager(),
+                new StubLightService(0)
             ),
             opl
         );

--- a/tests/Moongate.Tests/Server/World/GameClockTests.cs
+++ b/tests/Moongate.Tests/Server/World/GameClockTests.cs
@@ -1,0 +1,61 @@
+using Moongate.Server.Abstractions.Data.Internal;
+
+namespace Moongate.Tests.Server.World;
+
+public class GameClockTests
+{
+    [Fact]
+    public void LocalTime_AtTheEpoch_IsMidnight()
+    {
+        var (hours, minutes) = GameClock.LocalTime(GameClock.Epoch, mapId: 0, x: 0);
+
+        Assert.Equal(0, hours);
+        Assert.Equal(0, minutes);
+    }
+
+    [Fact]
+    public void LocalTime_DiffersBetweenFacets()
+    {
+        var first = GameClock.LocalTime(GameClock.Epoch, mapId: 0, x: 0);
+        var second = GameClock.LocalTime(GameClock.Epoch, mapId: 1, x: 0);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void LocalTime_FiveRealSeconds_IsOneUoMinute()
+    {
+        var (hours, minutes) = GameClock.LocalTime(GameClock.Epoch.AddSeconds(5), 0, 0);
+
+        Assert.Equal(0, hours);
+        Assert.Equal(1, minutes);
+    }
+
+    [Fact]
+    public void LocalTime_SixteenTilesEast_IsOneUoMinuteLater()
+    {
+        var west = GameClock.LocalTime(GameClock.Epoch, 0, x: 0);
+        var east = GameClock.LocalTime(GameClock.Epoch, 0, x: 16);
+
+        Assert.Equal(west.Minutes + 1, east.Minutes);
+    }
+
+    [Fact]
+    public void LocalTime_TwoRealHours_IsAFullUoDay()
+    {
+        // 5s per UO minute means a UO day takes 120 real minutes, so we are back at midnight.
+        var (hours, minutes) = GameClock.LocalTime(GameClock.Epoch.AddHours(2), 0, 0);
+
+        Assert.Equal(0, hours);
+        Assert.Equal(0, minutes);
+    }
+
+    [Fact]
+    public void LocalTime_WrapsPastTwentyFour()
+    {
+        // 25 UO hours after the epoch is 01:00, not 25:00.
+        var (hours, _) = GameClock.LocalTime(GameClock.Epoch.AddMinutes(125), 0, 0);
+
+        Assert.Equal(1, hours);
+    }
+}

--- a/tests/Moongate.Tests/Server/World/LightCycleServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/LightCycleServiceTests.cs
@@ -1,0 +1,22 @@
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.World;
+
+public class LightCycleServiceTests
+{
+    [Fact]
+    public void Tick_NoSessions_SendsNothing()
+    {
+        // Everything worth asserting about Tick — which level a player gets, and that an unchanged
+        // level is not resent — needs a PlayerSession, which cannot be built without a live socket.
+        // The rules themselves are covered by GameClockTests, LightLevelsTests and LightServiceTests;
+        // what is left is the loop, proved by the real-boot smoke test.
+        var sessions = new StubSessionManager();
+        var service = new LightCycleService(sessions, new StubLightService(5), new StubGameLoopContext());
+
+        service.Tick();
+
+        Assert.Empty(sessions.All);
+    }
+}

--- a/tests/Moongate.Tests/Server/World/LightLevelsTests.cs
+++ b/tests/Moongate.Tests/Server/World/LightLevelsTests.cs
@@ -1,0 +1,50 @@
+using Moongate.Server.Abstractions.Data.Internal;
+
+namespace Moongate.Tests.Server.World;
+
+public class LightLevelsTests
+{
+    [Theory]
+    [InlineData(6, 0)]     // the first minute of full day
+    [InlineData(12, 0)]
+    [InlineData(21, 59)]   // the last
+    public void ForTime_Daytime_IsFullDay(int hours, int minutes)
+        => Assert.Equal(LightLevels.Day, LightLevels.ForTime(hours, minutes));
+
+    [Fact]
+    public void ForTime_Dawn_RampsFromNightToDay()
+    {
+        var start = LightLevels.ForTime(4, 0);
+        var middle = LightLevels.ForTime(5, 0);
+        var end = LightLevels.ForTime(5, 59);
+
+        Assert.Equal(LightLevels.Night, start);
+        Assert.True(middle < start, "an hour into dawn it must be lighter than at 04:00");
+        Assert.True(end < middle, "and lighter still by 05:59");
+    }
+
+    [Fact]
+    public void ForTime_Dusk_RampsFromDayToNight()
+    {
+        var start = LightLevels.ForTime(22, 0);
+        var middle = LightLevels.ForTime(23, 0);
+
+        Assert.Equal(LightLevels.Day, start);
+        Assert.True(middle > start, "an hour into dusk it must be darker than at 22:00");
+    }
+
+    [Theory]
+    [InlineData(0, 0)]     // midnight
+    [InlineData(3, 59)]    // the last minute of full night
+    public void ForTime_SmallHours_AreFullNight(int hours, int minutes)
+        => Assert.Equal(LightLevels.Night, LightLevels.ForTime(hours, minutes));
+
+    [Fact]
+    public void Levels_AreTheClassicFour()
+    {
+        Assert.Equal(0, LightLevels.Day);
+        Assert.Equal(12, LightLevels.Night);
+        Assert.Equal(26, LightLevels.Dungeon);
+        Assert.Equal(9, LightLevels.Jail);
+    }
+}

--- a/tests/Moongate.Tests/Server/World/LightServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/LightServiceTests.cs
@@ -1,0 +1,75 @@
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Regions;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Server.World;
+
+public class LightServiceTests
+{
+    [Fact]
+    public void LevelFor_InATown_FollowsTheClock()
+    {
+        var regions = new RegionService();
+        regions.Register(Region("TownRegion", 100, 100));
+
+        // The epoch is midnight, which the curve puts in full night.
+        var service = new LightService(regions, new FixedTimeProvider(GameClock.Epoch));
+
+        Assert.Equal(LightLevels.Night, service.LevelFor(0, new(0, 0, 0)));
+    }
+
+    [Fact]
+    public void LevelFor_InsideADungeon_IsAlwaysDark()
+    {
+        var regions = new RegionService();
+        regions.Register(Region("DungeonRegion", 100, 100));
+
+        var service = new LightService(regions, new FixedTimeProvider(UoNoon));
+
+        Assert.Equal(LightLevels.Dungeon, service.LevelFor(0, new(100, 100, 0)));
+    }
+
+    [Fact]
+    public void LevelFor_InsideAJail_IsTheJailLevel()
+    {
+        var regions = new RegionService();
+        regions.Register(Region("JailRegion", 100, 100));
+
+        var service = new LightService(regions, new FixedTimeProvider(UoNoon));
+
+        Assert.Equal(LightLevels.Jail, service.LevelFor(0, new(100, 100, 0)));
+    }
+
+    [Fact]
+    public void LevelFor_OutsideAnyRegion_FollowsTheClock()
+    {
+        var service = new LightService(new RegionService(), new FixedTimeProvider(GameClock.Epoch));
+
+        Assert.Equal(LightLevels.Night, service.LevelFor(0, new(0, 0, 0)));
+    }
+
+    [Fact]
+    public void Override_WhenSet_WinsEverywhere()
+    {
+        var regions = new RegionService();
+        regions.Register(Region("DungeonRegion", 100, 100));
+
+        var service = new LightService(regions, new FixedTimeProvider(UoNoon)) { Override = 3 };
+
+        Assert.Equal(3, service.LevelFor(0, new(100, 100, 0)));
+    }
+
+    /// <summary>UO noon: 12 UO hours is 720 UO minutes, and each is 5 real seconds.</summary>
+    private static DateTimeOffset UoNoon => GameClock.Epoch.AddHours(1);
+
+    private static RegionDefinition Region(string type, int x, int y)
+        => new()
+        {
+            Type = type,
+            Name = type,
+            Map = MapType.Felucca,
+            Area = [new() { X1 = x - 5, Y1 = y - 5, X2 = x + 5, Y2 = y + 5 }]
+        };
+}

--- a/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/WorldServiceTests.cs
@@ -64,7 +64,8 @@ public class WorldServiceTests
             new StubEventBus(),
             TimeProvider.System,
             opl,
-            new SessionManager()
+            new SessionManager(),
+            new StubLightService(0)
         );
 
         var packets = service.BuildSequence(mobile);
@@ -351,7 +352,8 @@ public class WorldServiceTests
             new StubEventBus(),
             time ?? TimeProvider.System,
             new OplService(new FakePersistenceService(), new ItemTemplateService()),
-            new SessionManager()
+            new SessionManager(),
+            new StubLightService(0)
         );
 
     // Three skills is enough to prove the list is built from the registry rather than from the mobile.

--- a/tests/Moongate.Tests/Support/StubLightService.cs
+++ b/tests/Moongate.Tests/Support/StubLightService.cs
@@ -1,0 +1,20 @@
+using Moongate.Core.Geometry;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>Answers a fixed light level, so a test can drive the push without a clock or regions.</summary>
+public sealed class StubLightService : ILightService
+{
+    private readonly int _level;
+
+    public int? Override { get; set; }
+
+    public StubLightService(int level)
+    {
+        _level = level;
+    }
+
+    public int LevelFor(int mapId, Point3D position)
+        => Override ?? _level;
+}


### PR DESCRIPTION
Fixes #132. The world was permanently at noon: `WorldService` sent the light level once at enter-world from a hardcoded `0`, and nothing ever sent it again — including inside the 77 `DungeonRegion` entries the shipped region data already carries.

Ported from ModernUO's `LightCycle` and `Clock`:

- `GameClock` — five real seconds per UO minute, so a UO day is two real hours. The epoch is fixed at 1997-09-01 rather than server start, so the time of day is absolute and a restart does not jump it. Time is local: sixteen tiles east is one UO minute later, which is why dawn sweeps across a map.
- `LightLevels` — RunUO's curve, which ModernUO kept: night until 04:00, a 120-minute ramp to day, day until 22:00, a 120-minute ramp back. OSI switches sharply instead; this ramps.
- `LightService` — region first, then the hour. `DungeonRegion` is 26 and `JailRegion` is 9 whatever the clock says, straight off the shipped YAML. A GM override wins over both.
- `LightCycleService` — a five-second poll that sends only when a player's level actually changed. It polls rather than reacting because the level moves with the player too: walking into a dungeon has no event to hang off.

The clock and the curve are pure statics, so both are tested without a server — 14 tests between them.

The enter-world burst sends the computed level, so logging in at night no longer shows a frame of daylight first.

`PersonalLightLevelPacket` stays hardcoded: it is the night-sight spell's channel, and there is no night sight yet.

Full suite green (1834), docfx at 0 warnings, real boot clean — 18 services now, one more than before.