### PR TITLE
Guard the tiledata invariants against a real client

### DIFF
--- a/tests/Moongate.Tests/Data/Items/TileDataInvariantDataTests.cs
+++ b/tests/Moongate.Tests/Data/Items/TileDataInvariantDataTests.cs
@@ -1,0 +1,100 @@
+using Moongate.Server.Loaders;
+using Moongate.Server.Services.Items;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Items;
+using SquidStd.Core.Directories;
+using SquidStd.Core.Yaml;
+
+namespace Moongate.Tests.Data.Items;
+
+/// <summary>
+/// The shipped templates against a real client's tiledata. A template that declares what the client
+/// already says is not an override, it is a duplicate waiting to drift — these keep them from
+/// creeping back as content grows. Both skip where there is no client directory.
+/// </summary>
+[Collection("UltimaClientData")]
+public class TileDataInvariantDataTests
+{
+    [ClientFilesFact]
+    public async Task NoTemplate_DeclaresALayerTheClientAlreadyGives()
+    {
+        var redundant = new List<string>();
+
+        foreach (var template in await DeclaredTemplates())
+        {
+            if (template.Equip is not { Layer: not LayerType.None } equip || Tile(template.ItemId) is not { } tile)
+            {
+                continue;
+            }
+
+            if (TileDataTemplateResolver.LayerFor(tile.Wearable, tile.Quality) == equip.Layer)
+            {
+                redundant.Add($"{template.Id} ({equip.Layer})");
+            }
+        }
+
+        Assert.True(
+            redundant.Count == 0,
+            $"Templates declaring a layer the tiledata already gives: {string.Join(", ", redundant)}"
+        );
+    }
+
+    [ClientFilesFact]
+    public async Task NoTemplate_DeclaresAWeightTheClientAlreadyGives()
+    {
+        var redundant = new List<string>();
+
+        foreach (var template in await DeclaredTemplates())
+        {
+            // Zero is "not stated", not a declaration, so it cannot be redundant.
+            if (template.Weight == 0 || Tile(template.ItemId) is not { } tile)
+            {
+                continue;
+            }
+
+            if (Math.Abs(template.Weight - TileDataTemplateResolver.WeightFor(tile.Weight)) < 0.001)
+            {
+                redundant.Add($"{template.Id} ({template.Weight})");
+            }
+        }
+
+        Assert.True(
+            redundant.Count == 0,
+            $"Templates declaring a weight the tiledata already gives: {string.Join(", ", redundant)}"
+        );
+    }
+
+    private static ItemData? Tile(int itemId)
+        => TileData.ItemTable is { Length: > 0 } tiles && itemId >= 0 && itemId < tiles.Length
+               ? tiles[itemId]
+               : null;
+
+    /// <summary>
+    /// The templates as the YAML declares them. The loader resolves what it registers, which would
+    /// hide exactly what these tests look for, so this reads the seeded files instead of asking the
+    /// registry.
+    /// </summary>
+    private static async Task<IReadOnlyList<ItemTemplate>> DeclaredTemplates()
+    {
+        Files.SetDirectory(ClientFiles.Directory);
+        TileData.Initialize();
+
+        var root = Path.Combine(Path.GetTempPath(), "mg-tiledata-inv-" + Guid.NewGuid().ToString("N"));
+
+        await new ItemTemplatesLoader(new ItemTemplateService(), new DirectoriesConfig(root, [])).LoadAsync();
+
+        try
+        {
+            return Directory.GetFiles(Path.Combine(root, "templates", "items"), "*.yaml", SearchOption.AllDirectories)
+                            .SelectMany(path => YamlUtils.DeserializeFromFile<ItemTemplate[]>(path) ?? [])
+                            .ToList();
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}


### PR DESCRIPTION
Pays off a debt from #135, using the idiom #137 introduced.

That work said twice that CI could not check the shipped templates against real tiledata, because the runners have no UO client files, so the comparison was done once by hand and left to decay. Only half true: a test can read a real client directory and **skip itself** where there is none.

## The two invariants

- No template declares an `Equip.Layer` the tiledata already gives.
- No template declares a `Weight` the tiledata already gives (`0` and `255` resolving to `1`).

A declared value that matches the client is not an override — it is a duplicate waiting to drift. Both hold today with no exceptions, so these are regression guards rather than a fix: they stop redundancy creeping back as content grows.

## Two details that matter

They read the **seeded YAML**, not the template registry, because the loader resolves what it registers and would hide exactly what these look for. And the comparison runs through `TileDataTemplateResolver.LayerFor` / `.WeightFor`, so the test asserts against the rule production uses instead of a reimplementation that could drift from it.

**No `Stackable` invariant**, deliberately. There the template value is the *fallback* for when the client files are absent, not an override, so a value agreeing with the tiledata is intended — the opposite semantics.

## Verification

All three states checked, not just the green one:

| | |
|---|---|
| real client data | **Passed** |
| redundant `Layer: Pants` + `Weight: 7.0` injected into `plate_legs` | **Failed**, both, naming the culprit |
| `MOONGATE_UO_DIRECTORY=/nonexistent` | **Skipped**, which is what CI will show |

Full suite 1878 green, docs at 0 warnings.

Issue #138.