### PR TITLE
Name NPCs from the shipped name pools

### DIFF
--- a/docs/scripting/data/mobile-templates.md
+++ b/docs/scripting/data/mobile-templates.md
@@ -51,6 +51,7 @@ path order) into one flat list, then `MobileTemplateBaseResolver` resolves
 |---|---|---|---|
 | `Id` | `string` | required (no format check) | Not merged — the derived `Id` is kept. |
 | `Name` | `string` | optional, default `""` | Derived value wins if non-empty, else the base's. |
+| `NamePool` | `string` | optional, default `""` | Derived value wins if non-empty, else the base's. |
 | `Gender` | `MobileTemplateGenderType` enum | optional, default `Male` | Derived value wins **only if it is not `Male`**; see [Gender](#gender) for the caveat this creates. |
 | `Title` | `string` | optional, default `""` | Derived wins if non-empty, else base's. Displayed under the mobile's name (e.g. "the guard"). |
 | `Category` | `string` | optional, default `""` | Derived wins if non-empty, else base's. Matched by `GetByCategory`. |
@@ -66,6 +67,22 @@ path order) into one flat list, then `MobileTemplateBaseResolver` resolves
 | `Variants` | `List<MobileVariant>` | optional, default `[]` | **Wholesale replace**, same rule as `Equipment`. See [Variants](#variants). |
 | `LootTableId` | `string?` | optional, default `null` | Derived value wins if set, else the base's (`derived ?? base`). |
 | `BrainScript` | `string?` | optional, default `null` | Derived value wins if set, else the base's (`derived ?? base`). Binds the spawned NPC to `scripts/brains/<BrainScript>.lua`; the file's returned `id` must match. See [NPC brains](../guides/npc-brains.md). |
+
+### NamePool
+
+`NamePool` names a pool in [`names.yaml`](names.md) to draw a name from at
+spawn. It is only consulted when the template has no `Name` of its own: a named
+individual overrides its kind's naming, which is what lets `base_human_npc`
+declare `NamePool: male` for every human while `lilly` stays Lilly. A template
+with neither spawns nameless, which the client renders as a blank label.
+
+The pool is a **literal** type — nothing is appended for gender. The shipped
+pools spell gender in three different places (`male`, `tokuno male`,
+`male elf brigand`), so a template names the pool it wants in full.
+
+Naming a pool that does not exist **fails the load**: name pools are read at
+priority 30 and mobile templates at 150, so the reference is checked while the
+server is still starting.
 
 ### Gender
 
@@ -152,6 +169,7 @@ spawn — under `Variants:`:
 | `Name` | `string` | optional, default `""` | Descriptive label only; not referenced elsewhere. |
 | `Weight` | `int` | optional, default `1` | Share of the weighted pick among all variants (floored at `1` even if written lower). |
 | `Gender` | `MobileTemplateGenderType?` | optional, default `null` | Overrides the template's `Gender` for this variant when set. |
+| `NamePool` | `string?` | optional, default `null` | Overrides the template's `NamePool` for this variant when set. |
 | `LootTableId` | `string?` | optional, default `null` | Overrides the template's `LootTableId` for this variant when set. |
 | `Appearance` | `MobileAppearance` | optional, default `new()` | Per-field override of the template's `Appearance` (same zero/null-means-fallback rule as the base merge). |
 | `Equipment` | `List<MobileEquipmentEntry>` | optional, default `[]` | Wholesale replace of the template's `Equipment` when non-empty. |

--- a/docs/scripting/data/names.md
+++ b/docs/scripting/data/names.md
@@ -1,0 +1,57 @@
+# Name pools
+
+`names.yaml` holds the pools of candidate names an NPC draws from at spawn. It
+ships under `src/Moongate.Server/Assets/names.yaml` and is seeded into the
+runtime `data/` directory on first boot.
+
+| Concern | Type |
+|---|---|
+| DTO | `NameList` (`Moongate.UO.Data.Names`) |
+| Loader | `Moongate.Server.Loaders.NamesLoader` (priority 30) |
+| Registry | `Moongate.Server.Abstractions.Interfaces.Mobiles.INameService` |
+
+Pools load at priority 30 and mobile templates at 150, so a template's
+[`NamePool`](mobile-templates.md#namepool) is checked against this file while
+the server is still starting. Naming a pool that does not exist is a load error.
+
+## File shape
+
+A top-level list of pools, each a `Type` and its `Names`:
+
+```yaml
+-   Type: male
+    Names:
+        - Aaron
+        - Abbott
+        - Abdel
+-   Type: tokuno male
+    Names:
+        - Dosyaku
+        - Warimoto
+```
+
+`Type` is matched case-insensitively. Registering a pool whose type already
+exists replaces it.
+
+## Shipped pools
+
+Twenty-eight, ported from ModernUO's `Data/names.json`:
+
+`ancient lich`, `balron`, `bird`, `centaur`, `daemon`, `darknight creeper`,
+`demon knight`, `ethereal warrior`, `evil mage`, `evil mage lord`, `female`,
+`female elf brigand`, `fire gargoyle`, `gargoyle vendor`, `golem controller`,
+`impaler`, `lizardman`, `male`, `male elf brigand`, `orc`, `pixie`, `ratman`,
+`savage`, `savage rider`, `savage shaman`, `shadow knight`, `tokuno female`,
+`tokuno male`
+
+> [!WARNING]
+> **Gender is not a suffix.** The six pools that name a gender put it in three
+> different places — bare in `male` and `female`, trailing in `tokuno male`,
+> and **leading** in `male elf brigand`. A template must name the pool it wants
+> in full; nothing is composed for it. ModernUO does the same, writing each
+> pool out at the call site rather than normalising the names.
+
+## Adding a pool
+
+Append a `Type`/`Names` pair. Nothing else needs changing: a template can name
+it the moment it exists, and the load-time check will accept it.

--- a/docs/scripting/toc.yml
+++ b/docs/scripting/toc.yml
@@ -42,6 +42,8 @@
       href: data/item-templates.md
     - name: Mobile templates
       href: data/mobile-templates.md
+    - name: Name pools
+      href: data/names.md
     - name: Loot tables
       href: data/loot-tables.md
     - name: Starting items

--- a/src/Moongate.Server/Assets/Templates/Mobiles/base/human.yaml
+++ b/src/Moongate.Server/Assets/Templates/Mobiles/base/human.yaml
@@ -1,5 +1,6 @@
 -   Id: base_human_npc
     Title: a human
+    NamePool: male
     Category: npc
     Description: Base human NPC template for derived vendor/citizen profiles.
     Tags:

--- a/src/Moongate.Server/Assets/Templates/Mobiles/guards.yaml
+++ b/src/Moongate.Server/Assets/Templates/Mobiles/guards.yaml
@@ -40,6 +40,7 @@
     Title: the guard
     Category: npc
     Gender: Female
+    NamePool: female
     Description: Town female warrior guard NPC inspired by ModernUO WarriorGuard.
     Tags:
         - npc
@@ -119,6 +120,7 @@
     Title: the guard
     Category: npc
     Gender: Female
+    NamePool: female
     Description: Town female archer guard NPC inspired by ModernUO ArcherGuard.
     Tags:
         - npc

--- a/src/Moongate.Server/Assets/Templates/Mobiles/undead.yaml
+++ b/src/Moongate.Server/Assets/Templates/Mobiles/undead.yaml
@@ -1,5 +1,6 @@
 -   Id: zombie_npc
     Title: a zombie
+    Name: a zombie
     Category: monster
     Description: Static zombie template for spawn and combat testing.
     Tags:
@@ -16,6 +17,7 @@
     BrainScript: undead_melee
 -   Id: skeletal_knight_npc
     Title: a skeletal knight
+    Name: a skeletal knight
     Category: monster
     Description: Static skeletal knight template for corpse and loot testing.
     Tags:

--- a/src/Moongate.Server/Loaders/MobileTemplatesLoader.cs
+++ b/src/Moongate.Server/Loaders/MobileTemplatesLoader.cs
@@ -17,12 +17,18 @@ public sealed class MobileTemplatesLoader : IDataLoader
     private readonly ILogger _logger = Log.ForContext<MobileTemplatesLoader>();
     private readonly IMobileTemplateService _templates;
     private readonly DirectoriesConfig _directories;
+    private readonly INameService _names;
     private readonly MobileTemplateBaseResolver _resolver = new();
 
-    public MobileTemplatesLoader(IMobileTemplateService templates, DirectoriesConfig directories)
+    public MobileTemplatesLoader(
+        IMobileTemplateService templates,
+        DirectoriesConfig directories,
+        INameService names
+    )
     {
         _templates = templates;
         _directories = directories;
+        _names = names;
     }
 
     public ValueTask LoadAsync(CancellationToken ct = default)
@@ -68,6 +74,7 @@ public sealed class MobileTemplatesLoader : IDataLoader
 
         foreach (var template in resolved)
         {
+            ValidateNamePools(template);
             _templates.Register(template);
         }
 
@@ -79,5 +86,33 @@ public sealed class MobileTemplatesLoader : IDataLoader
         );
 
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// A NamePool naming no registered pool is a content typo. Names load at priority 30 and mobile
+    /// templates at 150, so it is caught while the server is still starting instead of producing
+    /// nameless NPCs long after. Runs after base resolution, so an inherited pool is checked on each
+    /// derived template rather than only on the base.
+    /// </summary>
+    private void ValidateNamePools(MobileTemplate template)
+    {
+        RequirePool(template.Id, template.NamePool);
+
+        foreach (var variant in template.Variants)
+        {
+            RequirePool(template.Id, variant.NamePool);
+        }
+    }
+
+    private void RequirePool(string templateId, string? pool)
+    {
+        if (string.IsNullOrEmpty(pool) || _names.GetByType(pool) is not null)
+        {
+            return;
+        }
+
+        throw new InvalidDataException(
+            $"Mobile template '{templateId}' references unknown name pool '{pool}'."
+        );
     }
 }

--- a/src/Moongate.Server/Services/Mobiles/MobileFactoryService.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileFactoryService.cs
@@ -27,12 +27,19 @@ public sealed class MobileFactoryService : IMobileFactoryService
     private readonly IStartingCityService _startingCityService;
     private readonly IMobileTemplateService _templates;
     private readonly Random _random;
+    private readonly INameService _names;
 
-    public MobileFactoryService(IStartingCityService startingCityService, IMobileTemplateService templates, Random random)
+    public MobileFactoryService(
+        IStartingCityService startingCityService,
+        IMobileTemplateService templates,
+        Random random,
+        INameService names
+    )
     {
         _startingCityService = startingCityService;
         _templates = templates;
         _random = random;
+        _names = names;
     }
 
     public MobileEntity Create(string name, int mapId, Point3D position)
@@ -56,7 +63,7 @@ public sealed class MobileFactoryService : IMobileFactoryService
 
         var mobile = new MobileEntity
         {
-            Name = template.Name,
+            Name = ResolveName(template, variant),
             MapId = mapId,
             Position = position,
             Gender = ResolveGender(variant?.Gender ?? template.Gender),
@@ -161,6 +168,33 @@ public sealed class MobileFactoryService : IMobileFactoryService
                 _logger.Warning("Unknown skill '{Skill}' on mobile template; skipping", name);
             }
         }
+    }
+
+    /// <summary>
+    /// A template's own <c>Name</c> wins: it is a named individual, and it is usually paired with a
+    /// pool inherited from its base. Otherwise the pool names it, the variant's overriding the
+    /// template's. Neither leaves the spawn nameless, which the OPL already renders as a blank
+    /// label rather than an error.
+    /// </summary>
+    private string ResolveName(MobileTemplate template, MobileVariant? variant)
+    {
+        if (template.Name.Length > 0)
+        {
+            return template.Name;
+        }
+
+        var pool = variant?.NamePool ?? template.NamePool;
+
+        if (string.IsNullOrEmpty(pool))
+        {
+            return string.Empty;
+        }
+
+        // A pool the service does not hold is rejected by the loader, so reaching here means a
+        // caller built a template by hand. Nameless beats throwing.
+        return _names.GetByType(pool)?.Names is { Count: > 0 } names
+                   ? names[_random.Next(names.Count)]
+                   : string.Empty;
     }
 
     private MobileVariant? PickVariant(List<MobileVariant> variants)

--- a/src/Moongate.Server/Services/Mobiles/MobileTemplateBaseResolver.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileTemplateBaseResolver.cs
@@ -30,6 +30,7 @@ public sealed class MobileTemplateBaseResolver
         {
             Id = derived.Id,
             Name = NonEmpty(derived.Name, baseTemplate.Name),
+            NamePool = NonEmpty(derived.NamePool, baseTemplate.NamePool),
             Title = NonEmpty(derived.Title, baseTemplate.Title),
             Category = NonEmpty(derived.Category, baseTemplate.Category),
             Description = NonEmpty(derived.Description, baseTemplate.Description),

--- a/src/Moongate.UO.Data/Mobiles/Templates/MobileTemplate.cs
+++ b/src/Moongate.UO.Data/Mobiles/Templates/MobileTemplate.cs
@@ -9,6 +9,13 @@ public sealed class MobileTemplate
 
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The <c>names.yaml</c> pool this template draws a name from when it has no <see cref="Name" />
+    /// of its own. A literal pool type — the shipped pools spell gender inconsistently
+    /// (<c>male</c>, <c>tokuno male</c>, <c>male elf brigand</c>), so nothing is appended for you.
+    /// </summary>
+    public string NamePool { get; set; } = string.Empty;
+
     public MobileTemplateGenderType Gender { get; set; } = MobileTemplateGenderType.Male;
 
     public string Title { get; set; } = string.Empty;

--- a/src/Moongate.UO.Data/Mobiles/Templates/MobileVariant.cs
+++ b/src/Moongate.UO.Data/Mobiles/Templates/MobileVariant.cs
@@ -12,6 +12,9 @@ public sealed class MobileVariant
     /// <summary>Gender for this variant; when null the template's gender is used.</summary>
     public MobileTemplateGenderType? Gender { get; set; }
 
+    /// <summary>Name pool for this variant; when null the template's pool is used.</summary>
+    public string? NamePool { get; set; }
+
     /// <summary>Loot table for this variant; when null the template's loot table is used.</summary>
     public string? LootTableId { get; set; }
 

--- a/tests/Moongate.Tests/Data/Mobiles/MobileNamePoolDataTests.cs
+++ b/tests/Moongate.Tests/Data/Mobiles/MobileNamePoolDataTests.cs
@@ -1,0 +1,73 @@
+using Moongate.Server.Loaders;
+using Moongate.Server.Services.Mobiles;
+using Moongate.UO.Data.Mobiles.Templates;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Data.Mobiles;
+
+/// <summary>
+/// The shipped mobile templates against the shipped name pools. Both files are ours, so unlike the
+/// tiledata invariants this is a real CI gate rather than a developer's check.
+/// </summary>
+public class MobileNamePoolDataTests
+{
+    [Fact]
+    public async Task EveryDeclaredNamePool_ExistsInNamesYaml()
+    {
+        var (templates, names) = await Load();
+
+        var unknown = new List<string>();
+
+        foreach (var template in templates)
+        {
+            var pools = new[] { template.NamePool }.Concat(template.Variants.Select(variant => variant.NamePool));
+
+            foreach (var pool in pools)
+            {
+                if (!string.IsNullOrEmpty(pool) && names.GetByType(pool) is null)
+                {
+                    unknown.Add($"{template.Id} -> {pool}");
+                }
+            }
+        }
+
+        Assert.True(unknown.Count == 0, $"Templates naming a pool that does not exist: {string.Join(", ", unknown)}");
+    }
+
+    // The whole point of the work: nothing that spawns should carry a blank label.
+    [Fact]
+    public async Task EveryShippedTemplate_ResolvesToAName()
+    {
+        var (templates, _) = await Load();
+
+        var nameless = templates
+                       .Where(template => template.Id != "base_human_npc")
+                       .Where(template => template.Name.Length == 0 && template.NamePool.Length == 0)
+                       .Select(template => template.Id)
+                       .ToList();
+
+        Assert.True(nameless.Count == 0, $"Templates that would spawn nameless: {string.Join(", ", nameless)}");
+    }
+
+    private static async Task<(IReadOnlyList<MobileTemplate> Templates, NameService Names)> Load()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-namepool-" + Guid.NewGuid().ToString("N"));
+        var directories = new DirectoriesConfig(root, []);
+        var names = new NameService();
+        var templates = new MobileTemplateService();
+
+        try
+        {
+            // Both loaders seed their embedded assets when the target directory is missing, which is
+            // what makes a bare temp root enough to read the shipped data.
+            await new NamesLoader(names, directories).LoadAsync();
+            await new MobileTemplatesLoader(templates, directories, names).LoadAsync();
+
+            return (templates.All, names);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/Loaders/MobileTemplatesLoaderTests.cs
+++ b/tests/Moongate.Tests/Server/Loaders/MobileTemplatesLoaderTests.cs
@@ -16,7 +16,7 @@ public class MobileTemplatesLoaderTests
 
         try
         {
-            await new MobileTemplatesLoader(service, directories).LoadAsync();
+            await new MobileTemplatesLoader(service, directories, new NameService()).LoadAsync();
             Assert.Equal(0, service.Count);
         }
         finally
@@ -59,7 +59,7 @@ public class MobileTemplatesLoaderTests
 
         try
         {
-            await new MobileTemplatesLoader(service, directories).LoadAsync();
+            await new MobileTemplatesLoader(service, directories, new NameService()).LoadAsync();
 
             Assert.Equal(2, service.Count);
             var guard = service.GetById("town_guard")!;
@@ -67,6 +67,43 @@ public class MobileTemplatesLoaderTests
             Assert.Equal(100, guard.Strength);
             Assert.Equal(400, guard.Appearance.Body); // inherited from base
             Assert.Equal(900, guard.Skills["Swordsmanship"]);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    // A typo in a pool name would otherwise produce nameless NPCs weeks later.
+    [Fact]
+    public async Task LoadAsync_TemplateWithUnknownNamePool_Throws()
+    {
+        var root = NewRoot();
+        var directories = new DirectoriesConfig(root, []);
+        var mobilesDirectory = Path.Combine(directories.RegisterDirectory("templates"), "mobiles");
+        Directory.CreateDirectory(mobilesDirectory);
+
+        File.WriteAllText(
+            Path.Combine(mobilesDirectory, "typo.yaml"),
+            """
+            -   Id: guard
+                Category: npc
+                NamePool: mael
+            """
+        );
+
+        var names = new NameService();
+        names.Register(new() { Type = "male", Names = ["Aaron"] });
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<InvalidDataException>(
+                async () => await new MobileTemplatesLoader(new MobileTemplateService(), directories, names)
+                    .LoadAsync()
+            );
+
+            Assert.Contains("guard", exception.Message);
+            Assert.Contains("mael", exception.Message);
         }
         finally
         {

--- a/tests/Moongate.Tests/Server/MobileFactoryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/MobileFactoryServiceTests.cs
@@ -298,8 +298,23 @@ public class MobileFactoryServiceTests
         return service;
     }
 
-    private static MobileFactoryService Factory(MobileTemplateService? templates = null)
-        => new(Cities(), templates ?? new MobileTemplateService(), new(1));
+    private static MobileFactoryService Factory(
+        MobileTemplateService? templates = null,
+        NameService? names = null
+    )
+        => new(Cities(), templates ?? new MobileTemplateService(), new(1), names ?? new NameService());
+
+    private static NameService Names(params (string Type, string[] Names)[] pools)
+    {
+        var service = new NameService();
+
+        foreach (var (type, names) in pools)
+        {
+            service.Register(new() { Type = type, Names = [.. names] });
+        }
+
+        return service;
+    }
 
     private static CharacterCreationPacket Packet(
         short startingCityIndex,
@@ -327,4 +342,71 @@ public class MobileFactoryServiceTests
             0x0765,
             0x0766
         );
+
+    [Fact]
+    public void CreateFromTemplate_WithANamePool_DrawsFromIt()
+    {
+        var templates = new MobileTemplateService();
+        templates.Register(new() { Id = "guard", NamePool = "male" });
+
+        var spawn = Factory(templates, Names(("male", ["Aaron", "Abbott"]))).CreateFromTemplate("guard", 1, new(1, 1, 0))!;
+
+        Assert.Contains(spawn.Mobile.Name, new[] { "Aaron", "Abbott" });
+    }
+
+    // A named individual overrides the kind's naming. This is not an edge case: lilly inherits a
+    // pool from base_human_npc and carries its own Name.
+    [Fact]
+    public void CreateFromTemplate_WithBothANameAndAPool_KeepsTheName()
+    {
+        var templates = new MobileTemplateService();
+        templates.Register(new() { Id = "lilly", Name = "Lilly", NamePool = "male" });
+
+        var spawn = Factory(templates, Names(("male", ["Aaron"]))).CreateFromTemplate("lilly", 1, new(1, 1, 0))!;
+
+        Assert.Equal("Lilly", spawn.Mobile.Name);
+    }
+
+    [Fact]
+    public void CreateFromTemplate_VariantPool_OverridesTheTemplates()
+    {
+        var templates = new MobileTemplateService();
+        templates.Register(
+            new()
+            {
+                Id = "guard",
+                NamePool = "male",
+                Variants = [new() { Name = "female", NamePool = "female" }]
+            }
+        );
+
+        var names = Names(("male", ["Aaron"]), ("female", ["Adrianna"]));
+        var spawn = Factory(templates, names).CreateFromTemplate("guard", 1, new(1, 1, 0))!;
+
+        Assert.Equal("Adrianna", spawn.Mobile.Name);
+    }
+
+    [Fact]
+    public void CreateFromTemplate_WithNeitherNameNorPool_SpawnsNameless()
+    {
+        var templates = new MobileTemplateService();
+        templates.Register(new() { Id = "zombie" });
+
+        var spawn = Factory(templates).CreateFromTemplate("zombie", 1, new(1, 1, 0))!;
+
+        Assert.Equal(string.Empty, spawn.Mobile.Name);
+    }
+
+    // A pool the service does not hold cannot happen through the loader, which rejects it -- but the
+    // factory is called directly from Lua and tests too, so it must not throw.
+    [Fact]
+    public void CreateFromTemplate_PoolTheServiceDoesNotHold_SpawnsNameless()
+    {
+        var templates = new MobileTemplateService();
+        templates.Register(new() { Id = "guard", NamePool = "nonexistent" });
+
+        var spawn = Factory(templates).CreateFromTemplate("guard", 1, new(1, 1, 0))!;
+
+        Assert.Equal(string.Empty, spawn.Mobile.Name);
+    }
 }

--- a/tests/Moongate.Tests/Server/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/MobileModuleTests.cs
@@ -309,7 +309,7 @@ public class MobileModuleTests
         var itemTemplates = new ItemTemplateService();
         itemTemplates.Register(new() { Id = "plate_chest", Name = "Plate Chest", Category = "Armor", ItemId = 5141 });
 
-        var factory = new MobileFactoryService(new StartingCityService(), mobileTemplates, random);
+        var factory = new MobileFactoryService(new StartingCityService(), mobileTemplates, random, new NameService());
         var itemFactory = new ItemFactoryService(itemTemplates, random);
         var items = new ItemService(persistence);
 

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateBaseResolverTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateBaseResolverTests.cs
@@ -62,4 +62,28 @@ public class MobileTemplateBaseResolverTests
         var ex = Assert.Throws<InvalidDataException>(() => new MobileTemplateBaseResolver().Resolve([derived]));
         Assert.Contains("missing", ex.Message);
     }
+
+    // The five-line data change hangs off this: base_human_npc declares the pool once and all
+    // thirteen human templates inherit it.
+    [Fact]
+    public void Resolve_DerivedWithNoNamePool_InheritsTheBase()
+    {
+        var baseTemplate = new MobileTemplate { Id = "base_human", NamePool = "male" };
+        var derived = new MobileTemplate { Id = "guard", BaseMobile = "base_human" };
+
+        var resolved = new MobileTemplateBaseResolver().Resolve([baseTemplate, derived]);
+
+        Assert.Equal("male", resolved.Single(template => template.Id == "guard").NamePool);
+    }
+
+    [Fact]
+    public void Resolve_DerivedWithItsOwnNamePool_KeepsIt()
+    {
+        var baseTemplate = new MobileTemplate { Id = "base_human", NamePool = "male" };
+        var derived = new MobileTemplate { Id = "guard_female", BaseMobile = "base_human", NamePool = "female" };
+
+        var resolved = new MobileTemplateBaseResolver().Resolve([baseTemplate, derived]);
+
+        Assert.Equal("female", resolved.Single(template => template.Id == "guard_female").NamePool);
+    }
 }

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
@@ -17,11 +17,17 @@ public class MobileTemplateRepositoryIntegrityTests
         var items = new ItemTemplateService();
         var mobiles = new MobileTemplateService();
         var loot = new LootTemplateService();
+        var names = new NameService();
 
         try
         {
             await new ItemTemplatesLoader(items, directories).LoadAsync();
-            await new MobileTemplatesLoader(mobiles, directories, new NameService()).LoadAsync();
+
+            // The mobile loader rejects a NamePool naming no registered pool, so the names have to
+            // be loaded first — exactly as at boot, where NamesLoader runs at priority 30 and the
+            // mobile templates at 150.
+            await new NamesLoader(names, directories).LoadAsync();
+            await new MobileTemplatesLoader(mobiles, directories, names).LoadAsync();
             await new LootTemplatesLoader(loot, items, directories).LoadAsync();
 
             Assert.NotEmpty(mobiles.All);

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
@@ -21,7 +21,7 @@ public class MobileTemplateRepositoryIntegrityTests
         try
         {
             await new ItemTemplatesLoader(items, directories).LoadAsync();
-            await new MobileTemplatesLoader(mobiles, directories).LoadAsync();
+            await new MobileTemplatesLoader(mobiles, directories, new NameService()).LoadAsync();
             await new LootTemplatesLoader(loot, items, directories).LoadAsync();
 
             Assert.NotEmpty(mobiles.All);

--- a/tests/Moongate.Tests/Support/CharacterServiceFixture.cs
+++ b/tests/Moongate.Tests/Support/CharacterServiceFixture.cs
@@ -45,7 +45,7 @@ public static class CharacterServiceFixture
 
         return new(
             persistence,
-            new MobileFactoryService(cities ?? Cities(), new MobileTemplateService(), random),
+            new MobileFactoryService(cities ?? Cities(), new MobileTemplateService(), random, new NameService()),
             new ItemFactoryService(templates, random),
             new ItemService(persistence),
             templates,


### PR DESCRIPTION
`names.yaml` ships **28 name pools** — a direct port of ModernUO's `Data/names.json` — and nothing read them: `INameService` had exactly one occurrence in the codebase, its own registration. Meanwhile `MobileFactoryService` did `Name = template.Name` and nothing else, so **15 of 19 mobile templates spawned with a blank label**: six vendors, four guards, a generic NPC, a healer and two undead.

## How

A `NamePool` key on the template and the variant names a pool **literally**. The factory resolves it at spawn beside the weighted variant pick it already does, so `INameService` keeps its shape and gains no dependency — the randomness stays where randomness already lived.

The chain is `Name` → pool → nameless. `Name` winning is not a preference: all thirteen human templates inherit from `base_human_npc`, so putting the pool on the base is what makes this **five lines of data instead of fourteen** — and that leaves `lilly` carrying an inherited pool and its own name. A named individual overrides its kind's naming.

An unknown pool **fails the load**: names read at priority 30 and mobile templates at 150, so a typo dies at boot with the template and the pool in the message.

## Why the pool is not a stem plus a gender suffix

The shipped pools put gender in three different places: bare in `male`, trailing in `tokuno male`, **leading** in `male elf brigand`. No mechanical rule reconciles those, and 22 of the 28 name no gender at all. ModernUO does not normalise them either — it writes each one out at the call site (`BaseVendor.cs:621`, `:678`, `:783`).

## The data

`NamePool: male` on the base, `female` on the two female guards, and a fixed `Name` on the two undead — nobody calls a zombie Aaron, and ModernUO's `Zombie` and `SkeletalKnight` set no `Name` either, only a `CorpseName`.

## Verification

1888 tests green, docs at 0 warnings, and a real boot loading 28 name lists and accepting all 19 templates.

Two data invariants guard the result and — unlike the tiledata ones — **run in CI**, because both files are ours: every declared pool exists, and no shipped template would spawn nameless. Both were seen red before being trusted, each naming exactly the template at fault.

`MobileTemplateRepositoryIntegrityTests` loads the shipped templates, so it now loads the name pools first — the same order the boot uses.

## Follow-up, deliberately out of scope

Merging the gendered guard pairs into variants and making vendors mixed-gender, as `BaseVendor` does. That needs per-gender appearance and equipment — the guard pairs differ in `Body` (400 vs 401) and carry five pieces against three — which is exactly what `MobileVariant` exists for and what no shipped template currently uses. The `NamePool` key on the variant is already in place for it.

Issue #140.