### PR TITLE
docs: make gumps discoverable

### DIFF
--- a/docs/contributing/writing-plugins/index.md
+++ b/docs/contributing/writing-plugins/index.md
@@ -19,6 +19,44 @@ inside the server process:
 - a **data loader** that reads your own files at startup;
 - a **REST endpoint**.
 
+## Using the server's own services
+
+Contributing is only half of it: a plugin can also **resolve the server's services** from the
+container and use them. Every service interface lives in `Moongate.Server.Abstractions`, which
+plugins reference — that is what the contract assembly is for.
+
+The one most likely to matter is `IGumpService`, because it is how a plugin puts a window in
+front of a player:
+
+```csharp
+var gumps = container.Resolve<IGumpService>();
+
+gumps.Show(
+    session,
+    "my_plugin_menu",
+    builder =>
+    {
+        builder.AddBackground(0, 0, 300, 200, 5054);
+        builder.AddLabel(20, 20, 1153, "Hello from a plugin");
+        builder.AddButton(20, 60, 4005, 4007, 1, 1, 0);
+    },
+    response =>
+    {
+        if (response.Button == 1)
+        {
+            // ...
+        }
+    }
+);
+```
+
+The element names are RunUO's, so gump code published for ServUO or ModernUO — and the output
+of the visual gump editors that target them — translates across argument for argument. The
+[`gump` scripting reference](../../scripting/reference/gump.md) documents every element and its
+fields; the Lua surface is the same builder with named tables instead of positional arguments.
+
+`IChatService`, `IItemService`, `IMobileService` and the rest resolve the same way.
+
 Reach for [Lua scripting](../../scripting/index.md) instead when you are writing game-content
 logic — item and mobile behaviour, loot, world events — and want to iterate live with no
 compile step. Scripting needs no C# at all.

--- a/docs/getting-started/what-is-moongate.md
+++ b/docs/getting-started/what-is-moongate.md
@@ -26,7 +26,11 @@ Moongate is young and moves fast. What works today:
   are drawn when they come into view, undrawn when they leave, and the same
   happens to you on everyone else's screen when they move.
 - Item, mobile and loot systems driven by YAML templates, with a Lua API
-  (`item`, `mobile`, `loot`, `game`, `events`, `log`) for shard logic.
+  (`item`, `mobile`, `loot`, `chat`, `gump`, `ai`, `memory`, `account`, `game`,
+  `events`, `log`) for shard logic.
+- **Gumps**: server-drawn dialogs a player can act on — buttons, checkboxes,
+  text fields — described in Lua and answered through a callback. Open to
+  plugins as well as scripts.
 - Binary snapshot persistence for accounts, mobiles and items.
 - UO client file loading (art, maps, and friends) from a ClassicUO-compatible
   installation.

--- a/docs/scripting/reference/gump.md
+++ b/docs/scripting/reference/gump.md
@@ -129,6 +129,26 @@ gump.show(player, "help", function(g)
 end)
 ```
 
+## A complete example
+
+The fragments above are fragments. `example_signpost.lua` ships with the server as a whole
+working script: double-clicking the item opens a menu of destinations with
+a checkbox, and the response teleports the player and optionally makes them announce
+themselves. It shows the whole loop — draw, wait, answer, act — including the two things that
+are easy to get wrong the first time:
+
+- `ctx.actor` can be **nil**, and there is then nobody to show a gump to;
+- the mobile can be **gone by the time the player answers**, which is why the callback goes
+  through [`mobile.ref`](mobile.md#mobileref) rather than assuming the target is still there.
+
+Point an item template at it with `ScriptId: items.example_signpost` — see
+[item scripts](item-scripts.md).
+
+> [!NOTE]
+> Item scripts are seeded **lazily**, the first time the server resolves a `ScriptId`. On a
+> bare first boot `scripts/items/` does not exist yet, so do not go looking for the file
+> before an item that uses one has been loaded.
+
 ## Drawing gumps with an editor
 
 Positions are pixels, and pixels are easier dragged than typed. The Ultima Online community

--- a/src/Moongate.Scripting/Assets/Items/example_signpost.lua
+++ b/src/Moongate.Scripting/Assets/Items/example_signpost.lua
@@ -1,0 +1,67 @@
+-- Example gump script. An item template with `ScriptId: items.example_signpost` runs these hooks —
+-- the dot is a namespace, so that id is this file, scripts/items/example_signpost.lua.
+--
+-- Double-clicking the item opens a dialog and acts on what the player chose. That is the whole
+-- loop: draw, wait, answer, act.
+
+local signpost = {
+    id = "items.example_signpost",
+}
+
+function signpost.on_double_click(ctx)
+    -- Always check the actor: a hook can fire with nobody behind it, and there is no one to
+    -- show a gump to.
+    if ctx.actor == nil then
+        return
+    end
+
+    gump.show(ctx.actor.serial, "example_signpost", function(g)
+        g.background { x = 0, y = 0, w = 320, h = 200, art = 5054 }
+        g.label { x = 24, y = 20, hue = 1153, text = "Where would you like to go?" }
+
+        -- One button per destination. The id is what comes back in the response, so it is the
+        -- only number here you have to keep track of.
+        g.button { x = 24, y = 60, art = 4005, pressed = 4007, id = 1 }
+        g.label { x = 60, y = 60, hue = 0, text = "Britain" }
+
+        g.button { x = 24, y = 90, art = 4005, pressed = 4007, id = 2 }
+        g.label { x = 60, y = 90, hue = 0, text = "Trinsic" }
+
+        -- A checkbox rides back in `switches` rather than in `button`.
+        g.check { x = 24, y = 130, art = 210, pressed = 211, id = 10 }
+        g.label { x = 60, y = 130, hue = 0, text = "Announce my arrival" }
+    end,
+    function(r)
+        -- Button 0 is the client's own close button: the player changed their mind.
+        if r.button == 0 then
+            return
+        end
+
+        local destination = r.button == 1 and { name = "Britain", x = 1495, y = 1629 }
+                                          or  { name = "Trinsic", x = 1828, y = 2745 }
+
+        local announce = false
+
+        for _, id in ipairs(r.switches) do
+            if id == 10 then
+                announce = true
+            end
+        end
+
+        local traveller = mobile.ref(ctx.actor.serial)
+
+        -- The mobile may be gone by the time the player answers: ref returns nil rather than
+        -- letting you act on a stale target.
+        if traveller == nil then
+            return
+        end
+
+        traveller.teleport(destination.x, destination.y, 0)
+
+        if announce then
+            traveller.say("I have arrived in " .. destination.name .. "!")
+        end
+    end)
+end
+
+return signpost


### PR DESCRIPTION
Closes #158.

The `gump` reference page and the generated packet pages were fine. The gap was in the two
places a reader would look to find out gumps are possible **at all**.

**The feature list** named six of the eleven Lua modules — `gump`, `chat`, `ai`, `memory` and
`account` were all missing — and did not list server-drawn dialogs as a capability.

**The plugin guide never mentioned them**, which is the worse of the two. Putting
`IGumpService` in `Moongate.Server.Abstractions` was the *first* design decision of that
feature, taken specifically so plugins could open dialogs — and nothing in
`docs/contributing/writing-plugins/` said the service exists. A capability was built for
plugin authors and never told to them.

The guide now has a short section on resolving the server's services at all (not only
contributing to it), with gumps as the worked example, a note that the element names are
RunUO's so published gump code and visual-editor output translate across, and a pointer to
the scripting reference for the full element set.

`dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings.