### PR TITLE
feat(world): target cursor — ask the player to click something

### DIFF
--- a/docs/getting-started/what-is-moongate.md
+++ b/docs/getting-started/what-is-moongate.md
@@ -26,11 +26,14 @@ Moongate is young and moves fast. What works today:
   are drawn when they come into view, undrawn when they leave, and the same
   happens to you on everyone else's screen when they move.
 - Item, mobile and loot systems driven by YAML templates, with a Lua API
-  (`item`, `mobile`, `loot`, `chat`, `gump`, `ai`, `memory`, `account`, `game`,
-  `events`, `log`) for shard logic.
+  (`item`, `mobile`, `loot`, `chat`, `gump`, `target`, `ai`, `memory`, `account`,
+  `game`, `events`, `log`) for shard logic.
 - **Gumps**: server-drawn dialogs a player can act on — buttons, checkboxes,
   text fields — described in Lua and answered through a callback. Open to
   plugins as well as scripts.
+- **Target cursor**: ask the player to click an entity or a spot on the ground
+  and act on what they picked, from Lua or from a command. `.where` ships as a
+  worked example.
 - Binary snapshot persistence for accounts, mobiles and items.
 - UO client file loading (art, maps, and friends) from a ClassicUO-compatible
   installation.

--- a/docs/packets/families/targeting.md
+++ b/docs/packets/families/targeting.md
@@ -1,0 +1,8 @@
+# Targeting
+
+The target cursor: the server asking the player to click something, and the answer.
+
+| Opcode | Name | Dir | Size | Description |
+|---|---|---|---|---|
+| [`0x6C`](../incoming/0x6c-target-cursor-response.md) | Target Cursor Response | C → S | 19 bytes (fixed) | What the player clicked. |
+| [`0x6C`](../outgoing/0x6c-target-cursor.md) | Target Cursor | S → C | 19 bytes (fixed) | Raises the client's targeting cursor, or takes it down when <paramref name="CursorType" /> is `Cancel`. |

--- a/docs/packets/includes/family-cards.md
+++ b/docs/packets/includes/family-cards.md
@@ -54,4 +54,9 @@
     <div class="mg-card-ops">0xB1 · 0xDD</div>
     <p>Server-drawn dialogs: the compressed gump and the response naming the button pressed.</p>
   </a>
+  <a class="mg-card" href="families/targeting.md">
+    <h3>Targeting</h3>
+    <div class="mg-card-ops">0x6C</div>
+    <p>The target cursor: the server asking the player to click something, and the answer.</p>
+  </a>
 </div>

--- a/docs/packets/includes/packet-table.md
+++ b/docs/packets/includes/packet-table.md
@@ -1,7 +1,7 @@
 <div class="mg-stats">
-  <div class="mg-stat"><div class="mg-stat-num">59</div><div class="mg-stat-label">implemented packets</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-grass">20</div><div class="mg-stat-label">incoming (client → server)</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-violet">39</div><div class="mg-stat-label">outgoing (server → client)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num">61</div><div class="mg-stat-label">implemented packets</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-grass">21</div><div class="mg-stat-label">incoming (client → server)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-violet">40</div><div class="mg-stat-label">outgoing (server → client)</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-stone">7.x</div><div class="mg-stat-label">client target</div></div>
 </div>
 
@@ -31,6 +31,8 @@
 | [`0x55`](../outgoing/0x55-login-complete.md) | Login Complete | S → C | 1 bytes (fixed) | The "you are now in the world" marker that unblocks the client. |
 | [`0x5B`](../outgoing/0x5b-game-time.md) | Game Time | S → C | 4 bytes (fixed) | The in-world clock shown to the client. |
 | [`0x5D`](../incoming/0x5d-character-select.md) | Character Select | C → S | 73 bytes (fixed) | The client picks an existing character slot to enter the world with. |
+| [`0x6C`](../incoming/0x6c-target-cursor-response.md) | Target Cursor Response | C → S | 19 bytes (fixed) | What the player clicked. |
+| [`0x6C`](../outgoing/0x6c-target-cursor.md) | Target Cursor | S → C | 19 bytes (fixed) | Raises the client's targeting cursor, or takes it down when <paramref name="CursorType" /> is `Cancel`. |
 | [`0x72`](../outgoing/0x72-war-mode.md) | War Mode | S → C | 5 bytes (fixed) | Toggles the client's combat stance. |
 | [`0x73`](../incoming/0x73-ping.md) | Ping | C → S | 2 bytes (fixed) | The client sends this periodically with a rolling sequence byte and expects the server to echo it straight back, or it eventually drops the connection. |
 | [`0x73`](../outgoing/0x73-ping-ack.md) | Ping Ack | S → C | 2 bytes (fixed) | Echoes the client's keep-alive sequence byte straight back. |

--- a/docs/packets/incoming/0x6c-target-cursor-response.md
+++ b/docs/packets/incoming/0x6c-target-cursor-response.md
@@ -1,0 +1,18 @@
+# 0x6C — Target Cursor Response
+
+<span class="mg-dir mg-dir-in">Client → Server</span>
+
+Target cursor response (0x6C, incoming): what the player clicked. <para> This record only reports. Whether the answer belongs to a cursor the server actually raised, and whether "nothing picked" means the player cancelled, is decided by the service that owns the pending request — the packet cannot tell. </para>
+
+- **Class:** [`TargetCursorResponsePacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Incoming/TargetCursorResponsePacket.cs)
+- **Size:** 19 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `CursorId` | `uint` |
+| `Selection` | `TargetSelectionType` |
+| `Clicked` | `Serial` |
+| `Location` | `Point3D` |
+| `Graphic` | `ushort` |

--- a/docs/packets/outgoing/0x6c-target-cursor.md
+++ b/docs/packets/outgoing/0x6c-target-cursor.md
@@ -1,0 +1,16 @@
+# 0x6C — Target Cursor
+
+<span class="mg-dir mg-dir-out">Server → Client</span>
+
+Target cursor (0x6C, outgoing): raises the client's targeting cursor, or takes it down when <paramref name="CursorType" /> is `Cancel`. <para> The same opcode carries the answer back, as `TargetCursorResponsePacket`. They are two records rather than one because every other packet here has a single direction — the interfaces differ and the docs generator files pages by them. </para> <para> Only the selection type, the cursor id and the cursor type mean anything outbound; the fields the client fills in on the way back are written as zero. 19 bytes fixed. </para>
+
+- **Class:** [`TargetCursorPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Outgoing/TargetCursorPacket.cs)
+- **Size:** 19 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `CursorId` | `uint` |
+| `Selection` | `TargetSelectionType` |
+| `CursorType` | `TargetCursorType` |

--- a/docs/packets/toc.yml
+++ b/docs/packets/toc.yml
@@ -24,6 +24,8 @@
       href: families/chat.md
     - name: "Gumps"
       href: families/gumps.md
+    - name: "Targeting"
+      href: families/targeting.md
 - name: Incoming (client → server)
   items:
     - name: "0x02 — Move Request"
@@ -40,6 +42,8 @@
       href: incoming/0x3a-skill-lock-change.md
     - name: "0x5D — Character Select"
       href: incoming/0x5d-character-select.md
+    - name: "0x6C — Target Cursor Response"
+      href: incoming/0x6c-target-cursor-response.md
     - name: "0x73 — Ping"
       href: incoming/0x73-ping.md
     - name: "0x80 — Account Login Request"
@@ -102,6 +106,8 @@
       href: outgoing/0x55-login-complete.md
     - name: "0x5B — Game Time"
       href: outgoing/0x5b-game-time.md
+    - name: "0x6C — Target Cursor"
+      href: outgoing/0x6c-target-cursor.md
     - name: "0x72 — War Mode"
       href: outgoing/0x72-war-mode.md
     - name: "0x73 — Ping Ack"

--- a/docs/scripting/reference/target.md
+++ b/docs/scripting/reference/target.md
@@ -1,0 +1,63 @@
+# target
+
+The target cursor: asking the player to click something. A [gump](gump.md) asks *which
+option*; a target asks *which thing*.
+
+## target.request
+
+```lua
+target.request(serial, selection, on_target) -> boolean
+```
+
+Raises the cursor for the player behind `serial` and calls `on_target` with what they picked.
+
+`selection` is `"object"` to pick an entity or `"location"` to pick a spot on the ground.
+Anything else is **refused** — the call returns `false` and no cursor appears, rather than
+quietly picking one of the two for you.
+
+Returns `false` when the serial names nobody online.
+
+```lua
+target.request(player, "object", function(r)
+    if r.cancelled then
+        return
+    end
+
+    chat.say(player, "you clicked " .. r.serial .. " at " .. r.x .. "," .. r.y)
+end)
+```
+
+> [!IMPORTANT]
+> **A player has one cursor.** It is a modal state in the client, so asking for a target while
+> one is already up replaces what is on screen. The request it replaced has its callback
+> called with `cancelled`, because it can no longer be answered — your script does not have to
+> track that.
+
+## The result
+
+| field | meaning |
+|---|---|
+| `cancelled` | `true` when the player picked nothing |
+| `type` | `"object"`, `"location"` or `"cancelled"` |
+| `serial` | the clicked entity, or `0` |
+| `x`, `y`, `z` | where it was, for both objects and ground |
+| `graphic` | the graphic the client reported, when it reported one |
+
+**Check `cancelled` first.** It is the answer players give most often: pressing Escape or
+right-clicking dismisses the cursor, and a script that assumes otherwise will act on a serial
+of zero and coordinates that mean nothing.
+
+## target.cancel
+
+```lua
+target.cancel(serial) -> boolean
+```
+
+Takes the cursor down. The pending callback is called with `cancelled`. Returns `false` when
+nothing was pending.
+
+## From a command
+
+`.where` is the shipped example: it raises an object cursor and reports what was clicked, to
+whoever ran it. Its source is `src/Moongate.Server/Commands/WhereCommand.cs`, and it is the
+shortest illustration of the whole loop from C# rather than Lua.

--- a/docs/scripting/toc.yml
+++ b/docs/scripting/toc.yml
@@ -22,6 +22,8 @@
       href: reference/chat.md
     - name: gump
       href: reference/gump.md
+    - name: target
+      href: reference/target.md
     - name: memory
       href: reference/memory.md
     - name: item scripts

--- a/scripts/generate-packet-docs.cs
+++ b/scripts/generate-packet-docs.cs
@@ -74,6 +74,8 @@ var familyInfos = new FamilyInfo[]
         "Player speech (say/emote/whisper/yell) and server-wide system broadcasts."),
     new("Gumps", "gumps", "Gumps",
         "Server-drawn dialogs: the compressed gump and the response naming the button pressed."),
+    new("Targeting", "targeting", "Targeting",
+        "The target cursor: the server asking the player to click something, and the answer."),
 };
 
 var knownFamilies = familyInfos.Select(f => f.Member).ToHashSet(StringComparer.Ordinal);

--- a/src/Moongate.Network/Packets/Incoming/TargetCursorResponsePacket.cs
+++ b/src/Moongate.Network/Packets/Incoming/TargetCursorResponsePacket.cs
@@ -1,0 +1,50 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Incoming;
+
+/// <summary>
+/// Target cursor response (0x6C, incoming): what the player clicked.
+/// <para>
+/// This record only reports. Whether the answer belongs to a cursor the server actually raised,
+/// and whether "nothing picked" means the player cancelled, is decided by the service that owns
+/// the pending request — the packet cannot tell.
+/// </para>
+/// </summary>
+[PacketDocumentation(PacketFamilyType.Targeting, Length = 19)]
+public readonly record struct TargetCursorResponsePacket(
+    uint CursorId,
+    TargetSelectionType Selection,
+    Serial Clicked,
+    Point3D Location,
+    ushort Graphic
+) : IIncomingPacket<TargetCursorResponsePacket>
+{
+    public static byte PacketId => 0x6C;
+
+    public static TargetCursorResponsePacket Read(ref SpanReader reader)
+    {
+        reader.ReadByte(); // packet id
+
+        var selection = (TargetSelectionType)reader.ReadByte();
+        var cursorId = reader.ReadUInt32();
+
+        reader.ReadByte(); // cursor type, echoed back and not needed
+
+        var clicked = new Serial(reader.ReadUInt32());
+        var x = reader.ReadUInt16();
+        var y = reader.ReadUInt16();
+
+        reader.ReadByte(); // unused
+
+        var z = (sbyte)reader.ReadByte();
+        var graphic = reader.ReadUInt16();
+
+        return new(cursorId, selection, clicked, new(x, y, z), graphic);
+    }
+}

--- a/src/Moongate.Network/Packets/Outgoing/TargetCursorPacket.cs
+++ b/src/Moongate.Network/Packets/Outgoing/TargetCursorPacket.cs
@@ -1,0 +1,44 @@
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Outgoing;
+
+/// <summary>
+/// Target cursor (0x6C, outgoing): raises the client's targeting cursor, or takes it down when
+/// <paramref name="CursorType" /> is <see cref="TargetCursorType.Cancel" />.
+/// <para>
+/// The same opcode carries the answer back, as <see cref="Incoming.TargetCursorResponsePacket" />.
+/// They are two records rather than one because every other packet here has a single direction —
+/// the interfaces differ and the docs generator files pages by them.
+/// </para>
+/// <para>
+/// Only the selection type, the cursor id and the cursor type mean anything outbound; the fields
+/// the client fills in on the way back are written as zero. 19 bytes fixed.
+/// </para>
+/// </summary>
+[PacketDocumentation(PacketFamilyType.Targeting, Length = 19)]
+public readonly record struct TargetCursorPacket(
+    uint CursorId,
+    TargetSelectionType Selection,
+    TargetCursorType CursorType
+) : IOutgoingPacket
+{
+    public const byte PacketId = 0x6C;
+
+    public void Write(ref SpanWriter writer)
+    {
+        writer.Write(PacketId);
+        writer.Write((byte)Selection);
+        writer.Write(CursorId);
+        writer.Write((byte)CursorType);
+        writer.Write(0u);       // clicked serial, filled by the client
+        writer.Write((ushort)0); // x
+        writer.Write((ushort)0); // y
+        writer.Write((byte)0);   // unused
+        writer.Write((byte)0);   // z
+        writer.Write((ushort)0); // graphic
+    }
+}

--- a/src/Moongate.Network/Types/PacketFamilyType.cs
+++ b/src/Moongate.Network/Types/PacketFamilyType.cs
@@ -19,5 +19,8 @@ public enum PacketFamilyType : byte
     Chat,
 
     /// <summary>Server-drawn dialogs: the compressed gump and its response.</summary>
-    Gumps
+    Gumps,
+
+    /// <summary>The target cursor: asking the player to click something, and their answer.</summary>
+    Targeting
 }

--- a/src/Moongate.Server.Abstractions/Data/World/TargetResult.cs
+++ b/src/Moongate.Server.Abstractions/Data/World/TargetResult.cs
@@ -1,0 +1,29 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Types.World;
+
+namespace Moongate.Server.Abstractions.Data.World;
+
+/// <summary>
+/// What a target cursor came back with, already interpreted — the caller is handed a decision
+/// rather than a packet to work out for itself.
+/// </summary>
+/// <param name="Type">Object, location, or cancelled.</param>
+/// <param name="Serial">The clicked entity when <paramref name="Type" /> is Object, otherwise zero.</param>
+/// <param name="Location">Where it was, for both Object and Location.</param>
+/// <param name="Graphic">The clicked graphic, when the client reported one.</param>
+public readonly record struct TargetResult(
+    TargetResultType Type,
+    Serial Serial,
+    Point3D Location,
+    int Graphic
+)
+{
+    /// <summary>The player did not pick anything.</summary>
+    public bool IsCancelled
+        => Type == TargetResultType.Cancelled;
+
+    /// <summary>A cancelled answer, carrying nothing else worth reading.</summary>
+    public static TargetResult Cancelled
+        => new(TargetResultType.Cancelled, Serial.Zero, default, 0);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IPlayerTargetService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IPlayerTargetService.cs
@@ -1,0 +1,42 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>
+/// Raises the client's target cursor and routes the answer back.
+/// <para>
+/// One pending request per session, not a keyed collection. A UO client has a single target
+/// cursor — it is a modal state, and asking for another replaces what is on screen — so a server
+/// holding several models something that cannot exist. Asking again supersedes the previous
+/// request, whose callback is invoked as <see cref="TargetResultType.Cancelled" />, which is the
+/// truth: the player can no longer answer it.
+/// </para>
+/// </summary>
+public interface IPlayerTargetService
+{
+    /// <summary>
+    /// Raises a cursor for this session and returns the id correlating its answer. Any request
+    /// already pending is cancelled first.
+    /// </summary>
+    uint Request(PlayerSession session, TargetSelectionType selection, Action<TargetResult> onTarget);
+
+    /// <summary>
+    /// Takes the cursor down and reports the pending request as cancelled. Returns false when
+    /// nothing was pending.
+    /// </summary>
+    bool Cancel(PlayerSession session);
+
+    /// <summary>
+    /// Handles an answer from the client, returning what it was taken to mean. An answer that does
+    /// not match the session's pending request is dropped — unlike a gump's fabricated button this
+    /// is ordinary traffic, since a superseded cursor can still be clicked.
+    /// </summary>
+    TargetResultType Handle(PlayerSession session, TargetCursorResponsePacket packet);
+
+    /// <summary>Drops a session's pending request without invoking it, on logout.</summary>
+    void Forget(PlayerSession session);
+}

--- a/src/Moongate.Server.Abstractions/Types/World/TargetResultType.cs
+++ b/src/Moongate.Server.Abstractions/Types/World/TargetResultType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.Server.Abstractions.Types.World;
+
+/// <summary>What the player did with a target cursor.</summary>
+public enum TargetResultType : byte
+{
+    /// <summary>
+    /// The player dismissed the cursor, or the request was superseded by another. The common case:
+    /// a player presses Escape constantly, and a caller that ignores this acts on a serial of zero.
+    /// </summary>
+    Cancelled = 0,
+
+    /// <summary>An entity was clicked.</summary>
+    Object,
+
+    /// <summary>A spot on the ground was clicked.</summary>
+    Location
+}

--- a/src/Moongate.Server/Commands/WhereCommand.cs
+++ b/src/Moongate.Server/Commands/WhereCommand.cs
@@ -1,0 +1,97 @@
+using System.Globalization;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Attributes;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.UO.Data.Types;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Server.Commands;
+
+/// <summary>
+/// Raises a target cursor and says what was clicked, to whoever ran it.
+/// <para>
+/// The first consumer of the targeting primitive, and deliberately a probe rather than a feature:
+/// it exercises both selection modes, which is what makes it a better test of the mechanism than a
+/// command a GM would actually reach for.
+/// </para>
+/// </summary>
+[Command(
+    "where",
+    AccountLevelType.GrandMaster,
+    "Raises a target cursor and reports what was clicked.",
+    Sources = CommandSourceType.InGame
+)]
+public sealed class WhereCommand : ICommand
+{
+    private readonly IPlayerTargetService _targets;
+    private readonly ISessionManager _sessions;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+
+    public WhereCommand(
+        IPlayerTargetService targets,
+        ISessionManager sessions,
+        IPersistenceService persistenceService
+    )
+    {
+        _targets = targets;
+        _sessions = sessions;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+    }
+
+    public void Execute(CommandContext context)
+    {
+        // A console has no cursor to raise. Saying so beats raising one for nobody.
+        if (context.Actor is not { } actor)
+        {
+            context.Reply("This command needs a player: there is no cursor to raise from here.");
+
+            return;
+        }
+
+        if (SessionFor(actor.Id) is not { } session)
+        {
+            context.Reply("You are not in the world.");
+
+            return;
+        }
+
+        var reply = context.Reply;
+
+        _targets.Request(session, TargetSelectionType.Object, result => reply(Describe(result)));
+    }
+
+    private string Describe(TargetResult result)
+    {
+        if (result.IsCancelled)
+        {
+            return "Nothing targeted.";
+        }
+
+        var where = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{result.Location.X}, {result.Location.Y}, {result.Location.Z}"
+        );
+
+        if (result.Type != TargetResultType.Object)
+        {
+            return $"Ground at {where}.";
+        }
+
+        var name = _mobiles.GetById(result.Serial)?.Name;
+
+        return name is null
+            ? string.Create(CultureInfo.InvariantCulture, $"Object 0x{result.Serial.Value:X} at {where}.")
+            : string.Create(CultureInfo.InvariantCulture, $"{name} (0x{result.Serial.Value:X}) at {where}.");
+    }
+
+    private Abstractions.Data.Session.PlayerSession? SessionFor(Serial mobile)
+        => _sessions.All.FirstOrDefault(session => session.Character?.Id == mobile);
+}

--- a/src/Moongate.Server/Handlers/TargetCursorResponseHandler.cs
+++ b/src/Moongate.Server/Handlers/TargetCursorResponseHandler.cs
@@ -1,0 +1,30 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Network;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Server.Handlers;
+
+/// <summary>
+/// Hands a target answer (0x6C inbound) to the service, which is the only thing that knows what it
+/// asked for and can tell a real answer from one to a cursor that no longer exists.
+/// </summary>
+public sealed class TargetCursorResponseHandler
+    : IPacketHandler<TargetCursorResponsePacket>, IPacketHandlerRegistration
+{
+    private readonly IPlayerTargetService _targets;
+
+    public TargetCursorResponseHandler(IPlayerTargetService targets)
+    {
+        _targets = targets;
+    }
+
+    public void Handle(TargetCursorResponsePacket packet, in PacketContext context)
+    {
+        // The verdict is the service's business: it logs a mismatch and drops it.
+        _targets.Handle(context.Session, packet);
+    }
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}

--- a/src/Moongate.Server/Plugins/MoongateCommandsPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateCommandsPlugin.cs
@@ -23,10 +23,20 @@ public class MoongateCommandsPlugin : ISquidStdPlugin
         };
 
     public void Configure(IContainer container, PluginContext context)
-        => container.RegisterCommand<BroadcastCommand>(
+    {
+        container.RegisterCommand<BroadcastCommand>(
             "broadcast|bc",
             AccountLevelType.GrandMaster,
             "Sends a server-wide system message.",
             CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest
         );
+
+        // In-game only: a console has no target cursor to raise.
+        container.RegisterCommand<WhereCommand>(
+            "where",
+            AccountLevelType.GrandMaster,
+            "Raises a target cursor and reports what was clicked.",
+            CommandSourceType.InGame
+        );
+    }
 }

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -30,6 +30,7 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
         container.RegisterEventSubscriber<SpatialSubscriber>();
         container.RegisterEventSubscriber<VisibilitySubscriber>();
         container.RegisterEventSubscriber<GumpSubscriber>();
+        container.RegisterEventSubscriber<TargetSubscriber>();
         container.RegisterEventSubscriber<AccountRegistrationSubscriber>();
         container.RegisterEventSubscriber<HeldItemBounceSubscriber>();
         container.RegisterEventSubscriber<ItemScriptSubscriber>();

--- a/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
@@ -42,5 +42,6 @@ public class MoongatePacketHandlersPlugin : ISquidStdPlugin
         container.RegisterPacketHandler<PickUpItemHandler>();
         container.RegisterPacketHandler<DropItemHandler>();
         container.RegisterPacketHandler<GumpMenuSelectionHandler>();
+        container.RegisterPacketHandler<TargetCursorResponseHandler>();
     }
 }

--- a/src/Moongate.Server/Plugins/MoongateScriptModulesPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateScriptModulesPlugin.cs
@@ -62,6 +62,17 @@ public class MoongateScriptModulesPlugin : ISquidStdPlugin
             Reuse.Singleton
         );
 
+        container.RegisterDelegate(
+            resolver => new TargetResultFactory(
+                resolver.Resolve<IScriptEngineService>() is LuaScriptEngineService targetLua
+                    ? targetLua.LuaScript
+                    : throw new InvalidOperationException(
+                        "TargetResultFactory requires the SquidStd Lua engine implementation."
+                    )
+            ),
+            Reuse.Singleton
+        );
+
         container.RegisterScriptModule<AccountModule>();
         container.RegisterScriptModule<ItemModule>();
         container.RegisterScriptModule<MobileModule>();
@@ -70,8 +81,10 @@ public class MoongateScriptModulesPlugin : ISquidStdPlugin
         container.RegisterScriptModule<AiModule>();
         container.RegisterScriptModule<MemoryModule>();
         container.RegisterScriptModule<GumpModule>();
+        container.RegisterScriptModule<TargetModule>();
 
         container.RegisterScriptEnum<AccountLevelType>();
+        container.RegisterScriptEnum<TargetSelectionType>();
         container.RegisterScriptEnum<SkillName>();
         container.RegisterScriptEnum<GenderType>();
         container.RegisterScriptEnum<RaceType>();

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -196,6 +196,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IChatService, ChatService>(Reuse.Singleton);
                 container.Register<IVisibilityService, VisibilityService>(Reuse.Singleton);
+                container.Register<IPlayerTargetService, PlayerTargetService>(Reuse.Singleton);
                 container.Register<IGumpService, GumpService>(Reuse.Singleton);
                 container.Register<IServerSettingsService, ServerSettingsService>(Reuse.Singleton);
 

--- a/src/Moongate.Server/Scripting/Refs/TargetResultFactory.cs
+++ b/src/Moongate.Server/Scripting/Refs/TargetResultFactory.cs
@@ -1,0 +1,43 @@
+using Moongate.Server.Abstractions.Data.World;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Server.Scripting.Refs;
+
+/// <summary>
+/// Turns a target answer into the table the Lua callback receives.
+/// <para>
+/// A separate type from the module because it needs the MoonSharp <see cref="Script" />, which is
+/// not a container service: a script module that asks for one compiles, passes every test, and
+/// fails only when the real server tries to construct it.
+/// </para>
+/// </summary>
+public sealed class TargetResultFactory
+{
+    private readonly Script _script;
+
+    public TargetResultFactory(Script script)
+    {
+        _script = script;
+    }
+
+    /// <summary>
+    /// The answer as Lua sees it: <c>cancelled</c>, <c>type</c>, <c>serial</c>, <c>x</c>, <c>y</c>,
+    /// <c>z</c> and <c>graphic</c>. Cancellation is a named field rather than a serial of zero,
+    /// because it is the answer a player gives most often.
+    /// </summary>
+    public DynValue ToTable(TargetResult result)
+    {
+        var table = new Table(_script)
+        {
+            ["cancelled"] = result.IsCancelled,
+            ["type"] = result.Type.ToString().ToLowerInvariant(),
+            ["serial"] = result.Serial.Value,
+            ["x"] = result.Location.X,
+            ["y"] = result.Location.Y,
+            ["z"] = result.Location.Z,
+            ["graphic"] = result.Graphic
+        };
+
+        return DynValue.NewTable(table);
+    }
+}

--- a/src/Moongate.Server/Scripting/TargetModule.cs
+++ b/src/Moongate.Server/Scripting/TargetModule.cs
@@ -1,0 +1,69 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Scripting.Refs;
+using Moongate.UO.Data.Types;
+using MoonSharp.Interpreter;
+using SquidStd.Scripting.Lua.Attributes.Scripts;
+
+namespace Moongate.Server.Scripting;
+
+/// <summary>
+/// Asks the player to click something.
+/// <para>
+/// A gump asks which option; a target asks which thing. There is one cursor per player, so a new
+/// request supersedes any pending one and the superseded callback is invoked as cancelled — the
+/// script does not have to track that itself.
+/// </para>
+/// </summary>
+[ScriptModule("target", "Raise the player's target cursor and act on what they click.")]
+public sealed class TargetModule
+{
+    private readonly IPlayerTargetService _targets;
+    private readonly ISessionManager _sessions;
+    private readonly TargetResultFactory _results;
+
+    public TargetModule(IPlayerTargetService targets, ISessionManager sessions, TargetResultFactory results)
+    {
+        _targets = targets;
+        _sessions = sessions;
+        _results = results;
+    }
+
+    /// <summary>
+    /// Raises a cursor for the mobile's player. <paramref name="selection" /> is <c>"object"</c> or
+    /// <c>"location"</c>. Returns false when the serial names nobody online, or when the selection
+    /// is neither — refused rather than defaulted, because targeting the wrong kind of thing in
+    /// silence is worse than doing nothing.
+    /// </summary>
+    [ScriptFunction("request", "Raises a target cursor: target.request(serial, selection, on_target).")]
+    public bool Request(uint serial, string selection, Closure onTarget)
+    {
+        if (!ScriptEnums.TryResolve<TargetSelectionType>(selection, out var parsed))
+        {
+            return false;
+        }
+
+        if (SessionFor(serial) is not { } session)
+        {
+            return false;
+        }
+
+        _targets.Request(session, parsed, result => onTarget.Call(_results.ToTable(result)));
+
+        return true;
+    }
+
+    /// <summary>Takes the cursor down. Returns false when nothing was pending.</summary>
+    [ScriptFunction("cancel", "Cancels a pending target cursor: target.cancel(serial).")]
+    public bool Cancel(uint serial)
+        => SessionFor(serial) is { } session && _targets.Cancel(session);
+
+    private PlayerSession? SessionFor(uint serial)
+    {
+        var id = (Serial)serial;
+
+        return _sessions.All.FirstOrDefault(session => session.Character?.Id == id);
+    }
+}

--- a/src/Moongate.Server/Services/World/PlayerTargetService.cs
+++ b/src/Moongate.Server/Services/World/PlayerTargetService.cs
@@ -1,0 +1,118 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.UO.Data.Types;
+using Serilog;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Holds the one target request a session can have outstanding, and turns the client's answer into
+/// a decision rather than a packet.
+/// </summary>
+public sealed class PlayerTargetService : IPlayerTargetService
+{
+    /// <summary>
+    /// The coordinate the client sends when the player dismissed the cursor instead of picking.
+    /// </summary>
+    private const int NothingPicked = 0xFFFF;
+
+    private readonly ILogger _logger = Log.ForContext<PlayerTargetService>();
+    private readonly Dictionary<long, PendingTarget> _pending = [];
+
+    private uint _nextCursorId = 1;
+
+    public uint Request(PlayerSession session, TargetSelectionType selection, Action<TargetResult> onTarget)
+    {
+        // Superseding rather than accumulating: the client only has one cursor, so the previous
+        // request can no longer be answered and saying otherwise would be a lie.
+        Supersede(session);
+
+        var cursorId = _nextCursorId++;
+
+        _pending[session.SessionId] = new(cursorId, selection, onTarget);
+
+        session.Send(new TargetCursorPacket(cursorId, selection, TargetCursorType.Neutral));
+
+        return cursorId;
+    }
+
+    public bool Cancel(PlayerSession session)
+    {
+        if (!_pending.TryGetValue(session.SessionId, out var pending))
+        {
+            return false;
+        }
+
+        _pending.Remove(session.SessionId);
+
+        session.Send(new TargetCursorPacket(pending.CursorId, pending.Selection, TargetCursorType.Cancel));
+        pending.OnTarget(TargetResult.Cancelled);
+
+        return true;
+    }
+
+    public TargetResultType Handle(PlayerSession session, TargetCursorResponsePacket packet)
+    {
+        if (!_pending.TryGetValue(session.SessionId, out var pending) || pending.CursorId != packet.CursorId)
+        {
+            _logger.Debug(
+                "Ignoring target answer for cursor {CursorId} from session {SessionId}: nothing pending matches it",
+                packet.CursorId,
+                session.SessionId
+            );
+
+            return TargetResultType.Cancelled;
+        }
+
+        _pending.Remove(session.SessionId);
+
+        var result = Interpret(pending, packet);
+
+        pending.OnTarget(result);
+
+        return result.Type;
+    }
+
+    public void Forget(PlayerSession session)
+        => _pending.Remove(session.SessionId);
+
+    /// <summary>
+    /// Nothing picked means the player dismissed the cursor. Everything else is an object when an
+    /// entity was clicked, and a location otherwise — a location request never carries a serial.
+    /// </summary>
+    private static TargetResult Interpret(PendingTarget pending, TargetCursorResponsePacket packet)
+    {
+        if (packet.Location.X == NothingPicked)
+        {
+            return TargetResult.Cancelled;
+        }
+
+        if (packet.Clicked != Serial.Zero)
+        {
+            return new(TargetResultType.Object, packet.Clicked, packet.Location, packet.Graphic);
+        }
+
+        return new(TargetResultType.Location, Serial.Zero, packet.Location, packet.Graphic);
+    }
+
+    private void Supersede(PlayerSession session)
+    {
+        if (!_pending.Remove(session.SessionId, out var pending))
+        {
+            return;
+        }
+
+        pending.OnTarget(TargetResult.Cancelled);
+    }
+
+    private readonly record struct PendingTarget(
+        uint CursorId,
+        TargetSelectionType Selection,
+        Action<TargetResult> OnTarget
+    );
+}

--- a/src/Moongate.Server/Subscribers/TargetSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/TargetSubscriber.cs
@@ -1,0 +1,34 @@
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>
+/// Drops a session's pending target request when it goes.
+/// <para>
+/// Wired in the same change as the service on purpose. <c>IGumpService.CloseAll</c> shipped
+/// declared, implemented and documented as running on logout, with nothing calling it — a method
+/// nobody calls fails no test, so the guard against that is doing it together, not remembering to.
+/// </para>
+/// </summary>
+public sealed class TargetSubscriber : IEventSubscriberRegistration
+{
+    private readonly IPlayerTargetService _targets;
+
+    public TargetSubscriber(IPlayerTargetService targets)
+    {
+        _targets = targets;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<SessionDestroyedEvent>(OnSessionDestroyed);
+
+    public Task OnSessionDestroyed(SessionDestroyedEvent @event, CancellationToken cancellationToken)
+    {
+        _targets.Forget(@event.Session);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Moongate.UO.Data/Types/TargetCursorType.cs
+++ b/src/Moongate.UO.Data/Types/TargetCursorType.cs
@@ -1,0 +1,17 @@
+namespace Moongate.UO.Data.Types;
+
+/// <summary>
+/// How the client tints the target cursor, and the one value that is not a colour:
+/// <see cref="Cancel" /> takes the cursor down instead of raising it.
+/// </summary>
+public enum TargetCursorType : byte
+{
+    Neutral = 0,
+
+    Harmful = 1,
+
+    Beneficial = 2,
+
+    /// <summary>Sent by the server to withdraw a cursor it raised.</summary>
+    Cancel = 3
+}

--- a/src/Moongate.UO.Data/Types/TargetSelectionType.cs
+++ b/src/Moongate.UO.Data/Types/TargetSelectionType.cs
@@ -1,0 +1,11 @@
+namespace Moongate.UO.Data.Types;
+
+/// <summary>What the client is being asked to pick with a target cursor.</summary>
+public enum TargetSelectionType : byte
+{
+    /// <summary>An entity — a mobile or an item.</summary>
+    Object = 0,
+
+    /// <summary>A spot on the ground.</summary>
+    Location = 1
+}

--- a/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
+++ b/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
@@ -24,7 +24,7 @@ public class PacketDocumentationTests
 
     [Fact]
     public void AllPacketTypes_AreDiscovered()
-        => Assert.Equal(59, PacketTypes.Count);
+        => Assert.Equal(61, PacketTypes.Count);
 
     [Theory, MemberData(nameof(Packets))]
     public void DeclaredSize_MatchesThePacketLengthsTable(Type packetType)

--- a/tests/Moongate.Tests/Network/Packets/TargetPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/TargetPacketTests.cs
@@ -1,0 +1,89 @@
+using System.Buffers.Binary;
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Tests.Network.Packets;
+
+/// <summary>
+/// The same opcode in both directions, as two records. Nineteen bytes each way, and the cursor id
+/// is the whole correlation: an answer that does not carry it back cannot be matched to anything.
+/// </summary>
+public class TargetPacketTests
+{
+    [Fact]
+    public void TargetCursor_WritesNineteenBytesCarryingTheCursorId()
+    {
+        var buffer = new byte[64];
+        var writer = new SpanWriter(buffer);
+
+        new TargetCursorPacket(0x1234u, TargetSelectionType.Location, TargetCursorType.Neutral).Write(ref writer);
+
+        Assert.Equal(19, writer.Position);
+        Assert.Equal(0x6C, buffer[0]);
+        Assert.Equal((byte)TargetSelectionType.Location, buffer[1]);
+        Assert.Equal(0x1234u, BinaryPrimitives.ReadUInt32BigEndian(buffer.AsSpan(2)));
+        Assert.Equal((byte)TargetCursorType.Neutral, buffer[6]);
+    }
+
+    // Withdrawing a cursor is the same packet with the cancel type, not a different one.
+    [Fact]
+    public void TargetCursor_Cancel_UsesTheCancelCursorType()
+    {
+        var buffer = new byte[64];
+        var writer = new SpanWriter(buffer);
+
+        new TargetCursorPacket(0x1234u, TargetSelectionType.Object, TargetCursorType.Cancel).Write(ref writer);
+
+        Assert.Equal((byte)TargetCursorType.Cancel, buffer[6]);
+    }
+
+    [Fact]
+    public void TargetCursorResponse_ReadsTheClickedSerialAndLocation()
+    {
+        var reader = new SpanReader(Response(0x1234u, clicked: 0x4000_0001u, x: 100, y: 200, z: 5, graphic: 0x0EED));
+
+        var packet = TargetCursorResponsePacket.Read(ref reader);
+
+        Assert.Equal(0x1234u, packet.CursorId);
+        Assert.Equal((Serial)0x4000_0001u, packet.Clicked);
+        Assert.Equal(100, packet.Location.X);
+        Assert.Equal(200, packet.Location.Y);
+        Assert.Equal(5, packet.Location.Z);
+        Assert.Equal(0x0EED, packet.Graphic);
+    }
+
+    // What the client sends when the player presses Escape: the cursor id it was given, and
+    // nothing picked. Interpreting that is the service's job -- the packet only reports it.
+    [Fact]
+    public void TargetCursorResponse_WithNothingPicked_IsStillReadable()
+    {
+        var reader = new SpanReader(Response(0x1234u, clicked: 0u, x: 0xFFFF, y: 0xFFFF, z: 0, graphic: 0));
+
+        var packet = TargetCursorResponsePacket.Read(ref reader);
+
+        Assert.Equal(0x1234u, packet.CursorId);
+        Assert.Equal(Serial.Zero, packet.Clicked);
+    }
+
+    private static byte[] Response(uint cursorId, uint clicked, ushort x, ushort y, sbyte z, ushort graphic)
+    {
+        var buffer = new byte[19];
+        var writer = new SpanWriter(buffer);
+
+        writer.Write((byte)0x6C);
+        writer.Write((byte)TargetSelectionType.Object);
+        writer.Write(cursorId);
+        writer.Write((byte)TargetCursorType.Neutral);
+        writer.Write(clicked);
+        writer.Write(x);
+        writer.Write(y);
+        writer.Write((byte)0);
+        writer.Write((byte)z);
+        writer.Write(graphic);
+
+        return buffer;
+    }
+}

--- a/tests/Moongate.Tests/Scripting/TargetLuaTests.cs
+++ b/tests/Moongate.Tests/Scripting/TargetLuaTests.cs
@@ -1,0 +1,66 @@
+using Moongate.Core.Primitives;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.Server.Scripting.Refs;
+using MoonSharp.Interpreter;
+
+namespace Moongate.Tests.Scripting;
+
+/// <summary>
+/// The result table as Lua actually sees it. Cancelled is the case a script writer meets most
+/// often, so it has to be readable without knowing a sentinel.
+/// </summary>
+public class TargetLuaTests
+{
+    [Fact]
+    public void ObjectResult_CarriesSerialAndPosition()
+    {
+        var script = new Script();
+
+        script.Globals["r"] = new TargetResultFactory(script)
+            .ToTable(new(TargetResultType.Object, (Serial)0x4000_0001u, new(10, 20, 5), 0x0EED));
+
+        Assert.False(script.DoString("return r.cancelled").Boolean);
+        Assert.Equal((double)0x4000_0001u, script.DoString("return r.serial").Number);
+        Assert.Equal(10d, script.DoString("return r.x").Number);
+        Assert.Equal(20d, script.DoString("return r.y").Number);
+        Assert.Equal(5d, script.DoString("return r.z").Number);
+        Assert.Equal((double)0x0EED, script.DoString("return r.graphic").Number);
+    }
+
+    [Fact]
+    public void LocationResult_HasNoSerial()
+    {
+        var script = new Script();
+
+        script.Globals["r"] = new TargetResultFactory(script)
+            .ToTable(new(TargetResultType.Location, Serial.Zero, new(40, 50, 0), 0));
+
+        Assert.Equal(0d, script.DoString("return r.serial").Number);
+        Assert.Equal(40d, script.DoString("return r.x").Number);
+    }
+
+    // Readable as `r.cancelled` rather than by comparing a serial to zero, which is what a script
+    // writer would otherwise have to guess.
+    [Fact]
+    public void CancelledResult_SaysSoDirectly()
+    {
+        var script = new Script();
+
+        script.Globals["r"] = new TargetResultFactory(script).ToTable(TargetResult.Cancelled);
+
+        Assert.True(script.DoString("return r.cancelled").Boolean);
+    }
+
+    // Also readable as a string, for a script that wants to branch three ways.
+    [Fact]
+    public void Result_CarriesItsTypeAsALowercaseString()
+    {
+        var script = new Script();
+
+        script.Globals["r"] = new TargetResultFactory(script)
+            .ToTable(new(TargetResultType.Location, Serial.Zero, new(1, 2, 3), 0));
+
+        Assert.Equal("location", script.DoString("return r.type").String);
+    }
+}

--- a/tests/Moongate.Tests/Scripting/TargetModuleTests.cs
+++ b/tests/Moongate.Tests/Scripting/TargetModuleTests.cs
@@ -1,0 +1,138 @@
+using System.Net.Sockets;
+using Moongate.Core.Extensions;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.Server.Scripting;
+using Moongate.Server.Scripting.Refs;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+using MoonSharp.Interpreter;
+using SquidStd.Network.Client;
+
+namespace Moongate.Tests.Scripting;
+
+/// <summary>
+/// The module only translates: a mobile serial into a session, a selection name into an enum, and
+/// a result into a table. The service is faked so those three are what is being tested.
+/// </summary>
+public class TargetModuleTests
+{
+    [Fact]
+    public void Request_ForAnOnlineMobile_RaisesTheCursor()
+    {
+        var world = new Fixture();
+        var session = world.Session();
+
+        Assert.True(world.Module.Request(session.Character!.Id.Value, "location", world.Handler()));
+        Assert.Equal(TargetSelectionType.Location, world.Targets.LastSelection);
+    }
+
+    // A serial nobody online owns raises nothing: there is no screen to put a cursor on.
+    [Fact]
+    public void Request_ForNobodyOnline_IsFalse()
+    {
+        var world = new Fixture();
+
+        Assert.False(world.Module.Request(0xDEAD, "object", world.Handler()));
+        Assert.Null(world.Targets.LastSelection);
+    }
+
+    // Refused rather than defaulting: silently targeting the wrong kind of thing is worse than
+    // doing nothing.
+    [Fact]
+    public void Request_WithAnUnknownSelection_IsFalse()
+    {
+        var world = new Fixture();
+        var session = world.Session();
+
+        Assert.False(world.Module.Request(session.Character!.Id.Value, "sideways", world.Handler()));
+        Assert.Null(world.Targets.LastSelection);
+    }
+
+    [Fact]
+    public void TheCallbackReceivesTheResultTable()
+    {
+        var world = new Fixture();
+        var session = world.Session();
+
+        world.Module.Request(session.Character!.Id.Value, "location", world.Handler("seen = r.x"));
+        world.Targets.Answer(new(TargetResultType.Location, default, new(42, 7, 0), 0));
+
+        Assert.Equal(42d, world.Script.Globals.Get("seen").Number);
+    }
+
+    [Fact]
+    public void Cancel_ForAnOnlineMobile_DelegatesToTheService()
+    {
+        var world = new Fixture();
+        var session = world.Session();
+
+        Assert.True(world.Module.Cancel(session.Character!.Id.Value));
+    }
+
+    private sealed class Fixture
+    {
+        private readonly FakePersistenceService _persistence = new();
+        private readonly StubSessionManager _sessions = new();
+
+        public Fixture()
+        {
+            Script = new();
+            Targets = new();
+            Module = new(Targets, _sessions, new TargetResultFactory(Script));
+        }
+
+        public Script Script { get; }
+
+        public RecordingTargetService Targets { get; }
+
+        public TargetModule Module { get; }
+
+        /// <summary>A Lua closure running <paramref name="body" /> with the result bound to `r`.</summary>
+        public Closure Handler(string body = "")
+            => Script.DoString($"return function(r) {body} end").Function;
+
+        public PlayerSession Session()
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var session = new PlayerSession(new SquidStdTcpClient(socket, Stream.Null));
+            var mobile = new MobileEntity { Name = "Squid", MapId = 1, Position = new(1, 1, 0) };
+
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+            session.SetCharacter(mobile);
+            _sessions.Connections.Add(session);
+
+            return session;
+        }
+    }
+
+    private sealed class RecordingTargetService : IPlayerTargetService
+    {
+        private Action<TargetResult>? _onTarget;
+
+        public TargetSelectionType? LastSelection { get; private set; }
+
+        public void Answer(TargetResult result)
+            => _onTarget?.Invoke(result);
+
+        public uint Request(PlayerSession session, TargetSelectionType selection, Action<TargetResult> onTarget)
+        {
+            LastSelection = selection;
+            _onTarget = onTarget;
+
+            return 1;
+        }
+
+        public bool Cancel(PlayerSession session)
+            => true;
+
+        public TargetResultType Handle(PlayerSession session, TargetCursorResponsePacket packet)
+            => TargetResultType.Cancelled;
+
+        public void Forget(PlayerSession session) { }
+    }
+}

--- a/tests/Moongate.Tests/Server/Commands/WhereCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/WhereCommandTests.cs
@@ -1,0 +1,155 @@
+using System.Net.Sockets;
+using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.Server.Commands;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Client;
+
+namespace Moongate.Tests.Server.Commands;
+
+/// <summary>
+/// The first consumer of the target cursor. What it says goes to whoever ran it — a reply, not a
+/// broadcast. The service is faked here because the command's job is raising a cursor and putting
+/// the answer into words, not correlating cursor ids.
+/// </summary>
+public class WhereCommandTests
+{
+    [Fact]
+    public void Execute_RaisesAnObjectCursorForTheCaller()
+    {
+        var world = new Fixture();
+        var session = world.Session();
+
+        world.Command.Execute(Context(session.Character));
+
+        Assert.Equal(TargetSelectionType.Object, world.Targets.LastSelection);
+    }
+
+    [Fact]
+    public void Execute_AnEntityWasClicked_NamesIt()
+    {
+        var world = new Fixture();
+        var replies = new List<string>();
+        var clicked = world.Mobile("Lord British");
+
+        world.Command.Execute(Context(world.Session().Character, replies.Add));
+        world.Targets.Answer(new(TargetResultType.Object, clicked.Id, new(100, 200, 5), 0));
+
+        Assert.Contains(replies, r => r.Contains("Lord British") && r.Contains("100"));
+    }
+
+    [Fact]
+    public void Execute_GroundWasClicked_ReportsTheCoordinates()
+    {
+        var world = new Fixture();
+        var replies = new List<string>();
+
+        world.Command.Execute(Context(world.Session().Character, replies.Add));
+        world.Targets.Answer(new(TargetResultType.Location, Serial.Zero, new(40, 50, 0), 0));
+
+        Assert.Contains(replies, r => r.Contains("40") && r.Contains("50"));
+    }
+
+    // Escape is the common answer, and saying nothing would leave the player wondering whether the
+    // command was broken.
+    [Fact]
+    public void Execute_ThePlayerCancelled_SaysSo()
+    {
+        var world = new Fixture();
+        var replies = new List<string>();
+
+        world.Command.Execute(Context(world.Session().Character, replies.Add));
+        world.Targets.Answer(TargetResult.Cancelled);
+
+        Assert.NotEmpty(replies);
+    }
+
+    // A console has no cursor to raise, so the command must say that rather than fail oddly.
+    [Fact]
+    public void Execute_WithNoActor_ExplainsAndRaisesNothing()
+    {
+        var world = new Fixture();
+        var replies = new List<string>();
+
+        world.Command.Execute(new(CommandSourceType.Console, null, [], replies.Add));
+
+        Assert.NotEmpty(replies);
+        Assert.Null(world.Targets.LastSelection);
+    }
+
+    private static CommandContext Context(MobileEntity? actor, Action<string>? reply = null)
+        => new(CommandSourceType.InGame, actor, [], reply ?? (_ => { }));
+
+    private sealed class Fixture
+    {
+        private readonly FakePersistenceService _persistence = new();
+        private readonly StubSessionManager _sessions = new();
+
+        public Fixture()
+        {
+            Targets = new();
+            Command = new(Targets, _sessions, _persistence);
+        }
+
+        public RecordingTargetService Targets { get; }
+
+        public WhereCommand Command { get; }
+
+        public PlayerSession Session()
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var session = new PlayerSession(new SquidStdTcpClient(socket, Stream.Null));
+
+            session.SetCharacter(Mobile("Squid"));
+            _sessions.Connections.Add(session);
+
+            return session;
+        }
+
+        public MobileEntity Mobile(string name)
+        {
+            var mobile = new MobileEntity { Name = name, MapId = 1, Position = new(1, 1, 0) };
+
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+            return mobile;
+        }
+    }
+
+    /// <summary>Captures the request so a test can answer it, without correlating cursor ids.</summary>
+    private sealed class RecordingTargetService : IPlayerTargetService
+    {
+        private Action<TargetResult>? _onTarget;
+
+        public TargetSelectionType? LastSelection { get; private set; }
+
+        public void Answer(TargetResult result)
+            => _onTarget?.Invoke(result);
+
+        public uint Request(PlayerSession session, TargetSelectionType selection, Action<TargetResult> onTarget)
+        {
+            LastSelection = selection;
+            _onTarget = onTarget;
+
+            return 1;
+        }
+
+        public bool Cancel(PlayerSession session)
+            => false;
+
+        public TargetResultType Handle(PlayerSession session, TargetCursorResponsePacket packet)
+            => TargetResultType.Cancelled;
+
+        public void Forget(PlayerSession session) { }
+    }
+}

--- a/tests/Moongate.Tests/Server/World/PlayerTargetServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/PlayerTargetServiceTests.cs
@@ -1,0 +1,149 @@
+using System.Net.Sockets;
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Types.World;
+using Moongate.Server.Services.World;
+using Moongate.UO.Data.Types;
+using SquidStd.Network.Client;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// One pending request per session, which is what the client can actually show. The test that
+/// matters most is the superseding one: it is what stands in for moongatev2's whole expiry
+/// dictionary and sweep timer.
+/// </summary>
+public class PlayerTargetServiceTests
+{
+    [Fact]
+    public void Request_ReturnsACursorIdAndRecordsThePending()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+
+        var cursorId = service.Request(session, TargetSelectionType.Object, _ => { });
+
+        Assert.NotEqual(0u, cursorId);
+    }
+
+    [Fact]
+    public void Handle_WithTheMatchingId_InvokesTheCallbackAndClearsIt()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+        TargetResult? seen = null;
+
+        var cursorId = service.Request(session, TargetSelectionType.Object, r => seen = r);
+
+        Assert.Equal(TargetResultType.Object, service.Handle(session, Clicked(cursorId, 0x4000_0001u, 10, 20, 5)));
+        Assert.Equal((Serial)0x4000_0001u, seen!.Value.Serial);
+        Assert.Equal(10, seen.Value.Location.X);
+
+        // Answered once: a second answer to the same cursor finds nothing pending.
+        Assert.Equal(TargetResultType.Cancelled, service.Handle(session, Clicked(cursorId, 0x4000_0001u, 10, 20, 5)));
+    }
+
+    // A stale answer is what an ordinary client produces when a request was superseded, so it is
+    // dropped rather than treated as tampering. No disconnect, unlike a gump's undrawn button.
+    [Fact]
+    public void Handle_WithAnIdThatIsNotPending_IsDropped()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+        var called = false;
+
+        service.Request(session, TargetSelectionType.Object, _ => called = true);
+
+        Assert.Equal(TargetResultType.Cancelled, service.Handle(session, Clicked(999u, 0x4000_0001u, 1, 1, 0)));
+        Assert.False(called);
+    }
+
+    // This replaces v2's expiry dictionary and its sweep timer: there is only ever one.
+    [Fact]
+    public void Request_WhileOneIsPending_CancelsTheFirst()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+        TargetResult? first = null;
+
+        var firstId = service.Request(session, TargetSelectionType.Object, r => first = r);
+        service.Request(session, TargetSelectionType.Location, _ => { });
+
+        Assert.True(first!.Value.IsCancelled);
+
+        // And the superseded cursor's answer no longer matches anything.
+        Assert.Equal(TargetResultType.Cancelled, service.Handle(session, Clicked(firstId, 0x4000_0001u, 1, 1, 0)));
+    }
+
+    // What the client sends on Escape. Reporting it as an object at serial zero would be worse
+    // than useless: callers would act on nothing.
+    [Fact]
+    public void Handle_ANothingPickedAnswer_IsCancelledRatherThanAnObject()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+        TargetResult? seen = null;
+
+        var cursorId = service.Request(session, TargetSelectionType.Object, r => seen = r);
+
+        Assert.Equal(TargetResultType.Cancelled, service.Handle(session, Cancelled(cursorId)));
+        Assert.True(seen!.Value.IsCancelled);
+    }
+
+    [Fact]
+    public void Handle_ALocationRequest_ReportsLocationEvenWithNoEntityClicked()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+
+        var cursorId = service.Request(session, TargetSelectionType.Location, _ => { });
+
+        Assert.Equal(TargetResultType.Location, service.Handle(session, Clicked(cursorId, 0u, 40, 50, 0)));
+    }
+
+    [Fact]
+    public void Cancel_ReportsTheRequestCancelledAndClearsIt()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+        TargetResult? seen = null;
+
+        service.Request(session, TargetSelectionType.Object, r => seen = r);
+
+        Assert.True(service.Cancel(session));
+        Assert.True(seen!.Value.IsCancelled);
+        Assert.False(service.Cancel(session));
+    }
+
+    // Logout drops it silently: there is nobody left to tell.
+    [Fact]
+    public void Forget_DropsThePendingWithoutInvokingIt()
+    {
+        var service = new PlayerTargetService();
+        var session = Session();
+        var called = false;
+
+        var cursorId = service.Request(session, TargetSelectionType.Object, _ => called = true);
+
+        service.Forget(session);
+
+        Assert.False(called);
+        Assert.Equal(TargetResultType.Cancelled, service.Handle(session, Clicked(cursorId, 0x4000_0001u, 1, 1, 0)));
+    }
+
+    private static TargetCursorResponsePacket Clicked(uint cursorId, uint serial, int x, int y, int z)
+        => new(cursorId, TargetSelectionType.Object, new(serial), new(x, y, z), 0);
+
+    private static TargetCursorResponsePacket Cancelled(uint cursorId)
+        => new(cursorId, TargetSelectionType.Object, Serial.Zero, new(0xFFFF, 0xFFFF, 0), 0);
+
+    private static PlayerSession Session()
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+        return new(new SquidStdTcpClient(socket, Stream.Null));
+    }
+}


### PR DESCRIPTION
Closes #160. Trello #65.

`0x6C` was declared bidirectional in the packet tables and nothing implemented it, so every GM
command and every future spell had nothing to build on. A gump asks *which option*; a target
asks *which thing*.

```lua
target.request(player, "object", function(r)
    if r.cancelled then return end
    chat.say(player, "you clicked " .. r.serial)
end)
```

## Three decisions worth the words

**Two records for one opcode.** This is the first packet implemented in both directions —
thirty-three are declared bidirectional and none had a record. The infrastructure assumes one
direction each: the interfaces differ and the docs generator files pages by them. Two records
keep every existing rule true instead of teaching the generator about a page facing both ways.

**One pending request per session, not a keyed collection.** moongatev2 kept a
`ConcurrentDictionary` of pending cursors with a five-minute expiry and a sweep timer commented
*"maybe the client is dead?"*. But a UO client has a **single** cursor — it is a modal state,
and asking for another replaces what is on screen — so a collection models something that
cannot exist. Holding one per session removed the dictionary, the expiry, the timer and that
whole case; a superseded request has its callback invoked as cancelled, which is the truth.

**A stale answer is dropped, not a disconnect.** Unlike a gump's undrawn button, an answer to a
superseded cursor is what an ordinary client produces. Expected traffic, not tampering.

## Also

- The callback gets an **interpreted result** rather than the raw packet. `cancelled` is
  first-class because players produce it constantly with Escape, and reporting it as an object
  at serial zero would have callers acting on nothing.
- `.where` is the first consumer and only the **second command in the server** after
  `BroadcastCommand`. Deliberately a probe: it exercises both selection modes, which makes it a
  better test of the mechanism than a command a GM would actually reach for.
- `Forget` is wired to `SessionDestroyedEvent` **in the same commit as the service**.
  `IGumpService.CloseAll` shipped declared, documented and never called (#156); the guard
  against repeating that is doing both together, not remembering to come back.

## Verification

- 2010 tests. The boot smoke is what proves `TargetModule` can actually be constructed — it
  holds the result factory rather than a `Script`, which is not a container service and which
  passed the entire suite while failing the real boot when `GumpModule` did it.
- Every new interface method checked for a **production** caller, not just a test one.
- `dotnet docfx docs/docfx.json --warningsAsErrors` — 0 warnings; 61 packet pages.

## Not verified by me

Whether the client draws the cursor and what exactly it sends on Escape. The service turns
"nothing picked" into `Cancelled` from the coordinates the client reports; that shape is taken
from v2 and should be confirmed with a real client before this is leaned on.

Also note #161: this branch flakes ~20% in the full suite where `develop` does not, on tests it
does not touch. The standing hypothesis is that adding a test class shifts xUnit's parallel
schedule and exposes a latent race; it is not proven, and it is not caused by anything here
that runs.