### PR TITLE
feat(mobiles): give vendors and guards both genders

### DIFF
--- a/docs/scripting/data/item-templates.md
+++ b/docs/scripting/data/item-templates.md
@@ -166,7 +166,7 @@ Values of the `Params` dictionary (`Params: { <name>: { Type, Value } }`).
 
 `halberd`, from
 `src/Moongate.Server/Assets/Templates/Items/weapons.yaml` (this is the
-`TwoHanded` weapon the `warrior_guard_male_npc` [mobile template](mobile-templates.md)
+`TwoHanded` weapon the `warrior_guard_npc` [mobile template](mobile-templates.md)
 equips):
 
 ```yaml

--- a/docs/scripting/data/loot-tables.md
+++ b/docs/scripting/data/loot-tables.md
@@ -96,8 +96,8 @@ the item factory, exactly the same way regardless of `Mode`.
 ## Full annotated example
 
 `guard.archer`, from `src/Moongate.Server/Assets/Templates/Loot/guards.yaml`
-— the table the `archer_guard_male_npc` / `archer_guard_female_npc`
-[mobile templates](mobile-templates.md#full-annotated-example) carry as
+— the table the `archer_guard_npc`
+[mobile template](mobile-templates.md#full-annotated-example) carries as
 `LootTableId`:
 
 ```yaml

--- a/docs/scripting/data/mobile-templates.md
+++ b/docs/scripting/data/mobile-templates.md
@@ -96,9 +96,10 @@ to an actual gender:
 | `Female` | always female |
 | `Random` | coin-flip (50/50) per spawn |
 
-No shipped template currently sets `Gender: Random`; `Female` is used (e.g.
-`archer_guard_female_npc`, `warrior_guard_female_npc` in
-`Mobiles/guards.yaml`).
+No shipped template sets a `Gender` at this level at all. The guards and vendors
+declare it per [variant](#variants) instead, which is how one id spawns both
+genders with the body, name pool and kit that belong to each. `Gender: Random`
+stays available for a template whose genders differ in nothing else.
 
 Omitting the key and writing `Gender: Male` mean different things. An omitted
 `Gender` is null, which inherits the base's; `Gender: Male` states male and
@@ -176,13 +177,22 @@ spawn — under `Variants:`:
 
 At spawn time `MobileFactoryService` picks one variant by weight (each
 variant's share is `Math.Max(1, Weight)` out of the sum of all shares), then
-overlays its `Gender`/`LootTableId`/`Appearance`/`Equipment` onto the
-template's own. **No shipped template currently declares `Variants`** — the
-mechanism is fully wired but unused in the current data set.
+overlays its `Gender`/`NamePool`/`LootTableId`/`Appearance`/`Equipment` onto the
+template's own.
+
+The last two overlay differently, and the asymmetry is deliberate. **Appearance
+merges field by field**, so a variant stating only `Body` keeps the template's
+skin hue, hair style and hair hue. **Equipment replaces wholesale**, because a
+gendered kit is not always a substitution: the female warrior guard has no Arms
+or Waist piece at all, and a per-layer merge could not express a piece's
+*absence*.
+
+The shipped guards and vendors all use variants for the same purpose — one id,
+both genders — and the guards use the equipment override on top of it.
 
 ## Full annotated example
 
-`base_human_npc` (the base) and `archer_guard_female_npc` (a derived
+`base_human_npc` (the base) and `archer_guard_npc` (a derived
 template that uses it), both from
 `src/Moongate.Server/Assets/Templates/Mobiles/`:
 
@@ -215,17 +225,15 @@ template that uses it), both from
 
 ```yaml
 # src/Moongate.Server/Assets/Templates/Mobiles/guards.yaml
--   Id: archer_guard_female_npc
+-   Id: archer_guard_npc
     Title: the guard
     Category: npc
-    Gender: Female                          # base has no Gender -> Female wins
-    Description: Town female archer guard NPC inspired by ModernUO ArcherGuard.
+    Description: Town archer guard NPC inspired by ModernUO ArcherGuard.
     Tags:
         - npc
         - guard
         - archer
-        - town
-        - female                            # concatenated with base's [npc, human, base]
+        - town                               # concatenated with base's [npc, human, base]
     BaseMobile: base_human_npc
     Strength: 100                            # != 50 -> overrides the base's 50
     Dexterity: 125
@@ -237,7 +245,7 @@ template that uses it), both from
         ResistingSpells: 1200
         DetectingHidden: 1000
     Appearance:
-        Body: 401                            # != 0 -> overrides the base's 400
+        Body: 400                            # same as the base's, stated for a caller that skips variants
         SkinHue: 'hue(1002:1058)'
         HairStyle: 8251
         HairHue: 'hue(1102:1149)'
@@ -258,11 +266,24 @@ template that uses it), both from
         Layer: Helm
       - Item: bow
         Layer: TwoHanded
+    Variants:                                 # one id, both genders
+      - Name: male
+        Weight: 1
+        Gender: Male
+        NamePool: male
+        Appearance:
+            Body: 400
+      - Name: female
+        Weight: 1
+        Gender: Female                        # template states no Gender -> the variant's wins
+        NamePool: female
+        Appearance:
+            Body: 401                         # != 0 -> overrides the template's 400
     LootTableId: guard.archer                 # see the Loot tables page
     BrainScript: guard
 ```
 
-After resolution, `archer_guard_female_npc` keeps `base_human_npc`'s
+After resolution, `archer_guard_npc` keeps `base_human_npc`'s
 `Title`/`Category`/`Description` fallback shape but ends up with its own
 `Strength`/`Dexterity`/`Intelligence`, `Body`, full `Tags` union, and a
 completely replaced `Equipment` list — while `BaseMobile` itself is cleared

--- a/docs/scripting/guides/how-scripting-works.md
+++ b/docs/scripting/guides/how-scripting-works.md
@@ -98,7 +98,7 @@ local heartbeat_id
 
 events.on("world_ready", function()
   -- Runs on the game-loop thread: safe to spawn directly.
-  local guard = mobile.create_from_template("warrior_guard_male_npc", 1, 1420, 1690, 0)
+  local guard = mobile.create_from_template("warrior_guard_npc", 1, 1420, 1690, 0)
 
   if guard then
     log.info("spawned guard {0}", guard)

--- a/docs/scripting/guides/items.md
+++ b/docs/scripting/guides/items.md
@@ -79,7 +79,7 @@ layer; you can pass the name `"OneHanded"` or the `layer_type.OneHanded`
 constant.
 
 ```lua
-local guard = mobile.create_from_template("warrior_guard_male_npc", 1, 1420, 1690, 0)
+local guard = mobile.create_from_template("warrior_guard_npc", 1, 1420, 1690, 0)
 if guard and item.equip(guard, blade, layer_type.OneHanded) then
   log.info("armed guard {0} with {1}", guard, item.get(blade).name)
 end
@@ -115,7 +115,7 @@ events.on("world_ready", function()
   end
 
   -- 5. Equip the blade on a freshly spawned guard.
-  local guard = mobile.create_from_template("warrior_guard_male_npc", 1, 1420, 1690, 0)
+  local guard = mobile.create_from_template("warrior_guard_npc", 1, 1420, 1690, 0)
   if guard and item.equip(guard, blade, layer_type.OneHanded) then
     log.info("armed guard {0}", guard)
   end

--- a/docs/scripting/guides/mobiles.md
+++ b/docs/scripting/guides/mobiles.md
@@ -21,20 +21,20 @@ takes a template id, a map id and an `(x, y, z)` position. It creates the mobile
 template is unknown).
 
 ```lua
-local guard = mobile.create_from_template("warrior_guard_male_npc", 1, 1420, 1690, 0)
+local guard = mobile.create_from_template("warrior_guard_npc", 1, 1420, 1690, 0)
 ```
 
-`warrior_guard_male_npc` is a real shipped template. It comes fully outfitted —
+`warrior_guard_npc` is a real shipped template. It comes fully outfitted —
 plate armour and a halberd — because its YAML declares an `Equipment:` list that
 the factory resolves and equips on spawn.
 
 ## How a template is built
 
-Templates are declarative YAML. The `warrior_guard_male_npc` entry looks like
+Templates are declarative YAML. The `warrior_guard_npc` entry looks like
 this (abridged):
 
 ```yaml
--   Id: warrior_guard_male_npc
+-   Id: warrior_guard_npc
     BaseMobile: base_human_npc
     Strength: 100
     Dexterity: 125
@@ -45,11 +45,27 @@ this (abridged):
         Swordsmanship: 1200
     Appearance:
         Body: 400
-    Equipment:
-      - Item: plate_chest
-        Layer: InnerTorso
-      - Item: halberd
-        Layer: TwoHanded
+    Variants:
+      - Name: male
+        Gender: Male
+        NamePool: male
+        Appearance:
+            Body: 400
+        Equipment:
+          - Item: plate_chest
+            Layer: InnerTorso
+          - Item: halberd
+            Layer: TwoHanded
+      - Name: female
+        Gender: Female
+        NamePool: female
+        Appearance:
+            Body: 401
+        Equipment:
+          - Item: female_plate_chest
+            Layer: InnerTorso
+          - Item: halberd
+            Layer: TwoHanded
     LootTableId: guard.warrior
 ```
 
@@ -77,17 +93,21 @@ Every template has a gender, chosen per spawn by the factory:
 | `Female` | always female |
 | `Random` | a coin-flip between male and female on each spawn |
 
-`warrior_guard_male_npc` uses the default, so it always spawns male; the shard
-also ships a separate `warrior_guard_female_npc` with `Gender: Female`. Setting
-`Gender: Random` on a template instead lets one id produce both.
+No shipped template sets `Gender` at this level any more. The guards and vendors
+state it **per [variant](#variants)** instead, so one id spawns a mixed
+population — `warrior_guard_npc` is male about half the time and female the
+other half, each with the body, name pool and kit that go with it.
+
+`Gender: Random` remains the way to get a coin flip without variants, for a
+template whose two genders differ in nothing else.
 
 ## Variants
 
 A template may also declare **variants** — weighted alternates picked once per
-spawn. Each variant has a `Weight` and may override the gender, loot table,
-appearance and equipment; anything it leaves out falls back to the template.
-The factory picks one variant by weight on every spawn, so a single id can yield
-a coherent mix of looks:
+spawn. Each variant has a `Weight` and may override the gender, name pool, loot
+table, appearance and equipment; anything it leaves out falls back to the
+template. The factory picks one variant by weight on every spawn, so a single id
+can yield a coherent mix of looks:
 
 ```yaml
     Variants:
@@ -100,8 +120,13 @@ a coherent mix of looks:
 ```
 
 With these weights a spawn is a veteran three times out of four and a recruit
-one time in four. (The shipped guard and undead templates keep things simple and
-do not use variants, but the mechanism is always available.)
+one time in four.
+
+This is how the shipped guards and vendors carry both genders: two equally
+weighted variants, each stating the gender, its name pool and its body. The
+guards go one step further and give each variant its own kit, because the
+female warrior's armour is not the male's with a substitution — she wears no
+Arms or Waist piece at all.
 
 ## Skills: read and write
 
@@ -134,7 +159,7 @@ end
 
 events.on("world_ready", function()
   -- Spawn a fully equipped town guard.
-  local guard = mobile.create_from_template("warrior_guard_male_npc", 1, 1420, 1690, 0)
+  local guard = mobile.create_from_template("warrior_guard_npc", 1, 1420, 1690, 0)
   if not guard then
     log.warn("guard template not found")
     return

--- a/docs/scripting/reference/events.md
+++ b/docs/scripting/reference/events.md
@@ -27,7 +27,7 @@ The same event may have multiple handlers.
 ```lua
 events.on("world_ready", function()
   -- Runs on the loop once the world is loaded — safe to spawn directly.
-  mobile.create_from_template("warrior_guard_male_npc", 1, 1420, 1690, 0)
+  mobile.create_from_template("warrior_guard_npc", 1, 1420, 1690, 0)
 end)
 ```
 

--- a/src/Moongate.Server/Assets/Templates/Mobiles/guards.yaml
+++ b/src/Moongate.Server/Assets/Templates/Mobiles/guards.yaml
@@ -1,4 +1,4 @@
--   Id: warrior_guard_male_npc
+-   Id: warrior_guard_npc
     Title: the guard
     Category: npc
     Description: Town warrior guard NPC inspired by ModernUO WarriorGuard.
@@ -7,7 +7,6 @@
         - guard
         - warrior
         - town
-        - male
     BaseMobile: base_human_npc
     Strength: 100
     Dexterity: 125
@@ -23,65 +22,48 @@
         SkinHue: 'hue(1002:1058)'
         HairStyle: 8251
         HairHue: 'hue(1102:1149)'
-    Equipment:
-        -   Item: plate_chest
-            Layer: InnerTorso
-        -   Item: plate_arms
-            Layer: Arms
-        -   Item: long_pants
-            Layer: Pants
-        -   Item: body_sash
-            Layer: Waist
-        -   Item: halberd
-            Layer: TwoHanded
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+            Equipment:
+                -   Item: plate_chest
+                    Layer: InnerTorso
+                -   Item: plate_arms
+                    Layer: Arms
+                -   Item: long_pants
+                    Layer: Pants
+                -   Item: body_sash
+                    Layer: Waist
+                -   Item: halberd
+                    Layer: TwoHanded
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
+            Equipment:
+                -   Item: leather_skirt
+                    Layer: Pants
+                -   Item: female_plate_chest
+                    Layer: InnerTorso
+                -   Item: halberd
+                    Layer: TwoHanded
     LootTableId: guard.warrior
     BrainScript: guard
--   Id: warrior_guard_female_npc
+-   Id: archer_guard_npc
     Title: the guard
     Category: npc
-    Gender: Female
-    NamePool: female
-    Description: Town female warrior guard NPC inspired by ModernUO WarriorGuard.
-    Tags:
-        - npc
-        - guard
-        - warrior
-        - town
-        - female
-    BaseMobile: base_human_npc
-    Strength: 100
-    Dexterity: 125
-    Intelligence: 25
-    Skills:
-        Anatomy: 1200
-        Tactics: 1200
-        Swordsmanship: 1200
-        ResistingSpells: 1200
-        DetectingHidden: 1000
-    Appearance:
-        Body: 401
-        SkinHue: 'hue(1002:1058)'
-        HairStyle: 8251
-        HairHue: 'hue(1102:1149)'
-    Equipment:
-        -   Item: leather_skirt
-            Layer: Pants
-        -   Item: female_plate_chest
-            Layer: InnerTorso
-        -   Item: halberd
-            Layer: TwoHanded
-    LootTableId: guard.warrior
-    BrainScript: guard
--   Id: archer_guard_male_npc
-    Title: the guard
-    Category: npc
-    Description: Town male archer guard NPC inspired by ModernUO ArcherGuard.
+    Description: Town archer guard NPC inspired by ModernUO ArcherGuard.
     Tags:
         - npc
         - guard
         - archer
         - town
-        - male
     BaseMobile: base_human_npc
     Strength: 100
     Dexterity: 125
@@ -114,51 +96,18 @@
             Layer: Helm
         -   Item: bow
             Layer: TwoHanded
-    LootTableId: guard.archer
-    BrainScript: guard
--   Id: archer_guard_female_npc
-    Title: the guard
-    Category: npc
-    Gender: Female
-    NamePool: female
-    Description: Town female archer guard NPC inspired by ModernUO ArcherGuard.
-    Tags:
-        - npc
-        - guard
-        - archer
-        - town
-        - female
-    BaseMobile: base_human_npc
-    Strength: 100
-    Dexterity: 125
-    Intelligence: 25
-    Skills:
-        Anatomy: 1200
-        Tactics: 1200
-        Archery: 1200
-        ResistingSpells: 1200
-        DetectingHidden: 1000
-    Appearance:
-        Body: 401
-        SkinHue: 'hue(1002:1058)'
-        HairStyle: 8251
-        HairHue: 'hue(1102:1149)'
-    Equipment:
-        -   Item: studded_chest
-            Layer: InnerTorso
-        -   Item: studded_arms
-            Layer: Arms
-        -   Item: studded_gloves
-            Layer: Gloves
-        -   Item: studded_gorget
-            Layer: Neck
-        -   Item: studded_legs
-            Layer: Pants
-        -   Item: boots
-            Layer: Shoes
-        -   Item: skull_cap
-            Layer: Helm
-        -   Item: bow
-            Layer: TwoHanded
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
     LootTableId: guard.archer
     BrainScript: guard

--- a/src/Moongate.Server/Assets/Templates/Mobiles/vendors.yaml
+++ b/src/Moongate.Server/Assets/Templates/Mobiles/vendors.yaml
@@ -25,6 +25,19 @@
         -   Item: tongs
             Layer: OneHanded
     LootTableId: vendor.blacksmith
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
 -   Id: weaponsmith_vendor_npc
     Title: the weaponsmith
     Category: npc
@@ -55,6 +68,19 @@
         -   Item: hatchet
             Layer: OneHanded
     LootTableId: vendor.weaponsmith
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
 -   Id: armorer_vendor_npc
     Title: an armorer
     Category: npc
@@ -82,6 +108,19 @@
         -   Item: helmet
             Layer: Helm
     LootTableId: vendor.armorer
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
 -   Id: provisioner_vendor_npc
     Title: the provisioner
     Category: npc
@@ -107,6 +146,19 @@
         -   Item: backpack
             Layer: Backpack
     LootTableId: vendor.provisioner
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
 -   Id: mage_vendor_npc
     Title: a mage
     Category: npc
@@ -132,6 +184,19 @@
         -   Item: spellbook
             Layer: OneHanded
     LootTableId: vendor.mage
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401
 -   Id: healer_vendor_npc
     Title: a healer
     Category: npc
@@ -153,3 +218,16 @@
         -   Item: sandals
             Layer: Shoes
     LootTableId: vendor.healer
+    Variants:
+        -   Name: male
+            Weight: 1
+            Gender: Male
+            NamePool: male
+            Appearance:
+                Body: 400
+        -   Name: female
+            Weight: 1
+            Gender: Female
+            NamePool: female
+            Appearance:
+                Body: 401

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
@@ -32,11 +32,22 @@ public class MobileTemplateRepositoryIntegrityTests
 
             Assert.NotEmpty(mobiles.All);
 
-            // Gender parses from YAML into the enum where it is declared, and stays null where it is
-            // not: the shipped female guard says Female, the male one says nothing at all and takes
-            // male from the factory's default rather than from the template.
-            Assert.Equal(MobileTemplateGenderType.Female, mobiles.GetById("warrior_guard_female_npc")!.Gender);
-            Assert.Null(mobiles.GetById("warrior_guard_male_npc")!.Gender);
+            // One id per guard kind, both genders inside it. The female warrior's kit is not the
+            // male's with a substitution -- it has no Arms or Waist piece at all, which is why a
+            // variant's equipment replaces the template's outright instead of merging by layer.
+            var warrior = mobiles.GetById("warrior_guard_npc")!;
+            Assert.Null(warrior.Gender);
+
+            var warriorFemale = Assert.Single(warrior.Variants, variant => variant.Gender == MobileTemplateGenderType.Female);
+            Assert.Equal(401, warriorFemale.Appearance.Body);
+            Assert.Equal("female", warriorFemale.NamePool);
+            Assert.DoesNotContain(warriorFemale.Equipment, entry => entry.Layer is "Arms" or "Waist");
+
+            // The archers' two kits were byte-identical, so neither variant states equipment and
+            // both genders wear the template's.
+            var archer = mobiles.GetById("archer_guard_npc")!;
+            Assert.All(archer.Variants, variant => Assert.Empty(variant.Equipment));
+            Assert.NotEmpty(archer.Equipment);
 
             // One id per vendor, a mixed population inside it -- what ModernUO gets out of
             // BaseVendor.GetGender()'s coin flip. Neither variant states equipment, so both wear

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
@@ -38,6 +38,31 @@ public class MobileTemplateRepositoryIntegrityTests
             Assert.Equal(MobileTemplateGenderType.Female, mobiles.GetById("warrior_guard_female_npc")!.Gender);
             Assert.Null(mobiles.GetById("warrior_guard_male_npc")!.Gender);
 
+            // One id per vendor, a mixed population inside it -- what ModernUO gets out of
+            // BaseVendor.GetGender()'s coin flip. Neither variant states equipment, so both wear
+            // the template's single kit; only the body differs, and appearance merges field by
+            // field, so the skin and hair the template rolls survive into either gender.
+            string[] vendors =
+            [
+                "blacksmith_vendor_npc", "weaponsmith_vendor_npc", "armorer_vendor_npc",
+                "provisioner_vendor_npc", "mage_vendor_npc", "healer_vendor_npc"
+            ];
+
+            foreach (var id in vendors)
+            {
+                var vendor = mobiles.GetById(id)!;
+
+                var male = Assert.Single(vendor.Variants, variant => variant.Gender == MobileTemplateGenderType.Male);
+                Assert.Equal("male", male.NamePool);
+                Assert.Equal(400, male.Appearance.Body);
+                Assert.Empty(male.Equipment);
+
+                var female = Assert.Single(vendor.Variants, variant => variant.Gender == MobileTemplateGenderType.Female);
+                Assert.Equal("female", female.NamePool);
+                Assert.Equal(401, female.Appearance.Body);
+                Assert.Empty(female.Equipment);
+            }
+
             foreach (var template in mobiles.All)
             {
                 Assert.Null(template.BaseMobile); // every base_mobile is resolved at load

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateRepositoryIntegrityTests.cs
@@ -80,6 +80,20 @@ public class MobileTemplateRepositoryIntegrityTests
                             $"Unknown loot table '{variant.LootTableId}' in variant '{variant.Name}' of mobile template '{template.Id}'"
                         );
                     }
+
+                    // A variant's equipment replaces the template's outright, so it is the only
+                    // list a spawn will wear -- it needs the validation the template's list gets.
+                    foreach (var entry in variant.Equipment)
+                    {
+                        Assert.True(
+                            Enum.TryParse<LayerType>(entry.Layer, true, out _),
+                            $"Unknown layer '{entry.Layer}' in variant '{variant.Name}' of mobile template '{template.Id}'"
+                        );
+                        Assert.True(
+                            items.GetById(entry.Item) is not null,
+                            $"Unknown item template '{entry.Item}' in variant '{variant.Name}' of mobile template '{template.Id}'"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #148.

Every shipped vendor was male — none of the six templates declared a `Gender` or a
`NamePool`, so they all fell on the default. Guards did the opposite and shipped one
template per gender, duplicating stats, skills, loot table and brain.

`MobileVariant` already carried everything needed and was live, tested code that no
shipped YAML used. This wires it up. **No engine change.**

## What changed

**Vendors** get two equally weighted variants differing in three fields: gender, name
pool, body. Neither states equipment, so both wear the template's single kit.

**Guards** collapse from four templates to two — `warrior_guard_npc` and
`archer_guard_npc` — with stats, skills, hues, loot table and brain stated once. This is
the duplication that produced the `Gender` defect fixed in #143: two twin blocks that had
to be edited together, until one day they weren't.

## Why the rules stay as they are

A variant's appearance merges field by field; its equipment replaces wholesale. I went in
expecting to have to reconcile that, and the data said otherwise: the female warrior guard
wears no Arms or Waist piece **at all**, so a per-layer merge could not express her kit —
it can override a layer but not remove one. The asymmetry is correct, and is now documented
with its reason.

The archers' two kits turned out byte-identical (diffed, not assumed), so their variants
state no equipment and both genders wear the template's list.

## Two things found while planning

**A coverage hole this change would have opened.** The integrity test validated a
*template's* equipment but its variant loop checked only the loot table. Moving the guards'
kits into variants would have dropped them out of validation entirely, so a typo in
`female_plate_chest` would have shipped silently. The first commit closes it, and the
assertion was proven to fail on both a bad item and a bad layer before being relied on.

**Three doc claims had gone stale**, and are corrected rather than reworded: the reference
said no shipped template declares `Variants`, the guide said the shipped guards don't use
them, and both described the separate female guard template.

## Deliberately not done

Giving the female vendors a skirt, or the female archer the unused `female_studded_chest`.
Either forces the variant to restate the whole kit — five and eight entries respectively —
which re-creates the divergence this PR exists to remove. Cosmetic gain, structural cost.

## Verification

- 1905 tests pass; `MobileNamePoolDataTests` now checks shipped variant pools for the first
  time, since no shipped template used a variant until now.
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings.
- Booted against a fresh isolated root: 19 services, no exception.