### PR TITLE
Let a derived mobile template state that it is male

### DIFF
--- a/docs/scripting/data/mobile-templates.md
+++ b/docs/scripting/data/mobile-templates.md
@@ -52,7 +52,7 @@ path order) into one flat list, then `MobileTemplateBaseResolver` resolves
 | `Id` | `string` | required (no format check) | Not merged — the derived `Id` is kept. |
 | `Name` | `string` | optional, default `""` | Derived value wins if non-empty, else the base's. |
 | `NamePool` | `string` | optional, default `""` | Derived value wins if non-empty, else the base's. |
-| `Gender` | `MobileTemplateGenderType` enum | optional, default `Male` | Derived value wins **only if it is not `Male`**; see [Gender](#gender) for the caveat this creates. |
+| `Gender` | `MobileTemplateGenderType?` enum | optional, default `null` | Derived value wins if set, else the base's (`derived ?? base`). |
 | `Title` | `string` | optional, default `""` | Derived wins if non-empty, else base's. Displayed under the mobile's name (e.g. "the guard"). |
 | `Category` | `string` | optional, default `""` | Derived wins if non-empty, else base's. Matched by `GetByCategory`. |
 | `Description` | `string` | optional, default `""` | Derived wins if non-empty, else base's. |
@@ -98,12 +98,12 @@ to an actual gender:
 
 No shipped template currently sets `Gender: Random`; `Female` is used (e.g.
 `archer_guard_female_npc`, `warrior_guard_female_npc` in
-`Mobiles/guards.yaml`). `Male` doubles as both "explicitly male" and "not
-set", which has one consequence worth calling out: **because the merge rule
-only takes the derived value when it is not `Male`, a derived template
-cannot force a base's `Female`/`Random` gender back to `Male` — omitting
-`Gender` and writing `Gender: Male` are indistinguishable, and both mean
-"inherit the base's gender" whenever `BaseMobile` is set.**
+`Mobiles/guards.yaml`).
+
+Omitting the key and writing `Gender: Male` mean different things. An omitted
+`Gender` is null, which inherits the base's; `Gender: Male` states male and
+wins over a `Female` or `Random` base. A template with no base and no `Gender`
+spawns male, which is what the factory's default arm does with null.
 
 The same caveat applies to `Strength`/`Dexterity`/`Intelligence`: because
 `50` is both the DTO default and a legitimate explicit value, a derived

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/PaperdollImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/PaperdollImageService.cs
@@ -85,7 +85,11 @@ public sealed class PaperdollImageService : IPaperdollImageService
         return path;
     }
 
-    private static GenderType ResolveGender(MobileTemplateGenderType gender)
+    /// <summary>
+    /// A template that states no gender renders male, the same as <c>Random</c> does — the image has
+    /// to be identical on every request for the cache key to mean anything.
+    /// </summary>
+    private static GenderType ResolveGender(MobileTemplateGenderType? gender)
         => gender == MobileTemplateGenderType.Female ? GenderType.Female : GenderType.Male;
 
     private static string Sanitize(string id)

--- a/src/Moongate.Server/Services/Mobiles/MobileFactoryService.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileFactoryService.cs
@@ -244,7 +244,11 @@ public sealed class MobileFactoryService : IMobileFactoryService
         return resolved;
     }
 
-    private GenderType ResolveGender(MobileTemplateGenderType gender)
+    /// <summary>
+    /// A template that states no gender spawns male, which is what the default was before the key
+    /// became nullable. The discard arm already covered <c>Male</c> and now covers null too.
+    /// </summary>
+    private GenderType ResolveGender(MobileTemplateGenderType? gender)
         => gender switch
         {
             MobileTemplateGenderType.Female => GenderType.Female,

--- a/src/Moongate.Server/Services/Mobiles/MobileTemplateBaseResolver.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileTemplateBaseResolver.cs
@@ -35,7 +35,7 @@ public sealed class MobileTemplateBaseResolver
             Category = NonEmpty(derived.Category, baseTemplate.Category),
             Description = NonEmpty(derived.Description, baseTemplate.Description),
             BaseMobile = null,
-            Gender = derived.Gender != MobileTemplateGenderType.Male ? derived.Gender : baseTemplate.Gender,
+            Gender = derived.Gender ?? baseTemplate.Gender,
             Strength = derived.Strength != DefaultStat ? derived.Strength : baseTemplate.Strength,
             Dexterity = derived.Dexterity != DefaultStat ? derived.Dexterity : baseTemplate.Dexterity,
             Intelligence = derived.Intelligence != DefaultStat ? derived.Intelligence : baseTemplate.Intelligence,

--- a/src/Moongate.UO.Data/Mobiles/Templates/MobileTemplate.cs
+++ b/src/Moongate.UO.Data/Mobiles/Templates/MobileTemplate.cs
@@ -16,7 +16,12 @@ public sealed class MobileTemplate
     /// </summary>
     public string NamePool { get; set; } = string.Empty;
 
-    public MobileTemplateGenderType Gender { get; set; } = MobileTemplateGenderType.Male;
+    /// <summary>
+    /// Gender for this template; when null the base's is used, and a template with no base spawns
+    /// male. Nullable so that omitting the key and writing <c>Gender: Male</c> mean different things
+    /// — without it a template deriving from a female base could never state that it is male.
+    /// </summary>
+    public MobileTemplateGenderType? Gender { get; set; }
 
     public string Title { get; set; } = string.Empty;
 

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateBaseResolverTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateBaseResolverTests.cs
@@ -1,5 +1,6 @@
 using Moongate.Server.Services.Mobiles;
 using Moongate.UO.Data.Mobiles.Templates;
+using Moongate.UO.Data.Types;
 
 namespace Moongate.Tests.Server.Mobiles;
 
@@ -85,5 +86,32 @@ public class MobileTemplateBaseResolverTests
         var resolved = new MobileTemplateBaseResolver().Resolve([baseTemplate, derived]);
 
         Assert.Equal("female", resolved.Single(template => template.Id == "guard_female").NamePool);
+    }
+
+    // Omitting Gender and writing Gender: Male used to be indistinguishable, so a derived template
+    // could never state that it is male against a female base.
+    [Fact]
+    public void Resolve_DerivedForcingMale_BeatsAFemaleBase()
+    {
+        var baseTemplate = new MobileTemplate { Id = "base_maid", Gender = MobileTemplateGenderType.Female };
+        var derived = new MobileTemplate
+        {
+            Id = "butler", BaseMobile = "base_maid", Gender = MobileTemplateGenderType.Male
+        };
+
+        var resolved = new MobileTemplateBaseResolver().Resolve([baseTemplate, derived]);
+
+        Assert.Equal(MobileTemplateGenderType.Male, resolved.Single(template => template.Id == "butler").Gender);
+    }
+
+    [Fact]
+    public void Resolve_DerivedWithNoGender_StillInheritsTheBase()
+    {
+        var baseTemplate = new MobileTemplate { Id = "base_maid", Gender = MobileTemplateGenderType.Female };
+        var derived = new MobileTemplate { Id = "maid", BaseMobile = "base_maid" };
+
+        var resolved = new MobileTemplateBaseResolver().Resolve([baseTemplate, derived]);
+
+        Assert.Equal(MobileTemplateGenderType.Female, resolved.Single(template => template.Id == "maid").Gender);
     }
 }

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
@@ -32,9 +32,11 @@ public class MobileTemplateRepositoryIntegrityTests
 
             Assert.NotEmpty(mobiles.All);
 
-            // Gender parses from YAML into the enum: the shipped female guard is Female, a male one Male.
+            // Gender parses from YAML into the enum where it is declared, and stays null where it is
+            // not: the shipped female guard says Female, the male one says nothing at all and takes
+            // male from the factory's default rather than from the template.
             Assert.Equal(MobileTemplateGenderType.Female, mobiles.GetById("warrior_guard_female_npc")!.Gender);
-            Assert.Equal(MobileTemplateGenderType.Male, mobiles.GetById("warrior_guard_male_npc")!.Gender);
+            Assert.Null(mobiles.GetById("warrior_guard_male_npc")!.Gender);
 
             foreach (var template in mobiles.All)
             {


### PR DESCRIPTION
`MobileTemplate.Gender` was a non-nullable enum defaulting to `Male`, merged with:

```csharp
Gender = derived.Gender != MobileTemplateGenderType.Male ? derived.Gender : baseTemplate.Gender
```

So **omitting the key and writing `Gender: Male` were indistinguishable**, and both meant "inherit the base". A template deriving from a `Female` or `Random` base could never state that it is male.

## The asymmetry was the bug

`MobileVariant.Gender` is already `MobileTemplateGenderType?` and already merges with `??`. Two fields with the same meaning, one class apart, with different types and different semantics — the template now matches its own variant, and the rule reads like `LootTableId` and `BrainScript` three lines below it.

## What does not change

The YAML. Omitting still inherits; `Gender: Male` starts meaning male. Null resolves to male at spawn, which is exactly what the factory's discard arm already did with `Male`.

No REST DTO exposes `MobileTemplate.Gender` — `CharacterResponse.Gender` is the entity's — so the OpenAPI contract does not move and the UI gate does not fire. It **is** source-breaking for plugin authors, since `Moongate.UO.Data` is published.

## Latent, not active

The only base template, `base_human_npc`, declares no `Gender`, so no shipped template was affected. This is the kind of trap that fires months later when someone adds a female base.

One consequence worth naming: `MobileTemplateRepositoryIntegrityTests` asserted the male guard's `Gender` was `Male`. It is now null, because that template states nothing at all — the assertion moved, and the comment now says where male actually comes from.

## Verification

1890 tests green, docs at 0 warnings, real boot clean. The caveat paragraph in `mobile-templates.md` that documented this limitation is rewritten, since it is no longer true.

Issue #142.