### PR TITLE
feat(scripting): mobile.ref, a method-style handle for Lua

### DIFF
--- a/docs/scripting/reference/mobile.md
+++ b/docs/scripting/reference/mobile.md
@@ -74,6 +74,46 @@ if m then
 end
 ```
 
+## mobile.ref
+
+```lua
+mobile.ref(serial) -> table | nil
+```
+
+A **handle** for the mobile: a table of methods you act through, rather than the
+field snapshot [`mobile.get`](#mobileget) hands back. One is a copy, the other a
+reference.
+
+| method | does |
+|---|---|
+| `say(text)` | speaks as the mobile, with the rules [`chat.say`](chat.md) applies |
+| `teleport(x, y, z)` | places it without validating terrain |
+| `equip(item_serial, layer)` | equips an item at a layer |
+
+`nil` means the serial named nothing **at the moment `ref` was called**. It is an
+early signal, not a guarantee: the handle stores a serial and re-reads on every
+call, so a mobile that dies afterwards simply makes each method return `false`
+rather than acting on the wrong target.
+
+> [!NOTE]
+> The methods are closures taking no `self`, so **the dot is the form to use**.
+> A colon happens to work as well — MoonSharp absorbs the extra argument it
+> passes — but that is an accident of the host rather than something to lean on.
+
+**Example**
+
+```lua
+local m = mobile.ref(ctx.actor.serial)
+
+if m then
+    m.say("Welcome back.")
+    m.teleport(1425, 1695, 0)
+end
+```
+
+The flat forms still exist and are unchanged: [`chat.say`](chat.md),
+[`mobile.teleport`](#mobileteleport) and `item.equip`.
+
 ## mobile.set
 
 ```lua

--- a/src/Moongate.Server/Plugins/MoongateScriptModulesPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateScriptModulesPlugin.cs
@@ -1,6 +1,13 @@
 using DryIoc;
 using Moongate.Core.Types;
 using Moongate.Server.Scripting;
+using SquidStd.Scripting.Lua.Services;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+using Moongate.Server.Scripting.Refs;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Ultima.Types;
 using Moongate.UO.Data.Types;
 using SquidStd.Core.Utils;
@@ -25,6 +32,23 @@ public class MoongateScriptModulesPlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
+        // Same unwrap as MoongateScriptingPlugin does for the item-script runtime: the MoonSharp
+        // Script belongs to the Lua engine, not the container.
+        container.RegisterDelegate(
+            resolver => new MobileRefFactory(
+                resolver.Resolve<IScriptEngineService>() is LuaScriptEngineService lua
+                    ? lua.LuaScript
+                    : throw new InvalidOperationException(
+                        "MobileRefFactory requires the SquidStd Lua engine implementation."
+                    ),
+                resolver.Resolve<IPersistenceService>(),
+                resolver.Resolve<IChatService>(),
+                resolver.Resolve<IMobileService>(),
+                resolver.Resolve<IItemService>()
+            ),
+            Reuse.Singleton
+        );
+
         container.RegisterScriptModule<AccountModule>();
         container.RegisterScriptModule<ItemModule>();
         container.RegisterScriptModule<MobileModule>();

--- a/src/Moongate.Server/Scripting/MobileModule.cs
+++ b/src/Moongate.Server/Scripting/MobileModule.cs
@@ -7,6 +7,7 @@ using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Scripting.Refs;
 using Moongate.Server.Scripting.Views;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
@@ -35,6 +36,7 @@ public sealed class MobileModule
     private readonly ISpatialIndexService _spatial;
     private readonly IEventBus _eventBus;
     private readonly IMobileService _mobileService;
+    private readonly MobileRefFactory _refs;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
 
     public MobileModule(
@@ -44,7 +46,8 @@ public sealed class MobileModule
         IPersistenceService persistence,
         ISpatialIndexService spatial,
         IEventBus eventBus,
-        IMobileService mobileService
+        IMobileService mobileService,
+        MobileRefFactory refs
     )
     {
         _factory = factory;
@@ -53,6 +56,7 @@ public sealed class MobileModule
         _spatial = spatial;
         _eventBus = eventBus;
         _mobileService = mobileService;
+        _refs = refs;
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
     }
 
@@ -147,6 +151,10 @@ public sealed class MobileModule
     [ScriptFunction("teleport", "Places the mobile at (x, y, z) on its map without validating terrain; false on unknown serial.")]
     public bool Teleport(uint serial, int x, int y, int z)
         => _mobileService.Teleport((Serial)serial, x, y, z);
+
+    [ScriptFunction("ref", "Returns a handle for the mobile with methods say/teleport/equip, or nil.")]
+    public DynValue Ref(uint serial)
+        => _refs.Create((Serial)serial);
 
     [ScriptFunction("set", "Mutates mobile fields from a table; returns true on success.")]
     public bool Set(uint serial, Table fields)

--- a/src/Moongate.Server/Scripting/Refs/MobileRefFactory.cs
+++ b/src/Moongate.Server/Scripting/Refs/MobileRefFactory.cs
@@ -1,0 +1,85 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Ultima.Types;
+using MoonSharp.Interpreter;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Scripting.Refs;
+
+/// <summary>
+/// Builds the handle <c>mobile.ref</c> hands to Lua: a table of closures over a serial, each
+/// delegating to the service that owns the operation.
+/// <para>
+/// The handle keeps a serial and never an entity, so it cannot go stale — every call re-reads, and a
+/// mobile that died between two calls is an ordinary false. Closures rather than MoonSharp userdata
+/// because userdata exposes members under their CLR names, which would put a capital in the middle
+/// of a snake_case surface; taking no <c>self</c> is also why Lua calls these with a dot.
+/// </para>
+/// </summary>
+public sealed class MobileRefFactory
+{
+    private readonly Script _script;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IChatService _chat;
+    private readonly IMobileService _mobileService;
+    private readonly IItemService _items;
+
+    public MobileRefFactory(
+        Script script,
+        IPersistenceService persistenceService,
+        IChatService chat,
+        IMobileService mobileService,
+        IItemService items
+    )
+    {
+        _script = script;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _chat = chat;
+        _mobileService = mobileService;
+        _items = items;
+    }
+
+    /// <summary>
+    /// A handle for the mobile, or <see cref="DynValue.Nil" /> when the serial names none. The nil is
+    /// an early signal only: the handle re-reads on every call, so it may still find nothing later.
+    /// </summary>
+    public DynValue Create(Serial mobile)
+    {
+        if (_mobiles.GetById(mobile) is null)
+        {
+            return DynValue.Nil;
+        }
+
+        var table = new Table(_script)
+        {
+            ["say"] = (Func<string, bool>)(text => Say(mobile, text)),
+            ["teleport"] = (Func<int, int, int, bool>)((x, y, z) => _mobileService.Teleport(mobile, x, y, z)),
+            ["equip"] = (Func<uint, object, bool>)((item, layer) => Equip(mobile, item, layer))
+        };
+
+        return DynValue.NewTable(table);
+    }
+
+    private bool Equip(Serial mobile, uint item, object layer)
+    {
+        if (!ScriptEnums.TryResolve<LayerType>(layer, out var parsed))
+        {
+            return false;
+        }
+
+        if (_mobiles.GetById(mobile) is not { } owner || _items.GetById((Serial)item) is not { } entity)
+        {
+            return false;
+        }
+
+        _items.Equip(owner, entity, parsed);
+
+        return true;
+    }
+
+    private bool Say(Serial mobile, string text)
+        => _mobiles.GetById(mobile) is { } speaker && _chat.SayAs(speaker, text);
+}

--- a/tests/Moongate.Tests/Scripting/MobileRefLuaTests.cs
+++ b/tests/Moongate.Tests/Scripting/MobileRefLuaTests.cs
@@ -1,0 +1,132 @@
+using DryIoc;
+using Moongate.Core.Extensions;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Scripting;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+using SquidStd.Core.Interfaces.Events;
+using Moongate.Server.Services.Accounts;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Scripting.Refs;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using SquidStd.Core.Data.Bootstrap;
+using SquidStd.Scripting.Lua.Extensions.Scripts;
+using SquidStd.Scripting.Lua.Interfaces.Scripts;
+using SquidStd.Scripting.Lua.Services;
+using SquidStd.Services.Core.Services;
+using SquidStd.Services.Core.Services.Bootstrap;
+
+namespace Moongate.Tests.Scripting;
+
+/// <summary>
+/// Exercises the handle through real Lua, which is where its two risks live: the dot call surviving
+/// the marshaller, and the layer argument arriving as something ScriptEnums accepts. Neither is
+/// visible to a C#-only test.
+/// </summary>
+public class MobileRefLuaTests
+{
+    [Fact]
+    public async Task MobileRef_FromLua_ExposesTheThreeMethodsAndSpeaks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mg-ref-lua-" + Guid.NewGuid().ToString("N"));
+        var scripts = Path.Combine(root, "scripts");
+        Directory.CreateDirectory(scripts);
+
+        var persistence = new FakePersistenceService();
+        var chat = new RecordingChatService();
+        var mobile = new MobileEntity { Name = "Squid", MapId = 1, Position = new(1, 1, 0) };
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        var bootstrap = SquidStdBootstrap.Create(new SquidStdOptions { ConfigName = "moongate", RootDirectory = root });
+
+        bootstrap.ConfigureServices(
+            container =>
+            {
+                container.RegisterLuaEngine(new(root, scripts, "MoongateTests", "1.0.0"));
+
+                // MobileModule takes eight dependencies; the module is registered rather than
+                // hand-built so the test goes through the same resolution production does.
+                var events = new EventBusService();
+                var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), events);
+                var items = new ItemService(persistence);
+                var mobiles = new MobileService(persistence, spatial, events);
+
+                container.RegisterInstance<IPersistenceService>(persistence);
+                container.RegisterInstance<IEventBus>(events);
+                container.RegisterInstance<ISpatialIndexService>(spatial);
+                container.RegisterInstance<IItemService>(items);
+                container.RegisterInstance<IMobileService>(mobiles);
+                container.RegisterInstance<IChatService>(chat);
+                container.RegisterInstance<IItemFactoryService>(new ItemFactoryService(new ItemTemplateService(), new Random(1)));
+                container.RegisterInstance<IMobileFactoryService>(
+                    new MobileFactoryService(new StartingCityService(), new MobileTemplateService(), new Random(1), new NameService())
+                );
+
+                // Registered the way production does, so the test exercises the real wiring.
+                container.RegisterDelegate(
+                    resolver => BuildFactory(resolver.Resolve<IScriptEngineService>(), persistence, chat),
+                    Reuse.Singleton
+                );
+
+                container.RegisterScriptModule<MobileModule>();
+
+                return container;
+            }
+        );
+
+        await bootstrap.StartAsync();
+
+        try
+        {
+            var engine = bootstrap.Resolve<IScriptEngineService>();
+            var serial = mobile.Id.Value;
+
+            // A handle for a serial nobody has is nil, and one for a real mobile is a table.
+            Assert.Equal("nil", engine.ExecuteFunction("type(mobile.ref(57005))").Data);
+            Assert.Equal("table", engine.ExecuteFunction($"type(mobile.ref({serial}))").Data);
+
+            // The dot is the documented form -- the closures take no self. The colon happens to work
+            // too, because MoonSharp's delegate adapter absorbs the extra leading argument rather than
+            // failing on it; verified by hand, not relied upon.
+            Assert.True(engine.ExecuteFunction($"mobile.ref({serial}).say('Welcome back.')").Data is true);
+            Assert.Single(chat.Messages);
+
+            // The layer arrives as a Lua string and must reach ScriptEnums intact. False because item
+            // 1 does not exist -- what it proves is that the string crossed the marshaller.
+            Assert.True(engine.ExecuteFunction($"mobile.ref({serial}).equip(1, 'Shirt')").Data is false);
+        }
+        finally
+        {
+            await bootstrap.StopAsync();
+            Directory.Delete(root, true);
+        }
+    }
+
+    private static MobileRefFactory BuildFactory(
+        IScriptEngineService engine,
+        FakePersistenceService persistence,
+        RecordingChatService chat
+    )
+    {
+        // The same unwrap the plugin performs: the MoonSharp Script belongs to the Lua engine.
+        var script = engine is LuaScriptEngineService lua
+            ? lua.LuaScript
+            : throw new InvalidOperationException("This test requires the SquidStd Lua engine implementation.");
+
+        var events = new EventBusService();
+        var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), events);
+
+        return new(
+            script,
+            persistence,
+            chat,
+            new MobileService(persistence, spatial, events),
+            new ItemService(persistence)
+        );
+    }
+}

--- a/tests/Moongate.Tests/Server/MobileModuleTests.cs
+++ b/tests/Moongate.Tests/Server/MobileModuleTests.cs
@@ -3,6 +3,7 @@ using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Scripting;
+using Moongate.Server.Scripting.Refs;
 using Moongate.Server.Services.Items;
 using Moongate.Server.Services.Mobiles;
 using Moongate.Server.Services.World;
@@ -313,7 +314,10 @@ public class MobileModuleTests
         var itemFactory = new ItemFactoryService(itemTemplates, random);
         var items = new ItemService(persistence);
 
-        return (new(factory, itemFactory, items, persistence, spatial, bus, new MobileService(persistence, spatial, bus)), persistence, spatial, bus);
+        var mobileService = new MobileService(persistence, spatial, bus);
+
+        return (new(factory, itemFactory, items, persistence, spatial, bus, mobileService,
+                    new MobileRefFactory(new Script(), persistence, new RecordingChatService(), mobileService, items)), persistence, spatial, bus);
     }
 
     private static (MobileModule Module, FakePersistenceService Persistence, SpatialIndexService Spatial, StubEventBus Bus)

--- a/tests/Moongate.Tests/Server/Scripting/Refs/MobileRefFactoryTests.cs
+++ b/tests/Moongate.Tests/Server/Scripting/Refs/MobileRefFactoryTests.cs
@@ -1,0 +1,130 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Scripting.Refs;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using MoonSharp.Interpreter;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.Scripting.Refs;
+
+/// <summary>
+/// The handle holds a serial and never an entity, so every call re-reads and a target that died
+/// between two calls is an ordinary false rather than a stale write.
+/// </summary>
+public class MobileRefFactoryTests
+{
+    [Fact]
+    public void Create_UnknownSerial_IsNil()
+    {
+        var (factory, _, _) = Build(out _);
+
+        Assert.Equal(DataType.Nil, factory.Create((Serial)0xDEAD).Type);
+    }
+
+    [Fact]
+    public void Create_CarriesExactlyTheThreeMethods()
+    {
+        var (factory, _, _) = Build(out var mobile);
+
+        var table = factory.Create(mobile.Id).Table;
+
+        // ClrFunction, not Function: MoonSharp marshals a Func<> into a callback rather than compiling
+        // Lua. Both are callable from a script; only the tag differs.
+        Assert.Equal(DataType.ClrFunction, table.Get("say").Type);
+        Assert.Equal(DataType.ClrFunction, table.Get("teleport").Type);
+        Assert.Equal(DataType.ClrFunction, table.Get("equip").Type);
+        Assert.Equal(3, table.Keys.Count());
+    }
+
+    [Fact]
+    public void Say_ReachesTheChatService()
+    {
+        var (factory, script, chat) = Build(out var mobile);
+
+        var said = Call(script, factory.Create(mobile.Id), "say", DynValue.NewString("Welcome back."));
+
+        Assert.True(said.Boolean);
+        Assert.Single(chat.Messages);
+    }
+
+    // The reason the handle holds a serial: the mobile can die between ref and the call.
+    [Fact]
+    public void Say_AfterTheMobileIsGone_IsFalseAndSaysNothing()
+    {
+        var (factory, script, chat) = Build(out var mobile, out var persistence);
+
+        var handle = factory.Create(mobile.Id);
+        persistence.Store<MobileEntity>().RemoveAsync(mobile.Id).WaitSync();
+
+        Assert.False(Call(script, handle, "say", DynValue.NewString("anyone there?")).Boolean);
+        Assert.Empty(chat.Messages);
+    }
+
+    [Fact]
+    public void Teleport_MovesTheMobile()
+    {
+        var (factory, script, _) = Build(out var mobile, out var persistence);
+
+        var moved = Call(
+            script,
+            factory.Create(mobile.Id),
+            "teleport",
+            DynValue.NewNumber(10),
+            DynValue.NewNumber(20),
+            DynValue.NewNumber(5)
+        );
+
+        Assert.True(moved.Boolean);
+        Assert.Equal(new(10, 20, 5), persistence.Store<MobileEntity>().GetById(mobile.Id)!.Position);
+    }
+
+    // The layer arrives from Lua as a string or a number; anything else is not a layer.
+    [Fact]
+    public void Equip_LayerThatResolvesToNothing_IsFalse()
+    {
+        var (factory, script, _) = Build(out var mobile);
+
+        var equipped = Call(
+            script,
+            factory.Create(mobile.Id),
+            "equip",
+            DynValue.NewNumber(1),
+            DynValue.NewString("NotALayer")
+        );
+
+        Assert.False(equipped.Boolean);
+    }
+
+    private static DynValue Call(Script script, DynValue handle, string method, params DynValue[] arguments)
+        => script.Call(handle.Table.Get(method), arguments);
+
+    private static (MobileRefFactory Factory, Script Script, RecordingChatService Chat) Build(out MobileEntity mobile)
+        => Build(out mobile, out _);
+
+    private static (MobileRefFactory Factory, Script Script, RecordingChatService Chat) Build(
+        out MobileEntity mobile,
+        out FakePersistenceService persistence
+    )
+    {
+        var script = new Script();
+        var store = new FakePersistenceService();
+        var events = new EventBusService();
+        var chat = new RecordingChatService();
+        var spatial = new SpatialIndexService(store, new StubLoopAffinity(), events);
+
+        mobile = new() { Name = "Squid", MapId = 1, Position = new(1, 1, 0) };
+        store.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        persistence = store;
+
+        return (
+            new(script, store, chat, new MobileService(store, spatial, events), new ItemService(store)),
+            script,
+            chat
+        );
+    }
+}


### PR DESCRIPTION
Closes #146.

`mobile.get(s)` hands back a snapshot of fields. This adds `mobile.ref(s)`, a
**handle** you act *through*:

```lua
local m = mobile.ref(ctx.actor.serial)

if m then
    m.say("Welcome back.")
    m.teleport(1425, 1695, 0)
end
```

It is the first of a series, so the shape matters more than the three methods it
starts with.

## Design

**Closures, not userdata.** MoonSharp exposes userdata members under their CLR
names, which would put `Teleport` in the middle of a snake_case surface. A table
of closures names its own keys.

**A serial, never an entity.** The handle re-reads on every call, so it cannot go
stale: a mobile that dies between two calls makes the next call an ordinary
`false` instead of a write against a dead target. `ref` returning `nil` is an
early signal only, and the docs say so.

**No new behaviour.** Each method delegates to the service that already owns the
operation — `IChatService.SayAs`, `IMobileService.Teleport`, `IItemService.Equip`
— all of which exist because of #144. The module itself hands a serial over and
learns nothing about MoonSharp tables; the `Script` is unwrapped in the plugin,
the same way the item-script runtime already gets it.

## What the tests caught

Both surprises came from the Lua-executing test, and neither is visible from C#:

- MoonSharp tags a marshalled `Func<>` as `ClrFunction`, not `Function`.
- **The colon does not fail.** The plan predicted `ref(s):say(text)` would break
  on the extra leading argument; MoonSharp absorbs it and the right text is
  spoken. The dot stays the documented form because the closures take no `self`,
  but calling the colon an error would have been wrong, so the docs and the test
  comment record what actually happens.

## Verification

- 1905 tests pass; 6 factory tests + 1 Lua integration test are new.
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings.
- Booted against an isolated root: 19 services, no resolution failures.