### PR TITLE
fix(tests): stop the brain-reload test racing its own wait

### DIFF
--- a/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
+++ b/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
@@ -49,17 +49,25 @@ public class GameLoopModuleTests
             // dispatcher drains. Observed through a shared Lua global (same script state).
             engine.ExecuteScript("ran = false");
             engine.ExecuteScript("game.post(function() ran = true end)");
-            Assert.True(engine.ExecuteFunction("ran").Data is false);
+
+            // Every assertion below carries what it saw. A bare Assert.True reports only
+            // "Expected: True, Actual: False", which is what left an earlier intermittent failure
+            // here with nothing to diagnose and no way to tell a stale value from a null one.
+            var beforeDrain = engine.ExecuteFunction("ran").Data;
+            Assert.True(beforeDrain is false, $"`ran` must still be false before the drain, was {Describe(beforeDrain)}");
 
             dispatcher.DrainPending();
-            Assert.True(engine.ExecuteFunction("ran").Data is true);
+
+            var afterDrain = engine.ExecuteFunction("ran").Data;
+            Assert.True(afterDrain is true, $"`ran` must be true after the drain, was {Describe(afterDrain)}");
 
             // game.schedule returns a timer id that game.cancel can remove (long delay so it never fires here).
-            var timerId = engine.ExecuteFunction("game.schedule('probe', 60000, function() end)").Data as string;
-            Assert.False(string.IsNullOrEmpty(timerId));
+            var scheduled = engine.ExecuteFunction("game.schedule('probe', 60000, function() end)").Data;
+            var timerId = scheduled as string;
+            Assert.False(string.IsNullOrEmpty(timerId), $"game.schedule must return a timer id, returned {Describe(scheduled)}");
 
             var cancelled = engine.ExecuteFunction($"game.cancel('{timerId}')").Data;
-            Assert.True(cancelled is true);
+            Assert.True(cancelled is true, $"game.cancel('{timerId}') must return true, returned {Describe(cancelled)}");
         }
         finally
         {
@@ -67,4 +75,7 @@ public class GameLoopModuleTests
             Directory.Delete(root, true);
         }
     }
+
+    private static string Describe(object? value)
+        => value is null ? "nil" : $"{value} ({value.GetType().Name})";
 }

--- a/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
+++ b/tests/Moongate.Tests/Scripting/LuaNpcBrainRuntimeTests.cs
@@ -1072,11 +1072,33 @@ public class LuaNpcBrainRuntimeTests
         Assert.Equal(expected, Assert.Single(fixture.AiSays));
     }
 
+    /// <summary>
+    /// Without a condition, lets pending continuations run before asserting that nothing happened.
+    /// With one, waits for it against a wall-clock deadline.
+    /// </summary>
+    /// <remarks>
+    /// A fixed number of yields is a guess at how long a thread-pool continuation takes to be
+    /// scheduled, and under load the guess expires before the continuation runs at all — the test
+    /// then asserts on work that has not started. The deadline costs nothing when the condition is
+    /// already true and is slow only when it genuinely never becomes true, which is a real failure.
+    /// </remarks>
     private static async Task DrainContinuationsAsync(Func<bool>? condition = null)
     {
-        for (var iteration = 0; iteration < 100 && condition?.Invoke() != true; iteration++)
+        if (condition is null)
         {
-            await Task.Yield();
+            for (var iteration = 0; iteration < 100; iteration++)
+            {
+                await Task.Yield();
+            }
+
+            return;
+        }
+
+        var deadline = Environment.TickCount64 + 5_000;
+
+        while (!condition() && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(1);
         }
     }
 }

--- a/tests/Moongate.Tests/Support/StubGameLoopContext.cs
+++ b/tests/Moongate.Tests/Support/StubGameLoopContext.cs
@@ -51,12 +51,15 @@ public sealed class StubGameLoopContext : IGameLoopContext
 
     public void Post(Action action)
     {
-        PostCount++;
-
         if (_answers)
         {
             action();
         }
+
+        // Counted after the work, not before: the caller may be a thread-pool continuation, and a
+        // test waiting on PostCount would otherwise be released between the two and assert on
+        // effects the action had not produced yet.
+        PostCount++;
     }
 
     public string Schedule(string name, TimeSpan delay, Action callback)


### PR DESCRIPTION
Closes #150.

`LuaNpcBrainRuntimeTests.StartAsync_RapidFileChanges_PostOneReloadToTheGameLoop` failed
intermittently in the full suite and passed alone. It reproduces **2 runs in 3** with the
machine under CPU contention and never in 26 unloaded runs, which is why it had only ever
been seen in CI-like conditions.

Both defects are in the test scaffolding. The runtime is unchanged.

## 1 — the stub counted the post before doing the work

```csharp
public void Post(Action action)
{
    PostCount++;      // the waiter is released here
    if (_answers) action();   // TryReload -> publish -> RecordReload happens here
}
```

The reload arrives on a thread-pool continuation (`DebounceReloadAsync` awaits its delay
with `ConfigureAwait(false)`), so a test waiting on `PostCount` was released between the
two lines and asserted on effects that had not happened yet.

The probe that pinned it printed `posts=1 successes=0 fallbacks=0 published=0` — the post
counted while `TryReload` had reached **neither** of its two `RecordReload` calls, which
rules out "the reload ran and failed" and leaves only "the reload had not run".

Counting after the work makes `PostCount` mean *handed over and done*, which is what every
waiter already assumed. The `answers: false` path still counts, since it deliberately
swallows the work.

## 2 — the wait was blind to time

`DrainContinuationsAsync` spun a fixed 100 `Task.Yield()`s — a guess at how long the pool
takes to schedule a continuation. Under load the guess expires before the continuation runs
at all. It now waits against a wall-clock deadline, which costs nothing when the condition
is already true and is slow only on a genuine failure.

**Fixing only the first moved the failure from line 746 to line 745**, which is how the
second surfaced. That is also the evidence that the first fix worked.

## Also here

`GameLoopModuleTests` failed twice earlier and has never reproduced since, including under
the load that reproduces the above. Its assertions were bare `Assert.True` calls reporting
only "Expected: True, Actual: False". They now carry the observed value and its type,
verified by breaking the global on purpose:

```
`ran` must still be false before the drain, was 42 (Double)
```

A background drain racing that flag was **ruled out** by experiment — nothing drained the
dispatcher after a 1.5s wait.

## Verification

- 12 runs of `LuaNpcBrainRuntimeTests` under the load that reproduced the flake: green.
- 4 full-suite runs under the same load: 1905 passed each.