### PR TITLE
Take item layer and weight from the client tiledata

### DIFF
--- a/docs/scripting/data/item-templates.md
+++ b/docs/scripting/data/item-templates.md
@@ -62,7 +62,7 @@ of templates.
 | `ItemId` | `int` | optional, default `0` | The UO art/tile id. Must be non-negative. |
 | `Hue` | `int` | optional, default `0` | Default hue index, used unless the caller passes an explicit hue (e.g. `item.create`'s hue argument). |
 | `GoldValue` | `int` | optional, default `0` | Declared gold value. **Reserved** — not read by `ItemFactoryService` or copied onto the spawned item today. |
-| `Weight` | `double` | optional, default `0.0` | Item weight. Must be finite and non-negative. |
+| `Weight` | `double` | optional, default `0.0` | **Override only.** An item's weight comes from the client's `tiledata.mul` — the weight byte on the tile named by `ItemId`, where both `0` and the `255` immovable sentinel resolve to `1`. This key overrides it; `0` means "not stated, ask the client files". Must be finite and non-negative. Resolved at load by `TileDataTemplateResolver`. Nothing reads it yet: there is no carry-weight system. |
 | `ScriptId` | `string` | optional, default `""` | Names the Lua script that runs when players interact with the item; the dot is a namespace, so `items.magic_torch` means `scripts/items/magic_torch.lua`. Must match `^[a-z0-9_]+(\.[a-z0-9_]+)*$`. `none` or empty means no script. See [Item scripts](../reference/item-scripts.md). |
 | `IsMovable` | `bool` | optional, default `false` | Whether the item can be picked up. `false` refuses the lift with `CannotLift` (0x27). Not read by `ItemFactoryService` — it is enforced at drag time by `DragDropService`. |
 | `Rarity` | `ItemRarityType` enum | optional, default `Common` | One of `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`, `Artifact`. Must be a defined member. Copied onto the spawned item's `Rarity`. |
@@ -74,7 +74,7 @@ of templates.
 | `FlippableItemIds` | `List<int>?` | optional, default `null` | Alternate `ItemId` graphics the item cycles through. Consumed by `item.flip` / `IItemService.Flip`. Each element must be non-negative and non-null. |
 | `LootTables` | `List<string>?` | optional, default `null` | Loot template ids associated with this item. Declared and shape-validated (elements non-null) but **not auto-rolled** by any loader — roll them explicitly with [`loot.roll`](../reference/loot.md#lootroll). |
 | `Params` | `Dictionary<string, ItemParam>?` | optional, default `null` | Typed script parameters keyed by name. Values must be non-null. **Reserved** — no script-parameter resolver currently reads this. |
-| `Equip` | `EquipSpec?` | optional, default `null` | Present ⇒ the item is wearable. See [EquipSpec](#equipspec). |
+| `Equip` | `EquipSpec?` | optional, default `null` | Overrides for a wearable item. Its absence does **not** mean the item is unwearable: the client's tiledata decides that, and a wearable tile gets an `EquipSpec` synthesised at load. See [EquipSpec](#equipspec). |
 | `Weapon` | `WeaponSpec?` | optional, default `null` | Present ⇒ the item is a weapon. See [WeaponSpec](#weaponspec). |
 | `Container` | `ContainerSpec?` | optional, default `null` | Present ⇒ the item is a container. See [ContainerSpec](#containerspec). |
 | `Book` | `BookSpec?` | optional, default `null` | Present ⇒ the item is a book. See [BookSpec](#bookspec). |
@@ -89,7 +89,7 @@ Nested under `Equip:`.
 
 | Key | Type | Required / default | Meaning |
 |---|---|---|---|
-| `Layer` | `LayerType` enum | optional, default `None` (0) | The [paperdoll layer](../reference/enums.md#layer_type) this item equips to. Must be a defined member. Consumed by `CharacterService` to auto-equip [starting items](starting-items.md). |
+| `Layer` | `LayerType` enum | optional, default `None` (0) | **Override only.** The [paperdoll layer](../reference/enums.md#layer_type) comes from the client's `tiledata.mul` — the layer byte on the tile named by `ItemId`, read only when that tile carries the `Wearable` flag. This key overrides it; `None` means "not stated, ask the client files". Must be a defined member. Declare it only where the game rule diverges from the client, as the shipped weapons do to force `TwoHanded` and take the shield slot. Resolved at load by `TileDataTemplateResolver`, then consumed by `CharacterService` to auto-equip [starting items](starting-items.md). |
 | `HitPoints` | `int?` | optional, default `null` | Durability. Must be non-negative when set. |
 | `StrengthReq` | `int?` | optional, default `null` | Strength required to equip. Must be non-negative. |
 | `DexterityReq` | `int?` | optional, default `null` | Dexterity required to equip. Must be non-negative. |
@@ -204,6 +204,9 @@ equips):
         MissSound: 568
         WeaponSkill: Swords       # free-form skill name, not enum-validated
 ```
+
+`Weight` and `Equip.Layer` appear here as overrides. Most shipped templates
+declare neither and let the client files decide — see the rows above.
 
 This entry has no `Container`, `Book`, `Params`, `LootTables`, `Stackable`,
 `Dyeable`, `Visibility` or `LootType` keys — all optional and omitted here.

--- a/src/Moongate.Server/Assets/Templates/Items/addons.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/addons.yaml
@@ -5,7 +5,6 @@
     ItemId: 12420
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -23,7 +22,6 @@
     ItemId: 11759
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -44,7 +42,6 @@
         - 2472
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -58,7 +55,6 @@
     ItemId: 12516
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -76,7 +72,6 @@
     ItemId: 12518
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -94,7 +89,6 @@
     ItemId: 12512
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -112,7 +106,6 @@
     ItemId: 12514
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -130,7 +123,6 @@
     ItemId: 12442
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -148,7 +140,6 @@
     ItemId: 12440
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/aquarium.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/aquarium.yaml
@@ -5,7 +5,6 @@
     ItemId: 15108
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 15117
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 3836
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 15121
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +57,6 @@
     ItemId: 15103
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -75,7 +70,6 @@
     ItemId: 15098
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -89,7 +83,6 @@
     ItemId: 5907
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -103,7 +96,6 @@
     ItemId: 15106
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -117,7 +109,6 @@
     ItemId: 15116
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -145,7 +136,6 @@
     ItemId: 15125
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -159,7 +149,6 @@
     ItemId: 15107
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -173,7 +162,6 @@
     ItemId: 15119
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -187,7 +175,6 @@
     ItemId: 15118
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -201,7 +188,6 @@
     ItemId: 15117
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -215,7 +201,6 @@
     ItemId: 15100
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -229,7 +214,6 @@
     ItemId: 15101
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -243,7 +227,6 @@
     ItemId: 15102
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -257,7 +240,6 @@
     ItemId: 15110
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -271,7 +253,6 @@
     ItemId: 15117
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -285,7 +266,6 @@
     ItemId: 15104
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -299,7 +279,6 @@
     ItemId: 15120
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -313,7 +292,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -327,7 +305,6 @@
     ItemId: 15124
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -341,7 +318,6 @@
     ItemId: 15105
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -355,7 +331,6 @@
     ItemId: 15100
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -369,7 +344,6 @@
     ItemId: 15109
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -383,7 +357,6 @@
     ItemId: 15113
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -397,7 +370,6 @@
     ItemId: 15114
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -411,7 +383,6 @@
     ItemId: 15114
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -428,7 +399,6 @@
         - 5364
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -443,7 +413,6 @@
     ItemId: 2419
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -457,7 +426,6 @@
     ItemId: 15112
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -471,7 +439,6 @@
     ItemId: 5905
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -485,7 +452,6 @@
     ItemId: 15111
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/armor.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/armor.yaml
@@ -5,7 +5,6 @@
     ItemId: 5132
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -27,7 +26,6 @@
         - 5203
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -50,7 +48,6 @@
         - 5204
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -96,7 +93,6 @@
         - 5206
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -119,7 +115,6 @@
         - 5207
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -142,7 +137,6 @@
         - 5060
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -185,7 +179,6 @@
     ItemId: 10100
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -207,7 +200,6 @@
         - 5059
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -230,7 +222,6 @@
         - 12645
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -250,7 +241,6 @@
     ItemId: 5128
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -272,7 +262,6 @@
         - 5203
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -295,7 +284,6 @@
         - 5204
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -341,7 +329,6 @@
         - 5206
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -364,7 +351,6 @@
         - 5207
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -384,7 +370,6 @@
     ItemId: 10104
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -406,7 +391,6 @@
         - 9816
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -429,7 +413,6 @@
         - 9794
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -452,7 +435,6 @@
         - 9796
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -475,7 +457,6 @@
         - 9798
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -498,7 +479,6 @@
         - 9800
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -518,7 +498,6 @@
     ItemId: 12216
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -540,7 +519,6 @@
         - 12644
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -563,7 +541,6 @@
         - 12673
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -586,7 +563,6 @@
         - 7175
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -609,7 +585,6 @@
         - 7173
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -632,7 +607,6 @@
         - 7171
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -652,7 +626,6 @@
     ItemId: 1028
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -671,7 +644,6 @@
     ItemId: 1027
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -728,7 +700,6 @@
     ItemId: 1032
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -750,7 +721,6 @@
     ItemId: 1031
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -810,7 +780,6 @@
     ItemId: 769
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -829,7 +798,6 @@
     ItemId: 770
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -848,7 +816,6 @@
     ItemId: 772
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -867,7 +834,6 @@
     ItemId: 771
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -971,7 +937,6 @@
         - 17791
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -991,7 +956,6 @@
     ItemId: 644
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1010,7 +974,6 @@
     ItemId: 643
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1029,7 +992,6 @@
     ItemId: 646
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1048,7 +1010,6 @@
     ItemId: 645
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1067,7 +1028,6 @@
     ItemId: 648
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1089,7 +1049,6 @@
     ItemId: 647
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1111,7 +1070,6 @@
     ItemId: 650
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1130,7 +1088,6 @@
     ItemId: 649
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1149,7 +1106,6 @@
     ItemId: 644
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1168,7 +1124,6 @@
     ItemId: 643
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1187,7 +1142,6 @@
     ItemId: 646
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1206,7 +1160,6 @@
     ItemId: 645
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1225,7 +1178,6 @@
     ItemId: 648
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1247,7 +1199,6 @@
     ItemId: 647
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1269,7 +1220,6 @@
     ItemId: 650
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1288,7 +1238,6 @@
     ItemId: 649
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1310,7 +1259,6 @@
         - 12647
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1330,7 +1278,6 @@
     ItemId: 10103
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1349,7 +1296,6 @@
     ItemId: 5130
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1371,7 +1317,6 @@
         - 12651
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1417,7 +1362,6 @@
         - 12652
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1440,7 +1384,6 @@
         - 12653
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1463,7 +1406,6 @@
         - 12655
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1486,7 +1428,6 @@
         - 12654
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1509,7 +1450,6 @@
         - 12670
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1532,7 +1472,6 @@
         - 12667
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1552,7 +1491,6 @@
     ItemId: 12230
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1571,7 +1509,6 @@
     ItemId: 12231
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1593,7 +1530,6 @@
         - 12671
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1616,7 +1552,6 @@
         - 12672
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1639,7 +1574,6 @@
         - 5061
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1662,7 +1596,6 @@
         - 7179
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1685,7 +1618,6 @@
         - 7610
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1708,7 +1640,6 @@
         - 5075
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1728,7 +1659,6 @@
     ItemId: 10182
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1750,7 +1680,6 @@
         - 5070
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1769,7 +1698,6 @@
     ItemId: 5063
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1788,7 +1716,6 @@
     ItemId: 10122
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1807,7 +1734,6 @@
     ItemId: 10110
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1826,7 +1752,6 @@
     ItemId: 10102
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1848,7 +1773,6 @@
         - 5074
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1868,7 +1792,6 @@
     ItemId: 10106
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1887,7 +1810,6 @@
     ItemId: 10126
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1906,7 +1828,6 @@
     ItemId: 10131
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1925,7 +1846,6 @@
     ItemId: 10130
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1944,7 +1864,6 @@
     ItemId: 10129
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1966,7 +1885,6 @@
         - 7169
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1989,7 +1907,6 @@
         - 7177
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2009,7 +1926,6 @@
     ItemId: 10118
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2028,7 +1944,6 @@
     ItemId: 10113
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2047,7 +1962,6 @@
     ItemId: 5134
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2066,7 +1980,6 @@
     ItemId: 7947
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2088,7 +2001,6 @@
         - 5143
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2108,7 +2020,6 @@
     ItemId: 10117
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2130,7 +2041,6 @@
         - 5142
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2150,7 +2060,6 @@
     ItemId: 10109
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2172,7 +2081,6 @@
         - 5144
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2192,7 +2100,6 @@
     ItemId: 5139
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2211,7 +2118,6 @@
     ItemId: 10125
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2230,7 +2136,6 @@
     ItemId: 10101
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2249,7 +2154,6 @@
     ItemId: 5138
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2290,7 +2194,6 @@
         - 5146
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2310,7 +2213,6 @@
     ItemId: 10105
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2329,7 +2231,6 @@
     ItemId: 10120
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2351,7 +2252,6 @@
         - 5076
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2374,7 +2274,6 @@
         - 5090
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2397,7 +2296,6 @@
         - 5085
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2417,7 +2315,6 @@
     ItemId: 5078
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2462,7 +2359,6 @@
         - 12648
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2508,7 +2404,6 @@
         - 5101
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2531,7 +2426,6 @@
         - 5106
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2554,7 +2448,6 @@
         - 5105
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2577,7 +2470,6 @@
         - 12646
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2597,7 +2489,6 @@
     ItemId: 10116
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2616,7 +2507,6 @@
     ItemId: 10121
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2638,7 +2528,6 @@
         - 5076
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2661,7 +2550,6 @@
         - 7181
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2684,7 +2572,6 @@
         - 5090
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2704,7 +2591,6 @@
     ItemId: 10183
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2726,7 +2612,6 @@
         - 5085
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2746,7 +2631,6 @@
     ItemId: 5078
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2765,7 +2649,6 @@
     ItemId: 10123
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2784,7 +2667,6 @@
     ItemId: 10111
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2806,7 +2688,6 @@
         - 5089
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2826,7 +2707,6 @@
     ItemId: 10141
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2845,7 +2725,6 @@
     ItemId: 10194
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2867,7 +2746,6 @@
         - 12649
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2890,7 +2768,6 @@
         - 12650
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2913,7 +2790,6 @@
         - 12643
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2936,7 +2812,6 @@
         - 12638
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2959,7 +2834,6 @@
         - 12641
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2982,7 +2856,6 @@
         - 12640
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3005,7 +2878,6 @@
         - 12642
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/armor.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/armor.yaml
@@ -13,7 +13,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -37,7 +36,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 30
         StrengthReq: 55
         DexterityReq: 0
@@ -61,7 +59,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 30
         StrengthReq: 60
         DexterityReq: 0
@@ -85,7 +82,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 30
         StrengthReq: 55
         DexterityReq: 0
@@ -109,7 +105,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 20
         DexterityReq: 0
@@ -133,7 +128,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 30
         StrengthReq: 55
         DexterityReq: 0
@@ -157,7 +151,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 60
         StrengthReq: 60
         DexterityReq: 0
@@ -181,7 +174,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 60
         StrengthReq: 60
         DexterityReq: 0
@@ -201,7 +193,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 75
         StrengthReq: 50
         DexterityReq: 0
@@ -225,7 +216,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 60
         StrengthReq: 60
         DexterityReq: 0
@@ -249,7 +239,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 65
         StrengthReq: 10
         DexterityReq: 0
@@ -269,7 +258,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 60
         StrengthReq: 55
         DexterityReq: 0
@@ -293,7 +281,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 255
         StrengthReq: 55
         DexterityReq: 0
@@ -317,7 +304,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 255
         StrengthReq: 60
         DexterityReq: 0
@@ -341,7 +327,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 255
         StrengthReq: 55
         DexterityReq: 0
@@ -365,7 +350,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 255
         StrengthReq: 20
         DexterityReq: 0
@@ -389,7 +373,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 255
         StrengthReq: 55
         DexterityReq: 0
@@ -409,7 +392,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 75
         StrengthReq: 70
         DexterityReq: 0
@@ -433,7 +415,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 75
         StrengthReq: 75
         DexterityReq: 0
@@ -457,7 +438,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 75
         StrengthReq: 75
         DexterityReq: 0
@@ -481,7 +461,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 75
         StrengthReq: 75
         DexterityReq: 0
@@ -505,7 +484,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 75
         StrengthReq: 75
         DexterityReq: 0
@@ -529,7 +507,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 75
         StrengthReq: 75
         DexterityReq: 0
@@ -549,7 +526,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 48
         StrengthReq: 45
         DexterityReq: 0
@@ -573,7 +549,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 65
         StrengthReq: 95
         DexterityReq: 0
@@ -597,7 +572,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -621,7 +595,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 40
         StrengthReq: 25
         DexterityReq: 0
@@ -645,7 +618,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 65
         StrengthReq: 95
         DexterityReq: 0
@@ -669,7 +641,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 45
         StrengthReq: 35
         DexterityReq: 0
@@ -689,7 +660,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -709,7 +679,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -729,7 +698,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -749,7 +717,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -768,6 +735,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -788,6 +757,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -809,7 +780,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -829,7 +799,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -849,7 +818,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -869,7 +837,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -889,7 +856,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -909,7 +875,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -928,6 +893,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -948,6 +915,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -969,7 +938,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -989,7 +957,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -1013,7 +980,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 0
         StrengthReq: 10
         DexterityReq: 0
@@ -1033,7 +999,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1053,7 +1018,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1073,7 +1037,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1093,7 +1056,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1112,6 +1074,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -1132,6 +1096,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -1153,7 +1119,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1173,7 +1138,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1193,7 +1157,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1213,7 +1176,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1233,7 +1195,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1253,7 +1214,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1272,6 +1232,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -1292,6 +1254,8 @@
     Tags:
         - modernuo
         - armor
+    # The client reports layer 7 (Gloves) for this tile, which is wrong for a kilt: the ItemId is
+    # right, the tiledata byte is not. Declared here so the resolver leaves it alone.
     Equip:
         Layer: OuterLegs
         HitPoints: 50
@@ -1313,7 +1277,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1333,7 +1296,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -1357,7 +1319,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 35
         StrengthReq: 10
         DexterityReq: 0
@@ -1377,7 +1338,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 70
         StrengthReq: 55
         DexterityReq: 0
@@ -1397,7 +1357,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 60
         StrengthReq: 45
         DexterityReq: 0
@@ -1421,7 +1380,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -1445,7 +1403,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 45
         StrengthReq: 35
         DexterityReq: 0
@@ -1469,7 +1426,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 45
         StrengthReq: 15
         DexterityReq: 0
@@ -1493,7 +1449,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Neck
         HitPoints: 45
         StrengthReq: 15
         DexterityReq: 0
@@ -1517,7 +1472,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Pants
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -1541,7 +1495,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 45
         StrengthReq: 20
         DexterityReq: 0
@@ -1565,7 +1518,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 40
         StrengthReq: 15
         DexterityReq: 0
@@ -1589,7 +1541,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1609,7 +1560,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Gloves
         HitPoints: 40
         StrengthReq: 10
         DexterityReq: 0
@@ -1629,7 +1579,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Neck
         HitPoints: 40
         StrengthReq: 10
         DexterityReq: 0
@@ -1653,7 +1602,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1677,7 +1625,6 @@
         - armor
         - flippable
     Equip:
-        Layer: OuterLegs
         HitPoints: 40
         StrengthReq: 10
         DexterityReq: 0
@@ -1701,7 +1648,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1725,7 +1671,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1749,7 +1694,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1773,7 +1717,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 40
         StrengthReq: 25
         DexterityReq: 0
@@ -1793,7 +1736,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 45
         StrengthReq: 40
         DexterityReq: 0
@@ -1816,7 +1758,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Gloves
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1836,7 +1777,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Neck
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1856,7 +1796,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1876,7 +1815,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 25
         DexterityReq: 0
@@ -1896,7 +1834,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 25
         DexterityReq: 0
@@ -1920,7 +1857,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -1940,7 +1876,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 40
         StrengthReq: 30
         DexterityReq: 0
@@ -1960,7 +1895,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 45
         StrengthReq: 10
         DexterityReq: 0
@@ -1980,7 +1914,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 65
         StrengthReq: 10
         DexterityReq: 0
@@ -2000,7 +1933,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Gloves
         HitPoints: 25
         StrengthReq: 10
         DexterityReq: 0
@@ -2020,7 +1952,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Pants
         HitPoints: 50
         StrengthReq: 10
         DexterityReq: 0
@@ -2044,7 +1975,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Pants
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -2068,7 +1998,6 @@
         - armor
         - flippable
     Equip:
-        Layer: OuterLegs
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -2088,7 +2017,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Shoes
         HitPoints: 40
         StrengthReq: 20
         DexterityReq: 0
@@ -2108,7 +2036,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 60
         StrengthReq: 55
         DexterityReq: 0
@@ -2128,7 +2055,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 60
         StrengthReq: 55
         DexterityReq: 0
@@ -2148,7 +2074,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 50
         StrengthReq: 30
         DexterityReq: 0
@@ -2172,7 +2097,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 65
         StrengthReq: 80
         DexterityReq: 0
@@ -2192,7 +2116,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 65
         StrengthReq: 70
         DexterityReq: 0
@@ -2216,7 +2139,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 65
         StrengthReq: 95
         DexterityReq: 0
@@ -2236,7 +2158,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 70
         StrengthReq: 85
         DexterityReq: 0
@@ -2260,7 +2181,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 65
         StrengthReq: 70
         DexterityReq: 0
@@ -2280,7 +2200,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Neck
         HitPoints: 65
         StrengthReq: 45
         DexterityReq: 0
@@ -2300,7 +2219,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 65
         StrengthReq: 80
         DexterityReq: 0
@@ -2320,7 +2238,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 75
         StrengthReq: 65
         DexterityReq: 0
@@ -2340,7 +2257,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 65
         StrengthReq: 80
         DexterityReq: 0
@@ -2360,7 +2276,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 75
         StrengthReq: 75
         DexterityReq: 0
@@ -2384,7 +2299,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 65
         StrengthReq: 90
         DexterityReq: 0
@@ -2404,7 +2318,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 70
         StrengthReq: 50
         DexterityReq: 0
@@ -2424,7 +2337,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Shoes
         HitPoints: 65
         StrengthReq: 80
         DexterityReq: 0
@@ -2448,7 +2360,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -2472,7 +2383,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 45
         StrengthReq: 35
         DexterityReq: 0
@@ -2496,7 +2406,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -2516,7 +2425,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Neck
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -2540,7 +2448,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 45
         StrengthReq: 30
         DexterityReq: 0
@@ -2564,7 +2471,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 65
         StrengthReq: 25
         DexterityReq: 0
@@ -2588,7 +2494,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -2612,7 +2517,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -2636,7 +2540,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -2660,7 +2563,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 50
         StrengthReq: 40
         DexterityReq: 0
@@ -2684,7 +2586,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 35
         StrengthReq: 10
         DexterityReq: 0
@@ -2704,7 +2605,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 60
         StrengthReq: 55
         DexterityReq: 0
@@ -2724,7 +2624,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 65
         StrengthReq: 70
         DexterityReq: 0
@@ -2748,7 +2647,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -2772,7 +2670,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 45
         StrengthReq: 35
         DexterityReq: 0
@@ -2796,7 +2693,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 45
         StrengthReq: 35
         DexterityReq: 0
@@ -2816,7 +2712,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerTorso
         HitPoints: 50
         StrengthReq: 55
         DexterityReq: 0
@@ -2840,7 +2735,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -2860,7 +2754,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Neck
         HitPoints: 45
         StrengthReq: 25
         DexterityReq: 0
@@ -2880,7 +2773,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: InnerLegs
         HitPoints: 45
         StrengthReq: 30
         DexterityReq: 0
@@ -2900,7 +2792,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Arms
         HitPoints: 55
         StrengthReq: 30
         DexterityReq: 0
@@ -2924,7 +2815,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 45
         StrengthReq: 30
         DexterityReq: 0
@@ -2944,7 +2834,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Helm
         HitPoints: 40
         StrengthReq: 30
         DexterityReq: 0
@@ -2964,7 +2853,6 @@
         - modernuo
         - armor
     Equip:
-        Layer: Shoes
         HitPoints: 50
         StrengthReq: 30
         DexterityReq: 0
@@ -2988,7 +2876,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 65
         StrengthReq: 25
         DexterityReq: 0
@@ -3012,7 +2899,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 55
         StrengthReq: 25
         DexterityReq: 0
@@ -3036,7 +2922,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Arms
         HitPoints: 65
         StrengthReq: 80
         DexterityReq: 0
@@ -3060,7 +2945,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 65
         StrengthReq: 95
         DexterityReq: 0
@@ -3084,7 +2968,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Gloves
         HitPoints: 65
         StrengthReq: 70
         DexterityReq: 0
@@ -3108,7 +2991,6 @@
         - armor
         - flippable
     Equip:
-        Layer: Neck
         HitPoints: 65
         StrengthReq: 45
         DexterityReq: 0
@@ -3132,7 +3014,6 @@
         - armor
         - flippable
     Equip:
-        Layer: InnerLegs
         HitPoints: 65
         StrengthReq: 90
         DexterityReq: 0

--- a/src/Moongate.Server/Assets/Templates/Items/base/books.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/books.yaml
@@ -5,7 +5,6 @@
     ItemId: 4080
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -23,7 +22,6 @@
     ItemId: 4080
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/base/dye.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/dye.yaml
@@ -5,7 +5,6 @@
     ItemId: 4011
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: items.dye_box
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/base/keys.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/keys.yaml
@@ -5,7 +5,6 @@
     ItemId: 4110
     Hue: 2000
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/base/royalty.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/royalty.yaml
@@ -5,7 +5,6 @@
     ItemId: 8974
     Hue: 1150
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -25,7 +24,6 @@
     ItemId: 5899
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/base/royalty.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/royalty.yaml
@@ -14,7 +14,6 @@
         - npc
         - clothing
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -35,7 +34,6 @@
         - npc
         - clothing
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0

--- a/src/Moongate.Server/Assets/Templates/Items/base/signs.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/signs.yaml
@@ -5,7 +5,6 @@
     ItemId: 3075
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: false
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/base/spawners.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/spawners.yaml
@@ -5,7 +5,6 @@
     ItemId: 7955
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.spawn
     IsMovable: false
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/base/static.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/base/static.yaml
@@ -5,7 +5,6 @@
     ItemId: 1
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: false
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/body_parts.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/body_parts.yaml
@@ -5,7 +5,6 @@
     ItemId: 7584
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 7585
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 7587
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 7586
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +57,6 @@
     ItemId: 7588
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/books.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/books.yaml
@@ -5,7 +5,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -21,7 +20,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -37,7 +35,6 @@
     ItemId: 4081
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -53,7 +50,6 @@
     ItemId: 4082
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -74,7 +70,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -90,7 +85,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -106,7 +100,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -127,7 +120,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -143,7 +135,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -159,7 +150,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -175,7 +165,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -191,7 +180,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -207,7 +195,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -223,7 +210,6 @@
     ItemId: 4082
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -239,7 +225,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -255,7 +240,6 @@
     ItemId: 4081
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -271,7 +255,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -287,7 +270,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -303,7 +285,6 @@
     ItemId: 4081
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -319,7 +300,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -335,7 +315,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -351,7 +330,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -367,7 +345,6 @@
     ItemId: 4082
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -383,7 +360,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -399,7 +375,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -415,7 +390,6 @@
     ItemId: 4081
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -436,7 +410,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -452,7 +425,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -468,7 +440,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -484,7 +455,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -500,7 +470,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -516,7 +485,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -532,7 +500,6 @@
     ItemId: 4080
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -553,7 +520,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -569,7 +535,6 @@
     ItemId: 4082
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -585,7 +550,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -601,7 +565,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -617,7 +580,6 @@
     ItemId: 4079
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/bulletin_boards.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/bulletin_boards.yaml
@@ -8,7 +8,6 @@
         - 7775
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.bulletin_board
     IsMovable: true
     Rarity: Common
@@ -26,7 +25,6 @@
         - 7775
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.bb
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/champion_artifacts.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/champion_artifacts.yaml
@@ -5,7 +5,6 @@
     ItemId: 2887
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 2888
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 2323
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -50,7 +47,6 @@
         - 9859
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -64,7 +60,6 @@
     ItemId: 7960
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -78,7 +73,6 @@
     ItemId: 4846
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -106,7 +100,6 @@
     ItemId: 12813
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -120,7 +113,6 @@
     ItemId: 3617
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -137,7 +129,6 @@
         - 9859
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -154,7 +145,6 @@
         - 9859
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -168,7 +158,6 @@
     ItemId: 13422
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -182,7 +171,6 @@
     ItemId: 7967
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/clothing.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/clothing.yaml
@@ -5,7 +5,6 @@
     ItemId: 5440
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -24,7 +23,6 @@
     ItemId: 5445
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -46,7 +44,6 @@
         - 5442
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -66,7 +63,6 @@
     ItemId: 5913
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -88,7 +84,6 @@
         - 5900
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -108,7 +103,6 @@
     ItemId: 5909
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -127,7 +121,6 @@
     ItemId: 5397
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -149,7 +142,6 @@
         - 10202
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -172,7 +164,6 @@
         - 10207
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -192,7 +183,6 @@
     ItemId: 5447
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -214,7 +204,6 @@
         - 8060
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -237,7 +226,6 @@
         - 12666
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -257,7 +245,6 @@
     ItemId: 12662
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -279,7 +266,6 @@
         - 12665
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -299,7 +285,6 @@
     ItemId: 12661
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -322,7 +307,6 @@
         - 7935
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -345,7 +329,6 @@
         - 7934
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -365,7 +348,6 @@
     ItemId: 5914
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -387,7 +369,6 @@
         - 12660
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -430,7 +411,6 @@
     ItemId: 5907
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -452,7 +432,6 @@
         - 8965
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -475,7 +454,6 @@
         - 8975
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -498,7 +476,6 @@
         - 5438
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -521,7 +498,6 @@
         - 8968
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -544,7 +520,6 @@
         - 8969
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -567,7 +542,6 @@
         - 8971
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -590,7 +564,6 @@
         - 8973
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -613,7 +586,6 @@
         - 10213
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -636,7 +608,6 @@
         - 10215
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -659,7 +630,6 @@
         - 5436
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -679,7 +649,6 @@
     ItemId: 5449
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -698,7 +667,6 @@
     ItemId: 5916
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -720,7 +688,6 @@
         - 8096
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -743,7 +710,6 @@
         - 10220
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -766,7 +732,6 @@
         - 10212
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -789,7 +754,6 @@
         - 10211
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -812,7 +776,6 @@
         - 5432
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -835,7 +798,6 @@
         - 5434
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -855,7 +817,6 @@
     ItemId: 5912
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -877,7 +838,6 @@
         - 12659
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -920,7 +880,6 @@
     ItemId: 9863
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -942,7 +901,6 @@
         - 10210
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -965,7 +923,6 @@
         - 10219
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1007,7 +964,6 @@
         - 7938
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1027,7 +983,6 @@
     ItemId: 5397
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1049,7 +1004,6 @@
         - 7938
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1071,7 +1025,6 @@
         - 7940
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1093,7 +1046,6 @@
         - 7940
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1115,7 +1067,6 @@
         - 10209
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1138,7 +1089,6 @@
         - 5902
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1158,7 +1108,6 @@
     ItemId: 5451
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1180,7 +1129,6 @@
         - 5400
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1203,7 +1151,6 @@
         - 5904
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1226,7 +1173,6 @@
         - 5423
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1249,7 +1195,6 @@
         - 5425
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1269,7 +1214,6 @@
     ItemId: 5444
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1288,7 +1232,6 @@
     ItemId: 5911
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1310,7 +1253,6 @@
         - 8190
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1330,7 +1272,6 @@
     ItemId: 5910
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1352,7 +1293,6 @@
         - 10214
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1372,7 +1312,6 @@
     ItemId: 5905
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1392,7 +1331,6 @@
     ItemId: 5451
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1411,7 +1349,6 @@
     ItemId: 5915
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1433,7 +1370,6 @@
         - 8098
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1456,7 +1392,6 @@
         - 10209
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1476,7 +1411,6 @@
     ItemId: 5908
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1495,7 +1429,6 @@
     ItemId: 5912
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1517,7 +1450,6 @@
         - 12639
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/clothing.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/clothing.yaml
@@ -13,7 +13,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -33,7 +32,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -57,7 +55,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -77,7 +74,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -101,7 +97,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -121,7 +116,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -141,7 +135,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Cloak
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -165,7 +158,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -189,7 +181,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: InnerTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -209,7 +200,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -233,7 +223,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -257,7 +246,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -277,7 +265,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Shirt
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -301,7 +288,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Pants
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -322,7 +308,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shirt
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -346,7 +331,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -370,7 +354,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shirt
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -390,7 +373,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -414,7 +396,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -438,7 +419,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -458,7 +438,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -482,7 +461,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -506,7 +484,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -530,7 +507,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -554,7 +530,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -578,7 +553,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Cloak
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -602,7 +576,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterLegs
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -626,7 +599,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -650,7 +622,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterLegs
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -674,7 +645,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -698,7 +668,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Waist
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -718,7 +687,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -738,7 +706,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -762,7 +729,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -786,7 +752,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -810,7 +775,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -834,7 +798,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -858,7 +821,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterLegs
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -882,7 +844,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Pants
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -902,7 +863,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -926,7 +886,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -950,7 +909,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -970,7 +928,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -994,7 +951,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1018,7 +974,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Waist
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1038,7 +993,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1062,7 +1016,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1082,7 +1035,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Cloak
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1105,7 +1057,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1128,7 +1079,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1151,7 +1101,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: OuterTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1175,7 +1124,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1199,7 +1147,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1219,7 +1166,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1243,7 +1189,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shirt
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1267,7 +1212,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1291,7 +1235,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Pants
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1315,7 +1258,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: OuterLegs
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1335,7 +1277,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1355,7 +1296,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1379,7 +1319,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1399,7 +1338,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1423,7 +1361,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Pants
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1444,7 +1381,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1464,7 +1400,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1484,7 +1419,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1508,7 +1442,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: MiddleTorso
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1532,7 +1465,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Shoes
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -1552,7 +1484,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1572,7 +1503,6 @@
         - modernuo
         - clothing
     Equip:
-        Layer: Helm
         HitPoints: 30
         StrengthReq: 0
         DexterityReq: 0
@@ -1596,7 +1526,6 @@
         - clothing
         - flippable
     Equip:
-        Layer: Waist
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0

--- a/src/Moongate.Server/Assets/Templates/Items/construction.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/construction.yaml
@@ -10,7 +10,6 @@
         - 2909
     Hue: 0
     GoldValue: 0
-    Weight: 20.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +60,6 @@
     ItemId: 7608
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -80,7 +78,6 @@
         - 7860
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -95,7 +92,6 @@
     ItemId: 4100
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -114,7 +110,6 @@
         - 11758
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -129,7 +124,6 @@
     ItemId: 1179
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -143,7 +137,6 @@
     ItemId: 1250
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -157,7 +150,6 @@
     ItemId: 1335
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -199,7 +191,6 @@
     ItemId: 1339
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -213,7 +204,6 @@
     ItemId: 1348
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -227,7 +217,6 @@
     ItemId: 1357
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -241,7 +230,6 @@
     ItemId: 1345
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -255,7 +243,6 @@
     ItemId: 1354
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -269,7 +256,6 @@
     ItemId: 1301
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -286,7 +272,6 @@
         - 3096
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -301,7 +286,6 @@
     ItemId: 1327
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -315,7 +299,6 @@
     ItemId: 1331
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -329,7 +312,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -344,7 +326,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -359,7 +340,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -374,7 +354,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -389,7 +368,6 @@
     ItemId: 5481
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -403,7 +381,6 @@
     ItemId: 5482
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -417,7 +394,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -432,7 +408,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -447,7 +422,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -462,7 +436,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -480,7 +453,6 @@
         - 5485
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -498,7 +470,6 @@
         - 5503
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -516,7 +487,6 @@
         - 5505
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -534,7 +504,6 @@
         - 5487
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -552,7 +521,6 @@
         - 5489
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -570,7 +538,6 @@
         - 5491
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -588,7 +555,6 @@
         - 5493
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -606,7 +572,6 @@
         - 5495
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -624,7 +589,6 @@
         - 5497
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -642,7 +606,6 @@
         - 5499
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -660,7 +623,6 @@
         - 5501
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -675,7 +637,6 @@
     ItemId: 5477
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -690,7 +651,6 @@
     ItemId: 5478
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -723,7 +683,6 @@
     ItemId: 10265
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -758,7 +717,6 @@
         - 11766
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -778,7 +736,6 @@
         - 2897
     Hue: 0
     GoldValue: 0
-    Weight: 20.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -807,7 +764,6 @@
     ItemId: 11594
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -821,7 +777,6 @@
     ItemId: 1295
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -835,7 +790,6 @@
     ItemId: 1276
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -849,7 +803,6 @@
     ItemId: 1297
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -863,7 +816,6 @@
     ItemId: 1180
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -880,7 +832,6 @@
         - 3749
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -898,7 +849,6 @@
         - 3752
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -913,7 +863,6 @@
     ItemId: 3744
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -930,7 +879,6 @@
         - 2941
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -945,7 +893,6 @@
     ItemId: 2885
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -962,7 +909,6 @@
         - 3745
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -980,7 +926,6 @@
         - 3748
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -995,7 +940,6 @@
     ItemId: 1293
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1009,7 +953,6 @@
     ItemId: 1173
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1023,7 +966,6 @@
     ItemId: 4650
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1040,7 +982,6 @@
         - 12633
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1058,7 +999,6 @@
         - 2868
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1073,7 +1013,6 @@
     ItemId: 4484
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1092,7 +1031,6 @@
         - 11750
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1107,7 +1045,6 @@
     ItemId: 10266
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1121,7 +1058,6 @@
     ItemId: 1782
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1135,7 +1071,6 @@
     ItemId: 1781
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1152,7 +1087,6 @@
         - 3090
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1170,7 +1104,6 @@
         - 3093
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1185,7 +1118,6 @@
     ItemId: 3094
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1205,7 +1137,6 @@
         - 3101
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1220,7 +1151,6 @@
     ItemId: 3103
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1238,7 +1168,6 @@
         - 3109
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1256,7 +1185,6 @@
         - 3089
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1274,7 +1202,6 @@
         - 3098
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1289,7 +1216,6 @@
     ItemId: 3116
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1304,7 +1230,6 @@
     ItemId: 1280
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1318,7 +1243,6 @@
     ItemId: 1317
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1332,7 +1256,6 @@
     ItemId: 1321
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1370,7 +1293,6 @@
         - 3768
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1565,7 +1487,6 @@
     ItemId: 1313
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1579,7 +1500,6 @@
     ItemId: 1305
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1593,7 +1513,6 @@
     ItemId: 1309
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1607,7 +1526,6 @@
     ItemId: 2602
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1624,7 +1542,6 @@
         - 3772
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1639,7 +1556,6 @@
     ItemId: 3754
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1653,7 +1569,6 @@
     ItemId: 3756
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1667,7 +1582,6 @@
     ItemId: 3758
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1681,7 +1595,6 @@
     ItemId: 4054
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1695,7 +1608,6 @@
     ItemId: 4055
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1709,7 +1621,6 @@
     ItemId: 4058
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1723,7 +1634,6 @@
     ItemId: 4059
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1737,7 +1647,6 @@
     ItemId: 4062
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1751,7 +1660,6 @@
     ItemId: 4063
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1765,7 +1673,6 @@
     ItemId: 4066
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1779,7 +1686,6 @@
     ItemId: 4067
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1796,7 +1702,6 @@
         - 2867
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1825,7 +1730,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1842,7 +1746,6 @@
         - 3784
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1860,7 +1763,6 @@
         - 3785
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1880,7 +1782,6 @@
         - 3120
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1918,7 +1819,6 @@
         - 2904
     Hue: 0
     GoldValue: 0
-    Weight: 20.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1938,7 +1838,6 @@
         - 2901
     Hue: 0
     GoldValue: 0
-    Weight: 20.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1958,7 +1857,6 @@
         - 2864
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1978,7 +1876,6 @@
         - 2892
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1996,7 +1893,6 @@
         - 2940
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2011,7 +1907,6 @@
     ItemId: 5481
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: false
     Rarity: Common
@@ -2025,7 +1920,6 @@
     ItemId: 5482
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: false
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/containers.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/containers.yaml
@@ -5,7 +5,6 @@
     ItemId: 2639
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -27,7 +26,6 @@
     ItemId: 3701
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -68,7 +66,6 @@
     ItemId: 3702
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -87,7 +84,6 @@
     ItemId: 3703
     Hue: 0
     GoldValue: 0
-    Weight: 25.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -105,7 +101,6 @@
     ItemId: 2448
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -145,7 +140,6 @@
     ItemId: 2604
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -189,7 +183,6 @@
     ItemId: 2717
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -211,7 +204,6 @@
     ItemId: 2637
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -233,7 +225,6 @@
     ItemId: 2608
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -255,7 +246,6 @@
     ItemId: 11527
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -276,7 +266,6 @@
     ItemId: 2711
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -320,7 +309,6 @@
     ItemId: 8791
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -360,7 +348,6 @@
     ItemId: 3706
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -400,7 +387,6 @@
     ItemId: 10263
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -422,7 +408,6 @@
     ItemId: 11525
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -443,7 +428,6 @@
     ItemId: 8790
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -461,7 +445,6 @@
     ItemId: 10261
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/decoration_artifacts.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/decoration_artifacts.yaml
@@ -5,7 +5,6 @@
     ItemId: 7717
     Hue: 2413
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -19,7 +18,6 @@
     ItemId: 2482
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -36,7 +34,6 @@
     ItemId: 9437
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -53,7 +50,6 @@
     ItemId: 9431
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -70,7 +66,6 @@
     ItemId: 9434
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -87,7 +82,6 @@
     ItemId: 9433
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -104,7 +98,6 @@
     ItemId: 9432
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -121,7 +114,6 @@
     ItemId: 9435
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -138,7 +130,6 @@
     ItemId: 9436
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -155,7 +146,6 @@
     ItemId: 9429
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -172,7 +162,6 @@
     ItemId: 3619
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -186,7 +175,6 @@
     ItemId: 7713
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -200,7 +188,6 @@
     ItemId: 7716
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -214,7 +201,6 @@
     ItemId: 7717
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -228,7 +214,6 @@
     ItemId: 3624
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -242,7 +227,6 @@
     ItemId: 9438
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -256,7 +240,6 @@
     ItemId: 9440
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -270,7 +253,6 @@
     ItemId: 9439
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -284,7 +266,6 @@
     ItemId: 3633
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -298,7 +279,6 @@
     ItemId: 4314
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -312,7 +292,6 @@
     ItemId: 9441
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -326,7 +305,6 @@
     ItemId: 3094
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -340,7 +318,6 @@
     ItemId: 10310
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -354,7 +331,6 @@
     ItemId: 10311
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -368,7 +344,6 @@
     ItemId: 4313
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -382,7 +357,6 @@
     ItemId: 9225
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -396,7 +370,6 @@
     ItemId: 9226
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -410,7 +383,6 @@
     ItemId: 10314
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -424,7 +396,6 @@
     ItemId: 1064
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -438,7 +409,6 @@
     ItemId: 2852
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -452,7 +422,6 @@
     ItemId: 5066
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -466,7 +435,6 @@
     ItemId: 10313
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -480,7 +448,6 @@
     ItemId: 10312
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -494,7 +461,6 @@
     ItemId: 9229
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -508,7 +474,6 @@
     ItemId: 9230
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -522,7 +487,6 @@
     ItemId: 9231
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -536,7 +500,6 @@
     ItemId: 9232
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -550,7 +513,6 @@
     ItemId: 9233
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -564,7 +526,6 @@
     ItemId: 9233
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -578,7 +539,6 @@
     ItemId: 9234
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -592,7 +552,6 @@
     ItemId: 9237
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -606,7 +565,6 @@
     ItemId: 9238
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -620,7 +578,6 @@
     ItemId: 9239
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -634,7 +591,6 @@
     ItemId: 9240
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -648,7 +604,6 @@
     ItemId: 4963
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -662,7 +617,6 @@
     ItemId: 3116
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -676,7 +630,6 @@
     ItemId: 3896
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -690,7 +643,6 @@
     ItemId: 9442
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -704,7 +656,6 @@
     ItemId: 9241
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -718,7 +669,6 @@
     ItemId: 9243
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -732,7 +682,6 @@
     ItemId: 7825
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -746,7 +695,6 @@
     ItemId: 7816
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -760,7 +708,6 @@
     ItemId: 6232
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -774,7 +721,6 @@
     ItemId: 4203
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -788,7 +734,6 @@
     ItemId: 5080
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -802,7 +747,6 @@
     ItemId: 5081
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -816,7 +760,6 @@
     ItemId: 10307
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -830,7 +773,6 @@
     ItemId: 10306
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -844,7 +786,6 @@
     ItemId: 10309
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -858,7 +799,6 @@
     ItemId: 10308
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -872,7 +812,6 @@
     ItemId: 10326
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -886,7 +825,6 @@
     ItemId: 10325
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -900,7 +838,6 @@
     ItemId: 10324
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -914,7 +851,6 @@
     ItemId: 10323
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -928,7 +864,6 @@
     ItemId: 10322
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -942,7 +877,6 @@
     ItemId: 10321
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -956,7 +890,6 @@
     ItemId: 4773
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -970,7 +903,6 @@
     ItemId: 9446
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -984,7 +916,6 @@
     ItemId: 9447
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -998,7 +929,6 @@
     ItemId: 9408
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1012,7 +942,6 @@
     ItemId: 9227
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1026,7 +955,6 @@
     ItemId: 9228
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1040,7 +968,6 @@
     ItemId: 9245
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1054,7 +981,6 @@
     ItemId: 9246
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1068,7 +994,6 @@
     ItemId: 9444
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1082,7 +1007,6 @@
     ItemId: 9443
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact
@@ -1096,7 +1020,6 @@
     ItemId: 9445
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Artifact

--- a/src/Moongate.Server/Assets/Templates/Items/deeds.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/deeds.yaml
@@ -8,7 +8,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -25,7 +24,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -42,7 +40,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -59,7 +56,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -76,7 +72,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -93,7 +88,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -110,7 +104,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -127,7 +120,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/food.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/food.yaml
@@ -5,7 +5,6 @@
     ItemId: 2512
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 4161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 10320
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 2425
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -64,7 +60,6 @@
         - 5920
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -97,7 +92,6 @@
     ItemId: 10294
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -111,7 +105,6 @@
     ItemId: 2463
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -126,7 +119,6 @@
     ItemId: 2459
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -141,7 +133,6 @@
     ItemId: 2503
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -170,7 +161,6 @@
     ItemId: 4155
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -201,7 +191,6 @@
         - 3196
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -216,7 +205,6 @@
     ItemId: 2537
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -230,7 +218,6 @@
     ItemId: 4159
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -247,7 +234,6 @@
         - 3194
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -265,7 +251,6 @@
         - 3192
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -280,7 +265,6 @@
     ItemId: 4160
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -336,7 +320,6 @@
     ItemId: 5640
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -350,7 +333,6 @@
     ItemId: 4164
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -364,7 +346,6 @@
     ItemId: 4159
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -378,7 +359,6 @@
     ItemId: 3964
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -392,7 +372,6 @@
     ItemId: 5926
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -406,7 +385,6 @@
     ItemId: 2487
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -420,7 +398,6 @@
     ItemId: 4159
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -434,7 +411,6 @@
     ItemId: 5643
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -448,7 +424,6 @@
     ItemId: 3856
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -462,7 +437,6 @@
     ItemId: 5927
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -476,7 +450,6 @@
     ItemId: 4157
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -493,7 +466,6 @@
         - 3201
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -522,7 +494,6 @@
     ItemId: 2485
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -550,7 +521,6 @@
     ItemId: 10292
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -564,7 +534,6 @@
     ItemId: 5629
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -578,7 +547,6 @@
     ItemId: 5635
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -592,7 +560,6 @@
     ItemId: 5624
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -606,7 +573,6 @@
     ItemId: 5637
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -634,7 +600,6 @@
     ItemId: 2444
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -648,7 +613,6 @@
     ItemId: 2486
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -676,7 +640,6 @@
     ItemId: 4161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -725,7 +688,6 @@
     ItemId: 8061
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -740,7 +702,6 @@
     ItemId: 8069
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -755,7 +716,6 @@
     ItemId: 8073
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -770,7 +730,6 @@
     ItemId: 8081
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -785,7 +744,6 @@
     ItemId: 8077
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -800,7 +758,6 @@
     ItemId: 2513
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -817,7 +774,6 @@
         - 3175
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -832,7 +788,6 @@
     ItemId: 10316
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -860,7 +815,6 @@
     ItemId: 2505
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -877,7 +831,6 @@
         - 3189
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -906,7 +859,6 @@
     ItemId: 5642
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -920,7 +872,6 @@
     ItemId: 5928
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -934,7 +885,6 @@
     ItemId: 5929
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -951,7 +901,6 @@
         - 3185
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -966,7 +915,6 @@
     ItemId: 5930
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -980,7 +928,6 @@
     ItemId: 5931
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -994,7 +941,6 @@
     ItemId: 4161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1008,7 +954,6 @@
     ItemId: 3864
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1022,7 +967,6 @@
     ItemId: 10317
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1050,7 +994,6 @@
     ItemId: 2542
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -1068,7 +1011,6 @@
         - 3182
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1083,7 +1025,6 @@
     ItemId: 5923
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1097,7 +1038,6 @@
     ItemId: 2514
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1111,7 +1051,6 @@
     ItemId: 4161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1125,7 +1064,6 @@
     ItemId: 2452
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1139,7 +1077,6 @@
     ItemId: 5630
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1153,7 +1090,6 @@
     ItemId: 5631
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1167,7 +1103,6 @@
     ItemId: 5632
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1181,7 +1116,6 @@
     ItemId: 5633
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1195,7 +1129,6 @@
     ItemId: 5634
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1209,7 +1142,6 @@
     ItemId: 8085
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -1224,7 +1156,6 @@
     ItemId: 8087
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -1239,7 +1170,6 @@
     ItemId: 8089
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -1269,7 +1199,6 @@
     ItemId: 8093
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -1284,7 +1213,6 @@
     ItemId: 8091
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.beverage
     IsMovable: true
     Rarity: Common
@@ -1302,7 +1230,6 @@
         - 3179
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1317,7 +1244,6 @@
     ItemId: 4161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1331,7 +1257,6 @@
     ItemId: 4161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1345,7 +1270,6 @@
     ItemId: 2489
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1359,7 +1283,6 @@
     ItemId: 5639
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1387,7 +1310,6 @@
     ItemId: 5641
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1401,7 +1323,6 @@
     ItemId: 2545
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1415,7 +1336,6 @@
     ItemId: 10319
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1429,7 +1349,6 @@
     ItemId: 2546
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1443,7 +1362,6 @@
     ItemId: 2491
     Hue: 0
     GoldValue: 0
-    Weight: 45.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1457,7 +1375,6 @@
     ItemId: 4153
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1485,7 +1402,6 @@
     ItemId: 2496
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1499,7 +1415,6 @@
     ItemId: 4160
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1513,7 +1428,6 @@
     ItemId: 3894
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1527,7 +1441,6 @@
     ItemId: 2422
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1541,7 +1454,6 @@
     ItemId: 3180
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1556,7 +1468,6 @@
     ItemId: 3165
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1570,7 +1481,6 @@
     ItemId: 5925
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1588,7 +1498,6 @@
         - 3187
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1603,7 +1512,6 @@
     ItemId: 10304
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1617,7 +1525,6 @@
     ItemId: 10302
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1631,7 +1538,6 @@
     ItemId: 4157
     Hue: 150
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1645,7 +1551,6 @@
     ItemId: 3386
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1660,7 +1565,6 @@
     ItemId: 4162
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1674,7 +1578,6 @@
     ItemId: 4162
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1688,7 +1591,6 @@
     ItemId: 4162
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1702,7 +1604,6 @@
     ItemId: 4162
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1716,7 +1617,6 @@
     ItemId: 4162
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1730,7 +1630,6 @@
     ItemId: 4162
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1744,7 +1643,6 @@
     ItemId: 4227
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1758,7 +1656,6 @@
     ItemId: 4227
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1772,7 +1669,6 @@
     ItemId: 3626
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1786,7 +1682,6 @@
     ItemId: 9448
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1800,7 +1695,6 @@
     ItemId: 9451
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1814,7 +1708,6 @@
     ItemId: 3164
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1828,7 +1721,6 @@
     ItemId: 7869
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1842,7 +1734,6 @@
     ItemId: 3857
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1856,7 +1747,6 @@
     ItemId: 10318
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1870,7 +1760,6 @@
     ItemId: 5624
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1884,7 +1773,6 @@
     ItemId: 5625
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1898,7 +1786,6 @@
     ItemId: 5626
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1912,7 +1799,6 @@
     ItemId: 5627
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1926,7 +1812,6 @@
     ItemId: 5628
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1940,7 +1825,6 @@
     ItemId: 5636
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1954,7 +1838,6 @@
     ItemId: 5638
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common
@@ -1971,7 +1854,6 @@
         - 3173
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.food
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/games.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/games.yaml
@@ -8,7 +8,6 @@
         - 4013
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -26,7 +25,6 @@
     ItemId: 4006
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -43,7 +41,6 @@
     ItemId: 4006
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -60,7 +57,6 @@
     ItemId: 4007
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -74,7 +70,6 @@
     ItemId: 4010
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/gm/gm_body.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/gm/gm_body.yaml
@@ -46,7 +46,6 @@
     ItemId: 6256
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.gm_hiding_stone
     IsMovable: true
     Rarity: Common
@@ -62,7 +61,6 @@
     ItemId: 8413
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.gm_ethereal
     IsMovable: true
     Rarity: Common
@@ -78,7 +76,6 @@
     ItemId: 3631
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.gm_staff_orb
     IsMovable: true
     Rarity: Common
@@ -94,7 +91,6 @@
     ItemId: 8967
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: items.gm_fur_boots
     IsMovable: true
     Rarity: Common
@@ -111,7 +107,6 @@
     ItemId: 5444
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.gm_skullcap
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/guilds.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/guilds.yaml
@@ -8,7 +8,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -22,7 +21,6 @@
     ItemId: 6249
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -39,7 +37,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/jewels.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/jewels.yaml
@@ -27,7 +27,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Neck
         HitPoints: 0
 -   Id: gold_bracelet
     Name: Gold Bracelet
@@ -44,7 +43,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Bracelet
         HitPoints: 0
 -   Id: gold_earrings
     Name: Gold Earrings
@@ -61,7 +59,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Earrings
         HitPoints: 0
 -   Id: gold_necklace
     Name: Gold Necklace
@@ -78,7 +75,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Neck
         HitPoints: 0
 -   Id: gold_ring
     Name: Gold Ring
@@ -95,7 +91,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Ring
         HitPoints: 0
 -   Id: necklace
     Name: Necklace
@@ -112,7 +107,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Neck
         HitPoints: 0
 -   Id: silver_bead_necklace
     Name: Silver Bead Necklace
@@ -129,7 +123,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Neck
         HitPoints: 0
 -   Id: silver_bracelet
     Name: Silver Bracelet
@@ -146,7 +139,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Bracelet
         HitPoints: 0
 -   Id: silver_earrings
     Name: Silver Earrings
@@ -163,7 +155,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Earrings
         HitPoints: 0
 -   Id: silver_necklace
     Name: Silver Necklace
@@ -180,7 +171,6 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Neck
         HitPoints: 0
 -   Id: silver_ring
     Name: Silver Ring
@@ -197,5 +187,4 @@
         - modernuo
         - jewels
     Equip:
-        Layer: Ring
         HitPoints: 0

--- a/src/Moongate.Server/Assets/Templates/Items/jewels.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/jewels.yaml
@@ -5,7 +5,6 @@
     ItemId: 4235
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/lights.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/lights.yaml
@@ -33,7 +33,6 @@
     ItemId: 2599
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -93,7 +92,6 @@
     ItemId: 2600
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -123,7 +121,6 @@
     ItemId: 2598
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -153,7 +150,6 @@
     ItemId: 5171
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -183,7 +179,6 @@
     ItemId: 5167
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -243,7 +238,6 @@
     ItemId: 5702
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -289,7 +283,6 @@
     ItemId: 6217
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -409,7 +402,6 @@
     ItemId: 2597
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common
@@ -439,7 +431,6 @@
     ItemId: 5703
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -573,7 +564,6 @@
     ItemId: 3947
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.light_source
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/lights.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/lights.yaml
@@ -116,8 +116,6 @@
         light_toggle_sound_off:
             Type: String
             Value: '0x03BE'
-    Equip:
-        Layer: TwoHanded
 -   Id: candle_large
     Name: Candle Large
     Category: Lights
@@ -434,8 +432,6 @@
         light_toggle_sound_off:
             Type: String
             Value: '0x03BE'
-    Equip:
-        Layer: TwoHanded
 -   Id: light_source
     Name: Light Source
     Category: Lights
@@ -450,8 +446,6 @@
     Tags:
         - modernuo
         - lights
-    Equip:
-        Layer: TwoHanded
 -   Id: paper_lantern
     Name: Paper Lantern
     Category: Lights
@@ -602,8 +596,6 @@
         light_toggle_sound_off:
             Type: String
             Value: '0x04BB'
-    Equip:
-        Layer: TwoHanded
 -   Id: wall_sconce
     Name: Wall Sconce
     Category: Lights

--- a/src/Moongate.Server/Assets/Templates/Items/loot_support.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/loot_support.yaml
@@ -5,7 +5,6 @@
     ItemId: 3535
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -43,7 +42,6 @@
     ItemId: 3717
     Hue: 0
     GoldValue: 0
-    Weight: 11.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/maps.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/maps.yaml
@@ -8,7 +8,6 @@
         - 5356
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -26,7 +25,6 @@
         - 5356
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/minor_artifacts.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/minor_artifacts.yaml
@@ -5,7 +5,6 @@
     ItemId: 12122
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 2854
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 5367
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 7147
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +57,6 @@
     ItemId: 1150
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -78,7 +73,6 @@
         - 7940
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -96,7 +90,6 @@
         - 7940
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -114,7 +107,6 @@
         - 5364
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -128,7 +120,6 @@
     ItemId: 12123
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -145,7 +136,6 @@
         - 5364
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/misc.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/misc.yaml
@@ -8,7 +8,6 @@
         - 6813
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -22,7 +21,6 @@
     ItemId: 4650
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -36,7 +34,6 @@
     ItemId: 525
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -50,7 +47,6 @@
     ItemId: 6209
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -64,7 +60,6 @@
     ItemId: 6206
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -78,7 +73,6 @@
     ItemId: 6212
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -92,7 +86,6 @@
     ItemId: 7847
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -109,7 +102,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -123,7 +115,6 @@
     ItemId: 5154
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -137,7 +128,6 @@
     ItemId: 8612
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -156,7 +146,6 @@
         - 6193
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -177,7 +166,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -191,7 +179,6 @@
     ItemId: 9900
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -219,7 +206,6 @@
     ItemId: 7888
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -275,7 +261,6 @@
     ItemId: 4328
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -292,7 +277,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -306,7 +290,6 @@
     ItemId: 6265
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -320,7 +303,6 @@
     ItemId: 8763
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -341,7 +323,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -356,7 +337,6 @@
     ItemId: 3633
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -370,7 +350,6 @@
     ItemId: 2526
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -384,7 +363,6 @@
     ItemId: 2524
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -398,7 +376,6 @@
     ItemId: 2536
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -412,7 +389,6 @@
     ItemId: 2534
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -426,7 +402,6 @@
     ItemId: 2527
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -440,7 +415,6 @@
     ItemId: 2525
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -454,7 +428,6 @@
     ItemId: 2535
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -468,7 +441,6 @@
     ItemId: 574
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -482,7 +454,6 @@
     ItemId: 3138
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -496,7 +467,6 @@
     ItemId: 3136
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -510,7 +480,6 @@
     ItemId: 7026
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -531,7 +500,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -552,7 +520,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -566,7 +533,6 @@
     ItemId: 7192
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -584,7 +550,6 @@
         - 6202
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -598,7 +563,6 @@
     ItemId: 3620
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -616,7 +580,6 @@
         - 6236
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -631,7 +594,6 @@
     ItemId: 8442
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -645,7 +607,6 @@
     ItemId: 3971
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -659,7 +620,6 @@
     ItemId: 10291
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -673,7 +633,6 @@
     ItemId: 4024
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -690,7 +649,6 @@
         - 6238
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -705,7 +663,6 @@
     ItemId: 755
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -719,7 +676,6 @@
     ItemId: 3821
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Stackable: true
@@ -734,7 +690,6 @@
     ItemId: 6264
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -753,7 +708,6 @@
         - 6193
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -767,7 +721,6 @@
     ItemId: 3835
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -789,7 +742,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -803,7 +755,6 @@
     ItemId: 3134
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -817,7 +768,6 @@
     ItemId: 8700
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -831,7 +781,6 @@
     ItemId: 4596
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -848,7 +797,6 @@
         - 4656
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -862,7 +810,6 @@
     ItemId: 3839
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -879,7 +826,6 @@
         - 12637
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -894,7 +840,6 @@
     ItemId: 4022
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -911,7 +856,6 @@
         - 6161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -928,7 +872,6 @@
         - 6161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -943,7 +886,6 @@
     ItemId: 8448
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -957,7 +899,6 @@
     ItemId: 9908
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -971,7 +912,6 @@
     ItemId: 587
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -985,7 +925,6 @@
     ItemId: 4033
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -999,7 +938,6 @@
     ItemId: 6262
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1013,7 +951,6 @@
     ItemId: 4113
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1031,7 +968,6 @@
         - 6205
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1049,7 +985,6 @@
         - 6205
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1068,7 +1003,6 @@
         - 6205
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1086,7 +1020,6 @@
         - 6205
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1104,7 +1037,6 @@
         - 6202
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1119,7 +1051,6 @@
     ItemId: 8610
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1140,7 +1071,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1157,7 +1087,6 @@
         - 3921
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1174,7 +1103,6 @@
         - 12631
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1194,7 +1122,6 @@
         - 6189
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1209,7 +1136,6 @@
     ItemId: 3839
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1223,7 +1149,6 @@
     ItemId: 2888
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1237,7 +1162,6 @@
     ItemId: 9779
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1251,7 +1175,6 @@
     ItemId: 3979
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1265,7 +1188,6 @@
     ItemId: 5981
     Hue: 2001
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1279,7 +1201,6 @@
     ItemId: 7192
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1293,7 +1214,6 @@
     ItemId: 8825
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1307,7 +1227,6 @@
     ItemId: 10296
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1321,7 +1240,6 @@
     ItemId: 10301
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1335,7 +1253,6 @@
     ItemId: 10298
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1349,7 +1266,6 @@
     ItemId: 10288
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1363,7 +1279,6 @@
     ItemId: 10299
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1377,7 +1292,6 @@
     ItemId: 10300
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1391,7 +1305,6 @@
     ItemId: 10297
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1405,7 +1318,6 @@
     ItemId: 4033
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1419,7 +1331,6 @@
     ItemId: 2518
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1433,7 +1344,6 @@
     ItemId: 7829
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1450,7 +1360,6 @@
         - 4032
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1464,7 +1373,6 @@
     ItemId: 8978
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1478,7 +1386,6 @@
     ItemId: 8977
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1492,7 +1399,6 @@
     ItemId: 7964
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1506,7 +1412,6 @@
     ItemId: 575
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1520,7 +1425,6 @@
     ItemId: 1
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1534,7 +1438,6 @@
     ItemId: 575
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1565,7 +1468,6 @@
     ItemId: 7888
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1584,7 +1486,6 @@
         - 6193
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1598,7 +1499,6 @@
     ItemId: 3836
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1620,7 +1520,6 @@
         - 6199
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1638,7 +1537,6 @@
         - 6202
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1652,7 +1550,6 @@
     ItemId: 4980
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1680,7 +1577,6 @@
     ItemId: 4128
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1694,7 +1590,6 @@
     ItemId: 3838
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1708,7 +1603,6 @@
     ItemId: 6226
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1722,7 +1616,6 @@
     ItemId: 572
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1736,7 +1629,6 @@
     ItemId: 9023
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1750,7 +1642,6 @@
     ItemId: 6263
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1764,7 +1655,6 @@
     ItemId: 6215
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1783,7 +1673,6 @@
         - 6189
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1797,7 +1686,6 @@
     ItemId: 3837
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1816,7 +1704,6 @@
         - 6189
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1835,7 +1722,6 @@
         - 6193
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1850,7 +1736,6 @@
     ItemId: 3841
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1864,7 +1749,6 @@
     ItemId: 6216
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1883,7 +1767,6 @@
         - 6189
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1897,7 +1780,6 @@
     ItemId: 3842
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1916,7 +1798,6 @@
         - 6189
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1930,7 +1811,6 @@
     ItemId: 3622
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1944,7 +1824,6 @@
     ItemId: 3622
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1961,7 +1840,6 @@
         - 6161
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1976,7 +1854,6 @@
     ItemId: 4050
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1990,7 +1867,6 @@
     ItemId: 2331
     Hue: 1
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2004,7 +1880,6 @@
     ItemId: 3841
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2018,7 +1893,6 @@
     ItemId: 8753
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2032,7 +1906,6 @@
     ItemId: 3578
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2046,7 +1919,6 @@
     ItemId: 7107
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2060,7 +1932,6 @@
     ItemId: 10922
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2077,7 +1948,6 @@
         - 6813
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2091,7 +1961,6 @@
     ItemId: 573
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2105,7 +1974,6 @@
     ItemId: 6178
     Hue: 1154
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2119,7 +1987,6 @@
     ItemId: 3844
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2133,7 +2000,6 @@
     ItemId: 3843
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2150,7 +2016,6 @@
         - 3806
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2164,7 +2029,6 @@
     ItemId: 3703
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2183,7 +2047,6 @@
         - 3648
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2200,7 +2063,6 @@
     ItemId: 4051
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2214,7 +2076,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2228,7 +2089,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2242,7 +2102,6 @@
     ItemId: 2512
     Hue: 6
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2256,7 +2115,6 @@
     ItemId: 2540
     Hue: 2101
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2270,7 +2128,6 @@
     ItemId: 3966
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2288,7 +2145,6 @@
         - 6202
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2307,7 +2163,6 @@
         - 7959
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2322,7 +2177,6 @@
     ItemId: 5742
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2336,7 +2190,6 @@
     ItemId: 3132
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2350,7 +2203,6 @@
     ItemId: 10290
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2369,7 +2221,6 @@
         - 6193
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2386,7 +2237,6 @@
         - 6236
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2404,7 +2254,6 @@
         - 6238
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2419,7 +2268,6 @@
     ItemId: 8610
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: false
     Rarity: Common
@@ -2433,7 +2281,6 @@
     ItemId: 8978
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2447,7 +2294,6 @@
     ItemId: 8977
     Hue: 0
     GoldValue: 0
-    Weight: 15.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/mounts.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/mounts.yaml
@@ -5,7 +5,6 @@
     ItemId: 8413
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.ethereal_horse
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/new_haven_quest_rewards.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/new_haven_quest_rewards.yaml
@@ -5,7 +5,6 @@
     ItemId: 500
     Hue: 1895
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/resources.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/resources.yaml
@@ -19,7 +19,6 @@
     ItemId: 12687
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +32,6 @@
     ItemId: 3960
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +45,6 @@
     ItemId: 2508
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +58,6 @@
     ItemId: 3962
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -76,7 +72,6 @@
     ItemId: 12675
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -90,7 +85,6 @@
     ItemId: 3963
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -105,7 +99,6 @@
     ItemId: 12696
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -142,7 +135,6 @@
         - 3996
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -157,7 +149,6 @@
     ItemId: 3966
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -171,7 +162,6 @@
     ItemId: 12697
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -185,7 +175,6 @@
     ItemId: 12686
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -217,7 +206,6 @@
     ItemId: 12676
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -231,7 +219,6 @@
     ItemId: 3577
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -245,7 +232,6 @@
     ItemId: 3965
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -259,7 +245,6 @@
     ItemId: 3968
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -273,7 +258,6 @@
     ItemId: 12690
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -287,7 +271,6 @@
     ItemId: 3613
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -301,7 +284,6 @@
     ItemId: 3984
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -315,7 +297,6 @@
     ItemId: 12683
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -329,7 +310,6 @@
     ItemId: 16503
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -343,7 +323,6 @@
     ItemId: 12682
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -357,7 +336,6 @@
     ItemId: 12693
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -371,7 +349,6 @@
     ItemId: 12685
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -399,7 +376,6 @@
     ItemId: 12695
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -413,7 +389,6 @@
     ItemId: 4
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -430,7 +405,6 @@
         - 6813
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -445,7 +419,6 @@
     ItemId: 3972
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -460,7 +433,6 @@
     ItemId: 3973
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -475,7 +447,6 @@
     ItemId: 3983
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -489,7 +460,6 @@
     ItemId: 12684
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -503,7 +473,6 @@
     ItemId: 12681
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -517,7 +486,6 @@
     ItemId: 3614
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -531,7 +499,6 @@
     ItemId: 3615
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -545,7 +512,6 @@
     ItemId: 12689
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -559,7 +525,6 @@
     ItemId: 3974
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -574,7 +539,6 @@
     ItemId: 12680
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -588,7 +552,6 @@
     ItemId: 3976
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -603,7 +566,6 @@
     ItemId: 3982
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -617,7 +579,6 @@
     ItemId: 12688
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -631,7 +592,6 @@
     ItemId: 66
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -645,7 +605,6 @@
     ItemId: 12692
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -659,7 +618,6 @@
     ItemId: 3978
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -676,7 +634,6 @@
         - 12635
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -691,7 +648,6 @@
     ItemId: 51
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -705,7 +661,6 @@
     ItemId: 12678
     Hue: 883
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -719,7 +674,6 @@
     ItemId: 12677
     Hue: 150
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -747,7 +701,6 @@
     ItemId: 3981
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -762,7 +715,6 @@
     ItemId: 4000
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -776,7 +728,6 @@
     ItemId: 3980
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -791,7 +742,6 @@
     ItemId: 12127
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -806,7 +756,6 @@
     ItemId: 12679
     Hue: 731
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -820,7 +769,6 @@
     ItemId: 4127
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -834,7 +782,6 @@
     ItemId: 76
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -848,7 +795,6 @@
     ItemId: 12691
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -880,7 +826,6 @@
     ItemId: 12694
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -894,7 +839,6 @@
     ItemId: 86
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -908,7 +852,6 @@
     ItemId: 3576
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/resurrection.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/resurrection.yaml
@@ -5,7 +5,6 @@
     ItemId: 4
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.resurrection_shrine
     IsMovable: false
     Rarity: Common
@@ -24,7 +23,6 @@
     ItemId: 3
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.resurrection_shrine
     IsMovable: false
     Rarity: Common
@@ -43,7 +41,6 @@
     ItemId: 4
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.resurrection_shrine
     IsMovable: false
     Rarity: Common
@@ -62,7 +59,6 @@
     ItemId: 3
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.resurrection_shrine
     IsMovable: false
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/shields.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/shields.yaml
@@ -5,7 +5,6 @@
     ItemId: 7026
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -22,7 +21,6 @@
     ItemId: 7027
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -59,7 +57,6 @@
         - 16903
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -77,7 +74,6 @@
     ItemId: 7030
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -94,7 +90,6 @@
     ItemId: 7028
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -111,7 +106,6 @@
     ItemId: 7035
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -128,7 +122,6 @@
     ItemId: 7108
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -145,7 +138,6 @@
     ItemId: 7033
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -162,7 +154,6 @@
     ItemId: 7034
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/shields.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/shields.yaml
@@ -13,7 +13,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 30
         StrengthReq: 35
 -   Id: buckler
@@ -31,7 +30,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 50
         StrengthReq: 20
 -   Id: chaos_shield
@@ -49,7 +47,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 125
         StrengthReq: 95
 -   Id: gargish_wooden_shield
@@ -71,7 +68,6 @@
         - shields
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 25
         StrengthReq: 20
 -   Id: heater_shield
@@ -89,7 +85,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 65
         StrengthReq: 90
 -   Id: metal_kite_shield
@@ -107,7 +102,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 45
 -   Id: metal_shield
@@ -125,7 +119,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 65
         StrengthReq: 45
 -   Id: order_shield
@@ -143,7 +136,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 125
         StrengthReq: 95
 -   Id: wooden_kite_shield
@@ -161,7 +153,6 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 65
         StrengthReq: 20
 -   Id: wooden_shield
@@ -179,6 +170,5 @@
         - modernuo
         - shields
     Equip:
-        Layer: TwoHanded
         HitPoints: 25
         StrengthReq: 20

--- a/src/Moongate.Server/Assets/Templates/Items/skill_items.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/skill_items.yaml
@@ -5,7 +5,6 @@
     ItemId: 8
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 3848
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.agility_potion
     IsMovable: true
     Rarity: Common
@@ -35,7 +33,6 @@
     ItemId: 100
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -49,7 +46,6 @@
     ItemId: 683
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -66,7 +62,6 @@
         - 4016
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -81,7 +76,6 @@
     ItemId: 600
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -95,7 +89,6 @@
     ItemId: 615
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -109,7 +102,6 @@
     ItemId: 24
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -123,7 +115,6 @@
     ItemId: 25
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -137,7 +128,6 @@
     ItemId: 603
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -154,7 +144,6 @@
         - 4188
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -172,7 +161,6 @@
         - 4178
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -187,7 +175,6 @@
     ItemId: 10245
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -220,7 +207,6 @@
         - 2649
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -235,7 +221,6 @@
     ItemId: 32
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -249,7 +234,6 @@
     ItemId: 3827
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -263,7 +247,6 @@
     ItemId: 16
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -277,7 +260,6 @@
     ItemId: 101
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -294,7 +276,6 @@
         - 3721
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -312,7 +293,6 @@
         - 7130
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -330,7 +310,6 @@
         - 4172
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: items.clock
     IsMovable: true
     Rarity: Common
@@ -345,7 +324,6 @@
     ItemId: 688
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -359,7 +337,6 @@
     ItemId: 9100
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -373,7 +350,6 @@
     ItemId: 8786
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -387,7 +363,6 @@
     ItemId: 9120
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -401,7 +376,6 @@
     ItemId: 3854
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -415,7 +389,6 @@
     ItemId: 48
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -429,7 +402,6 @@
     ItemId: 687
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -446,7 +418,6 @@
         - 4174
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -464,7 +435,6 @@
         - 4172
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.clock
     IsMovable: true
     Rarity: Common
@@ -482,7 +452,6 @@
         - 4176
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -497,7 +466,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -511,7 +479,6 @@
     ItemId: 102
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -525,7 +492,6 @@
     ItemId: 1
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -539,7 +505,6 @@
     ItemId: 9
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -553,7 +518,6 @@
     ItemId: 10
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -567,7 +531,6 @@
     ItemId: 26
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -581,7 +544,6 @@
     ItemId: 103
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -595,7 +557,6 @@
     ItemId: 3589
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -609,7 +570,6 @@
     ItemId: 33
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -623,7 +583,6 @@
     ItemId: 40
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -640,7 +599,6 @@
         - 4137
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -655,7 +613,6 @@
     ItemId: 4324
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -672,7 +629,6 @@
         - 3783
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -687,7 +643,6 @@
     ItemId: 3740
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -701,7 +656,6 @@
     ItemId: 611
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -715,7 +669,6 @@
     ItemId: 4011
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: items.dye_tub
     IsMovable: true
     Rarity: Common
@@ -729,7 +682,6 @@
     ItemId: 4009
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -743,7 +695,6 @@
     ItemId: 682
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -757,7 +708,6 @@
     ItemId: 56
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -771,7 +721,6 @@
     ItemId: 10248
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -785,7 +734,6 @@
     ItemId: 680
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -799,7 +747,6 @@
     ItemId: 41
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -813,7 +760,6 @@
     ItemId: 49
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -827,7 +773,6 @@
     ItemId: 57
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -841,7 +786,6 @@
     ItemId: 610
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -855,7 +799,6 @@
     ItemId: 612
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -869,7 +812,6 @@
     ItemId: 104
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -883,7 +825,6 @@
     ItemId: 116
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -897,7 +838,6 @@
     ItemId: 42
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -911,7 +851,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -925,7 +864,6 @@
     ItemId: 27
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -939,7 +877,6 @@
     ItemId: 4039
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -953,7 +890,6 @@
     ItemId: 17
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -967,7 +903,6 @@
     ItemId: 3520
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -981,7 +916,6 @@
     ItemId: 50
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -998,7 +932,6 @@
         - 4131
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1013,7 +946,6 @@
     ItemId: 4158
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1027,7 +959,6 @@
     ItemId: 4017
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1047,7 +978,6 @@
         - 2468
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1067,7 +997,6 @@
         - 2468
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1087,7 +1016,6 @@
         - 2468
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1102,7 +1030,6 @@
     ItemId: 4325
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1134,7 +1061,6 @@
     ItemId: 10246
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1148,7 +1074,6 @@
     ItemId: 51
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1165,7 +1090,6 @@
         - 4180
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1180,7 +1104,6 @@
     ItemId: 614
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1194,7 +1117,6 @@
     ItemId: 601
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1222,7 +1144,6 @@
     ItemId: 4167
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1236,7 +1157,6 @@
     ItemId: 28
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1250,7 +1170,6 @@
     ItemId: 690
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1264,7 +1183,6 @@
     ItemId: 4138
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1278,7 +1196,6 @@
     ItemId: 11
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1292,7 +1209,6 @@
     ItemId: 3761
     Hue: 0
     GoldValue: 0
-    Weight: 35.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1306,7 +1222,6 @@
     ItemId: 3
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1320,7 +1235,6 @@
     ItemId: 678
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1337,7 +1251,6 @@
         - 4182
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1352,7 +1265,6 @@
     ItemId: 105
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1366,7 +1278,6 @@
     ItemId: 602
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1380,7 +1291,6 @@
     ItemId: 34
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1394,7 +1304,6 @@
     ItemId: 4326
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1408,7 +1317,6 @@
     ItemId: 3850
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1422,7 +1330,6 @@
     ItemId: 43
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1439,7 +1346,6 @@
         - 4145
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1454,7 +1360,6 @@
     ItemId: 3553
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1473,7 +1378,6 @@
         - 2470
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1493,7 +1397,6 @@
         - 2470
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1513,7 +1416,6 @@
         - 2470
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1528,7 +1430,6 @@
     ItemId: 3762
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1542,7 +1443,6 @@
     ItemId: 6522
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1556,7 +1456,6 @@
     ItemId: 6554
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1573,7 +1472,6 @@
         - 10203
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1588,7 +1486,6 @@
     ItemId: 106
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1602,7 +1499,6 @@
     ItemId: 3847
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.lesser_cure_potion
     IsMovable: true
     Rarity: Common
@@ -1618,7 +1514,6 @@
     ItemId: 3853
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.lesser_explosion_potion
     IsMovable: true
     Rarity: Common
@@ -1634,7 +1529,6 @@
     ItemId: 3852
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.lesser_heal_potion
     IsMovable: true
     Rarity: Common
@@ -1650,7 +1544,6 @@
     ItemId: 3850
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.lesser_poison_potion
     IsMovable: true
     Rarity: Common
@@ -1688,7 +1581,6 @@
         - 4226
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1704,7 +1596,6 @@
     ItemId: 29
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1721,7 +1612,6 @@
         - 5371
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1739,7 +1629,6 @@
         - 7136
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1754,7 +1643,6 @@
     ItemId: 3763
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1768,7 +1656,6 @@
     ItemId: 4
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1782,7 +1669,6 @@
     ItemId: 18
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1796,7 +1682,6 @@
     ItemId: 35
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1810,7 +1695,6 @@
     ItemId: 12
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1824,7 +1708,6 @@
     ItemId: 13
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1838,7 +1721,6 @@
     ItemId: 4787
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1852,7 +1734,6 @@
     ItemId: 30
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1866,7 +1747,6 @@
     ItemId: 52
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1883,7 +1763,6 @@
         - 4032
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1898,7 +1777,6 @@
     ItemId: 44
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1926,7 +1804,6 @@
     ItemId: 45
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1940,7 +1817,6 @@
     ItemId: 53
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1954,7 +1830,6 @@
     ItemId: 686
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1968,7 +1843,6 @@
     ItemId: 2463
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1982,7 +1856,6 @@
     ItemId: 54
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1996,7 +1869,6 @@
     ItemId: 36
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2010,7 +1882,6 @@
     ItemId: 107
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2024,7 +1895,6 @@
     ItemId: 3948
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2038,7 +1908,6 @@
     ItemId: 3739
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2055,7 +1924,6 @@
         - 4141
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2070,7 +1938,6 @@
     ItemId: 11677
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2087,7 +1954,6 @@
         - 4143
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2102,7 +1968,6 @@
     ItemId: 605
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2116,7 +1981,6 @@
     ItemId: 8787
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2130,7 +1994,6 @@
     ItemId: 3834
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2144,7 +2007,6 @@
     ItemId: 677
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2158,7 +2020,6 @@
     ItemId: 691
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2172,7 +2033,6 @@
     ItemId: 3846
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2186,7 +2046,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2200,7 +2059,6 @@
     ItemId: 108
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2214,7 +2072,6 @@
     ItemId: 46
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2228,7 +2085,6 @@
     ItemId: 37
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2242,7 +2098,6 @@
     ItemId: 2519
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2256,7 +2111,6 @@
     ItemId: 38
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2270,7 +2124,6 @@
     ItemId: 19
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2284,7 +2137,6 @@
     ItemId: 109
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2298,7 +2150,6 @@
     ItemId: 55
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2347,7 +2198,6 @@
     ItemId: 14
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2361,7 +2211,6 @@
     ItemId: 679
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2375,7 +2224,6 @@
     ItemId: 6
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2389,7 +2237,6 @@
     ItemId: 608
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2408,7 +2255,6 @@
         - 7959
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2423,7 +2269,6 @@
     ItemId: 31
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2437,7 +2282,6 @@
     ItemId: 10289
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2454,7 +2298,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2468,7 +2311,6 @@
     ItemId: 3851
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.refresh_potion
     IsMovable: true
     Rarity: Common
@@ -2484,7 +2326,6 @@
     ItemId: 58
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2498,7 +2339,6 @@
     ItemId: 47
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2512,7 +2352,6 @@
     ItemId: 692
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2526,7 +2365,6 @@
     ItemId: 4163
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2543,7 +2381,6 @@
         - 4137
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2560,7 +2397,6 @@
         - 4131
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2577,7 +2413,6 @@
         - 5092
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2592,7 +2427,6 @@
     ItemId: 3997
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2609,7 +2443,6 @@
         - 4587
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2641,7 +2474,6 @@
         - 4149
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2659,7 +2491,6 @@
         - 3998
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2674,7 +2505,6 @@
     ItemId: 4327
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2691,7 +2521,6 @@
         - 4032
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2706,7 +2535,6 @@
     ItemId: 3997
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2720,7 +2548,6 @@
     ItemId: 4184
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2737,7 +2564,6 @@
         - 4186
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2752,7 +2578,6 @@
     ItemId: 3897
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2769,7 +2594,6 @@
         - 10231
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2784,7 +2608,6 @@
     ItemId: 2431
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2801,7 +2624,6 @@
         - 4020
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2816,7 +2638,6 @@
     ItemId: 681
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2833,7 +2654,6 @@
         - 5092
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2848,7 +2668,6 @@
     ItemId: 10248
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2865,7 +2684,6 @@
         - 4147
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2883,7 +2701,6 @@
         - 5358
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2898,7 +2715,6 @@
     ItemId: 3530
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2912,7 +2728,6 @@
     ItemId: 689
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2926,7 +2741,6 @@
     ItemId: 685
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2940,7 +2754,6 @@
     ItemId: 11600
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2959,7 +2772,6 @@
         - 2499
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2979,7 +2791,6 @@
         - 2499
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2999,7 +2810,6 @@
         - 2499
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3017,7 +2827,6 @@
         - 4190
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3035,7 +2844,6 @@
         - 5366
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3050,7 +2858,6 @@
     ItemId: 684
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3078,7 +2885,6 @@
     ItemId: 110
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3092,7 +2898,6 @@
     ItemId: 15
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3106,7 +2911,6 @@
     ItemId: 3849
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: items.strength_potion
     IsMovable: true
     Rarity: Common
@@ -3125,7 +2929,6 @@
         - 3717
     Hue: 0
     GoldValue: 0
-    Weight: 11.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3143,7 +2946,6 @@
     ItemId: 3897
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3157,7 +2959,6 @@
     ItemId: 59
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3171,7 +2972,6 @@
     ItemId: 39
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3185,7 +2985,6 @@
     ItemId: 60
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3199,7 +2998,6 @@
     ItemId: 61
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3213,7 +3011,6 @@
     ItemId: 111
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3227,7 +3024,6 @@
     ItemId: 606
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3241,7 +3037,6 @@
     ItemId: 607
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3255,7 +3050,6 @@
     ItemId: 62
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3269,7 +3063,6 @@
     ItemId: 63
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3283,7 +3076,6 @@
     ItemId: 3741
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3297,7 +3089,6 @@
     ItemId: 3742
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3314,7 +3105,6 @@
         - 7867
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3329,7 +3119,6 @@
     ItemId: 20
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3343,7 +3132,6 @@
     ItemId: 21
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3357,7 +3145,6 @@
     ItemId: 604
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3374,7 +3161,6 @@
         - 7865
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3389,7 +3175,6 @@
     ItemId: 7868
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3407,7 +3192,6 @@
         - 4028
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3422,7 +3206,6 @@
     ItemId: 22
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3436,7 +3219,6 @@
     ItemId: 112
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3450,7 +3232,6 @@
     ItemId: 113
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3464,7 +3245,6 @@
     ItemId: 23
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3478,7 +3258,6 @@
     ItemId: 7
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3492,7 +3271,6 @@
     ItemId: 609
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3506,7 +3284,6 @@
     ItemId: 114
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3520,7 +3297,6 @@
     ItemId: 613
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3534,7 +3310,6 @@
     ItemId: 115
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/skill_items.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/skill_items.yaml
@@ -2077,8 +2077,6 @@
     Tags:
         - modernuo
         - skill items
-    Equip:
-        Layer: OneHanded
 -   Id: nails
     Name: Nails
     Category: Skill Items
@@ -2125,8 +2123,6 @@
     Tags:
         - modernuo
         - skill items
-    Equip:
-        Layer: OneHanded
 -   Id: spellbook
     Name: Spellbook
     Category: Skill Items
@@ -2141,8 +2137,6 @@
     Tags:
         - modernuo
         - skill items
-    Equip:
-        Layer: OneHanded
 -   Id: nether_bolt_scroll
     Name: Nether Bolt Scroll
     Category: Skill Items

--- a/src/Moongate.Server/Assets/Templates/Items/special.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/special.yaml
@@ -8,7 +8,6 @@
         - 5092
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -26,7 +25,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -40,7 +38,6 @@
     ItemId: 3702
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -54,7 +51,6 @@
     ItemId: 3630
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -71,7 +67,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -85,7 +80,6 @@
     ItemId: 9006
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -99,7 +93,6 @@
     ItemId: 10972
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -116,7 +109,6 @@
         - 8314
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -135,7 +127,6 @@
     ItemId: 4230
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -149,7 +140,6 @@
     ItemId: 3609
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -163,7 +153,6 @@
     ItemId: 3606
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -177,7 +166,6 @@
     ItemId: 3605
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -191,7 +179,6 @@
     ItemId: 3607
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -205,7 +192,6 @@
     ItemId: 3610
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -219,7 +205,6 @@
     ItemId: 3611
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -233,7 +218,6 @@
     ItemId: 3603
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -247,7 +231,6 @@
     ItemId: 3602
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -261,7 +244,6 @@
     ItemId: 3604
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -275,7 +257,6 @@
     ItemId: 4014
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -293,7 +274,6 @@
     ItemId: 6585
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -328,7 +308,6 @@
         - 3709
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -346,7 +325,6 @@
     ItemId: 7164
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -363,7 +341,6 @@
         - 11005
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -381,7 +358,6 @@
         - 4180
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -396,7 +372,6 @@
     ItemId: 3961
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -410,7 +385,6 @@
     ItemId: 3964
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -424,7 +398,6 @@
     ItemId: 4132
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -438,7 +411,6 @@
     ItemId: 2462
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -452,7 +424,6 @@
     ItemId: 4980
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -466,7 +437,6 @@
     ItemId: 4981
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -480,7 +450,6 @@
     ItemId: 3967
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -494,7 +463,6 @@
     ItemId: 3608
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -508,7 +476,6 @@
     ItemId: 3630
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -522,7 +489,6 @@
     ItemId: 4779
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -536,7 +502,6 @@
     ItemId: 4780
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -550,7 +515,6 @@
     ItemId: 16503
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -564,7 +528,6 @@
     ItemId: 3970
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -578,7 +541,6 @@
     ItemId: 3975
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -592,7 +554,6 @@
     ItemId: 6362
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -606,7 +567,6 @@
     ItemId: 6361
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -620,7 +580,6 @@
     ItemId: 4102
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -634,7 +593,6 @@
     ItemId: 3658
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -648,7 +606,6 @@
     ItemId: 3659
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -662,7 +619,6 @@
     ItemId: 6369
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -676,7 +632,6 @@
     ItemId: 6371
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -690,7 +645,6 @@
     ItemId: 6372
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -704,7 +658,6 @@
     ItemId: 6370
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -718,7 +671,6 @@
     ItemId: 6377
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -732,7 +684,6 @@
     ItemId: 6379
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -746,7 +697,6 @@
     ItemId: 6380
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -760,7 +710,6 @@
     ItemId: 6378
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -774,7 +723,6 @@
     ItemId: 7145
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -788,7 +736,6 @@
     ItemId: 7148
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -802,7 +749,6 @@
     ItemId: 7146
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -816,7 +762,6 @@
     ItemId: 7147
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -830,7 +775,6 @@
     ItemId: 7149
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -844,7 +788,6 @@
     ItemId: 7150
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -858,7 +801,6 @@
     ItemId: 3893
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -872,7 +814,6 @@
     ItemId: 3892
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -886,7 +827,6 @@
     ItemId: 3899
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -903,7 +843,6 @@
         - 7151
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -920,7 +859,6 @@
         - 7151
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -934,7 +872,6 @@
     ItemId: 7153
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -948,7 +885,6 @@
     ItemId: 7152
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -962,7 +898,6 @@
     ItemId: 7152
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -976,7 +911,6 @@
     ItemId: 7153
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -990,7 +924,6 @@
     ItemId: 7155
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1004,7 +937,6 @@
     ItemId: 7156
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1018,7 +950,6 @@
     ItemId: 7961
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1032,7 +963,6 @@
     ItemId: 6367
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1046,7 +976,6 @@
     ItemId: 6366
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1060,7 +989,6 @@
     ItemId: 6365
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1074,7 +1002,6 @@
     ItemId: 6368
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1088,7 +1015,6 @@
     ItemId: 6367
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1102,7 +1028,6 @@
     ItemId: 6375
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1116,7 +1041,6 @@
     ItemId: 6373
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1130,7 +1054,6 @@
     ItemId: 6374
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1144,7 +1067,6 @@
     ItemId: 3977
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1158,7 +1080,6 @@
     ItemId: 3979
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1172,7 +1093,6 @@
     ItemId: 6008
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1186,7 +1106,6 @@
     ItemId: 4963
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1200,7 +1119,6 @@
     ItemId: 4967
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1214,7 +1132,6 @@
     ItemId: 4973
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1231,7 +1148,6 @@
         - 9037
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1248,7 +1164,6 @@
         - 9037
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1262,7 +1177,6 @@
     ItemId: 9035
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1276,7 +1190,6 @@
     ItemId: 7157
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1290,7 +1203,6 @@
     ItemId: 7160
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1304,7 +1216,6 @@
     ItemId: 7162
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1318,7 +1229,6 @@
     ItemId: 7158
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1332,7 +1242,6 @@
     ItemId: 7159
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1346,7 +1255,6 @@
     ItemId: 7161
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1360,7 +1268,6 @@
     ItemId: 7162
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1374,7 +1281,6 @@
     ItemId: 4099
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1388,7 +1294,6 @@
     ItemId: 4773
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1402,7 +1307,6 @@
     ItemId: 4774
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1416,7 +1320,6 @@
     ItemId: 4775
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1430,7 +1333,6 @@
     ItemId: 4776
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1444,7 +1346,6 @@
     ItemId: 4777
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1458,7 +1359,6 @@
     ItemId: 4778
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1472,7 +1372,6 @@
     ItemId: 4773
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1486,7 +1385,6 @@
     ItemId: 2449
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1500,7 +1398,6 @@
     ItemId: 3985
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1517,7 +1414,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1531,7 +1427,6 @@
     ItemId: 11009
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1545,7 +1440,6 @@
     ItemId: 4231
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1559,7 +1453,6 @@
     ItemId: 4101
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1573,7 +1466,6 @@
     ItemId: 3652
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1587,7 +1479,6 @@
     ItemId: 3653
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1601,7 +1492,6 @@
     ItemId: 3654
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1615,7 +1505,6 @@
     ItemId: 3655
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1629,7 +1518,6 @@
     ItemId: 7862
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1643,7 +1531,6 @@
     ItemId: 7863
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1660,7 +1547,6 @@
         - 7867
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1677,7 +1563,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1694,7 +1579,6 @@
         - 10947
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1726,7 +1610,6 @@
     ItemId: 18087
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1744,7 +1627,6 @@
     ItemId: 18082
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1763,7 +1645,6 @@
     ItemId: 18083
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1781,7 +1662,6 @@
     ItemId: 18084
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1799,7 +1679,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1814,7 +1693,6 @@
     ItemId: 9751
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1828,7 +1706,6 @@
     ItemId: 4103
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1842,7 +1719,6 @@
     ItemId: 3660
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1859,7 +1735,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1873,7 +1748,6 @@
     ItemId: 13946
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1887,7 +1761,6 @@
     ItemId: 7186
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1901,7 +1774,6 @@
     ItemId: 4230
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1933,7 +1805,6 @@
     ItemId: 10288
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1950,7 +1821,6 @@
         - 3806
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1965,7 +1835,6 @@
     ItemId: 17781
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1979,7 +1848,6 @@
     ItemId: 17778
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1993,7 +1861,6 @@
     ItemId: 17782
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2007,7 +1874,6 @@
     ItemId: 17779
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2021,7 +1887,6 @@
     ItemId: 17783
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2035,7 +1900,6 @@
     ItemId: 17780
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2049,7 +1913,6 @@
     ItemId: 3661
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2063,7 +1926,6 @@
     ItemId: 3662
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2077,7 +1939,6 @@
     ItemId: 3663
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2091,7 +1952,6 @@
     ItemId: 5916
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2108,7 +1968,6 @@
         - 5070
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2123,7 +1982,6 @@
     ItemId: 4232
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2137,7 +1995,6 @@
     ItemId: 4
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2151,7 +2008,6 @@
     ItemId: 7407
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2165,7 +2021,6 @@
     ItemId: 7408
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2179,7 +2034,6 @@
     ItemId: 4003
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2193,7 +2047,6 @@
     ItemId: 4002
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2210,7 +2063,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2227,7 +2079,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2241,7 +2092,6 @@
     ItemId: 4102
     Hue: 2419
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2272,7 +2122,6 @@
         - 12657
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2291,7 +2140,6 @@
     ItemId: 11010
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2312,7 +2160,6 @@
     ItemId: 9008
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2326,7 +2173,6 @@
     ItemId: 13043
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2340,7 +2186,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2355,7 +2200,6 @@
     ItemId: 3706
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2376,7 +2220,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2390,7 +2233,6 @@
     ItemId: 2537
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2422,7 +2264,6 @@
     ItemId: 3760
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2439,7 +2280,6 @@
         - 9037
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2454,7 +2294,6 @@
     ItemId: 4129
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2468,7 +2307,6 @@
     ItemId: 10907
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2487,7 +2325,6 @@
         - 9069
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2505,7 +2342,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2523,7 +2359,6 @@
         - 17789
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2541,7 +2376,6 @@
         - 17787
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2559,7 +2393,6 @@
         - 17775
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2577,7 +2410,6 @@
         - 17785
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2607,7 +2439,6 @@
     ItemId: 9
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2621,7 +2452,6 @@
     ItemId: 4164
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2656,7 +2486,6 @@
         - 9039
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2671,7 +2500,6 @@
     ItemId: 2
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2685,7 +2513,6 @@
     ItemId: 7861
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2699,7 +2526,6 @@
     ItemId: 3774
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2713,7 +2539,6 @@
     ItemId: 3773
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2727,7 +2552,6 @@
     ItemId: 13048
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2741,7 +2565,6 @@
     ItemId: 9009
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2755,7 +2578,6 @@
     ItemId: 9007
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2769,7 +2591,6 @@
     ItemId: 9004
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2786,7 +2607,6 @@
         - 5359
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2801,7 +2621,6 @@
     ItemId: 4230
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2829,7 +2648,6 @@
     ItemId: 3760
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/suits.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/suits.yaml
@@ -40,8 +40,6 @@
     Tags:
         - modernuo
         - suits
-    Equip:
-        Layer: OuterTorso
 -   Id: dupre_suit
     Name: Dupre Suit
     Category: Suits

--- a/src/Moongate.Server/Assets/Templates/Items/suits.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/suits.yaml
@@ -5,7 +5,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 3
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +45,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +58,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -75,7 +71,6 @@
     ItemId: 0
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -89,7 +84,6 @@
     ItemId: 467
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -103,7 +97,6 @@
     ItemId: 38
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/talismans.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/talismans.yaml
@@ -5,7 +5,6 @@
     ItemId: 12124
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 12125
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 12126
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 12119
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +57,6 @@
     ItemId: 12129
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/training_items.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/training_items.yaml
@@ -5,7 +5,6 @@
     ItemId: 4212
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.training_dummy
     IsMovable: false
     Rarity: Common
@@ -24,7 +23,6 @@
     ItemId: 4212
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.training_dummy
     IsMovable: false
     Rarity: Common
@@ -43,7 +41,6 @@
     ItemId: 4208
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.training_dummy
     IsMovable: false
     Rarity: Common
@@ -62,7 +59,6 @@
     ItemId: 4106
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.archery_butte
     IsMovable: false
     Rarity: Common
@@ -77,7 +73,6 @@
     ItemId: 4107
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.archery_butte
     IsMovable: false
     Rarity: Common
@@ -95,7 +90,6 @@
         - 7875
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.pickpocket_dip
     IsMovable: false
     Rarity: Common
@@ -113,7 +107,6 @@
         - 7875
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: items.pickpocket_dip
     IsMovable: false
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/traps.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/traps.yaml
@@ -5,7 +5,6 @@
     ItemId: 7025
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 7025
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 1
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 4389
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +57,6 @@
     ItemId: 4348
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/treasure_chests.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/treasure_chests.yaml
@@ -8,7 +8,6 @@
         - 3648
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -29,7 +28,6 @@
         - 3648
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -50,7 +48,6 @@
         - 3648
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -71,7 +68,6 @@
         - 3648
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/wands.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/wands.yaml
@@ -5,7 +5,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -19,7 +18,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -33,7 +31,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -47,7 +44,6 @@
     ItemId: 1
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -61,7 +57,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -75,7 +70,6 @@
     ItemId: 10
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -89,7 +83,6 @@
     ItemId: 25
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -103,7 +96,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -117,7 +109,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -131,7 +122,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -145,7 +135,6 @@
     ItemId: 5
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Assets/Templates/Items/weapons.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/weapons.yaml
@@ -16,7 +16,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -113,7 +112,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -145,7 +143,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -180,7 +177,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 110
         StrengthReq: 35
         DexterityReq: 0
@@ -212,7 +208,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -247,7 +242,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 100
         StrengthReq: 45
         DexterityReq: 0
@@ -313,7 +307,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 70
         StrengthReq: 35
         DexterityReq: 0
@@ -346,7 +339,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 110
         StrengthReq: 40
         DexterityReq: 0
@@ -379,7 +371,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 90
         StrengthReq: 10
         DexterityReq: 0
@@ -412,7 +403,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -445,7 +435,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 70
         StrengthReq: 25
         DexterityReq: 0
@@ -477,7 +466,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 5
         StrengthReq: 20
         DexterityReq: 0
@@ -506,7 +494,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 25
         DexterityReq: 0
@@ -574,7 +561,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 100
         StrengthReq: 30
         DexterityReq: 0
@@ -607,7 +593,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 40
         StrengthReq: 5
         DexterityReq: 0
@@ -639,7 +624,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -671,7 +655,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -704,7 +687,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 50
         StrengthReq: 10
         DexterityReq: 0
@@ -737,7 +719,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 40
         StrengthReq: 40
         DexterityReq: 0
@@ -770,7 +751,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 70
         StrengthReq: 45
         DexterityReq: 0
@@ -804,7 +784,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 30
         DexterityReq: 0
@@ -905,7 +884,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 70
         StrengthReq: 25
         DexterityReq: 0
@@ -934,7 +912,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 40
         DexterityReq: 0
@@ -967,7 +944,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 40
         StrengthReq: 10
         DexterityReq: 0
@@ -1000,7 +976,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 65
         StrengthReq: 40
         DexterityReq: 0
@@ -1032,7 +1007,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -1065,7 +1039,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -1098,7 +1071,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 45
         DexterityReq: 0
@@ -1130,7 +1102,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -1163,7 +1134,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 110
         StrengthReq: 45
         DexterityReq: 0
@@ -1196,7 +1166,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 50
         DexterityReq: 0
@@ -1229,7 +1198,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 35
         DexterityReq: 0
@@ -1262,7 +1230,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 50
         DexterityReq: 0
@@ -1295,7 +1262,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 110
         StrengthReq: 35
         DexterityReq: 0
@@ -1328,7 +1294,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -1363,7 +1328,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -1396,7 +1360,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -1428,7 +1391,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -1461,7 +1423,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 70
         StrengthReq: 40
         DexterityReq: 0
@@ -1493,7 +1454,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -1522,7 +1482,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 5
         DexterityReq: 0
@@ -1554,7 +1513,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -1621,7 +1579,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 70
         StrengthReq: 35
         DexterityReq: 0
@@ -1654,7 +1611,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 70
         StrengthReq: 20
         DexterityReq: 0
@@ -1687,7 +1643,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 90
         StrengthReq: 20
         DexterityReq: 0
@@ -1720,7 +1675,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -1752,7 +1706,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 45
         DexterityReq: 0
@@ -1785,7 +1738,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 95
         DexterityReq: 0
@@ -1818,7 +1770,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 70
         StrengthReq: 45
         DexterityReq: 0
@@ -1883,7 +1834,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 20
         DexterityReq: 0
@@ -1950,7 +1900,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 45
         DexterityReq: 0
@@ -1982,7 +1931,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2014,7 +1962,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -2082,7 +2029,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -2115,7 +2061,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 90
         StrengthReq: 25
         DexterityReq: 0
@@ -2147,7 +2092,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -2180,7 +2124,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 90
         StrengthReq: 10
         DexterityReq: 0
@@ -2213,7 +2156,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 95
         StrengthReq: 65
         DexterityReq: 0
@@ -2246,7 +2188,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 95
         DexterityReq: 0
@@ -2279,7 +2220,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 70
         StrengthReq: 80
         DexterityReq: 0
@@ -2312,7 +2252,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2344,7 +2283,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2376,7 +2314,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -2410,7 +2347,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -2445,7 +2381,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 35
         DexterityReq: 0
@@ -2477,7 +2412,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2510,7 +2444,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 70
         StrengthReq: 45
         DexterityReq: 0
@@ -2542,7 +2475,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2574,7 +2506,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -2606,7 +2537,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2638,7 +2568,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 30
         DexterityReq: 0
@@ -2667,7 +2596,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 5
         DexterityReq: 0
@@ -2700,7 +2628,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -2735,7 +2662,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 70
         StrengthReq: 45
         DexterityReq: 0
@@ -2767,7 +2693,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -2802,7 +2727,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 40
         DexterityReq: 0
@@ -2867,7 +2791,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -2900,7 +2823,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 45
         DexterityReq: 0
@@ -2933,7 +2855,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 50
         DexterityReq: 0
@@ -2966,7 +2887,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 110
         StrengthReq: 50
         DexterityReq: 0
@@ -2999,7 +2919,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 55
         DexterityReq: 0
@@ -3032,7 +2951,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 30
         DexterityReq: 0
@@ -3065,7 +2983,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -3097,7 +3014,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -3132,7 +3048,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 30
         DexterityReq: 0
@@ -3166,7 +3081,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -3199,7 +3113,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 30
         DexterityReq: 0
@@ -3231,7 +3144,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 30
         DexterityReq: 0
@@ -3263,7 +3175,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 30
         DexterityReq: 0
@@ -3296,7 +3207,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -3328,7 +3238,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -3361,7 +3270,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 40
         DexterityReq: 0
@@ -3394,7 +3302,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 90
         StrengthReq: 25
         DexterityReq: 0
@@ -3427,7 +3334,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 100
         StrengthReq: 45
         DexterityReq: 0
@@ -3460,7 +3366,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 50
         StrengthReq: 35
         DexterityReq: 0
@@ -3492,7 +3397,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -3525,7 +3429,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -3590,7 +3493,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -3622,7 +3524,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 45
         DexterityReq: 0
@@ -3655,7 +3556,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 40
         StrengthReq: 5
         DexterityReq: 0
@@ -3687,7 +3587,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 45
         DexterityReq: 0
@@ -3718,7 +3617,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 65
         StrengthReq: 60
         DexterityReq: 0
@@ -3751,7 +3649,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 50
         DexterityReq: 0
@@ -3783,7 +3680,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -3816,7 +3712,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 10
         DexterityReq: 0
@@ -3849,7 +3744,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 10
         DexterityReq: 0
@@ -3882,7 +3776,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 65
         StrengthReq: 35
         DexterityReq: 0
@@ -3915,7 +3808,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 35
         DexterityReq: 0
@@ -3980,7 +3872,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 0
         StrengthReq: 0
         DexterityReq: 0
@@ -4011,7 +3902,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 45
         DexterityReq: 0
@@ -4044,7 +3934,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 80
         StrengthReq: 50
         DexterityReq: 0
@@ -4076,7 +3965,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -4108,7 +3996,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -4140,7 +4027,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -4172,7 +4058,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0
@@ -4204,7 +4089,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -4236,7 +4120,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 20
         DexterityReq: 0
@@ -4269,7 +4152,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 90
         StrengthReq: 40
         DexterityReq: 0
@@ -4302,7 +4184,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 100
         StrengthReq: 40
         DexterityReq: 0
@@ -4335,7 +4216,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 50
         StrengthReq: 20
         DexterityReq: 0
@@ -4368,7 +4248,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 80
         StrengthReq: 35
         DexterityReq: 0
@@ -4401,7 +4280,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -4434,7 +4312,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 45
         DexterityReq: 0
@@ -4500,7 +4377,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: OneHanded
         HitPoints: 110
         StrengthReq: 80
         DexterityReq: 0
@@ -4565,7 +4441,6 @@
         - modernuo
         - weapons
     Equip:
-        Layer: OneHanded
         HitPoints: 60
         StrengthReq: 15
         DexterityReq: 0
@@ -4598,7 +4473,6 @@
         - weapons
         - flippable
     Equip:
-        Layer: TwoHanded
         HitPoints: 60
         StrengthReq: 35
         DexterityReq: 0

--- a/src/Moongate.Server/Assets/Templates/Items/weapons.yaml
+++ b/src/Moongate.Server/Assets/Templates/Items/weapons.yaml
@@ -8,7 +8,6 @@
         - 11561
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -39,7 +38,6 @@
         - 11569
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -71,7 +69,6 @@
         - 11569
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -103,7 +100,6 @@
         - 11565
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -135,7 +131,6 @@
         - 11551
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -168,7 +163,6 @@
         - 3914
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -200,7 +194,6 @@
         - 11562
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -233,7 +226,6 @@
         - 3918
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -265,7 +257,6 @@
         - 3912
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -298,7 +289,6 @@
         - 3568
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -330,7 +320,6 @@
         - 9927
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -362,7 +351,6 @@
         - 16498
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -394,7 +382,6 @@
         - 10227
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -426,7 +413,6 @@
         - 9925
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -458,7 +444,6 @@
         - 11561
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -486,7 +471,6 @@
     ItemId: 2303
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -517,7 +501,6 @@
         - 5041
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -552,7 +535,6 @@
         - 3935
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -584,7 +566,6 @@
         - 5111
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -616,7 +597,6 @@
         - 11555
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -647,7 +627,6 @@
         - 11565
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -678,7 +657,6 @@
         - 3778
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -710,7 +688,6 @@
         - 5043
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -742,7 +719,6 @@
         - 9932
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -776,7 +752,6 @@
         - 11558
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -807,7 +782,6 @@
         - 9931
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -840,7 +814,6 @@
         - 3919
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -875,7 +848,6 @@
         - 5184
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -935,7 +907,6 @@
         - 3921
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -967,7 +938,6 @@
         - 10228
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -999,7 +969,6 @@
         - 11559
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1030,7 +999,6 @@
         - 11568
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1062,7 +1030,6 @@
         - 16494
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1094,7 +1061,6 @@
         - 11561
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1125,7 +1091,6 @@
         - 3916
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1157,7 +1122,6 @@
         - 9929
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1189,7 +1153,6 @@
         - 16500
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1221,7 +1184,6 @@
         - 16493
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1253,7 +1215,6 @@
         - 16488
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1285,7 +1246,6 @@
         - 11562
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1319,7 +1279,6 @@
         - 11561
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1351,7 +1310,6 @@
         - 11564
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1383,7 +1341,6 @@
         - 11568
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1414,7 +1371,6 @@
         - 3910
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1446,7 +1402,6 @@
         - 11564
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1474,7 +1429,6 @@
     ItemId: 3570
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1505,7 +1459,6 @@
         - 11562
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1538,7 +1491,6 @@
         - 16501
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1571,7 +1523,6 @@
         - 3568
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1602,7 +1553,6 @@
         - 16496
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1634,7 +1584,6 @@
         - 16499
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1666,7 +1615,6 @@
         - 5113
     Hue: 0
     GoldValue: 0
-    Weight: 3.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1698,7 +1646,6 @@
         - 11572
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1729,7 +1676,6 @@
         - 5183
     Hue: 0
     GoldValue: 0
-    Weight: 16.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1761,7 +1707,6 @@
         - 5180
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1793,7 +1738,6 @@
         - 11569
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1825,7 +1769,6 @@
         - 3908
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1857,7 +1800,6 @@
         - 5116
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1892,7 +1834,6 @@
         - 11572
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1923,7 +1864,6 @@
         - 11559
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1954,7 +1894,6 @@
         - 11564
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -1985,7 +1924,6 @@
         - 5041
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2020,7 +1958,6 @@
         - 10232
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2052,7 +1989,6 @@
         - 5118
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2084,7 +2020,6 @@
         - 11555
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2115,7 +2050,6 @@
         - 5120
     Hue: 0
     GoldValue: 0
-    Weight: 2.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2147,7 +2081,6 @@
         - 10226
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2179,7 +2112,6 @@
         - 9930
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2211,7 +2143,6 @@
         - 5114
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2243,7 +2174,6 @@
         - 11566
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2275,7 +2205,6 @@
         - 11566
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2306,7 +2235,6 @@
         - 11551
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2339,7 +2267,6 @@
         - 11562
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2372,7 +2299,6 @@
         - 3936
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2404,7 +2330,6 @@
         - 11566
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2435,7 +2360,6 @@
         - 3933
     Hue: 0
     GoldValue: 0
-    Weight: 14.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2467,7 +2391,6 @@
         - 11561
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2498,7 +2421,6 @@
         - 11565
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2529,7 +2451,6 @@
         - 11566
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2560,7 +2481,6 @@
         - 11558
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2588,7 +2508,6 @@
     ItemId: 3570
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2619,7 +2538,6 @@
         - 11551
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2653,7 +2571,6 @@
         - 5178
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2685,7 +2602,6 @@
         - 11551
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2718,7 +2634,6 @@
         - 10221
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2750,7 +2665,6 @@
         - 10233
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2783,7 +2697,6 @@
         - 11561
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2814,7 +2727,6 @@
         - 11572
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2846,7 +2758,6 @@
         - 3717
     Hue: 0
     GoldValue: 0
-    Weight: 11.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2878,7 +2789,6 @@
         - 9928
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2910,7 +2820,6 @@
         - 3720
     Hue: 0
     GoldValue: 0
-    Weight: 11.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2942,7 +2851,6 @@
         - 3721
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -2974,7 +2882,6 @@
         - 11559
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3006,7 +2913,6 @@
         - 11551
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3039,7 +2945,6 @@
         - 9933
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3073,7 +2978,6 @@
         - 11568
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3104,7 +3008,6 @@
         - 11558
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3136,7 +3039,6 @@
         - 11558
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3167,7 +3069,6 @@
         - 11558
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3198,7 +3099,6 @@
         - 10234
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3230,7 +3130,6 @@
         - 11568
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3261,7 +3160,6 @@
         - 9926
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3293,7 +3191,6 @@
         - 5045
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3325,7 +3222,6 @@
         - 9924
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3357,7 +3253,6 @@
         - 16495
     Hue: 0
     GoldValue: 0
-    Weight: 0.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3389,7 +3284,6 @@
         - 11555
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3420,7 +3314,6 @@
         - 3714
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3452,7 +3345,6 @@
         - 5122
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3485,7 +3377,6 @@
         - 11568
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3516,7 +3407,6 @@
         - 11572
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3547,7 +3437,6 @@
         - 3781
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3579,7 +3468,6 @@
         - 11562
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3640,7 +3528,6 @@
         - 3939
     Hue: 0
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3672,7 +3559,6 @@
         - 11564
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3703,7 +3589,6 @@
         - 10230
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3735,7 +3620,6 @@
         - 10222
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3767,7 +3651,6 @@
         - 10225
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3799,7 +3682,6 @@
         - 5047
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3831,7 +3713,6 @@
         - 11569
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3863,7 +3744,6 @@
         - 3921
     Hue: 0
     GoldValue: 0
-    Weight: 1.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3894,7 +3774,6 @@
         - 11572
     Hue: 0
     GoldValue: 0
-    Weight: 12.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3925,7 +3804,6 @@
         - 3939
     Hue: 837
     GoldValue: 0
-    Weight: 7.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3957,7 +3835,6 @@
         - 11565
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -3988,7 +3865,6 @@
         - 11566
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4019,7 +3895,6 @@
         - 11559
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4050,7 +3925,6 @@
         - 11564
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4081,7 +3955,6 @@
         - 11555
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4112,7 +3985,6 @@
         - 11559
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4143,7 +4015,6 @@
         - 5186
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4175,7 +4046,6 @@
         - 5050
     Hue: 0
     GoldValue: 0
-    Weight: 6.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4207,7 +4077,6 @@
         - 10223
     Hue: 0
     GoldValue: 0
-    Weight: 5.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4239,7 +4108,6 @@
         - 5039
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4271,7 +4139,6 @@
         - 11555
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4303,7 +4170,6 @@
         - 5124
     Hue: 0
     GoldValue: 0
-    Weight: 9.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4335,7 +4201,6 @@
         - 5176
     Hue: 0
     GoldValue: 0
-    Weight: 10.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4368,7 +4233,6 @@
         - 5126
     Hue: 0
     GoldValue: 0
-    Weight: 17.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4400,7 +4264,6 @@
         - 11569
     Hue: 0
     GoldValue: 0
-    Weight: 8.0
     ScriptId: none
     IsMovable: true
     Rarity: Common
@@ -4433,7 +4296,6 @@
         - 11565
     Hue: 0
     GoldValue: 0
-    Weight: 4.0
     ScriptId: none
     IsMovable: true
     Rarity: Common

--- a/src/Moongate.Server/Loaders/ItemTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/ItemTemplatesLoader.cs
@@ -77,16 +77,27 @@ public sealed class ItemTemplatesLoader : IDataLoader
 
         ItemTemplateValidator.Validate(sources);
 
+        var resolved = 0;
+
         foreach (var source in sources)
         {
+            // The client files decide layer and weight wherever the template does not state them.
+            // Nothing downstream needs to know: they all keep reading the template.
+            if (TileDataTemplateResolver.Resolve(source.Template))
+            {
+                resolved++;
+            }
+
             _templates.Register(source.Template);
         }
 
         _logger.Information(
-            "Loaded {TemplateCount} item template(s) from {YamlFileCount} YAML file(s) in {Path}",
+            "Loaded {TemplateCount} item template(s) from {YamlFileCount} YAML file(s) in {Path}; " +
+            "{ResolvedCount} took a layer or weight from the client tiledata",
             sources.Count,
             files.Length,
-            itemsDirectory
+            itemsDirectory,
+            resolved
         );
 
         return ValueTask.CompletedTask;

--- a/src/Moongate.Server/Services/Items/TileDataTemplateResolver.cs
+++ b/src/Moongate.Server/Services/Items/TileDataTemplateResolver.cs
@@ -1,4 +1,6 @@
+using Moongate.Ultima.Tiles;
 using Moongate.Ultima.Types;
+using Moongate.UO.Data.Items;
 
 namespace Moongate.Server.Services.Items;
 
@@ -36,5 +38,45 @@ public static class TileDataTemplateResolver
         }
 
         return (LayerType)layerByte;
+    }
+
+    /// <summary>
+    /// Fills <paramref name="template" />'s layer and weight from the tile its <c>ItemId</c> names, and
+    /// reports whether anything changed. A template whose tile the client files do not describe — or a
+    /// shard with no client files at all — is left exactly as the YAML wrote it.
+    /// </summary>
+    public static bool Resolve(ItemTemplate template)
+    {
+        if (TileData.ItemTable is not { Length: > 0 } tiles ||
+            template.ItemId < 0 ||
+            template.ItemId >= tiles.Length)
+        {
+            return false;
+        }
+
+        var tile = tiles[template.ItemId];
+        var changed = false;
+
+        if (LayerFor(tile.Wearable, tile.Quality) is { } layer)
+        {
+            if (template.Equip is null)
+            {
+                template.Equip = new() { Layer = layer };
+                changed = true;
+            }
+            else if (template.Equip.Layer == LayerType.None)
+            {
+                template.Equip.Layer = layer;
+                changed = true;
+            }
+        }
+
+        if (template.Weight == 0)
+        {
+            template.Weight = WeightFor(tile.Weight);
+            changed = true;
+        }
+
+        return changed;
     }
 }

--- a/src/Moongate.Server/Services/Items/TileDataTemplateResolver.cs
+++ b/src/Moongate.Server/Services/Items/TileDataTemplateResolver.cs
@@ -1,0 +1,40 @@
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Services.Items;
+
+/// <summary>
+/// Fills an item template's layer and weight from the client's own tiledata, so the shard agrees with
+/// what the client draws. The template keeps whatever it states outright; a layer of
+/// <see cref="LayerType.None" /> and a weight of zero are read as "the file did not say".
+/// <para>
+/// Static, like <c>ItemTemplateYamlDeserializer</c> and <c>ItemTemplateValidator</c> beside it in the
+/// loader: this runs once per template at load, not per call, and has no dependencies of its own.
+/// </para>
+/// </summary>
+public static class TileDataTemplateResolver
+{
+    /// <summary>What a tile reporting no usable weight is worth instead.</summary>
+    private const double NoWeightData = 1.0;
+
+    /// <summary>
+    /// The weight a tile implies. Both 0 and 255 mean "no usable data" — 255 is the sentinel UO uses
+    /// for things that cannot be carried — and ModernUO's <c>Item.DefaultWeight</c> substitutes 1 for
+    /// each rather than reporting a 255-stone item.
+    /// </summary>
+    public static double WeightFor(int tileWeight)
+        => tileWeight is 0 or 255 ? NoWeightData : tileWeight;
+
+    /// <summary>
+    /// The layer a tile implies, or null when it implies none. The byte is only meaningful on a tile
+    /// the client marks wearable, and a value outside <see cref="LayerType" /> is not a layer.
+    /// </summary>
+    public static LayerType? LayerFor(bool wearable, int layerByte)
+    {
+        if (!wearable || layerByte == 0 || !Enum.IsDefined((LayerType)layerByte))
+        {
+            return null;
+        }
+
+        return (LayerType)layerByte;
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/TileDataTemplateResolverTests.cs
+++ b/tests/Moongate.Tests/Server/Items/TileDataTemplateResolverTests.cs
@@ -1,5 +1,9 @@
 using Moongate.Server.Services.Items;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Tiles;
 using Moongate.Ultima.Types;
+using Moongate.UO.Data.Items;
 
 namespace Moongate.Tests.Server.Items;
 
@@ -7,8 +11,14 @@ namespace Moongate.Tests.Server.Items;
 /// The client's tiledata is the authority on an item's layer and weight; the template keeps only the
 /// values that deliberately diverge.
 /// </summary>
+[Collection("UltimaClientData")]
 public class TileDataTemplateResolverTests
 {
+    // Kept inside 0-31: UltimaFixtures.BuildTileData() allocates exactly one 32-item old-format group.
+    private const int WearableId = 4;
+    private const int PlainId = 5;
+    private const int UndescribedId = 900;
+
     // ModernUO's Item.DefaultWeight reads both 0 and the 255 immovable sentinel as "no usable
     // weight" and substitutes 1, rather than claiming a 255-stone item.
     [Theory]
@@ -45,5 +55,151 @@ public class TileDataTemplateResolverTests
     public void LayerFor_ByteOutsideTheEnum_HasNoLayer()
     {
         Assert.Null(TileDataTemplateResolver.LayerFor(wearable: true, layerByte: 200));
+    }
+
+    [Fact]
+    public void Resolve_WearableTileAndNoEquipBlock_SynthesisesOne()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate { Id = "book_of_bushido", ItemId = WearableId };
+
+                Assert.True(TileDataTemplateResolver.Resolve(template));
+                Assert.Equal(LayerType.Shirt, template.Equip?.Layer);
+            }
+        );
+    }
+
+    // An Equip block that carries only stat requirements still has a layer to learn.
+    [Fact]
+    public void Resolve_EquipBlockWithNoLayer_TakesTheTileLayer()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate
+                {
+                    Id = "hat", ItemId = WearableId, Equip = new() { StrengthReq = 10 }
+                };
+
+                Assert.True(TileDataTemplateResolver.Resolve(template));
+                Assert.Equal(LayerType.Shirt, template.Equip!.Layer);
+                Assert.Equal(10, template.Equip.StrengthReq);
+            }
+        );
+    }
+
+    [Fact]
+    public void Resolve_DeclaredLayer_IsLeftAlone()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate
+                {
+                    Id = "bow", ItemId = WearableId, Equip = new() { Layer = LayerType.TwoHanded }
+                };
+
+                TileDataTemplateResolver.Resolve(template);
+
+                Assert.Equal(LayerType.TwoHanded, template.Equip!.Layer);
+            }
+        );
+    }
+
+    [Fact]
+    public void Resolve_TileTheClientDoesNotCallWearable_GainsNoEquipBlock()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate { Id = "table", ItemId = PlainId };
+
+                TileDataTemplateResolver.Resolve(template);
+
+                Assert.Null(template.Equip);
+            }
+        );
+    }
+
+    [Fact]
+    public void Resolve_WeightLeftAtZero_TakesTheTileWeight()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate { Id = "shirt", ItemId = WearableId };
+
+                Assert.True(TileDataTemplateResolver.Resolve(template));
+                Assert.Equal(6.0, template.Weight);
+            }
+        );
+    }
+
+    [Fact]
+    public void Resolve_DeclaredWeight_IsLeftAlone()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate { Id = "bandage", ItemId = WearableId, Weight = 0.1 };
+
+                TileDataTemplateResolver.Resolve(template);
+
+                Assert.Equal(0.1, template.Weight);
+            }
+        );
+    }
+
+    // Past the end of the shipped tables there is nothing to defer to.
+    [Fact]
+    public void Resolve_IdTheClientFilesDoNotDescribe_ChangesNothing()
+    {
+        WithClientFiles(
+            () =>
+            {
+                var template = new ItemTemplate { Id = "custom", ItemId = UndescribedId };
+
+                Assert.False(TileDataTemplateResolver.Resolve(template));
+                Assert.Null(template.Equip);
+                Assert.Equal(0.0, template.Weight);
+            }
+        );
+    }
+
+    /// <summary>
+    /// Loads a tiledata.mul holding one wearable tile on the Shirt layer weighing 6, and one plain
+    /// weightless tile. TileData is a process-wide static, which is why this class joins the
+    /// serialized UltimaClientData collection.
+    /// </summary>
+    private static void WithClientFiles(Action assert)
+    {
+        var tileData = UltimaFixtures.BuildTileData();
+
+        UltimaFixtures.SetItem(
+            tileData,
+            WearableId,
+            (uint)TileFlagType.Wearable,
+            0,
+            "shirt",
+            weight: 6,
+            layer: (byte)LayerType.Shirt
+        );
+        UltimaFixtures.SetItem(tileData, PlainId, (uint)TileFlagType.Surface, 0, "table");
+
+        var dir = UltimaFixtures.CreateClientDirectory(("tiledata.mul", tileData));
+
+        try
+        {
+            Files.SetDirectory(dir);
+            TileData.Initialize();
+
+            assert();
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
     }
 }

--- a/tests/Moongate.Tests/Server/Items/TileDataTemplateResolverTests.cs
+++ b/tests/Moongate.Tests/Server/Items/TileDataTemplateResolverTests.cs
@@ -1,0 +1,49 @@
+using Moongate.Server.Services.Items;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// The client's tiledata is the authority on an item's layer and weight; the template keeps only the
+/// values that deliberately diverge.
+/// </summary>
+public class TileDataTemplateResolverTests
+{
+    // ModernUO's Item.DefaultWeight reads both 0 and the 255 immovable sentinel as "no usable
+    // weight" and substitutes 1, rather than claiming a 255-stone item.
+    [Theory]
+    [InlineData(0, 1.0)]
+    [InlineData(255, 1.0)]
+    [InlineData(1, 1.0)]
+    [InlineData(6, 6.0)]
+    [InlineData(200, 200.0)]
+    public void WeightFor_ZeroAndTheImmovableSentinel_BecomeOne(int tileWeight, double expected)
+    {
+        Assert.Equal(expected, TileDataTemplateResolver.WeightFor(tileWeight));
+    }
+
+    [Fact]
+    public void LayerFor_WearableTile_ReadsTheByteAsALayer()
+    {
+        Assert.Equal(LayerType.Shirt, TileDataTemplateResolver.LayerFor(wearable: true, layerByte: 5));
+    }
+
+    [Fact]
+    public void LayerFor_TileTheClientDoesNotCallWearable_HasNoLayer()
+    {
+        Assert.Null(TileDataTemplateResolver.LayerFor(wearable: false, layerByte: 5));
+    }
+
+    [Fact]
+    public void LayerFor_WearableTileWithNoLayerByte_HasNoLayer()
+    {
+        Assert.Null(TileDataTemplateResolver.LayerFor(wearable: true, layerByte: 0));
+    }
+
+    // Nothing guarantees the byte lands inside LayerType; a value we cannot name is not a layer.
+    [Fact]
+    public void LayerFor_ByteOutsideTheEnum_HasNoLayer()
+    {
+        Assert.Null(TileDataTemplateResolver.LayerFor(wearable: true, layerByte: 200));
+    }
+}

--- a/tests/Moongate.Tests/Support/UltimaFixtures.cs
+++ b/tests/Moongate.Tests/Support/UltimaFixtures.cs
@@ -618,12 +618,26 @@ public static class UltimaFixtures
         return dir;
     }
 
-    /// <summary>Writes an old-format item record (flags, anim, height, name) for item <paramref name="id" /> (first group only).</summary>
-    public static void SetItem(byte[] tileData, int id, uint flags, byte height, string name, short anim = 0)
+    /// <summary>
+    /// Writes an old-format item record for item <paramref name="id" /> (first group only). Weight sits
+    /// at offset 4 and the layer byte — the one the MUL format calls quality — at 5.
+    /// </summary>
+    public static void SetItem(
+        byte[] tileData,
+        int id,
+        uint flags,
+        byte height,
+        string name,
+        short anim = 0,
+        byte weight = 0,
+        byte layer = 0
+    )
     {
         var offset = 512 * LandGroupSize + 4 + id * OldItemRecordSize;
 
         BinaryPrimitives.WriteUInt32LittleEndian(tileData.AsSpan(offset), flags);
+        tileData[offset + 4] = weight;
+        tileData[offset + 5] = layer;
         BinaryPrimitives.WriteInt16LittleEndian(tileData.AsSpan(offset + 10), anim);
         tileData[offset + 16] = height;
         WriteName(tileData, offset + 17, name);


### PR DESCRIPTION
Resolves `Equip.Layer` and `Weight` from `tiledata.mul` at template load, keeping the YAML value as an override, and strips the shipped templates of the values that duplicated or contradicted the client files.

Extends to layer and weight the principle already applied to stackability in `bd592be`.

## What this fixes

- **50 wearable tiles had no `Equip` block at all** and could not be equipped: `book_of_bushido`, `fishing_pole`, `blowpipe`, the talismans, 15 entries in `special.yaml`.
- **Leg armour declared `InnerLegs`** — a paperdoll-only slot — where the client says `Pants`, so it equipped to the wrong place. Same story for the three mempo (`Neck`), the three suneate (`Pants`) and the two bustiers (`InnerTorso`).
- **709 templates carried a weight of `0.0`.**

## How

`TileDataTemplateResolver` is static, like `ItemTemplateYamlDeserializer` and `ItemTemplateValidator` beside it in the loader. `ItemTemplatesLoader` calls it between validation and registration, so every consumer — the starting-items equip path, the paperdoll figure renderer, the REST DTO — keeps reading `template.Equip.Layer` and needs no change. `FilesLoaderService` runs at priority 100 and the data loaders at 110, so the MULs are already loaded.

`0` and `255` both mean "no usable weight" and resolve to `1`, matching ModernUO's `Item.DefaultWeight`. `LayerType.None` and `0.0` mean "the file did not say" — no nullable types, so `Moongate.UO.Data` stays source-compatible and the OpenAPI contract does not move.

This is what ModernUO does too: `BaseWeapon.cs:199` and `BaseArmor.cs:166` both take the layer from the tile, and override per class where the rule differs. POL goes further and equips straight off it (`eqpitem.cpp:63`).

## What stays declared

**24 layers.** Fifteen weapons force `TwoHanded` so the weapon takes the shield slot, the same override ModernUO makes in `Bow.cs`, `Crossbow.cs` and `HeavyCrossbow.cs`. Eight gargoyle kilts keep `OuterLegs` against a client that reports `Gloves` for a tile named `gargoyle_stone_kilt_` — the `ItemId` is right and the byte is not, and each carries a comment saying so. `dark_source` keeps its layer because its tile is not wearable.

**185 weights.** Unlike a layer, where a disagreement means the item lands in the wrong slot, a differing weight is plausibly a balance value ported from ModernUO — `bandage` and `iron_ingot` at `0.1` against a tile reporting 0 are exactly its numbers.

## Verification

Full suite green (1858), docs at 0 warnings, and a real boot reporting 1094 of 1665 templates taking a value from the client files. Spot-checked through the real loader against a real client directory:

```
gold                       itemId=3821   layer=-            weight=1
plate_legs                 itemId=5137   layer=Pants        weight=7
book_of_bushido            itemId=9100   layer=OneHanded    weight=3
bow                        itemId=5042   layer=TwoHanded    weight=6
gargish_stone_kilt_type1   itemId=648    layer=OuterLegs    weight=10
```

**CI has no UO client files**, so it covers the resolver's logic and not the data. The data comparison was verified once, locally. No test pretends otherwise.

Issue #134.