### PR TITLE
feat(world): draw and undraw the world as it enters and leaves view

### DIFF
--- a/docs/getting-started/connect-with-classicuo.md
+++ b/docs/getting-started/connect-with-classicuo.md
@@ -43,14 +43,11 @@ The flow the server implements today:
    and the season of the facet you stand on.
 
 > [!IMPORTANT]
-> World entry is self-only: the server sends you your own character, but
-> nearby mobiles and items already in range are not sent to you when you
-> first log in (that needs SendEverything, still pending). You can walk and
-> turn — moves are validated against the map and broadcast to players
-> already in range of you — but no new objects appear as you walk into view
-> of them yet. Your backpack cannot be opened yet either, so the starting
-> kit stays out of reach. Nearby mobiles and items staying invisible until
-> SendEverything lands is the current frontier of the project.
+> You log in with the mobiles and items already around you, and the world
+> keeps up as you move: things are drawn as they come into view and undrawn
+> as they leave, in both directions — someone walking toward you appears on
+> your screen just as you appear on theirs. Your backpack cannot be opened
+> yet, so the starting kit stays out of reach.
 
 ## Troubleshooting
 

--- a/docs/getting-started/what-is-moongate.md
+++ b/docs/getting-started/what-is-moongate.md
@@ -20,12 +20,11 @@ Moongate is young and moves fast. What works today:
 - TCP login pipeline: seed, account login, server list, game-server handoff,
   character list, **character creation and deletion** (the created player
   mobile is persisted) and **world entry** — creating or selecting a character
-  loads you into the map with its stats, skills and gear. World entry is
-  self-only: nearby mobiles and items already in range are not sent to you
-  on login (SendEverything, still pending). Movement is handled — validated
-  against the map, rate-limited, and broadcast to players already in range —
-  but objects entering view as you walk are not yet, which is the next
-  milestone.
+  loads you into the map with its stats, skills and gear, and with the mobiles
+  and items already around you. Movement is handled: validated against the map,
+  rate-limited, and **the world appears and disappears as you walk** — things
+  are drawn when they come into view, undrawn when they leave, and the same
+  happens to you on everyone else's screen when they move.
 - Item, mobile and loot systems driven by YAML templates, with a Lua API
   (`item`, `mobile`, `loot`, `game`, `events`, `log`) for shard logic.
 - Binary snapshot persistence for accounts, mobiles and items.

--- a/src/Moongate.Server.Abstractions/Data/World/VisibilityDelta.cs
+++ b/src/Moongate.Server.Abstractions/Data/World/VisibilityDelta.cs
@@ -1,0 +1,15 @@
+using Moongate.Core.Primitives;
+
+namespace Moongate.Server.Abstractions.Data.World;
+
+/// <summary>
+/// What changed in one session's view: what it must now be shown, and what it must be told is gone.
+/// </summary>
+/// <param name="Entered">Serials the client did not know and now does.</param>
+/// <param name="Left">Serials the client knew and must forget.</param>
+public readonly record struct VisibilityDelta(IReadOnlyList<Serial> Entered, IReadOnlyList<Serial> Left)
+{
+    /// <summary>Nothing moved in or out — the common case, and the one that must send no packets.</summary>
+    public bool IsEmpty
+        => Entered.Count == 0 && Left.Count == 0;
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IVisibilityService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IVisibilityService.cs
@@ -33,8 +33,11 @@ public interface IVisibilityService
     /// <summary>Applies one item's change to one session.</summary>
     VisibilityChangeType UpdateFor(PlayerSession session, ItemEntity item);
 
-    /// <summary>Tells every session that knows this serial to forget it, and returns how many did.</summary>
-    int Undraw(Serial serial);
+    /// <summary>
+    /// Tells every session that knew this serial to forget it, and returns how many did. For things
+    /// that left the world rather than the view: range says nothing about something that is gone.
+    /// </summary>
+    int Undraw(IEnumerable<PlayerSession> sessions, Serial serial);
 
     /// <summary>Drops everything this session was told, on logout.</summary>
     void Forget(PlayerSession session);

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IVisibilityService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IVisibilityService.cs
@@ -1,0 +1,44 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Types.World;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>
+/// Remembers what each client has been told exists, and sends the difference when that stops
+/// matching the world.
+/// <para>
+/// Two operations rather than one, and the split is about cost. <see cref="Refresh" /> recomputes a
+/// whole view and is for the moments when all of it may have changed: entering the world, the player
+/// themselves moving, and the periodic reconciliation. <see cref="UpdateFor(PlayerSession,
+/// MobileEntity)" /> applies a single object's change and is what every other mobile's step uses —
+/// recomputing every nearby session's whole view on every NPC step would be many full-radius scans
+/// per tick for one standing player.
+/// </para>
+/// </summary>
+public interface IVisibilityService
+{
+    /// <summary>
+    /// Recomputes what this session can see, sends what entered and what left, and returns the
+    /// difference. An empty delta means no packets were sent, which is what the reconciliation sweep
+    /// should see almost every time.
+    /// </summary>
+    VisibilityDelta Refresh(PlayerSession session);
+
+    /// <summary>Applies one mobile's change to one session: draw it, undraw it, or move it.</summary>
+    VisibilityChangeType UpdateFor(PlayerSession session, MobileEntity mobile);
+
+    /// <summary>Applies one item's change to one session.</summary>
+    VisibilityChangeType UpdateFor(PlayerSession session, ItemEntity item);
+
+    /// <summary>Tells every session that knows this serial to forget it, and returns how many did.</summary>
+    int Undraw(Serial serial);
+
+    /// <summary>Drops everything this session was told, on logout.</summary>
+    void Forget(PlayerSession session);
+
+    /// <summary>What this client currently believes exists, for tests and admin views.</summary>
+    IReadOnlySet<Serial> KnownTo(PlayerSession session);
+}

--- a/src/Moongate.Server.Abstractions/Types/World/VisibilityChangeType.cs
+++ b/src/Moongate.Server.Abstractions/Types/World/VisibilityChangeType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Server.Abstractions.Types.World;
+
+/// <summary>What one object's change meant for one client.</summary>
+public enum VisibilityChangeType : byte
+{
+    /// <summary>Out of range and unknown: the client neither had it nor needs it.</summary>
+    None = 0,
+
+    /// <summary>It came into range and was drawn.</summary>
+    Drawn,
+
+    /// <summary>It left range and the client was told to forget it.</summary>
+    Undrawn,
+
+    /// <summary>It was already known and stayed in range: a position update, not a redraw.</summary>
+    Moved
+}

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -28,6 +28,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<PaperdollSubscriber>();
         container.RegisterEventSubscriber<ContainerSubscriber>();
         container.RegisterEventSubscriber<SpatialSubscriber>();
+        container.RegisterEventSubscriber<VisibilitySubscriber>();
         container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
         container.RegisterEventSubscriber<HeldItemBounceSubscriber>();
         container.RegisterEventSubscriber<ItemScriptSubscriber>();

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -204,6 +204,7 @@ await ConsoleApp.RunAsync(
                 // same singleton in both roles.
                 container.RegisterStdService<IServerStatsService, ServerStatsService>();
                 container.RegisterStdService<LightCycleService, LightCycleService>();
+                container.RegisterStdService<VisibilityReconciler, VisibilityReconciler>();
 
                 // INotificationTemplateService is registered by the data-loader plugin, alongside the
                 // loader that fills it, the same way the template services are.

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -195,6 +195,7 @@ await ConsoleApp.RunAsync(
                 container.Register<ILightService, LightService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IChatService, ChatService>(Reuse.Singleton);
+                container.Register<IVisibilityService, VisibilityService>(Reuse.Singleton);
                 container.Register<IGumpService, GumpService>(Reuse.Singleton);
                 container.Register<IServerSettingsService, ServerSettingsService>(Reuse.Singleton);
 

--- a/src/Moongate.Server/Services/World/MobileDrawing.cs
+++ b/src/Moongate.Server/Services/World/MobileDrawing.cs
@@ -2,6 +2,7 @@ using Moongate.Network.Data;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.UO.Data.Types;
 using Moongate.Ultima.Types;
 
 namespace Moongate.Server.Services.World;
@@ -12,6 +13,8 @@ namespace Moongate.Server.Services.World;
 /// </summary>
 public static class MobileDrawing
 {
+    private const byte FemaleFlag = 0x02;
+
     /// <summary>
     /// Builds the worn items the client draws on a mobile: its equipment, then hair and facial hair as
     /// pseudo-items. One item per layer wins, as in ModernUO — the client cannot render two things on the
@@ -62,4 +65,8 @@ public static class MobileDrawing
 
         return drawn;
     }
+
+    /// <summary>The body flags a mobile is drawn with. Only the female bit today.</summary>
+    public static byte BuildFlags(MobileEntity mobile)
+        => mobile.Gender == GenderType.Female ? FemaleFlag : (byte)0;
 }

--- a/src/Moongate.Server/Services/World/MobileDrawing.cs
+++ b/src/Moongate.Server/Services/World/MobileDrawing.cs
@@ -1,0 +1,65 @@
+using Moongate.Network.Data;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// What a mobile looks like on the wire. Shared because drawing a mobile is not only something its
+/// owner's client does: everyone who can see it draws the same equipment.
+/// </summary>
+public static class MobileDrawing
+{
+    /// <summary>
+    /// Builds the worn items the client draws on a mobile: its equipment, then hair and facial hair as
+    /// pseudo-items. One item per layer wins, as in ModernUO — the client cannot render two things on the
+    /// same slot, and hair only goes out if nothing real already claimed its layer (a helm, say).
+    /// </summary>
+    public static List<MobileIncomingItem> BuildEquipment(
+        MobileEntity mobile,
+        IItemService items,
+        IVirtualSerialService virtualSerials
+    )
+    {
+        var drawn = new List<MobileIncomingItem>();
+        var takenLayers = new HashSet<LayerType>();
+
+        foreach (var item in items.GetEquipped(mobile))
+        {
+            if (item.EquippedLayer is not { } layer || !takenLayers.Add(layer))
+            {
+                continue;
+            }
+
+            drawn.Add(new(item.Id, (ushort)item.ItemId, layer, item.Hue));
+        }
+
+        if (mobile.HairStyle != 0 && takenLayers.Add(LayerType.Hair))
+        {
+            drawn.Add(
+                new(
+                    virtualSerials.GetOrCreate(mobile.Id, LayerType.Hair),
+                    mobile.HairStyle,
+                    LayerType.Hair,
+                    mobile.HairHue
+                )
+            );
+        }
+
+        if (mobile.FacialHairStyle != 0 && takenLayers.Add(LayerType.FacialHair))
+        {
+            drawn.Add(
+                new(
+                    virtualSerials.GetOrCreate(mobile.Id, LayerType.FacialHair),
+                    mobile.FacialHairStyle,
+                    LayerType.FacialHair,
+                    mobile.FacialHairHue
+                )
+            );
+        }
+
+        return drawn;
+    }
+}

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -214,7 +214,6 @@ public sealed class MovementService : IMovementService
 
         _mobiles.UpsertAsync(mobile).WaitSync();
         _spatial.AddOrUpdate(mobile);
-        Broadcast(mobile);
 
         if (decision.PositionChanged)
         {
@@ -222,24 +221,9 @@ public sealed class MovementService : IMovementService
         }
     }
 
-    private void Broadcast(MobileEntity mobile)
-        => _world.SendToPlayersInRange(
-            mobile.MapId,
-            mobile.Position,
-            PlayerSession.MaxViewRange,
-            new UpdatePlayerPacket(
-                mobile.Id,
-                (ushort)mobile.Body,
-                (ushort)mobile.Position.X,
-                (ushort)mobile.Position.Y,
-                (sbyte)mobile.Position.Z,
-                mobile.Direction,
-                mobile.SkinHue,
-                0,
-                Notoriety.Resolve(mobile.Kills, mobile.Criminal)
-            ),
-            mobile.Id
-        );
+    // The 0x77 that used to live here is now the third row of IVisibilityService.UpdateFor, sent
+    // only to clients that know the serial -- this broadcast reached every session in range,
+    // including ones that had never been told the mobile exists.
 
     private void Reject(PlayerSession session, MobileEntity mobile, byte sequence)
         => session.Send(

--- a/src/Moongate.Server/Services/World/VisibilityReconciler.cs
+++ b/src/Moongate.Server/Services/World/VisibilityReconciler.cs
@@ -1,0 +1,83 @@
+using Moongate.Core.Interfaces;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Periodically realigns what each client believes with what is true.
+/// <para>
+/// The reactive path is what makes the world appear and disappear; this is the net under it. Any
+/// mutation route that forgets to update visibility — a teleport, a map change, a future hiding
+/// system — leaves a <em>ghost</em>: something the client still draws that is not there. Without a
+/// sweep those survive until the player relogs, which is the classic bug of this system in every
+/// emulator that only reacts.
+/// </para>
+/// <para>
+/// It is not a second algorithm. It is the same <see cref="IVisibilityService.Refresh" />, which on
+/// a correct session finds nothing and sends nothing — so the net costs a walk over the sessions and
+/// no packets.
+/// </para>
+/// </summary>
+public sealed class VisibilityReconciler : ISquidStdService
+{
+    private const string TimerName = "visibility-reconcile";
+
+    /// <summary>
+    /// Deliberately a constant rather than config: this is a safety net, and a knob would invite
+    /// tuning it to paper over a missed trigger instead of fixing the trigger.
+    /// </summary>
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(10);
+
+    private readonly ILogger _logger = Log.ForContext<VisibilityReconciler>();
+    private readonly ISessionManager _sessions;
+    private readonly IVisibilityService _visibility;
+    private readonly IGameLoopContext _loop;
+
+    public VisibilityReconciler(ISessionManager sessions, IVisibilityService visibility, IGameLoopContext loop)
+    {
+        _sessions = sessions;
+        _visibility = visibility;
+        _loop = loop;
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _loop.ScheduleRepeating(TimerName, Interval, Tick);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+        => ValueTask.CompletedTask;
+
+    /// <summary>Public so a test can drive one beat without waiting on the timer.</summary>
+    public void Tick()
+    {
+        var corrected = 0;
+
+        foreach (var session in _sessions.All)
+        {
+            if (session.Character is null)
+            {
+                continue;
+            }
+
+            var delta = _visibility.Refresh(session);
+
+            if (!delta.IsEmpty)
+            {
+                corrected++;
+            }
+        }
+
+        // A quiet sweep is the expected case, so anything it had to fix is worth knowing about: it
+        // means a reactive path missed something.
+        if (corrected > 0)
+        {
+            _logger.Debug("Visibility reconciliation corrected {Count} session(s)", corrected);
+        }
+    }
+}

--- a/src/Moongate.Server/Services/World/VisibilityService.cs
+++ b/src/Moongate.Server/Services/World/VisibilityService.cs
@@ -1,0 +1,219 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.UO.Data.Mobiles;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Holds what each client has been told exists and sends the difference. The known set is the whole
+/// point: a client cannot be told something appeared without knowing what it already has.
+/// </summary>
+public sealed class VisibilityService : IVisibilityService
+{
+    private readonly ISpatialIndexService _spatial;
+    private readonly IItemService _items;
+    private readonly IVirtualSerialService _virtualSerials;
+    private readonly Dictionary<long, HashSet<Serial>> _known = [];
+
+    public VisibilityService(ISpatialIndexService spatial, IItemService items, IVirtualSerialService virtualSerials)
+    {
+        _spatial = spatial;
+        _items = items;
+        _virtualSerials = virtualSerials;
+    }
+
+    public VisibilityDelta Refresh(PlayerSession session)
+    {
+        if (session.Character is not { } character)
+        {
+            return new([], []);
+        }
+
+        var range = session.ViewRange;
+        var mobiles = _spatial.GetMobilesInRange(character.MapId, character.Position, range)
+                              .Where(mobile => mobile.Id != character.Id)
+                              .ToList();
+        var items = _spatial.GetItemsInRange(character.MapId, character.Position, range);
+
+        var visible = new HashSet<Serial>(mobiles.Count + items.Count);
+        var known = KnownSet(session);
+        var entered = new List<Serial>();
+
+        foreach (var mobile in mobiles)
+        {
+            visible.Add(mobile.Id);
+
+            if (known.Add(mobile.Id))
+            {
+                entered.Add(mobile.Id);
+                session.Send(Incoming(mobile));
+            }
+        }
+
+        foreach (var item in items)
+        {
+            visible.Add(item.Id);
+
+            if (known.Add(item.Id))
+            {
+                entered.Add(item.Id);
+                session.Send(Incoming(item));
+            }
+        }
+
+        var left = known.Where(serial => !visible.Contains(serial)).ToList();
+
+        foreach (var serial in left)
+        {
+            known.Remove(serial);
+            session.Send(new DeleteObjectPacket(serial));
+        }
+
+        return new(entered, left);
+    }
+
+    public VisibilityChangeType UpdateFor(PlayerSession session, MobileEntity mobile)
+    {
+        if (session.Character is not { } character || mobile.Id == character.Id)
+        {
+            return VisibilityChangeType.None;
+        }
+
+        return Apply(
+            session,
+            mobile.Id,
+            InRange(character, session, mobile.MapId, mobile.Position),
+            () => Incoming(mobile),
+            () => new UpdatePlayerPacket(
+                mobile.Id,
+                (ushort)mobile.Body,
+                (ushort)mobile.Position.X,
+                (ushort)mobile.Position.Y,
+                (sbyte)mobile.Position.Z,
+                mobile.Direction,
+                mobile.SkinHue,
+                MobileDrawing.BuildFlags(mobile),
+                Notoriety.Resolve(mobile.Kills, mobile.Criminal)
+            )
+        );
+    }
+
+    public VisibilityChangeType UpdateFor(PlayerSession session, ItemEntity item)
+    {
+        if (session.Character is not { } character)
+        {
+            return VisibilityChangeType.None;
+        }
+
+        // An item has no separate "it moved" packet: redrawing it is how it moves.
+        return Apply(
+            session,
+            item.Id,
+            InRange(character, session, item.MapId, item.Position),
+            () => Incoming(item),
+            () => Incoming(item)
+        );
+    }
+
+    public int Undraw(Serial serial)
+    {
+        var count = 0;
+
+        foreach (var known in _known.Values)
+        {
+            if (known.Remove(serial))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    public void Forget(PlayerSession session)
+        => _known.Remove(session.SessionId);
+
+    public IReadOnlySet<Serial> KnownTo(PlayerSession session)
+        => _known.TryGetValue(session.SessionId, out var known) ? known : new HashSet<Serial>();
+
+    /// <summary>
+    /// The three-row table: in range and unknown means draw, out of range and known means undraw,
+    /// known and still in range means move. Anything else is not news.
+    /// </summary>
+    private VisibilityChangeType Apply<TDraw, TMove>(
+        PlayerSession session,
+        Serial serial,
+        bool inRange,
+        Func<TDraw> draw,
+        Func<TMove> move
+    )
+        where TDraw : IOutgoingPacket
+        where TMove : IOutgoingPacket
+    {
+        var known = KnownSet(session);
+
+        if (inRange)
+        {
+            if (known.Add(serial))
+            {
+                session.Send(draw());
+
+                return VisibilityChangeType.Drawn;
+            }
+
+            session.Send(move());
+
+            return VisibilityChangeType.Moved;
+        }
+
+        if (!known.Remove(serial))
+        {
+            return VisibilityChangeType.None;
+        }
+
+        session.Send(new DeleteObjectPacket(serial));
+
+        return VisibilityChangeType.Undrawn;
+    }
+
+    private static bool InRange(MobileEntity character, PlayerSession session, int mapId, Point3D position)
+        => character.MapId == mapId && character.Position.InRange(position, session.ViewRange);
+
+    private MobileIncomingPacket Incoming(MobileEntity mobile)
+        => new(
+            mobile.Id,
+            (ushort)mobile.Body,
+            (ushort)mobile.Position.X,
+            (ushort)mobile.Position.Y,
+            (sbyte)mobile.Position.Z,
+            mobile.Direction,
+            mobile.SkinHue,
+            MobileDrawing.BuildFlags(mobile),
+            Notoriety.Resolve(mobile.Kills, mobile.Criminal),
+            MobileDrawing.BuildEquipment(mobile, _items, _virtualSerials)
+        );
+
+    private static WorldItemPacket Incoming(ItemEntity item)
+        => new(item.Id, (ushort)item.ItemId, (ushort)item.Amount, item.Position, item.Hue);
+
+    private HashSet<Serial> KnownSet(PlayerSession session)
+    {
+        if (_known.TryGetValue(session.SessionId, out var known))
+        {
+            return known;
+        }
+
+        known = [];
+        _known[session.SessionId] = known;
+
+        return known;
+    }
+}

--- a/src/Moongate.Server/Services/World/VisibilityService.cs
+++ b/src/Moongate.Server/Services/World/VisibilityService.cs
@@ -123,16 +123,19 @@ public sealed class VisibilityService : IVisibilityService
         );
     }
 
-    public int Undraw(Serial serial)
+    public int Undraw(IEnumerable<PlayerSession> sessions, Serial serial)
     {
         var count = 0;
 
-        foreach (var known in _known.Values)
+        foreach (var session in sessions)
         {
-            if (known.Remove(serial))
+            if (!_known.TryGetValue(session.SessionId, out var known) || !known.Remove(serial))
             {
-                count++;
+                continue;
             }
+
+            session.Send(new DeleteObjectPacket(serial));
+            count++;
         }
 
         return count;

--- a/src/Moongate.Server/Services/World/WorldService.cs
+++ b/src/Moongate.Server/Services/World/WorldService.cs
@@ -95,7 +95,7 @@ public sealed class WorldService : IWorldService
         var map = MapDefinitions.Get(mobile.MapId);
         var position = mobile.Position;
         var body = (ushort)mobile.Body;
-        var flags = GetBodyFlags(mobile);
+        var flags = MobileDrawing.BuildFlags(mobile);
         var now = _timeProvider.GetLocalNow();
 
         List<IOutgoingPacket> packets =
@@ -283,15 +283,4 @@ public sealed class WorldService : IWorldService
             (byte)mobile.FollowersMax
         );
 
-    private static byte GetBodyFlags(MobileEntity mobile)
-    {
-        byte flags = 0;
-
-        if (mobile.Gender == GenderType.Female)
-        {
-            flags |= FemaleFlag;
-        }
-
-        return flags;
-    }
 }

--- a/src/Moongate.Server/Services/World/WorldService.cs
+++ b/src/Moongate.Server/Services/World/WorldService.cs
@@ -136,7 +136,7 @@ public sealed class WorldService : IWorldService
                 mobile.SkinHue,
                 flags,
                 Notoriety.Resolve(mobile.Kills, mobile.Criminal),
-                BuildEquipment(mobile)
+                MobileDrawing.BuildEquipment(mobile, _items, _virtualSerials)
             ),
             BuildStatus(mobile),
 
@@ -241,52 +241,6 @@ public sealed class WorldService : IWorldService
         }
     }
 
-    /// <summary>
-    /// Builds the worn items the client draws on a mobile: its equipment, then hair and facial hair as
-    /// pseudo-items. One item per layer wins, as in ModernUO — the client cannot render two things on the
-    /// same slot, and hair only goes out if nothing real already claimed its layer (a helm, say).
-    /// </summary>
-    private List<MobileIncomingItem> BuildEquipment(MobileEntity mobile)
-    {
-        var items = new List<MobileIncomingItem>();
-        var takenLayers = new HashSet<LayerType>();
-
-        foreach (var item in _items.GetEquipped(mobile))
-        {
-            if (item.EquippedLayer is not { } layer || !takenLayers.Add(layer))
-            {
-                continue;
-            }
-
-            items.Add(new(item.Id, (ushort)item.ItemId, layer, item.Hue));
-        }
-
-        if (mobile.HairStyle != 0 && takenLayers.Add(LayerType.Hair))
-        {
-            items.Add(
-                new(
-                    _virtualSerials.GetOrCreate(mobile.Id, LayerType.Hair),
-                    mobile.HairStyle,
-                    LayerType.Hair,
-                    mobile.HairHue
-                )
-            );
-        }
-
-        if (mobile.FacialHairStyle != 0 && takenLayers.Add(LayerType.FacialHair))
-        {
-            items.Add(
-                new(
-                    _virtualSerials.GetOrCreate(mobile.Id, LayerType.FacialHair),
-                    mobile.FacialHairStyle,
-                    LayerType.FacialHair,
-                    mobile.FacialHairHue
-                )
-            );
-        }
-
-        return items;
-    }
 
     /// <summary>
     /// Builds the full skill list: every registered skill, including the ones this mobile never

--- a/src/Moongate.Server/Subscribers/ItemRefreshSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/ItemRefreshSubscriber.cs
@@ -54,10 +54,11 @@ public sealed class ItemRefreshSubscriber : IEventSubscriberRegistration
         {
             RefreshOnMobile(item);
         }
-        else
-        {
-            RefreshOnGround(item);
-        }
+
+
+        // Nothing for a ground item: VisibilitySubscriber owns those now, because drawing one is
+        // inseparable from remembering that the client has it -- and from telling the client when it
+        // stops being there.
 
         return Task.CompletedTask;
     }
@@ -110,19 +111,6 @@ public sealed class ItemRefreshSubscriber : IEventSubscriberRegistration
         }
     }
 
-    private void RefreshOnGround(ItemEntity item)
-        => _world.SendToPlayersInRange(
-            item.MapId,
-            item.Position,
-            PlayerSession.MaxViewRange,
-            new WorldItemPacket(
-                item.Id,
-                (ushort)item.ItemId,
-                (ushort)item.Amount,
-                item.Position,
-                item.Hue
-            )
-        );
 
     /// <summary>The item is worn: its layer redraws on the paperdoll for everyone watching the wearer.</summary>
     private void RefreshOnMobile(ItemEntity item)

--- a/src/Moongate.Server/Subscribers/VisibilitySubscriber.cs
+++ b/src/Moongate.Server/Subscribers/VisibilitySubscriber.cs
@@ -4,6 +4,7 @@ using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Core.Primitives;
 using SquidStd.Core.Interfaces.Events;
@@ -20,16 +21,19 @@ public sealed class VisibilitySubscriber : IEventSubscriberRegistration
     private readonly IVisibilityService _visibility;
     private readonly ISessionManager _sessions;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IItemService _items;
 
     public VisibilitySubscriber(
         IVisibilityService visibility,
         ISessionManager sessions,
-        IPersistenceService persistenceService
+        IPersistenceService persistenceService,
+        IItemService items
     )
     {
         _visibility = visibility;
         _sessions = sessions;
         _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _items = items;
     }
 
     public void Subscribe(IEventBus eventBus)
@@ -38,6 +42,7 @@ public sealed class VisibilitySubscriber : IEventSubscriberRegistration
         eventBus.Subscribe<MobileMovedEvent>(OnMobileMoved);
         eventBus.Subscribe<MobileCreatedEvent>(OnMobileCreated);
         eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
+        eventBus.Subscribe<ItemChangedEvent>(OnItemChanged);
         eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
     }
 
@@ -111,6 +116,37 @@ public sealed class VisibilitySubscriber : IEventSubscriberRegistration
     public Task OnMobileDeleted(MobileDeletedEvent @event, CancellationToken cancellationToken)
     {
         _visibility.Undraw(_sessions.All, @event.Mobile.Id);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// An item on the ground is drawn or undrawn by range like anything else. One that is no longer
+    /// on the ground has left the world — picked up, or worn — and range says nothing about it, so
+    /// everyone who had it drawn is told directly. Without that it would linger on their screen
+    /// until the reconciliation sweep.
+    /// </summary>
+    public Task OnItemChanged(ItemChangedEvent @event, CancellationToken cancellationToken)
+    {
+        if (_items.GetById(@event.Item) is not { } item)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (item.ParentContainerId != Serial.Zero || item.EquippedMobileId != Serial.Zero)
+        {
+            _visibility.Undraw(_sessions.All, item.Id);
+
+            return Task.CompletedTask;
+        }
+
+        foreach (var session in _sessions.All)
+        {
+            if (session.Character is not null)
+            {
+                _visibility.UpdateFor(session, item);
+            }
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Moongate.Server/Subscribers/VisibilitySubscriber.cs
+++ b/src/Moongate.Server/Subscribers/VisibilitySubscriber.cs
@@ -1,0 +1,127 @@
+using Moongate.Core.Geometry;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Core.Primitives;
+using SquidStd.Core.Interfaces.Events;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Turns world events into visibility updates. Every handler here runs on the game-loop thread, as
+/// each of these events is loop-affine.
+/// </summary>
+public sealed class VisibilitySubscriber : IEventSubscriberRegistration
+{
+    private readonly IVisibilityService _visibility;
+    private readonly ISessionManager _sessions;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+
+    public VisibilitySubscriber(
+        IVisibilityService visibility,
+        ISessionManager sessions,
+        IPersistenceService persistenceService
+    )
+    {
+        _visibility = visibility;
+        _sessions = sessions;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+    }
+
+    public void Subscribe(IEventBus eventBus)
+    {
+        eventBus.Subscribe<PlayerEnteredWorldEvent>(OnPlayerEnteredWorld);
+        eventBus.Subscribe<MobileMovedEvent>(OnMobileMoved);
+        eventBus.Subscribe<MobileCreatedEvent>(OnMobileCreated);
+        eventBus.Subscribe<MobileDeletedEvent>(OnMobileDeleted);
+        eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+    }
+
+    /// <summary>The login burst draws the player; this draws everything around them.</summary>
+    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent @event, CancellationToken cancellationToken)
+    {
+        if (_sessions.TryGet(@event.SessionId, out var session))
+        {
+            _visibility.Refresh(session);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileMoved(MobileMovedEvent @event, CancellationToken cancellationToken)
+    {
+        // From the store, not from the sessions: an NPC has no session and would never be found.
+        var mobile = _mobiles.GetById(@event.Mobile);
+
+        if (mobile is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var session in _sessions.All)
+        {
+            if (session.Character is not { } character)
+            {
+                continue;
+            }
+
+            // The mover's own view translated entirely, so it is recomputed rather than patched.
+            if (character.Id == @event.Mobile)
+            {
+                _visibility.Refresh(session);
+
+                continue;
+            }
+
+            // Both positions matter: watching only the destination would never tell anyone that
+            // something walked away from them.
+            if (!Watches(character, session, @event.FromMapId, @event.FromPosition) &&
+                !Watches(character, session, @event.ToMapId, @event.ToPosition))
+            {
+                continue;
+            }
+
+            _visibility.UpdateFor(session, mobile);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnMobileCreated(MobileCreatedEvent @event, CancellationToken cancellationToken)
+    {
+        foreach (var session in _sessions.All)
+        {
+            if (session.Character is not null)
+            {
+                _visibility.UpdateFor(session, @event.Mobile);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A deleted mobile is gone from the world, so range says nothing about it: every client that
+    /// knew it is told directly.
+    /// </summary>
+    public Task OnMobileDeleted(MobileDeletedEvent @event, CancellationToken cancellationToken)
+    {
+        _visibility.Undraw(_sessions.All, @event.Mobile.Id);
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnSessionDestroyed(SessionDestroyedEvent @event, CancellationToken cancellationToken)
+    {
+        _visibility.Forget(@event.Session);
+
+        return Task.CompletedTask;
+    }
+
+    private static bool Watches(MobileEntity character, PlayerSession session, int mapId, Point3D position)
+        => character.MapId == mapId && character.Position.InRange(position, session.ViewRange);
+}

--- a/tests/Moongate.Tests/Server/Items/ItemRefreshSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Items/ItemRefreshSubscriberTests.cs
@@ -40,20 +40,6 @@ public class ItemRefreshSubscriberTests
     }
 
     [Fact]
-    public async Task OnItemChanged_GroundItem_SendsWorldItemToPlayersInRange()
-    {
-        var (subscriber, world, items, _) = Build();
-        var coin = new ItemEntity { ItemId = 3821, MapId = 1, Position = new(10, 20, 0) };
-        items.Create(coin);
-
-        await subscriber.OnItemChanged(new(coin.Id), CancellationToken.None);
-
-        var sent = Assert.Single(world.InRange);
-        Assert.IsType<WorldItemPacket>(sent.Packet);
-        Assert.Equal(1, sent.MapId);
-    }
-
-    [Fact]
     public async Task OnItemChanged_OpenerOutOfRange_IsDroppedAndNotSentTo()
     {
         var (subscriber, world, items, persistence) = Build(out var openers);

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -787,6 +787,11 @@ public class LoginFlowIntegrationTests
             var movement =
                 new MovementService(mapTiles, regions, spatial, world, persistence, TimeProvider.System, eventBus);
 
+            // Drawing and undrawing is the visibility service's job now, so it has to be here for Bob
+            // to learn Alice exists at all.
+            var visibility = new VisibilityService(spatial, new ItemService(persistence, opl), new VirtualSerialService());
+            new VisibilitySubscriber(visibility, sessions, persistence).Subscribe(eventBus);
+
             // CharacterServiceFixture.Create wires its own MobileFactoryService, whose starting-city
             // lookup is independent of the city StartServerWithMovementAsync registers for the
             // client-facing character list — the fixture's default (Britain, off this tiny map) has to
@@ -876,10 +881,14 @@ public class LoginFlowIntegrationTests
                 Assert.True(PollUntil(aliceSocket, aliceCompressed, stepAck), "Alice never received an ack for the step.");
 
                 var bobCompressed = new List<byte>();
+                // Still 0x77, but now for a reason. Bob was shown Alice (0x78) when he entered the
+                // world and she was already in range, so her step is a position update for a mobile
+                // he knows. The broadcast this replaces sent 0x77 to everyone in range whether or not
+                // they had ever been told the mobile exists.
                 var broadcastPattern = new byte[] { 0x77 }.Concat(SerialBytes(aliceMobile.Id)).ToArray();
                 Assert.True(
                     PollUntil(bobSocket, bobCompressed, broadcastPattern),
-                    "Bob never received Alice's movement broadcast (0x77)."
+                    "Bob never received Alice's movement update (0x77)."
                 );
 
                 var moved = persistence.Store<MobileEntity>().GetById(aliceMobile.Id)!;

--- a/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/LoginFlowIntegrationTests.cs
@@ -789,8 +789,9 @@ public class LoginFlowIntegrationTests
 
             // Drawing and undrawing is the visibility service's job now, so it has to be here for Bob
             // to learn Alice exists at all.
-            var visibility = new VisibilityService(spatial, new ItemService(persistence, opl), new VirtualSerialService());
-            new VisibilitySubscriber(visibility, sessions, persistence).Subscribe(eventBus);
+            var visibilityItems = new ItemService(persistence, opl);
+            var visibility = new VisibilityService(spatial, visibilityItems, new VirtualSerialService());
+            new VisibilitySubscriber(visibility, sessions, persistence, visibilityItems).Subscribe(eventBus);
 
             // CharacterServiceFixture.Create wires its own MobileFactoryService, whose starting-city
             // lookup is independent of the city StartServerWithMovementAsync registers for the

--- a/tests/Moongate.Tests/Server/World/MobileDrawingTests.cs
+++ b/tests/Moongate.Tests/Server/World/MobileDrawingTests.cs
@@ -1,0 +1,77 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// The equipment list a mobile is drawn with. Its two rules are easy to lose in a move, and were
+/// untested while the method had a single private caller.
+/// </summary>
+public class MobileDrawingTests
+{
+    // One item per layer reaches the client, because it cannot render two things on one slot.
+    // Which one survives is settled earlier, by IItemService.Equip replacing what was there —
+    // the guard here is the second line of defence, for a store that somehow holds both.
+    [Fact]
+    public void Equipment_DrawsOneItemPerLayer()
+    {
+        var (items, mobile) = World();
+
+        Equip(items, mobile, 0x1410, LayerType.Helm);
+        Equip(items, mobile, 0x1411, LayerType.Helm);
+
+        var drawn = MobileDrawing.BuildEquipment(mobile, items, new VirtualSerialService());
+
+        Assert.Equal(LayerType.Helm, Assert.Single(drawn).Layer);
+    }
+
+    [Fact]
+    public void Equipment_AddsHairAsAPseudoItem()
+    {
+        var (items, mobile) = World();
+
+        mobile.HairStyle = 0x203B;
+
+        var drawn = MobileDrawing.BuildEquipment(mobile, items, new VirtualSerialService());
+
+        Assert.Equal(LayerType.Hair, Assert.Single(drawn).Layer);
+        Assert.Equal(0x203B, Assert.Single(drawn).ItemId);
+    }
+
+    // Hair is drawn only if nothing real claimed its layer: a helm hides it.
+    [Fact]
+    public void Equipment_SkipsHairWhenSomethingRealAlreadyHoldsItsLayer()
+    {
+        var (items, mobile) = World();
+
+        mobile.HairStyle = 0x203B;
+        Equip(items, mobile, 0x1410, LayerType.Hair);
+
+        var drawn = MobileDrawing.BuildEquipment(mobile, items, new VirtualSerialService());
+
+        Assert.Equal(0x1410, Assert.Single(drawn).ItemId);
+    }
+
+    private static (ItemService Items, MobileEntity Mobile) World()
+    {
+        var persistence = new FakePersistenceService();
+        var mobile = new MobileEntity { Name = "Squid", MapId = 1, Position = new(1, 1, 0) };
+
+        persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+        return (new(persistence), mobile);
+    }
+
+    private static void Equip(ItemService items, MobileEntity mobile, int itemId, LayerType layer)
+    {
+        var item = new ItemEntity { ItemId = itemId };
+
+        items.Save(item);
+        items.Equip(mobile, item, layer);
+    }
+}

--- a/tests/Moongate.Tests/Server/World/VisibilityReconcilerTests.cs
+++ b/tests/Moongate.Tests/Server/World/VisibilityReconcilerTests.cs
@@ -1,0 +1,121 @@
+using System.Net.Sockets;
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using SquidStd.Network.Client;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// The net under the reactive path. Its two properties are that it heals a session the reactive path
+/// left wrong, and that it says nothing about one that is already right.
+/// </summary>
+public class VisibilityReconcilerTests
+{
+    [Fact]
+    public void Tick_HealsASessionTheReactivePathLeftWrong()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var ghost = world.Mobile(new(105, 100, 0));
+
+        world.Visibility.Refresh(session);
+        Assert.Contains(ghost.Id, world.Visibility.KnownTo(session));
+
+        // Moved with no event published: exactly what a mutation path that forgot to tell the
+        // visibility service looks like.
+        world.Move(ghost, new(400, 400, 0));
+
+        world.Reconciler.Tick();
+
+        Assert.DoesNotContain(ghost.Id, world.Visibility.KnownTo(session));
+    }
+
+    // If a correct session produced packets, the net would be a storm every ten seconds.
+    [Fact]
+    public void Tick_OnACorrectSession_ChangesNothing()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+
+        world.Mobile(new(105, 100, 0));
+        world.Visibility.Refresh(session);
+
+        var before = world.Visibility.KnownTo(session).ToHashSet();
+
+        world.Reconciler.Tick();
+
+        Assert.Equal(before, world.Visibility.KnownTo(session));
+        Assert.True(world.Visibility.Refresh(session).IsEmpty);
+    }
+
+    // A session that has not picked a character yet has no view to reconcile.
+    [Fact]
+    public void Tick_SkipsSessionsWithoutACharacter()
+    {
+        var world = new Fixture();
+
+        world.SessionWithoutCharacter();
+
+        world.Reconciler.Tick();
+    }
+
+    private sealed class Fixture
+    {
+        private readonly FakePersistenceService _persistence = new();
+        private readonly SpatialIndexService _spatial;
+        private readonly StubSessionManager _sessions = new();
+
+        public Fixture()
+        {
+            _spatial = new(_persistence, new StubLoopAffinity(), new EventBusService());
+            Visibility = new VisibilityService(_spatial, new ItemService(_persistence), new VirtualSerialService());
+            Reconciler = new(_sessions, Visibility, new StubGameLoopContext());
+        }
+
+        public VisibilityService Visibility { get; }
+
+        public VisibilityReconciler Reconciler { get; }
+
+        public PlayerSession Session(Point3D position)
+        {
+            var session = SessionWithoutCharacter();
+
+            session.SetCharacter(Mobile(position));
+
+            return session;
+        }
+
+        public PlayerSession SessionWithoutCharacter()
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var session = new PlayerSession(new SquidStdTcpClient(socket, Stream.Null));
+
+            _sessions.Connections.Add(session);
+
+            return session;
+        }
+
+        public MobileEntity Mobile(Point3D position)
+        {
+            var mobile = new MobileEntity { Name = "Someone", MapId = 1, Position = position };
+
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            _spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+
+        public void Move(MobileEntity mobile, Point3D position)
+        {
+            mobile.Position = position;
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            _spatial.AddOrUpdate(mobile);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/World/VisibilityServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/VisibilityServiceTests.cs
@@ -1,0 +1,199 @@
+using System.Net.Sockets;
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+using SquidStd.Network.Client;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// Each test here is a bug that would otherwise be found in play rather than in CI: a ghost left
+/// behind, a mobile drawn twice, a client shown what it asked not to see, or a reconciliation sweep
+/// that talks when it has nothing to say.
+/// </summary>
+public class VisibilityServiceTests
+{
+    [Fact]
+    public void Refresh_OnAFreshSession_DrawsEverythingInRangeButNotTheSessionItself()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var other = world.Mobile(new(105, 100, 0));
+        var item = world.Item(new(103, 100, 0));
+
+        var delta = world.Visibility.Refresh(session);
+
+        Assert.Equal([other.Id, item.Id], delta.Entered.Order().ToArray().Order());
+        Assert.Empty(delta.Left);
+        Assert.DoesNotContain(session.Character!.Id, world.Visibility.KnownTo(session));
+    }
+
+    // The ghost case. Without this the client keeps drawing something that walked away, until relog.
+    [Fact]
+    public void Refresh_AfterSomethingLeftRange_ForgetsIt()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var other = world.Mobile(new(105, 100, 0));
+
+        world.Visibility.Refresh(session);
+        world.Move(other, new(400, 400, 0));
+
+        var delta = world.Visibility.Refresh(session);
+
+        Assert.Equal([other.Id], delta.Left);
+        Assert.Empty(world.Visibility.KnownTo(session));
+    }
+
+    // The reconciliation sweep runs every ten seconds over every session. If a correct session
+    // produced packets, the safety net would be a packet storm.
+    [Fact]
+    public void Refresh_Twice_ChangesNothingTheSecondTime()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+
+        world.Mobile(new(105, 100, 0));
+        world.Visibility.Refresh(session);
+
+        Assert.True(world.Visibility.Refresh(session).IsEmpty);
+    }
+
+    [Fact]
+    public void Refresh_RespectsTheSessionsOwnViewRange()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+
+        world.Mobile(new(115, 100, 0)); // 15 tiles: inside the default 18, outside a reduced 10
+        session.SetViewRange(10);
+
+        Assert.True(world.Visibility.Refresh(session).IsEmpty);
+    }
+
+    // The double-draw case: something already known that moves inside the view is a position
+    // update, not a second incoming packet.
+    [Fact]
+    public void UpdateFor_AKnownMobileStillInRange_IsAMove()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var other = world.Mobile(new(105, 100, 0));
+
+        world.Visibility.Refresh(session);
+        world.Move(other, new(106, 100, 0));
+
+        Assert.Equal(VisibilityChangeType.Moved, world.Visibility.UpdateFor(session, other));
+    }
+
+    [Fact]
+    public void UpdateFor_AnUnknownMobileInRange_IsDrawnAndRemembered()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var other = world.Mobile(new(105, 100, 0));
+
+        Assert.Equal(VisibilityChangeType.Drawn, world.Visibility.UpdateFor(session, other));
+        Assert.Contains(other.Id, world.Visibility.KnownTo(session));
+    }
+
+    [Fact]
+    public void UpdateFor_AKnownMobileNowOutOfRange_IsUndrawnAndForgotten()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var other = world.Mobile(new(105, 100, 0));
+
+        world.Visibility.Refresh(session);
+        world.Move(other, new(400, 400, 0));
+
+        Assert.Equal(VisibilityChangeType.Undrawn, world.Visibility.UpdateFor(session, other));
+        Assert.Empty(world.Visibility.KnownTo(session));
+    }
+
+    // Something the client never had and still cannot see is not news.
+    [Fact]
+    public void UpdateFor_AnUnknownMobileOutOfRange_IsNothing()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var other = world.Mobile(new(400, 400, 0));
+
+        Assert.Equal(VisibilityChangeType.None, world.Visibility.UpdateFor(session, other));
+    }
+
+    [Fact]
+    public void Forget_DropsTheWholeKnownSet()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+
+        world.Mobile(new(105, 100, 0));
+        world.Visibility.Refresh(session);
+
+        world.Visibility.Forget(session);
+
+        Assert.Empty(world.Visibility.KnownTo(session));
+    }
+
+    private sealed class Fixture
+    {
+        private readonly FakePersistenceService _persistence = new();
+        private readonly SpatialIndexService _spatial;
+        private readonly ItemService _items;
+
+        public Fixture()
+        {
+            _spatial = new(_persistence, new StubLoopAffinity(), new EventBusService());
+            _items = new(_persistence);
+            Visibility = new VisibilityService(_spatial, _items, new VirtualSerialService());
+        }
+
+        public VisibilityService Visibility { get; }
+
+        public PlayerSession Session(Point3D position)
+        {
+            var character = Mobile(position);
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var session = new PlayerSession(new SquidStdTcpClient(socket, Stream.Null));
+
+            session.SetCharacter(character);
+
+            return session;
+        }
+
+        public MobileEntity Mobile(Point3D position)
+        {
+            var mobile = new MobileEntity { Name = "Someone", MapId = 1, Position = position };
+
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            _spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+
+        public ItemEntity Item(Point3D position)
+        {
+            var item = new ItemEntity { ItemId = 0x0EED, MapId = 1, Position = position };
+
+            _items.Save(item);
+            _spatial.AddOrUpdate(item);
+
+            return item;
+        }
+
+        public void Move(MobileEntity mobile, Point3D position)
+        {
+            mobile.Position = position;
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            _spatial.AddOrUpdate(mobile);
+        }
+    }
+}

--- a/tests/Moongate.Tests/Server/World/VisibilitySubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/World/VisibilitySubscriberTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using Moongate.Core.Extensions;
 using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
 using Moongate.Server.Abstractions.Data.Session;
@@ -83,6 +84,41 @@ public class VisibilitySubscriberTests
         Assert.DoesNotContain(doomed.Id, world.Visibility.KnownTo(session));
     }
 
+    // An item dropped beside someone must reach them without waiting for the ten-second sweep.
+    [Fact]
+    public async Task ItemChanged_OnTheGroundInRange_IsDrawnAndRemembered()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+
+        world.Visibility.Refresh(session);
+
+        var item = world.Item(new(103, 100, 0));
+
+        await world.Subscriber.OnItemChanged(new(item.Id), CancellationToken.None);
+
+        Assert.Contains(item.Id, world.Visibility.KnownTo(session));
+    }
+
+    // Picked up is not "moved": the item leaves the world entirely, so range says nothing about it
+    // and everyone who had it drawn has to be told directly.
+    [Fact]
+    public async Task ItemChanged_PickedUp_IsUndrawnForEveryoneWhoKnewIt()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var item = world.Item(new(103, 100, 0));
+
+        world.Visibility.Refresh(session);
+        Assert.Contains(item.Id, world.Visibility.KnownTo(session));
+
+        world.PickUp(item);
+
+        await world.Subscriber.OnItemChanged(new(item.Id), CancellationToken.None);
+
+        Assert.DoesNotContain(item.Id, world.Visibility.KnownTo(session));
+    }
+
     private sealed class Fixture
     {
         private readonly FakePersistenceService _persistence = new();
@@ -92,9 +128,12 @@ public class VisibilitySubscriberTests
         public Fixture()
         {
             _spatial = new(_persistence, new StubLoopAffinity(), new EventBusService());
-            Visibility = new VisibilityService(_spatial, new ItemService(_persistence), new VirtualSerialService());
-            Subscriber = new(Visibility, _sessions, _persistence);
+            Items = new(_persistence);
+            Visibility = new VisibilityService(_spatial, Items, new VirtualSerialService());
+            Subscriber = new(Visibility, _sessions, _persistence, Items);
         }
+
+        public ItemService Items { get; }
 
         public VisibilityService Visibility { get; }
 
@@ -120,6 +159,24 @@ public class VisibilitySubscriberTests
             _spatial.AddOrUpdate(mobile);
 
             return mobile;
+        }
+
+        public ItemEntity Item(Point3D position)
+        {
+            var item = new ItemEntity { ItemId = 0x0EED, MapId = 1, Position = position };
+
+            Items.Save(item);
+            _spatial.AddOrUpdate(item);
+
+            return item;
+        }
+
+        /// <summary>Off the ground and into a backpack: no longer in the world.</summary>
+        public void PickUp(ItemEntity item)
+        {
+            item.ParentContainerId = (Serial)0xFFFF;
+            Items.Save(item);
+            _spatial.AddOrUpdate(item);
         }
 
         public void Move(MobileEntity mobile, Point3D position)

--- a/tests/Moongate.Tests/Server/World/VisibilitySubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/World/VisibilitySubscriberTests.cs
@@ -1,0 +1,132 @@
+using System.Net.Sockets;
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using SquidStd.Network.Client;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// Routing world events to the visibility service. The interesting one is a mobile that walks out of
+/// someone's view: nothing about the destination says it happened.
+/// </summary>
+public class VisibilitySubscriberTests
+{
+    // Watching only the new position would leave the walker drawn on the client for ever.
+    [Fact]
+    public async Task MobileMoved_AwayFromAWatcher_UndrawsIt()
+    {
+        var world = new Fixture();
+        var watcher = world.Session(new(100, 100, 0));
+        var walker = world.Mobile(new(105, 100, 0));
+
+        world.Visibility.Refresh(watcher);
+        Assert.Contains(walker.Id, world.Visibility.KnownTo(watcher));
+
+        var from = walker.Position;
+        world.Move(walker, new(400, 400, 0));
+
+        await world.Subscriber.OnMobileMoved(new(walker.Id, 1, from, 1, walker.Position), CancellationToken.None);
+
+        Assert.DoesNotContain(walker.Id, world.Visibility.KnownTo(watcher));
+    }
+
+    [Fact]
+    public async Task MobileMoved_TowardAWatcher_DrawsIt()
+    {
+        var world = new Fixture();
+        var watcher = world.Session(new(100, 100, 0));
+        var walker = world.Mobile(new(400, 400, 0));
+
+        world.Visibility.Refresh(watcher);
+
+        var from = walker.Position;
+        world.Move(walker, new(105, 100, 0));
+
+        await world.Subscriber.OnMobileMoved(new(walker.Id, 1, from, 1, walker.Position), CancellationToken.None);
+
+        Assert.Contains(walker.Id, world.Visibility.KnownTo(watcher));
+    }
+
+    [Fact]
+    public async Task SessionDestroyed_ForgetsWhatItKnew()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+
+        world.Mobile(new(105, 100, 0));
+        world.Visibility.Refresh(session);
+
+        await world.Subscriber.OnSessionDestroyed(new(session), CancellationToken.None);
+
+        Assert.Empty(world.Visibility.KnownTo(session));
+    }
+
+    [Fact]
+    public async Task MobileDeleted_IsUndrawnForEveryoneWhoKnewIt()
+    {
+        var world = new Fixture();
+        var session = world.Session(new(100, 100, 0));
+        var doomed = world.Mobile(new(105, 100, 0));
+
+        world.Visibility.Refresh(session);
+
+        await world.Subscriber.OnMobileDeleted(new(doomed), CancellationToken.None);
+
+        Assert.DoesNotContain(doomed.Id, world.Visibility.KnownTo(session));
+    }
+
+    private sealed class Fixture
+    {
+        private readonly FakePersistenceService _persistence = new();
+        private readonly SpatialIndexService _spatial;
+        private readonly StubSessionManager _sessions = new();
+
+        public Fixture()
+        {
+            _spatial = new(_persistence, new StubLoopAffinity(), new EventBusService());
+            Visibility = new VisibilityService(_spatial, new ItemService(_persistence), new VirtualSerialService());
+            Subscriber = new(Visibility, _sessions, _persistence);
+        }
+
+        public VisibilityService Visibility { get; }
+
+        public VisibilitySubscriber Subscriber { get; }
+
+        public PlayerSession Session(Point3D position)
+        {
+            var character = Mobile(position);
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var session = new PlayerSession(new SquidStdTcpClient(socket, Stream.Null));
+
+            session.SetCharacter(character);
+            _sessions.Connections.Add(session);
+
+            return session;
+        }
+
+        public MobileEntity Mobile(Point3D position)
+        {
+            var mobile = new MobileEntity { Name = "Someone", MapId = 1, Position = position };
+
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            _spatial.AddOrUpdate(mobile);
+
+            return mobile;
+        }
+
+        public void Move(MobileEntity mobile, Point3D position)
+        {
+            mobile.Position = position;
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            _spatial.AddOrUpdate(mobile);
+        }
+    }
+}


### PR DESCRIPTION
Closes #154. Trello #68.

Every building block for this existed and nothing joined them. The packets were written, the
spatial queries were written, the events were written — but **nobody computed the delta**, so
a player saw only themselves plus whatever happened to move or change while they stood next
to it.

The missing piece was **memory rather than packets**: you cannot tell a client something
appeared without knowing what it already has, and nothing tracked that.

## Design

**Hybrid.** Reactive on the events, plus a 10-second reconciliation sweep. Purely reactive is
cheap but leaves *ghosts* when a mutation path is missed — a teleport, a map change, a future
hiding system — and those survive until relog. Purely polled cannot forget a case but pays
for a still world every tick. The sweep is **not a second algorithm**: it is the same
`Refresh`, which on a correct session finds nothing and sends nothing.

**Two operations, and the split is cost rather than taste.** `Refresh(session)` recomputes a
whole view — entering the world, the player's own step, the sweep. `UpdateFor(session, x)`
applies one object's change in O(1), because recomputing every nearby session's whole view on
every NPC step would be many full-radius scans per tick for one standing player.

`UpdateFor`'s third row — known and still in range — is the 0x77 that `MovementService.Broadcast`
used to send. The defect was that it went to every session in range whether or not that client
had ever been told the mobile exists.

## Fixed along the way

- The broadcast used the global `MaxViewRange` for everyone while each session has its own
  `ViewRange`, set by the client with 0xC8. Reduced-range clients were sent things they had
  asked not to receive.
- `BuildEquipment` and `GetBodyFlags` were private to `WorldService` although drawing any
  mobile needs both. They moved to `MobileDrawing` and gained the tests they never had.

## Things worth knowing

**The integration test asserted the defect.** It checked that Bob receives Alice's 0x77
without anything having told him Alice exists. It now asserts the same packet for a different
reason: Bob is *shown* Alice (0x78) when he enters the world with her in range, so her step is
an update for a mobile he knows. I first changed it to expect 0x78 and had that wrong — she
enters his view at his login, not at her step.

**Looking the moved mobile up among session characters would have excluded every NPC**, which
is most of what moves. It comes from the store.

## Verification

- 1977 tests. Both load-bearing cases were watched failing before being relied on: with the
  exit computation disabled the ghost survived, and with the origin check removed a walker
  stayed drawn on the client it had left behind.
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings. Two getting-started pages
  said world entry is self-only and called this "the current frontier"; both are corrected.
- Booted against an isolated root: 20 services.

## Not verified by me

**This needs a client.** Its whole point is visible only there, and no test can stand in:
walk toward a static item and watch it appear, walk away and watch it go, stand still while
an NPC walks past. Worth doing before merge.