### PR TITLE
fix(gumps): forget a session's open gumps when it disconnects

### DIFF
--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -29,6 +29,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<ContainerSubscriber>();
         container.RegisterEventSubscriber<SpatialSubscriber>();
         container.RegisterEventSubscriber<VisibilitySubscriber>();
+        container.RegisterEventSubscriber<GumpSubscriber>();
         container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
         container.RegisterEventSubscriber<HeldItemBounceSubscriber>();
         container.RegisterEventSubscriber<ItemScriptSubscriber>();

--- a/src/Moongate.Server/Subscribers/GumpSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/GumpSubscriber.cs
@@ -1,0 +1,36 @@
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.Gumps;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Drops a session's open gumps when it goes.
+/// <para>
+/// The service keeps what it drew for each session so a response can be checked against it, and
+/// nothing else ever removes that entry: a gump is forgotten when it answers, but a player who
+/// closes the client with one open never answers. Without this the map grows for the life of the
+/// process, and a reused session id would inherit a stranger's open gumps — including the button ids
+/// that pass validation.
+/// </para>
+/// </summary>
+public sealed class GumpSubscriber : IEventSubscriberRegistration
+{
+    private readonly IGumpService _gumps;
+
+    public GumpSubscriber(IGumpService gumps)
+    {
+        _gumps = gumps;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+
+    public Task OnSessionDestroyed(SessionDestroyedEvent @event, CancellationToken cancellationToken)
+    {
+        _gumps.CloseAll(@event.Session);
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Moongate.Tests/Server/Gumps/GumpSubscriberTests.cs
+++ b/tests/Moongate.Tests/Server/Gumps/GumpSubscriberTests.cs
@@ -1,0 +1,46 @@
+using System.Net.Sockets;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Services.Gumps;
+using Moongate.Server.Subscribers;
+using SquidStd.Network.Client;
+
+namespace Moongate.Tests.Server.Gumps;
+
+/// <summary>
+/// A gump outlives its own answer only until the player leaves. Without this the per-session map
+/// grows for the life of the process, and a reused session id would inherit a stranger's open gumps
+/// along with the button ids that pass validation.
+/// </summary>
+public class GumpSubscriberTests
+{
+    [Fact]
+    public async Task SessionDestroyed_ForgetsThatSessionsGumps()
+    {
+        var gumps = new GumpService();
+        var session = Session();
+
+        gumps.Show(session, "bank", builder => builder.AddButton(0, 0, 1, 2, 7, 1, 0));
+        Assert.Single(gumps.OpenFor(session));
+
+        await new GumpSubscriber(gumps).OnSessionDestroyed(new(session), CancellationToken.None);
+
+        Assert.Empty(gumps.OpenFor(session));
+    }
+
+    // A player who left with nothing open is not a special case, and must not throw.
+    [Fact]
+    public async Task SessionDestroyed_WithNothingOpen_IsHarmless()
+    {
+        var gumps = new GumpService();
+
+        await new GumpSubscriber(gumps).OnSessionDestroyed(new(Session()), CancellationToken.None);
+    }
+
+    private static PlayerSession Session()
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+        return new(new SquidStdTcpClient(socket, Stream.Null));
+    }
+}


### PR DESCRIPTION
Closes #156.

`IGumpService.CloseAll` was declared, implemented and documented as *"drops everything this
session was told, on logout"* — and nothing called it. A gump is forgotten when it **answers**,
but a player who closes the client with one open never answers, so `GumpService`'s
per-session map only ever grew.

Two consequences, one slow and one sharp:

- a leak proportional to **logins**, not to players online, for the life of the process;
- a reused session id would inherit a stranger's open gumps — and with them the button ids
  that pass validation, which is the check standing between the callback and a fabricated
  response.

## Why no test caught it

This is the **second instance of the same mistake in two days**: contract surface written and
never wired. The other was `IVisibilityService.UpdateFor` for items, fixed in #155, where
wiring the dead method exposed a real behaviour gap underneath it.

A method nobody calls fails nothing. Both were found by re-reading my own branch, not by CI,
and that is worth saying plainly rather than filing as routine.

## Verification

- 1980 tests. The new one was watched failing with the `CloseAll` call removed.
- Booted against an isolated root: 20 services.