### PR TITLE
Give speech and placement one definition each

### DIFF
--- a/docs/scripting/reference/ai.md
+++ b/docs/scripting/reference/ai.md
@@ -17,9 +17,14 @@ the file format, hooks, context, and lifecycle.
 ai.say(text) -> boolean
 ```
 
-Speaks as the brain owner with regular speech, the default hue, and range 15.
-Returns `false` when `text` is blank or longer than 128 characters. It takes no
-serial, so a brain cannot choose an arbitrary speaker.
+Speaks as the brain owner. It takes no serial, so a brain cannot choose an
+arbitrary speaker.
+
+The rules are the same ones [`chat.say`](chat.md) applies, because both go
+through the same service: `false` when the text is blank, longer than 128
+characters, or a command rather than speech. The leading character decides how
+it is spoken and at what range — see [chat](chat.md) for the table. Ordinary
+text is regular speech in the default hue, heard 15 tiles away.
 
 ## ai.patrol
 

--- a/docs/scripting/reference/chat.md
+++ b/docs/scripting/reference/chat.md
@@ -1,0 +1,54 @@
+# chat
+
+Speech and system messages. A mobile speaks by serial; a broadcast reaches every
+in-world session.
+
+## chat.say
+
+```lua
+chat.say(serial, text) -> boolean
+```
+
+Speaks as the mobile with that serial. Returns `false` — and says nothing — when
+the serial is unknown, the text is blank, the text is longer than **128
+characters**, or the text is a command rather than speech.
+
+The leading character decides how it is spoken:
+
+| prefix | result | range |
+|---|---|---|
+| `.` | **command — refused**, never spoken | — |
+| `*…*` | emote, the asterisks stripped | 15 |
+| `!` | yell | 18 |
+| `;` | whisper | 1 |
+| anything else | ordinary speech | 15 |
+
+**Example**
+
+```lua
+chat.say(npc, "Welcome back.")     -- ordinary, heard 15 tiles away
+chat.say(npc, "*nods*")            -- emote, spoken as "nods"
+chat.say(npc, "!Guards!")          -- yelled, heard 18
+chat.say(npc, ".help")             -- false, nothing is said
+```
+
+## chat.broadcast
+
+```lua
+chat.broadcast(text)
+```
+
+Sends a system message to every in-world session, with no range check and no
+speaker. Returns nothing.
+
+**Example**
+
+```lua
+chat.broadcast("The shard restarts in five minutes.")
+```
+
+## See also
+
+[`ai.say`](ai.md) speaks as the NPC a brain is running for, with no serial to
+pass. It applies these same rules — both go through one service, so they cannot
+drift apart.

--- a/docs/scripting/reference/mobile.md
+++ b/docs/scripting/reference/mobile.md
@@ -112,20 +112,35 @@ mobile.set(guard, {
 })
 ```
 
+## mobile.teleport
+
+```lua
+mobile.teleport(serial, x, y, z) -> boolean
+```
+
+Places the mobile at `(x, y, z)` on its current map **without validating the
+terrain** — it will land inside a wall or on top of a mountain if you ask it to.
+That is the point: this is a GM move or a spawner placement, not a walk. Returns
+`false` when the serial is unknown.
+
+For validated movement a brain uses [`ai.step`](ai.md), which refuses a step the
+terrain does not allow.
+
+**Example**
+
+```lua
+mobile.teleport(guard, 1425, 1695, 0)
+```
+
 ## mobile.move
 
 ```lua
 mobile.move(serial, x, y, z) -> boolean
 ```
 
-Moves the mobile to `(x, y, z)` on its current map. Returns `false` when the
-serial is unknown.
-
-**Example**
-
-```lua
-mobile.move(guard, 1425, 1695, 0)
-```
+An alias of [`mobile.teleport`](#mobileteleport), kept for scripts already
+written. Same behaviour, including the absence of terrain validation — the name
+predates the distinction.
 
 ## mobile.get_skill
 

--- a/docs/scripting/toc.yml
+++ b/docs/scripting/toc.yml
@@ -18,6 +18,8 @@
       href: reference/log.md
     - name: ai
       href: reference/ai.md
+    - name: chat
+      href: reference/chat.md
     - name: memory
       href: reference/memory.md
     - name: item scripts

--- a/src/Moongate.Server.Abstractions/Interfaces/Chat/IChatService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Chat/IChatService.cs
@@ -15,4 +15,11 @@ public interface IChatService
     void Broadcast(string text, Hue? hue = null);
 
     void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range);
+
+    /// <summary>
+    /// Speaks as <paramref name="speaker" />, applying every rule that governs speech: blank and
+    /// overlong text are refused, and text the classifier reads as a command is refused rather than
+    /// spoken. True when something was said.
+    /// </summary>
+    bool SayAs(MobileEntity speaker, string text);
 }

--- a/src/Moongate.Server.Abstractions/Interfaces/Mobiles/IMobileService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Mobiles/IMobileService.cs
@@ -1,0 +1,18 @@
+using Moongate.Core.Primitives;
+
+namespace Moongate.Server.Abstractions.Interfaces.Mobiles;
+
+/// <summary>
+/// Owns mobile state that scripts and systems mutate outside the movement rules. It is the seam
+/// <c>MobileModule</c> lacked: the module wrote the entity store directly and so could carry no
+/// loop-affinity guard of its own.
+/// </summary>
+public interface IMobileService
+{
+    /// <summary>
+    /// Places the mobile at (x, y, z) on its current map <b>without validating the terrain</b> — a GM
+    /// move or a spawner placement, not a walk. <see cref="World.IMovementService" /> owns the
+    /// validated verb. False on an unknown serial.
+    /// </summary>
+    bool Teleport(Serial mobile, int x, int y, int z);
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -179,6 +179,7 @@ await ConsoleApp.RunAsync(
                 container.Register<ICharacterService, CharacterService>(Reuse.Singleton);
                 container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
                 container.Register<IMobileFactoryService, MobileFactoryService>(Reuse.Singleton);
+                container.Register<IMobileService, MobileService>(Reuse.Singleton);
 
                 container.RegisterInstance(Random.Shared);
                 container.RegisterInstance(TimeProvider.System);

--- a/src/Moongate.Server/Scripting/ChatModule.cs
+++ b/src/Moongate.Server/Scripting/ChatModule.cs
@@ -30,23 +30,12 @@ public sealed class ChatModule
     public void Broadcast(string text)
         => _chat.Broadcast(text);
 
-    [ScriptFunction("say", "Speaks as the mobile with the given serial; false on unknown serial.")]
+    [ScriptFunction("say", "Speaks as the mobile with the given serial; false on unknown serial, blank, overlong or command text.")]
     public bool Say(uint serial, string text)
     {
         var mobile = _mobiles.GetById((Serial)serial);
 
-        if (mobile is null)
-        {
-            return false;
-        }
-
-        var decision = ChatService.Classify(text);
-
-        if (!decision.IsCommand && decision.Text.Length > 0)
-        {
-            _chat.Say(mobile, decision.Type, decision.Text, Hue.Default, decision.Range);
-        }
-
-        return true;
+        return mobile is not null && _chat.SayAs(mobile, text);
     }
+
 }

--- a/src/Moongate.Server/Scripting/MobileModule.cs
+++ b/src/Moongate.Server/Scripting/MobileModule.cs
@@ -34,6 +34,7 @@ public sealed class MobileModule
     private readonly IItemService _items;
     private readonly ISpatialIndexService _spatial;
     private readonly IEventBus _eventBus;
+    private readonly IMobileService _mobileService;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
 
     public MobileModule(
@@ -42,7 +43,8 @@ public sealed class MobileModule
         IItemService items,
         IPersistenceService persistence,
         ISpatialIndexService spatial,
-        IEventBus eventBus
+        IEventBus eventBus,
+        IMobileService mobileService
     )
     {
         _factory = factory;
@@ -50,6 +52,7 @@ public sealed class MobileModule
         _items = items;
         _spatial = spatial;
         _eventBus = eventBus;
+        _mobileService = mobileService;
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
     }
 
@@ -137,29 +140,13 @@ public sealed class MobileModule
         return mobile.Skills.TryGetValue(skillId, out var skillState) ? skillState.Value : 0;
     }
 
-    [ScriptFunction("move", "Moves the mobile to (x, y, z) on the same map; false on unknown serial.")]
+    [ScriptFunction("move", "Alias of teleport: places the mobile at (x, y, z) without validating terrain.")]
     public bool Move(uint serial, int x, int y, int z)
-    {
-        var mobile = _mobiles.GetById((Serial)serial);
+        => _mobileService.Teleport((Serial)serial, x, y, z);
 
-        if (mobile is null)
-        {
-            return false;
-        }
-
-        var fromMapId = mobile.MapId;
-        var fromPosition = mobile.Position;
-        mobile.Position = new(x, y, z);
-        _mobiles.UpsertAsync(mobile).WaitSync();
-        _spatial.AddOrUpdate(mobile);
-
-        if (mobile.MapId != fromMapId || mobile.Position != fromPosition)
-        {
-            _eventBus.Publish(new MobileMovedEvent(mobile.Id, fromMapId, fromPosition, mobile.MapId, mobile.Position));
-        }
-
-        return true;
-    }
+    [ScriptFunction("teleport", "Places the mobile at (x, y, z) on its map without validating terrain; false on unknown serial.")]
+    public bool Teleport(uint serial, int x, int y, int z)
+        => _mobileService.Teleport((Serial)serial, x, y, z);
 
     [ScriptFunction("set", "Mutates mobile fields from a table; returns true on success.")]
     public bool Set(uint serial, Table fields)

--- a/src/Moongate.Server/Services/AI/AiActionService.cs
+++ b/src/Moongate.Server/Services/AI/AiActionService.cs
@@ -20,8 +20,6 @@ namespace Moongate.Server.Services.AI;
 /// <summary>Applies NPC brain actions against the mobile of the active tick, resolved from an ambient context.</summary>
 public sealed class AiActionService : IAiActionService
 {
-    private const int SpeechRange = 15;
-    private const int SpeechMaximumLength = 128;
     private const int HomeLeashRange = 8;
 
     private readonly ILogger _logger = Log.ForContext<AiActionService>();
@@ -336,23 +334,15 @@ public sealed class AiActionService : IAiActionService
 
     private bool TrySay(MobileEntity owner, string? text, out string reason)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        if (_chat.SayAs(owner, text ?? string.Empty))
         {
-            reason = "speech text is blank";
+            reason = "";
 
-            return false;
+            return true;
         }
 
-        if (text.Length > SpeechMaximumLength)
-        {
-            reason = "speech text exceeds the maximum length";
+        reason = "chat service rejected the speech";
 
-            return false;
-        }
-
-        _chat.Say(owner, ChatMessageType.Regular, text, Hue.Default, SpeechRange);
-        reason = "";
-
-        return true;
+        return false;
     }
 }

--- a/src/Moongate.Server/Services/Chat/ChatService.cs
+++ b/src/Moongate.Server/Services/Chat/ChatService.cs
@@ -21,6 +21,9 @@ public sealed class ChatService : IChatService
 {
     private static readonly TimeSpan MinInterval = TimeSpan.FromMilliseconds(25);
 
+    /// <summary>Longest a single utterance may be. Moved here from AiActionService, which enforced it alone.</summary>
+    private const int MaximumLength = 128;
+
     private const int DefaultRange = 15;
     private const int YellRange = 18;
     private const int WhisperRange = 1;
@@ -64,6 +67,26 @@ public sealed class ChatService : IChatService
 
     public static bool IsRateLimited(DateTimeOffset lastChatAt, DateTimeOffset now)
         => now - lastChatAt < MinInterval;
+
+    public bool SayAs(MobileEntity speaker, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text) || text.Length > MaximumLength)
+        {
+            return false;
+        }
+
+        var decision = Classify(text);
+
+        // A command is not speech: it was typed to be executed, not heard.
+        if (decision.IsCommand || decision.Text.Length == 0)
+        {
+            return false;
+        }
+
+        Say(speaker, decision.Type, decision.Text, Hue.Default, decision.Range);
+
+        return true;
+    }
 
     public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
     {

--- a/src/Moongate.Server/Services/Mobiles/MobileService.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileService.cs
@@ -1,0 +1,63 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Services.Mobiles;
+
+/// <summary>
+/// Default <see cref="IMobileService" />. Carries the loop-affinity guard on every mutation, the way
+/// <c>ItemService</c> does — which is what <c>MobileModule</c>'s own comment asked for and could not
+/// have while it wrote the store directly.
+/// </summary>
+public sealed class MobileService : IMobileService
+{
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly ISpatialIndexService _spatial;
+    private readonly IEventBus _eventBus;
+    private readonly ILoopAffinity? _loopAffinity;
+
+    public MobileService(
+        IPersistenceService persistenceService,
+        ISpatialIndexService spatial,
+        IEventBus eventBus,
+        ILoopAffinity? loopAffinity = null
+    )
+    {
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _spatial = spatial;
+        _eventBus = eventBus;
+        _loopAffinity = loopAffinity;
+    }
+
+    public bool Teleport(Serial mobile, int x, int y, int z)
+    {
+        _loopAffinity?.AssertOnLoop("mobile.teleport");
+
+        if (_mobiles.GetById(mobile) is not { } entity)
+        {
+            return false;
+        }
+
+        var fromMapId = entity.MapId;
+        var fromPosition = entity.Position;
+
+        entity.Position = new(x, y, z);
+        _mobiles.UpsertAsync(entity).WaitSync();
+        _spatial.AddOrUpdate(entity);
+
+        // Only a real move is worth telling the world about: the brain router and every other
+        // subscriber would otherwise wake for nothing.
+        if (entity.MapId != fromMapId || entity.Position != fromPosition)
+        {
+            _eventBus.Publish(new MobileMovedEvent(entity.Id, fromMapId, fromPosition, entity.MapId, entity.Position));
+        }
+
+        return true;
+    }
+}

--- a/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
@@ -26,6 +26,10 @@ public class ConsoleAdminIntegrationTests
             => Broadcasts.Add(text);
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+
+        // A fake: it enforces nothing, because the rules belong to ChatService.
+        public bool SayAs(MobileEntity speaker, string text)
+            => true;
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
@@ -26,6 +26,10 @@ public class ConsoleEndpointsTests
         public void Broadcast(string text, Hue? hue = null) { }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+
+        // A fake: it enforces nothing, because the rules belong to ChatService.
+        public bool SayAs(MobileEntity speaker, string text)
+            => true;
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
@@ -29,6 +29,10 @@ public class RestConsoleIntegrationTests
             => Broadcasts.Add(text);
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+
+        // A fake: it enforces nothing, because the rules belong to ChatService.
+        public bool SayAs(MobileEntity speaker, string text)
+            => true;
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
@@ -23,6 +23,23 @@ public class AiActionServiceTests
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
             => Messages.Add((speaker.Id, type, text, hue, range));
+
+        /// <summary>Set to make every SayAs refuse, standing in for a rule ChatService would enforce.</summary>
+        public bool Refuse { get; set; }
+
+        // Records rather than enforcing: the rules belong to ChatService, and the tests that pin them
+        // live in ChatServiceTests.
+        public bool SayAs(MobileEntity speaker, string text)
+        {
+            if (Refuse)
+            {
+                return false;
+            }
+
+            Say(speaker, ChatMessageType.Regular, text, Hue.Default, 15);
+
+            return true;
+        }
     }
 
     private sealed class RecordingMovementService : IMovementService
@@ -329,34 +346,23 @@ public class AiActionServiceTests
         Assert.Equal(1, metrics.Current.IntentsRejected);
     }
 
-    [Theory, InlineData(null), InlineData(""), InlineData("   ")]
-    public void Say_BlankText_Rejects(string? text)
+    // Blank and oversize text are refused by ChatService now, not here -- that is what unified the
+    // rules with chat.say. The refusals themselves are pinned in ChatServiceTests; what this asserts
+    // is that a refusal reaches the brain as a rejected intent rather than being swallowed.
+    [Fact]
+    public void Say_WhenTheChatServiceRefuses_CountsARejectedIntent()
     {
         var (service, persistence, chat, _, metrics) = Build();
         var owner = AddOwner(persistence);
+        chat.Refuse = true;
 
         using (service.Begin(Context(owner)))
         {
-            Assert.False(service.Say(text!));
+            Assert.False(service.Say("anything at all"));
         }
 
         Assert.Empty(chat.Messages);
         Assert.Equal(0, metrics.Current.IntentsAccepted);
-        Assert.Equal(1, metrics.Current.IntentsRejected);
-    }
-
-    [Fact]
-    public void Say_OversizeText_Rejects()
-    {
-        var (service, persistence, chat, _, metrics) = Build();
-        var owner = AddOwner(persistence);
-
-        using (service.Begin(Context(owner)))
-        {
-            Assert.False(service.Say(new('a', 129)));
-        }
-
-        Assert.Empty(chat.Messages);
         Assert.Equal(1, metrics.Current.IntentsRejected);
     }
 

--- a/tests/Moongate.Tests/Server/Chat/ChatServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Chat/ChatServiceTests.cs
@@ -146,4 +146,68 @@ public class ChatServiceTests
         Assert.Equal(ChatMessageType.Regular, evt.Type);
         Assert.Equal("hi", evt.Text);
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SayAs_BlankText_SaysNothing(string text)
+    {
+        var (service, world) = Build();
+
+        Assert.False(service.SayAs(Speaker(), text));
+        Assert.Empty(world.InRange);
+    }
+
+    // The limit ai.say used to enforce alone, now applying to every caller.
+    [Fact]
+    public void SayAs_TextOverTheMaximum_SaysNothing()
+    {
+        var (service, world) = Build();
+
+        Assert.False(service.SayAs(Speaker(), new string('a', 129)));
+        Assert.Empty(world.InRange);
+    }
+
+    // The filter chat.say used to enforce alone. A leading dot is a command, not speech.
+    [Fact]
+    public void SayAs_ACommand_SaysNothing()
+    {
+        var (service, world) = Build();
+
+        Assert.False(service.SayAs(Speaker(), ".help"));
+        Assert.Empty(world.InRange);
+    }
+
+    // Coverage that moved here from ChatModuleTests when classification became the service's job.
+    [Theory]
+    [InlineData("*nods*", ChatMessageType.Emote)]
+    [InlineData("!Guards!", ChatMessageType.Yell)]
+    [InlineData(";psst", ChatMessageType.Whisper)]
+    public void SayAs_PrefixedText_SpeaksItAsThatKind(string text, ChatMessageType expected)
+    {
+        var (service, world) = Build();
+
+        Assert.True(service.SayAs(Speaker(), text));
+        Assert.Single(world.InRange);
+        Assert.Equal(expected, ChatService.Classify(text).Type);
+    }
+
+    [Fact]
+    public void SayAs_OrdinaryText_SaysItOnce()
+    {
+        var (service, world) = Build();
+
+        Assert.True(service.SayAs(Speaker(), "Welcome back."));
+        Assert.Single(world.InRange);
+    }
+
+    private static (ChatService Service, RecordingWorldService World) Build()
+    {
+        var world = new RecordingWorldService();
+
+        return (new(world, new StubEventBus()), world);
+    }
+
+    private static MobileEntity Speaker()
+        => new() { Name = "Squid", Body = 400, MapId = 1, Position = new(1, 1, 0) };
 }

--- a/tests/Moongate.Tests/Server/ChatModuleTests.cs
+++ b/tests/Moongate.Tests/Server/ChatModuleTests.cs
@@ -20,6 +20,16 @@ public class ChatModuleTests
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
             => Said.Add((speaker.Id, type, text));
+
+        public List<(Serial Speaker, string Text)> SaidAs { get; } = [];
+
+        // Records the delegation. The rules it would apply belong to ChatService and are pinned there.
+        public bool SayAs(MobileEntity speaker, string text)
+        {
+            SaidAs.Add((speaker.Id, text));
+
+            return true;
+        }
     }
 
     [Fact]
@@ -34,8 +44,10 @@ public class ChatModuleTests
         Assert.Null(hue);
     }
 
+    // The module looks the mobile up and hands the raw text over; deciding what the text means -- emote,
+    // yell, command, too long -- is ChatService's job and is pinned in ChatServiceTests.
     [Fact]
-    public void Say_ClassifiesEmoteBeforeForwarding()
+    public void Say_ForwardsTheRawTextToTheChatService()
     {
         var (module, persistence, chat) = Build();
         var mobile = new MobileEntity { Id = new(0x1), Name = "Guard", MapId = 0 };
@@ -44,10 +56,9 @@ public class ChatModuleTests
         var result = module.Say(mobile.Id.Value, "*nods*");
 
         Assert.True(result);
-        var (speaker, type, text) = Assert.Single(chat.Said);
+        var (speaker, text) = Assert.Single(chat.SaidAs);
         Assert.Equal(mobile.Id, speaker);
-        Assert.Equal(ChatMessageType.Emote, type);
-        Assert.Equal("nods", text);
+        Assert.Equal("*nods*", text);
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
@@ -18,6 +18,10 @@ public class BroadcastCommandTests
             => Broadcasts.Add(text);
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+
+        // A fake: it enforces nothing, because the rules belong to ChatService.
+        public bool SayAs(MobileEntity speaker, string text)
+            => true;
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Server/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/MobileModuleTests.cs
@@ -313,7 +313,7 @@ public class MobileModuleTests
         var itemFactory = new ItemFactoryService(itemTemplates, random);
         var items = new ItemService(persistence);
 
-        return (new(factory, itemFactory, items, persistence, spatial, bus), persistence, spatial, bus);
+        return (new(factory, itemFactory, items, persistence, spatial, bus, new MobileService(persistence, spatial, bus)), persistence, spatial, bus);
     }
 
     private static (MobileModule Module, FakePersistenceService Persistence, SpatialIndexService Spatial, StubEventBus Bus)

--- a/tests/Moongate.Tests/Server/Mobiles/MobileServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileServiceTests.cs
@@ -1,0 +1,72 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Mobiles;
+
+/// <summary>
+/// Raw placement: no terrain validation, and the world is told only when something actually moved.
+/// </summary>
+public class MobileServiceTests
+{
+    [Fact]
+    public void Teleport_MovesTheMobileAndAnnouncesItOnce()
+    {
+        var (service, persistence, moves) = Build(out var mobile);
+
+        Assert.True(service.Teleport(mobile.Id, 10, 20, 5));
+
+        Assert.Equal(new(10, 20, 5), persistence.Store<MobileEntity>().GetById(mobile.Id)!.Position);
+        Assert.Single(moves);
+    }
+
+    // The guard MobileModule already had, and the reason this is not a blind write.
+    [Fact]
+    public void Teleport_ToWhereItAlreadyIs_AnnouncesNothing()
+    {
+        var (service, _, moves) = Build(out var mobile);
+
+        Assert.True(service.Teleport(mobile.Id, mobile.Position.X, mobile.Position.Y, mobile.Position.Z));
+
+        Assert.Empty(moves);
+    }
+
+    [Fact]
+    public void Teleport_UnknownSerial_IsRefused()
+    {
+        var (service, _, moves) = Build(out _);
+
+        Assert.False(service.Teleport((Serial)0xDEAD, 1, 2, 3));
+        Assert.Empty(moves);
+    }
+
+    private static (MobileService Service, FakePersistenceService Persistence, List<MobileMovedEvent> Moves) Build(
+        out MobileEntity mobile
+    )
+    {
+        var persistence = new FakePersistenceService();
+        var events = new EventBusService();
+        var moves = new List<MobileMovedEvent>();
+
+        events.Subscribe<MobileMovedEvent>(
+            (message, _) =>
+            {
+                moves.Add(message);
+
+                return Task.CompletedTask;
+            }
+        );
+
+        mobile = new() { Name = "Squid", MapId = 1, Position = new(1, 1, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), events);
+
+        return (new(persistence, spatial, events), persistence, moves);
+    }
+}

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -41,6 +41,10 @@ public sealed class MoongateNpcAiPluginTests
         public void Broadcast(string text, Hue? hue = null) { }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
+
+        // A fake: it enforces nothing, because the rules belong to ChatService.
+        public bool SayAs(MobileEntity speaker, string text)
+            => true;
     }
 
     [Fact]

--- a/tests/Moongate.Tests/Support/RecordingChatService.cs
+++ b/tests/Moongate.Tests/Support/RecordingChatService.cs
@@ -21,4 +21,15 @@ public sealed class RecordingChatService : IChatService
 
     public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
         => _messages.Add((speaker.Id, type, text, hue, range));
+
+    /// <summary>
+    /// Records rather than enforcing: the rules live in ChatService, and a test that pins them builds
+    /// a real one instead of this double.
+    /// </summary>
+    public bool SayAs(MobileEntity speaker, string text)
+    {
+        Say(speaker, ChatMessageType.Regular, text, Hue.Default, 15);
+
+        return true;
+    }
 }


### PR DESCRIPTION
The Lua modules held logic rather than delegating, and it had diverged.

## Speech had two rule sets

| | length | classification |
|---|---|---|
| `chat.say` | unchecked | classifies, drops commands |
| `ai.say` | max 128 | none |

A script could emit a 10 000-character string through one, and make an NPC pronounce `.help` as ordinary speech through the other. Neither protection existed by accident — each was wanted, in a different place. `IChatService.SayAs` applies both, and both callers route through it, so they cannot drift apart again.

`SpeechRange` disappears rather than moving: `ChatService.DefaultRange` is already 15, the same value, so ordinary NPC speech reaches exactly the range it did before.

## Placement had two meanings and three identical lines

`MovementService` validates terrain; `MobileModule.Move` raw-teleports. The `Publish(new MobileMovedEvent(...))` line appeared three times, character for character.

The new `IMobileService.Teleport` owns the raw verb — and carries the loop-affinity guard `MobileModule`'s own class comment asked for:

> This module has no loop-affinity guard of its own: it mutates the entity store directly with no service seam to carry one. **A future IMobileService should carry the guard the way IItemService does.**

`mobile.teleport` is the honest name; `mobile.move` stays as its alias, so no script breaks.

## Behaviour that changes

`chat.say` gains the length limit, `ai.say` gains classification. Checked against shipped content: the only two `ai.say` calls are ordinary sentences in `Brains/guard.lua`, so no shipped brain changes.

## Tests followed the logic

Classification coverage moved from `ChatModuleTests` to `ChatServiceTests`, and the module now asserts it hands the raw text over. The AI's blank and oversize cases moved the same way; what `AiActionServiceTests` keeps is that a refusal reaches the brain as a rejected intent rather than being swallowed.

**Eight test doubles implement `IChatService`** and each needed the new member — worth knowing before the next change to that interface.

## Documentation

`chat` was the only Lua module with no reference page. It has one now, with the classification prefixes and the length limit. `ai.move_to` was left alone: its section already said it steps one tile and is greedy, so the trap the code's name sets was already defused there.

## Out of scope

`mobile.set` — no position key; it writes `map` and publishes on a map change, a different operation. `equip` — strip the Lua enum resolution and nothing remains but two lookups over the existing `IItemService.Equip`.

This is the first of two: the method-style handles that started this (`mobile.ref(s):say("x")`) become a thin façade over these services.

Issue #144.