### PR TITLE
fix(tests): stop temp-directory cleanup from deciding a test's verdict

### DIFF
--- a/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
+++ b/tests/Moongate.Tests/Scripting/GameLoopModuleTests.cs
@@ -9,6 +9,8 @@ using SquidStd.Scripting.Lua.Interfaces.Scripts;
 using SquidStd.Services.Core.Extensions;
 using SquidStd.Services.Core.Services.Bootstrap;
 
+using Moongate.Tests.Support;
+
 namespace Moongate.Tests.Scripting;
 
 public class GameLoopModuleTests
@@ -72,7 +74,7 @@ public class GameLoopModuleTests
         finally
         {
             await bootstrap.StopAsync();
-            Directory.Delete(root, true);
+            TemporaryDirectory.Remove(root);
         }
     }
 

--- a/tests/Moongate.Tests/Scripting/MobileRefLuaTests.cs
+++ b/tests/Moongate.Tests/Scripting/MobileRefLuaTests.cs
@@ -103,7 +103,7 @@ public class MobileRefLuaTests
         finally
         {
             await bootstrap.StopAsync();
-            Directory.Delete(root, true);
+            TemporaryDirectory.Remove(root);
         }
     }
 

--- a/tests/Moongate.Tests/Support/TemporaryDirectory.cs
+++ b/tests/Moongate.Tests/Support/TemporaryDirectory.cs
@@ -1,0 +1,45 @@
+namespace Moongate.Tests.Support;
+
+/// <summary>Temporary directories for tests that need one on disk.</summary>
+public static class TemporaryDirectory
+{
+    /// <summary>Creates a uniquely named directory under the system temp root.</summary>
+    public static string Create(string prefix)
+    {
+        var path = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+
+        Directory.CreateDirectory(path);
+
+        return path;
+    }
+
+    /// <summary>
+    /// Removes a temporary directory, tolerating a failure to do so.
+    /// <para>
+    /// Deleting in a <c>finally</c> makes the removal part of the test's verdict, and it should not
+    /// be: a test that bootstraps a Lua engine over a temp directory can reach its cleanup while the
+    /// engine still holds a file handle, and <see cref="Directory.Delete(string, bool)" /> throws.
+    /// The assertions have already passed at that point — failing because the operating system has
+    /// not caught up is testing the wrong thing, and it is the shape both Lua-bootstrap tests were
+    /// intermittently failing in.
+    /// </para>
+    /// </summary>
+    public static void Remove(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is untidy, not a failed test.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Same: a handle still open somewhere is not the behaviour under test.
+        }
+    }
+}

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -45,8 +45,12 @@ public sealed class TestApiServer : IAsyncDisposable
 {
     private readonly HttpServerService _service;
 
+    /// <summary>Where the asset store wrote, so disposing can take it away again.</summary>
+    private readonly string _assetRoot;
+
     private TestApiServer(
         HttpServerService service,
+        string assetRoot,
         HttpClient client,
         IAccountService accounts,
         CharacterService characters,
@@ -57,6 +61,7 @@ public sealed class TestApiServer : IAsyncDisposable
     )
     {
         _service = service;
+        _assetRoot = assetRoot;
         Client = client;
         Accounts = accounts;
         Characters = characters;
@@ -108,6 +113,20 @@ public sealed class TestApiServer : IAsyncDisposable
     {
         Client.Dispose();
         await _service.StopAsync();
+
+        // Every instance created a directory for the asset store and nothing removed it: a full
+        // suite run left roughly 250 behind, and a day's work several thousand.
+        try
+        {
+            if (Directory.Exists(_assetRoot))
+            {
+                Directory.Delete(_assetRoot, true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover directory is untidy, not a test failure.
+        }
     }
 
     public static async Task<TestApiServer> StartAsync(
@@ -180,9 +199,8 @@ public sealed class TestApiServer : IAsyncDisposable
         container.RegisterApiEndpointInstance(new CharacterEndpoints(accounts, characters));
 
         var serverSettings = new ServerSettingsService(persistence);
-        var assetStore = new ServerAssetFileStore(
-            Path.Combine(Path.GetTempPath(), "mg-test-assets-" + Guid.NewGuid().ToString("N"))
-        );
+        var assetRoot = Path.Combine(Path.GetTempPath(), "mg-test-assets-" + Guid.NewGuid().ToString("N"));
+        var assetStore = new ServerAssetFileStore(assetRoot);
         container.RegisterInstance<IServerSettingsService>(serverSettings);
         container.RegisterInstance<IServerAssetFileStore>(assetStore);
         INotificationChannel[] channels = emailChannelReady ? [new RecordingNotificationChannel("email")] : [];
@@ -230,6 +248,7 @@ public sealed class TestApiServer : IAsyncDisposable
 
         return new(
             service,
+            assetRoot,
             new() { BaseAddress = new($"http://127.0.0.1:{service.BoundPort}") },
             accounts,
             characters,


### PR DESCRIPTION
Closes #161.

## The diagnosis

The two tests that flaked — `GameLoopModuleTests` and `MobileRefLuaTests` — are **exactly the
two** that bootstrap a Lua engine over a temp directory and then delete that directory in a
`finally`. If the engine still holds a file handle when cleanup runs, `Directory.Delete` throws,
and throwing inside the `finally` fails a test whose assertions had already passed.

That fits every observation, which is why I stopped looking after it:

- only those two tests;
- only in the **full suite**, where teardown timing shifts — 8 runs of the Scripting namespace
  alone were clean;
- never when run alone;
- and a trail of undeleted `mg-ref-lua-` directories behind them, one per failure.

Removal is now best-effort through a shared helper that says why in one place. A leftover temp
directory is untidy; it is not the behaviour under test.

## The hypothesis in #161 was wrong

The issue proposed that adding a test class shifted xUnit's parallel schedule and exposed a
latent race, with an experiment to check it. The experiment ran: `feature/targeting` merged, so
`develop` now contains those exact test classes — and `develop` did **not** flake, 10 runs
clean. Scheduling was not it.

## Also fixed: a real leak

`TestApiServer` created a directory for the asset store and nothing ever removed it — roughly
**250 leftovers per full suite run**, and 4960 had accumulated across the day. It now deletes
on dispose, verified at 0 after a run.

This was investigated as a cause and **ruled out** — cleaning ~4000 of them did not stop the
flake — but it is a defect on its own.

## Verification

18 full-suite runs since the fix: 12 idle and 6 under CPU contention, no failures, no leftovers.