### PR TITLE
feat(images): a real character's figure and paperdoll

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -389,6 +389,22 @@ order. Pass `background=false` to drop the backdrop. A template with
 `Gender: Random` renders as male, the same "pick one and stick to it"
 determinism hue ranges get from `LowestHue`.
 
+The same two pictures exist for a **real character** rather than a template:
+`GET /api/v1/images/mobiles/{serial}.png` and
+`GET /api/v1/images/mobiles/{serial}/paperdoll.png` show what that character is
+actually wearing. There are no hue specs to resolve here — a real mobile carries
+hues that are already resolved.
+
+Their cache is **content-addressed**: the file is named with a fingerprint of the
+appearance, so changing clothes writes a new picture instead of invalidating an
+old one, and two characters dressed alike share a file. That fingerprint is also
+the **ETag**, which is why the URL never changes: a client that already has the
+current look revalidates and gets `304` with no body, at the cost of a string
+comparison rather than a render.
+
+Pictures nobody has asked for in seven days are swept, and re-rendered if asked
+for again.
+
 Three staff routes support the pickers and the cache:
 `GET /api/v1/admin/bodies` pages the classified bodies (mobtypes.txt,
 Equipment excluded, decimal or hex search); `GET /api/v1/admin/hair-styles`

--- a/plugins/Moongate.Http.Plugin/Data/Mobiles/MobileImage.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Mobiles/MobileImage.cs
@@ -1,0 +1,9 @@
+namespace Moongate.Http.Plugin.Data.Mobiles;
+
+/// <summary>
+/// A rendered image and the fingerprint it was rendered from. The hash travels with the path
+/// because the route needs it as an ETag, and recomputing it there would be doing the work twice.
+/// </summary>
+/// <param name="Path">Where the PNG sits in the cache.</param>
+/// <param name="Hash">The appearance fingerprint: the file's name, and the ETag.</param>
+public sealed record MobileImage(string Path, string Hash);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileCharacterImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileCharacterImageEndpoints.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Net.Http.Headers;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+
+namespace Moongate.Http.Plugin.Endpoints.Mobiles;
+
+/// <summary>Public PNG views of a real character, wearing what they actually wear.</summary>
+public sealed class MobileCharacterImageEndpoints : IApiEndpointRegistration
+{
+    private readonly IMobileCharacterImageService _images;
+
+    public MobileCharacterImageEndpoints(IMobileCharacterImageService images)
+    {
+        _images = images;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/images/mobiles/{serial:long}.png", GetFigure)
+              .WithName("GetMobileCharacterImage")
+              .WithTags("mobiles")
+              .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+
+        routes.MapGet("/api/v1/images/mobiles/{serial:long}/paperdoll.png", GetPaperdoll)
+              .WithName("GetMobileCharacterPaperdoll")
+              .WithTags("mobiles")
+              .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
+    }
+
+    /// <summary>Serves a character's dressed figure as PNG: body, hair and the items they are wearing.</summary>
+    /// <remarks>
+    /// The ETag is a fingerprint of the appearance, so a client that already has the current look gets
+    /// 304 without a body. 404 when the serial names no mobile, or when its body has no animation.
+    /// </remarks>
+    private async Task<IResult> GetFigure(long serial, HttpRequest request, CancellationToken cancellationToken)
+        => Respond(await _images.GetFigureAsync((Serial)(uint)serial, cancellationToken), request);
+
+    /// <summary>Serves a character's paperdoll as PNG, with the equipment they are wearing.</summary>
+    /// <remarks>
+    /// Pass <c>background=false</c> for the doll without its backdrop. The ETag is a fingerprint of
+    /// the appearance, so an unchanged character gets 304 without a body.
+    /// </remarks>
+    private async Task<IResult> GetPaperdoll(
+        long serial,
+        HttpRequest request,
+        CancellationToken cancellationToken,
+        bool background = true
+    )
+        => Respond(await _images.GetPaperdollAsync((Serial)(uint)serial, background, cancellationToken), request);
+
+    /// <summary>
+    /// The one HTTP decision this endpoint makes: hand back the file, or say the caller already has
+    /// it. Comparing the fingerprint costs a string comparison where the alternative is a download.
+    /// </summary>
+    private static IResult Respond(MobileImage? image, HttpRequest request)
+    {
+        if (image is null)
+        {
+            return Results.Problem("No renderable image for that mobile.", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        var tag = new EntityTagHeaderValue($"\"{image.Hash}\"");
+
+        if (request.Headers.IfNoneMatch.Any(value => value == tag.ToString()))
+        {
+            return Results.StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        return Results.File(image.Path, "image/png", entityTag: tag);
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Interfaces/Mobiles/IMobileCharacterImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Interfaces/Mobiles/IMobileCharacterImageService.cs
@@ -1,0 +1,25 @@
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Mobiles;
+
+namespace Moongate.Http.Plugin.Interfaces.Mobiles;
+
+/// <summary>
+/// Images of a real character, wearing what they actually wear.
+/// <para>
+/// The cache is content-addressed: a file is named with the fingerprint of the appearance it
+/// shows, so changing clothes produces a different file and there is nothing to invalidate. Two
+/// characters dressed alike share one.
+/// </para>
+/// </summary>
+public interface IMobileCharacterImageService
+{
+    /// <summary>The dressed figure, or null when the serial names no mobile or its body cannot be drawn.</summary>
+    Task<MobileImage?> GetFigureAsync(Serial serial, CancellationToken cancellationToken = default);
+
+    /// <summary>The paperdoll, or null when the serial names no mobile.</summary>
+    Task<MobileImage?> GetPaperdollAsync(
+        Serial serial,
+        bool includeBackground,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -103,6 +103,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.Register<IPaperdollRenderer, PaperdollRenderer>(Reuse.Singleton);
         container.Register<IPaperdollImageService, PaperdollImageService>(Reuse.Singleton);
         container.Register<IMobileCharacterImageService, MobileCharacterImageService>(Reuse.Singleton);
+        container.RegisterStdService<CharacterImageCacheSweeper, CharacterImageCacheSweeper>();
         container.RegisterApiEndpoint<PaperdollEndpoints>();
         container.RegisterApiEndpoint<MobileCharacterImageEndpoints>();
 

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -102,7 +102,9 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.Register<IGumpCatalog, GumpCatalog>(Reuse.Singleton);
         container.Register<IPaperdollRenderer, PaperdollRenderer>(Reuse.Singleton);
         container.Register<IPaperdollImageService, PaperdollImageService>(Reuse.Singleton);
+        container.Register<IMobileCharacterImageService, MobileCharacterImageService>(Reuse.Singleton);
         container.RegisterApiEndpoint<PaperdollEndpoints>();
+        container.RegisterApiEndpoint<MobileCharacterImageEndpoints>();
 
         // The game-facing groups consume the contracts in Moongate.Server.Abstractions, which the
         // server implements — the plugin never sees Moongate.Server itself.

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/CharacterImageCacheSweeper.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/CharacterImageCacheSweeper.cs
@@ -1,0 +1,90 @@
+using Moongate.Core.Interfaces;
+using Serilog;
+using SquidStd.Abstractions.Interfaces.Services;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Takes away character images nobody has looked at for a while.
+/// <para>
+/// Content addressing is what removes the need to invalidate anything, and this is its price: a
+/// character who changes clothes leaves the previous picture behind. Unbounded growth proportional
+/// to outfit changes is the same shape as any other leak, so it is swept rather than accepted.
+/// </para>
+/// </summary>
+public sealed class CharacterImageCacheSweeper : ISquidStdService
+{
+    private const string TimerName = "character-image-sweep";
+    private const string CacheDirectory = "cache/images/characters";
+
+    /// <summary>How long a picture survives without being served. A swept one is simply re-rendered.</summary>
+    private static readonly TimeSpan Window = TimeSpan.FromDays(7);
+
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(6);
+
+    private readonly ILogger _logger = Log.ForContext<CharacterImageCacheSweeper>();
+    private readonly string _cachePath;
+    private readonly IGameLoopContext? _loop;
+
+    public CharacterImageCacheSweeper(DirectoriesConfig directories, IGameLoopContext? loop = null)
+    {
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+        _loop = loop;
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _loop?.ScheduleRepeating(TimerName, Interval, () => Sweep());
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+        => ValueTask.CompletedTask;
+
+    /// <summary>
+    /// Removes pictures untouched for longer than the window, and returns how many went. Public so a
+    /// test can drive one beat without waiting on the timer.
+    /// </summary>
+    /// <remarks>
+    /// It reads last-*write* time on purpose, and the image service touches a file when it serves one
+    /// from cache: last-access time is disabled or coarsened on many mounts, so a picture in daily
+    /// use could otherwise look untouched for a week on a host mounted in a way we do not control.
+    /// </remarks>
+    public int Sweep()
+    {
+        if (!Directory.Exists(_cachePath))
+        {
+            return 0;
+        }
+
+        var cutoff = DateTime.UtcNow - Window;
+        var removed = 0;
+
+        foreach (var path in Directory.EnumerateFiles(_cachePath, "*.png"))
+        {
+            if (File.GetLastWriteTimeUtc(path) > cutoff)
+            {
+                continue;
+            }
+
+            try
+            {
+                File.Delete(path);
+                removed++;
+            }
+            catch (IOException)
+            {
+                // Being read as it is swept is untidy, not a failure: it will go next time.
+            }
+        }
+
+        if (removed > 0)
+        {
+            _logger.Debug("Swept {Count} character image(s) unread for more than {Days} days", removed, Window.Days);
+        }
+
+        return removed;
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileAppearanceHash.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileAppearanceHash.cs
@@ -14,6 +14,11 @@ public static class MobileAppearanceHash
     /// <summary>
     /// FNV-1a over the appearance, with worn items ordered by layer so an outfit hashes the same
     /// however the store hands it back.
+    /// <para>
+    /// Items are fingerprinted by <c>TemplateId</c> and not <c>ItemId</c>, because the template id is
+    /// what the renderer is given: hashing the art id would sign something the picture does not
+    /// depend on while leaving out something it does.
+    /// </para>
     /// </summary>
     /// <remarks>
     /// Deliberately not <c>string.GetHashCode</c>, which is randomised per process: a cache key that
@@ -34,7 +39,7 @@ public static class MobileAppearanceHash
         {
             builder.Append(
                 CultureInfo.InvariantCulture,
-                $"|{(int)item.EquippedLayer!.Value}:{item.ItemId}:{item.Hue.Value}"
+                $"|{(int)item.EquippedLayer!.Value}:{item.TemplateId}:{item.Hue.Value}"
             );
         }
 

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileAppearanceHash.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileAppearanceHash.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using System.Text;
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// A stable fingerprint of everything visible about a mobile. It is the cache file's name and the
+/// response's ETag, which is what makes a change of clothes a new file rather than a cache to
+/// invalidate.
+/// </summary>
+public static class MobileAppearanceHash
+{
+    /// <summary>
+    /// FNV-1a over the appearance, with worn items ordered by layer so an outfit hashes the same
+    /// however the store hands it back.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>string.GetHashCode</c>, which is randomised per process: a cache key that
+    /// changed between restarts would silently re-render everything after every boot.
+    /// </remarks>
+    public static string Of(MobileEntity mobile, IReadOnlyList<ItemEntity> equipped)
+    {
+        var builder = new StringBuilder();
+
+        builder.Append(
+            CultureInfo.InvariantCulture,
+            $"{mobile.Body}|{mobile.SkinHue.Value}|{mobile.HairStyle}|{mobile.HairHue.Value}|{mobile.FacialHairStyle}|{mobile.FacialHairHue.Value}"
+        );
+
+        // Anything not on a layer is carried rather than worn, and cannot be seen.
+        foreach (var item in equipped.Where(worn => worn.EquippedLayer is not null)
+                                     .OrderBy(worn => (int)worn.EquippedLayer!.Value))
+        {
+            builder.Append(
+                CultureInfo.InvariantCulture,
+                $"|{(int)item.EquippedLayer!.Value}:{item.ItemId}:{item.Hue.Value}"
+            );
+        }
+
+        return Fnv(builder.ToString());
+    }
+
+    private static string Fnv(string value)
+    {
+        const uint offset = 2166136261;
+        const uint prime = 16777619;
+
+        var hash = offset;
+
+        foreach (var b in Encoding.UTF8.GetBytes(value))
+        {
+            hash = (hash ^ b) * prime;
+        }
+
+        return hash.ToString("x8", CultureInfo.InvariantCulture);
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileCharacterImageService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Mobiles/MobileCharacterImageService.cs
@@ -1,0 +1,166 @@
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Ultima;
+using Moongate.Persistence.Entities;
+using Moongate.Ultima.Imaging;
+using Moongate.UO.Data.Types;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using SquidStd.Core.Directories;
+using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
+
+namespace Moongate.Http.Plugin.Services.Mobiles;
+
+/// <summary>
+/// Images of a real character, cached by what they look like rather than by who they are.
+/// <para>
+/// The file is named with the appearance fingerprint, so a change of clothes writes a new file and
+/// leaves the old one alone — there is no invalidation to get wrong, and no path by which a
+/// picture can be confidently out of date. Two characters dressed alike share a file.
+/// </para>
+/// <para>
+/// Unlike the template services there is no <c>LowestHue</c> resolution here: a template carries
+/// hue *specs*, a real mobile carries hues that are already resolved.
+/// </para>
+/// </summary>
+public sealed class MobileCharacterImageService : IMobileCharacterImageService
+{
+    private const string CacheDirectory = "cache/images/characters";
+
+    private readonly IMobileFigureRenderer _figures;
+    private readonly IPaperdollRenderer _paperdolls;
+    private readonly IEntityStore<MobileEntity, Serial> _mobiles;
+    private readonly IItemService _items;
+    private readonly IUltimaReadGate _gate;
+    private readonly string _cachePath;
+
+    public MobileCharacterImageService(
+        IMobileFigureRenderer figures,
+        IPaperdollRenderer paperdolls,
+        IPersistenceService persistenceService,
+        IItemService items,
+        DirectoriesConfig directories,
+        IUltimaReadGate gate
+    )
+    {
+        _figures = figures;
+        _paperdolls = paperdolls;
+        _mobiles = persistenceService.GetStore<MobileEntity, Serial>();
+        _items = items;
+        _gate = gate;
+        _cachePath = directories.RegisterDirectory(CacheDirectory);
+    }
+
+    public async Task<MobileImage?> GetFigureAsync(Serial serial, CancellationToken cancellationToken = default)
+    {
+        if (_mobiles.GetById(serial) is not { } mobile)
+        {
+            return null;
+        }
+
+        var equipped = _items.GetEquipped(mobile).ToList();
+        var hash = MobileAppearanceHash.Of(mobile, equipped);
+        var path = Path.Combine(_cachePath, $"{hash}.png");
+
+        if (Cached(path))
+        {
+            return new(path, hash);
+        }
+
+        var request = new MobileFigureRequest(
+            mobile.Body,
+            mobile.SkinHue.Value,
+            mobile.HairStyle,
+            mobile.HairHue.Value,
+            mobile.FacialHairStyle,
+            mobile.FacialHairHue.Value,
+            [.. equipped.Where(worn => worn.EquippedLayer is not null)
+                        .Select(worn => new MobileFigureEquipment(worn.TemplateId, worn.Hue.Value))]
+        );
+
+        return await RenderAsync(() => _figures.Render(request), path, hash, cancellationToken);
+    }
+
+    public async Task<MobileImage?> GetPaperdollAsync(
+        Serial serial,
+        bool includeBackground,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (_mobiles.GetById(serial) is not { } mobile)
+        {
+            return null;
+        }
+
+        var equipped = _items.GetEquipped(mobile).ToList();
+
+        // The background is part of the picture, so it is part of the key.
+        var hash = MobileAppearanceHash.Of(mobile, equipped) + (includeBackground ? "_doll" : "_doll_nobg");
+        var path = Path.Combine(_cachePath, $"{hash}.png");
+
+        if (Cached(path))
+        {
+            return new(path, hash);
+        }
+
+        var request = new PaperdollRenderRequest(
+            mobile.Gender,
+            includeBackground,
+            mobile.SkinHue.Value,
+            mobile.HairStyle,
+            mobile.HairHue.Value,
+            mobile.FacialHairStyle,
+            mobile.FacialHairHue.Value,
+            [.. equipped.Where(worn => worn.EquippedLayer is not null)
+                        .Select(worn => new MobileFigureEquipment(worn.TemplateId, worn.Hue.Value))]
+        );
+
+        return await RenderAsync(() => _paperdolls.Render(request), path, hash, cancellationToken);
+    }
+
+    /// <summary>
+    /// A hit, and the touch that keeps it alive. The sweep reads last-write time — deliberately, since
+    /// last-*access* time is disabled or coarsened on many mounts and a picture in daily use could
+    /// otherwise look untouched for a week.
+    /// </summary>
+    private static bool Cached(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow);
+        }
+        catch (IOException)
+        {
+            // Failing to touch it only risks an early sweep, and the picture would be re-rendered.
+        }
+
+        return true;
+    }
+
+    private async Task<MobileImage?> RenderAsync(
+        Func<UltimaBitmap?> render,
+        string path,
+        string hash,
+        CancellationToken cancellationToken
+    )
+    {
+        var image = await _gate.ReadAsync(() => File.Exists(path) ? null : render(), cancellationToken);
+
+        if (image is null)
+        {
+            return File.Exists(path) ? new MobileImage(path, hash) : null;
+        }
+
+        using (image)
+        {
+            PngWriter.WriteAtomically(path, image);
+        }
+
+        return new(path, hash);
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileCharacterImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileCharacterImageEndpointsTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Headers;
+using DryIoc;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Endpoints.Mobiles;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Http.Endpoints.Mobiles;
+
+/// <summary>
+/// What the route owns is the HTTP conversation, not the picture: a 404 for nobody, an ETag that
+/// is the appearance fingerprint, and a 304 when the caller already has that appearance. The 304
+/// is what lets the URL stay stable while the picture changes.
+/// </summary>
+public class MobileCharacterImageEndpointsTests
+{
+    [Fact]
+    public async Task Get_AnUnknownSerial_Is404()
+    {
+        await using var server = await StartAsync(new StubImageService(null));
+
+        var response = await server.Client.GetAsync("/api/v1/images/mobiles/57005.png");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AKnownCharacter_ReturnsPngWithTheFingerprintAsETag()
+    {
+        var image = Png("abc12345");
+        await using var server = await StartAsync(new StubImageService(image));
+
+        var response = await server.Client.GetAsync("/api/v1/images/mobiles/1.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("image/png", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("\"abc12345\"", response.Headers.ETag?.ToString());
+    }
+
+    // The whole reason the URL does not carry the hash: an unchanged character costs a string
+    // comparison rather than a render or a download.
+    [Fact]
+    public async Task Get_WithAMatchingIfNoneMatch_Is304WithNoBody()
+    {
+        var image = Png("abc12345");
+        await using var server = await StartAsync(new StubImageService(image));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/images/mobiles/1.png");
+
+        request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"abc12345\""));
+
+        var response = await server.Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    // A stale fingerprint is exactly the case the design exists for: the character changed, so the
+    // caller must be given the new picture rather than a 304.
+    [Fact]
+    public async Task Get_WithAStaleIfNoneMatch_ReturnsTheNewImage()
+    {
+        var image = Png("newhash1");
+        await using var server = await StartAsync(new StubImageService(image));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/images/mobiles/1.png");
+
+        request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"oldhash0\""));
+
+        var response = await server.Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotEmpty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public async Task GetPaperdoll_ForAKnownCharacter_ReturnsPng()
+    {
+        var image = Png("dollhash");
+        await using var server = await StartAsync(new StubImageService(image));
+
+        var response = await server.Client.GetAsync("/api/v1/images/mobiles/1/paperdoll.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("\"dollhash\"", response.Headers.ETag?.ToString());
+    }
+
+    private static MobileImage Png(string hash)
+    {
+        var path = Path.Combine(TemporaryDirectory.Create("mg-character-route-"), $"{hash}.png");
+
+        File.WriteAllBytes(path, [0x89, (byte)'P', (byte)'N', (byte)'G']);
+
+        return new(path, hash);
+    }
+
+    private static async Task<TestApiServer> StartAsync(StubImageService images)
+        => await TestApiServer.StartAsync(
+               configure: container =>
+                          {
+                              container.RegisterInstance<IMobileCharacterImageService>(images);
+                              container.RegisterApiEndpointInstance(new MobileCharacterImageEndpoints(images));
+                          }
+           );
+
+    private sealed class StubImageService : IMobileCharacterImageService
+    {
+        private readonly MobileImage? _image;
+
+        public StubImageService(MobileImage? image)
+        {
+            _image = image;
+        }
+
+        public Task<MobileImage?> GetFigureAsync(Serial serial, CancellationToken cancellationToken = default)
+            => Task.FromResult(_image);
+
+        public Task<MobileImage?> GetPaperdollAsync(
+            Serial serial,
+            bool includeBackground,
+            CancellationToken cancellationToken = default
+        )
+            => Task.FromResult(_image);
+    }
+}

--- a/tests/Moongate.Tests/Http/Mobiles/CharacterImageCacheSweeperTests.cs
+++ b/tests/Moongate.Tests/Http/Mobiles/CharacterImageCacheSweeperTests.cs
@@ -1,0 +1,77 @@
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Tests.Support;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Http.Mobiles;
+
+/// <summary>
+/// Content-addressed caching means a character who changes clothes leaves the old file behind, so
+/// something has to take them away. The sweep's two properties matter equally: it removes what is
+/// stale, and it keeps what is not.
+/// </summary>
+public class CharacterImageCacheSweeperTests
+{
+    [Fact]
+    public void Sweep_RemovesAFileOlderThanTheWindow()
+    {
+        var world = new Fixture();
+        var stale = world.Image("stale", DateTime.UtcNow.AddDays(-30));
+
+        world.Sweeper.Sweep();
+
+        Assert.False(File.Exists(stale));
+    }
+
+    // A sweep that deletes everything also passes a test that only checks deletion.
+    [Fact]
+    public void Sweep_KeepsAFileInsideTheWindow()
+    {
+        var world = new Fixture();
+        var fresh = world.Image("fresh", DateTime.UtcNow);
+
+        world.Sweeper.Sweep();
+
+        Assert.True(File.Exists(fresh));
+    }
+
+    [Fact]
+    public void Sweep_ReportsHowManyItRemoved()
+    {
+        var world = new Fixture();
+
+        world.Image("old-one", DateTime.UtcNow.AddDays(-30));
+        world.Image("old-two", DateTime.UtcNow.AddDays(-30));
+        world.Image("kept", DateTime.UtcNow);
+
+        Assert.Equal(2, world.Sweeper.Sweep());
+    }
+
+    [Fact]
+    public void Sweep_OnAnEmptyDirectory_DoesNothing()
+        => Assert.Equal(0, new Fixture().Sweeper.Sweep());
+
+    private sealed class Fixture
+    {
+        private readonly string _cachePath;
+
+        public Fixture()
+        {
+            var root = TemporaryDirectory.Create("mg-character-sweep-");
+
+            Sweeper = new(new DirectoriesConfig(root, []));
+            _cachePath = Path.Combine(root, "cache", "images", "characters");
+        }
+
+        public CharacterImageCacheSweeper Sweeper { get; }
+
+        public string Image(string name, DateTime writtenUtc)
+        {
+            var path = Path.Combine(_cachePath, $"{name}.png");
+
+            File.WriteAllBytes(path, [0x89, (byte)'P', (byte)'N', (byte)'G']);
+            File.SetLastWriteTimeUtc(path, writtenUtc);
+
+            return path;
+        }
+    }
+}

--- a/tests/Moongate.Tests/Http/Mobiles/MobileAppearanceHashTests.cs
+++ b/tests/Moongate.Tests/Http/Mobiles/MobileAppearanceHashTests.cs
@@ -1,0 +1,107 @@
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Persistence.Entities;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Http.Mobiles;
+
+/// <summary>
+/// The hash is the cache file's name and the ETag, so everything visible has to be in it and
+/// nothing invisible may be. It is also why nothing needs invalidating: a new look is a new key.
+/// </summary>
+public class MobileAppearanceHashTests
+{
+    [Fact]
+    public void TheSameAppearance_HashesTheSame()
+        => Assert.Equal(MobileAppearanceHash.Of(Mobile(), []), MobileAppearanceHash.Of(Mobile(), []));
+
+    [Fact]
+    public void ADifferentBody_HashesDifferently()
+    {
+        var other = Mobile();
+
+        other.Body = 401;
+
+        Assert.NotEqual(MobileAppearanceHash.Of(Mobile(), []), MobileAppearanceHash.Of(other, []));
+    }
+
+    [Fact]
+    public void ADifferentSkinHue_HashesDifferently()
+    {
+        var other = Mobile();
+
+        other.SkinHue = new(1002);
+
+        Assert.NotEqual(MobileAppearanceHash.Of(Mobile(), []), MobileAppearanceHash.Of(other, []));
+    }
+
+    [Fact]
+    public void ADifferentHairStyle_HashesDifferently()
+    {
+        var other = Mobile();
+
+        other.HairStyle = 0x203C;
+
+        Assert.NotEqual(MobileAppearanceHash.Of(Mobile(), []), MobileAppearanceHash.Of(other, []));
+    }
+
+    [Fact]
+    public void AWornItem_ChangesTheHash()
+        => Assert.NotEqual(
+            MobileAppearanceHash.Of(Mobile(), []),
+            MobileAppearanceHash.Of(Mobile(), [Worn(0x1410, LayerType.Helm, 0)])
+        );
+
+    [Fact]
+    public void ADifferentItemHue_ChangesTheHash()
+        => Assert.NotEqual(
+            MobileAppearanceHash.Of(Mobile(), [Worn(0x1410, LayerType.Helm, 0)]),
+            MobileAppearanceHash.Of(Mobile(), [Worn(0x1410, LayerType.Helm, 33)])
+        );
+
+    // Ordered by layer before hashing, so the store handing them back in a different order does
+    // not produce a second file for the same outfit.
+    [Fact]
+    public void TheOrderItemsComeBackIn_DoesNotMatter()
+    {
+        ItemEntity[] helmFirst = [Worn(0x1410, LayerType.Helm, 0), Worn(0x1411, LayerType.Gloves, 0)];
+        ItemEntity[] glovesFirst = [Worn(0x1411, LayerType.Gloves, 0), Worn(0x1410, LayerType.Helm, 0)];
+
+        Assert.Equal(MobileAppearanceHash.Of(Mobile(), helmFirst), MobileAppearanceHash.Of(Mobile(), glovesFirst));
+    }
+
+    // The whole point of content addressing: two characters dressed alike share one file.
+    [Fact]
+    public void TwoIdenticallyDressedMobiles_ShareAHash()
+    {
+        var one = Mobile();
+        var two = Mobile();
+
+        two.Name = "Someone Else";
+
+        Assert.Equal(
+            MobileAppearanceHash.Of(one, [Worn(0x1410, LayerType.Helm, 0)]),
+            MobileAppearanceHash.Of(two, [Worn(0x1410, LayerType.Helm, 0)])
+        );
+    }
+
+    // An item held or carried is not worn, and must not move the fingerprint.
+    [Fact]
+    public void AnItemOnNoLayer_IsIgnored()
+        => Assert.Equal(
+            MobileAppearanceHash.Of(Mobile(), []),
+            MobileAppearanceHash.Of(Mobile(), [new() { ItemId = 0x1410 }])
+        );
+
+    private static MobileEntity Mobile()
+        => new()
+        {
+            Name = "Squid",
+            Body = 400,
+            SkinHue = new(1001),
+            HairStyle = 0x203B,
+            HairHue = new(1102)
+        };
+
+    private static ItemEntity Worn(int itemId, LayerType layer, ushort hue)
+        => new() { ItemId = itemId, EquippedLayer = layer, Hue = new(hue) };
+}

--- a/tests/Moongate.Tests/Http/Mobiles/MobileAppearanceHashTests.cs
+++ b/tests/Moongate.Tests/Http/Mobiles/MobileAppearanceHashTests.cs
@@ -48,14 +48,14 @@ public class MobileAppearanceHashTests
     public void AWornItem_ChangesTheHash()
         => Assert.NotEqual(
             MobileAppearanceHash.Of(Mobile(), []),
-            MobileAppearanceHash.Of(Mobile(), [Worn(0x1410, LayerType.Helm, 0)])
+            MobileAppearanceHash.Of(Mobile(), [Worn("plate_helm", LayerType.Helm, 0)])
         );
 
     [Fact]
     public void ADifferentItemHue_ChangesTheHash()
         => Assert.NotEqual(
-            MobileAppearanceHash.Of(Mobile(), [Worn(0x1410, LayerType.Helm, 0)]),
-            MobileAppearanceHash.Of(Mobile(), [Worn(0x1410, LayerType.Helm, 33)])
+            MobileAppearanceHash.Of(Mobile(), [Worn("plate_helm", LayerType.Helm, 0)]),
+            MobileAppearanceHash.Of(Mobile(), [Worn("plate_helm", LayerType.Helm, 33)])
         );
 
     // Ordered by layer before hashing, so the store handing them back in a different order does
@@ -63,8 +63,8 @@ public class MobileAppearanceHashTests
     [Fact]
     public void TheOrderItemsComeBackIn_DoesNotMatter()
     {
-        ItemEntity[] helmFirst = [Worn(0x1410, LayerType.Helm, 0), Worn(0x1411, LayerType.Gloves, 0)];
-        ItemEntity[] glovesFirst = [Worn(0x1411, LayerType.Gloves, 0), Worn(0x1410, LayerType.Helm, 0)];
+        ItemEntity[] helmFirst = [Worn("plate_helm", LayerType.Helm, 0), Worn("plate_gloves", LayerType.Gloves, 0)];
+        ItemEntity[] glovesFirst = [Worn("plate_gloves", LayerType.Gloves, 0), Worn("plate_helm", LayerType.Helm, 0)];
 
         Assert.Equal(MobileAppearanceHash.Of(Mobile(), helmFirst), MobileAppearanceHash.Of(Mobile(), glovesFirst));
     }
@@ -79,8 +79,8 @@ public class MobileAppearanceHashTests
         two.Name = "Someone Else";
 
         Assert.Equal(
-            MobileAppearanceHash.Of(one, [Worn(0x1410, LayerType.Helm, 0)]),
-            MobileAppearanceHash.Of(two, [Worn(0x1410, LayerType.Helm, 0)])
+            MobileAppearanceHash.Of(one, [Worn("plate_helm", LayerType.Helm, 0)]),
+            MobileAppearanceHash.Of(two, [Worn("plate_helm", LayerType.Helm, 0)])
         );
     }
 
@@ -89,7 +89,7 @@ public class MobileAppearanceHashTests
     public void AnItemOnNoLayer_IsIgnored()
         => Assert.Equal(
             MobileAppearanceHash.Of(Mobile(), []),
-            MobileAppearanceHash.Of(Mobile(), [new() { ItemId = 0x1410 }])
+            MobileAppearanceHash.Of(Mobile(), [new() { TemplateId = "plate_helm" }])
         );
 
     private static MobileEntity Mobile()
@@ -102,6 +102,7 @@ public class MobileAppearanceHashTests
             HairHue = new(1102)
         };
 
-    private static ItemEntity Worn(int itemId, LayerType layer, ushort hue)
-        => new() { ItemId = itemId, EquippedLayer = layer, Hue = new(hue) };
+    // Fingerprinted by template id, which is what the renderer is handed -- not by art id.
+    private static ItemEntity Worn(string templateId, LayerType layer, ushort hue)
+        => new() { TemplateId = templateId, EquippedLayer = layer, Hue = new(hue) };
 }

--- a/tests/Moongate.Tests/Http/Mobiles/MobileCharacterImageServiceTests.cs
+++ b/tests/Moongate.Tests/Http/Mobiles/MobileCharacterImageServiceTests.cs
@@ -1,0 +1,185 @@
+using Moongate.Core.Extensions;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Ultima;
+using Moongate.Http.Plugin.Services.Mobiles;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Imaging;
+using Moongate.Ultima.Types;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Tests.Http.Mobiles;
+
+/// <summary>
+/// The cache is content-addressed, so the behaviour worth pinning is that a change of clothes
+/// produces a different file rather than replacing one — and that serving from cache moves the
+/// file's write time, because the sweep reads it.
+/// </summary>
+public class MobileCharacterImageServiceTests
+{
+    // Null rather than an exception: the route turns it into a 404, as the template routes do.
+    [Fact]
+    public async Task GetFigure_ForAnUnknownSerial_IsNull()
+    {
+        var world = new Fixture();
+
+        Assert.Null(await world.Service.GetFigureAsync((Serial)0xDEAD));
+    }
+
+    [Fact]
+    public async Task GetFigure_RendersOnceAndReusesTheFile()
+    {
+        var world = new Fixture();
+        var mobile = world.Mobile();
+
+        var first = await world.Service.GetFigureAsync(mobile.Id);
+        var second = await world.Service.GetFigureAsync(mobile.Id);
+
+        Assert.Equal(first!.Path, second!.Path);
+        Assert.Equal(1, world.Renderer.Renders);
+    }
+
+    // The point of the whole design: dressing differently is a different file, and the old one is
+    // left alone rather than invalidated.
+    [Fact]
+    public async Task GetFigure_AfterTheCharacterChangesClothes_IsADifferentFile()
+    {
+        var world = new Fixture();
+        var mobile = world.Mobile();
+
+        var before = await world.Service.GetFigureAsync(mobile.Id);
+
+        world.Equip(mobile, 0x1410, LayerType.Helm);
+
+        var after = await world.Service.GetFigureAsync(mobile.Id);
+
+        Assert.NotEqual(before!.Hash, after!.Hash);
+        Assert.NotEqual(before.Path, after.Path);
+        Assert.True(File.Exists(before.Path), "the old file is left alone, not invalidated");
+    }
+
+    // The sweep reads last-write time, so a cache hit has to move it or a picture in daily use
+    // would look untouched and be swept.
+    [Fact]
+    public async Task GetFigure_OnACacheHit_TouchesTheFile()
+    {
+        var world = new Fixture();
+        var mobile = world.Mobile();
+
+        var image = await world.Service.GetFigureAsync(mobile.Id);
+        var backdated = DateTime.UtcNow.AddDays(-30);
+
+        File.SetLastWriteTimeUtc(image!.Path, backdated);
+
+        await world.Service.GetFigureAsync(mobile.Id);
+
+        Assert.True(File.GetLastWriteTimeUtc(image.Path) > backdated);
+    }
+
+    [Fact]
+    public async Task GetPaperdoll_ForAKnownCharacter_RendersAndCaches()
+    {
+        var world = new Fixture();
+        var mobile = world.Mobile();
+
+        var image = await world.Service.GetPaperdollAsync(mobile.Id, true);
+
+        Assert.NotNull(image);
+        Assert.True(File.Exists(image.Path));
+    }
+
+    // With and without the background are different pictures and must not share a file.
+    [Fact]
+    public async Task GetPaperdoll_WithAndWithoutBackground_AreDifferentFiles()
+    {
+        var world = new Fixture();
+        var mobile = world.Mobile();
+
+        var withBackground = await world.Service.GetPaperdollAsync(mobile.Id, true);
+        var without = await world.Service.GetPaperdollAsync(mobile.Id, false);
+
+        Assert.NotEqual(withBackground!.Path, without!.Path);
+    }
+
+    private sealed class Fixture
+    {
+        private readonly FakePersistenceService _persistence = new();
+        private readonly ItemService _items;
+
+        public Fixture()
+        {
+            _items = new(_persistence);
+            Renderer = new();
+
+            var root = TemporaryDirectory.Create("mg-character-images-");
+
+            Service = new MobileCharacterImageService(
+                Renderer,
+                Renderer,
+                _persistence,
+                _items,
+                new DirectoriesConfig(root, []),
+                new ImmediateReadGate()
+            );
+        }
+
+        public RecordingRenderer Renderer { get; }
+
+        public MobileCharacterImageService Service { get; }
+
+        public MobileEntity Mobile()
+        {
+            var mobile = new MobileEntity
+            {
+                Name = "Squid",
+                Body = 400,
+                SkinHue = new(1001),
+                HairStyle = 0x203B,
+                HairHue = new(1102),
+                MapId = 1,
+                Position = new(1, 1, 0)
+            };
+
+            _persistence.Store<MobileEntity>().UpsertAsync(mobile).WaitSync();
+
+            return mobile;
+        }
+
+        public void Equip(MobileEntity mobile, int itemId, LayerType layer)
+        {
+            var item = new ItemEntity { ItemId = itemId };
+
+            _items.Save(item);
+            _items.Equip(mobile, item, layer);
+        }
+    }
+
+    /// <summary>Counts renders and returns a 1x1 bitmap, so the tests are about caching, not pixels.</summary>
+    private sealed class RecordingRenderer : IMobileFigureRenderer, IPaperdollRenderer
+    {
+        public int Renders { get; private set; }
+
+        public UltimaBitmap? Render(MobileFigureRequest request)
+        {
+            Renders++;
+
+            return new(1, 1);
+        }
+
+        public UltimaBitmap? Render(PaperdollRenderRequest request)
+        {
+            Renders++;
+
+            return new(1, 1);
+        }
+    }
+
+    private sealed class ImmediateReadGate : IUltimaReadGate
+    {
+        public Task<T> ReadAsync<T>(Func<T> read, CancellationToken cancellationToken = default)
+            => Task.FromResult(read());
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -55,6 +55,7 @@ public class MoongateHttpPluginTests
                 typeof(ItemTemplateEndpoints),
                 typeof(MapImageAdminEndpoints),
                 typeof(MapImageEndpoints),
+                typeof(MobileCharacterImageEndpoints),
                 typeof(MobileImageAdminEndpoints),
                 typeof(MobileTemplateImageEndpoints),
                 typeof(OnlinePlayerAdminEndpoints),

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -947,6 +947,82 @@
         }
       }
     },
+    "/api/v1/images/mobiles/{serial}.png": {
+      "get": {
+        "tags": [
+          "mobiles"
+        ],
+        "summary": "Serves a character's dressed figure as PNG: body, hair and the items they are wearing.",
+        "description": "The ETag is a fingerprint of the appearance, so a client that already has the current look gets\n304 without a body. 404 when the serial names no mobile, or when its body has no animation.",
+        "operationId": "GetMobileCharacterImage",
+        "parameters": [
+          {
+            "name": "serial",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/images/mobiles/{serial}/paperdoll.png": {
+      "get": {
+        "tags": [
+          "mobiles"
+        ],
+        "summary": "Serves a character's paperdoll as PNG, with the equipment they are wearing.",
+        "description": "Pass `background=false` for the doll without its backdrop. The ETag is a fingerprint of\nthe appearance, so an unchanged character gets 304 without a body.",
+        "operationId": "GetMobileCharacterPaperdoll",
+        "parameters": [
+          {
+            "name": "serial",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "background",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/admin/images/bodies": {
       "post": {
         "tags": [

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -537,6 +537,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/images/mobiles/{serial}.png": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Serves a character's dressed figure as PNG: body, hair and the items they are wearing.
+         * @description The ETag is a fingerprint of the appearance, so a client that already has the current look gets
+         *     304 without a body. 404 when the serial names no mobile, or when its body has no animation.
+         */
+        get: operations["GetMobileCharacterImage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/images/mobiles/{serial}/paperdoll.png": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Serves a character's paperdoll as PNG, with the equipment they are wearing.
+         * @description Pass `background=false` for the doll without its backdrop. The ETag is a fingerprint of
+         *     the appearance, so an unchanged character gets 304 without a body.
+         */
+        get: operations["GetMobileCharacterPaperdoll"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/images/bodies": {
         parameters: {
             query?: never;
@@ -2194,6 +2236,52 @@ export interface operations {
             header?: never;
             path: {
                 id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/png": string;
+                };
+            };
+        };
+    };
+    GetMobileCharacterImage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serial: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/png": string;
+                };
+            };
+        };
+    };
+    GetMobileCharacterPaperdoll: {
+        parameters: {
+            query?: {
+                background?: boolean;
+            };
+            header?: never;
+            path: {
+                serial: number;
             };
             cookie?: never;
         };


### PR DESCRIPTION
Closes #164. Trello #77.

The renderers and routes already existed but dressed a **template**. These two show what a real
character is actually wearing:

```
/api/v1/images/mobiles/{serial}.png
/api/v1/images/mobiles/{serial}/paperdoll.png
```

## The design decision

The card proposed invalidating the cache on equipment events. **Rejected**, because that is the
only option that can be silently *wrong*: it needs every appearance-changing path to remember to
fire, and a missed one leaves a picture that is confidently out of date. A ghost is a ghost
whether it is drawn in a client or served over HTTP.

Instead the cache is **content-addressed** — the file is named with a fingerprint of the
appearance. Changing clothes writes a new file and leaves the old one alone, so **there is
nothing to invalidate and no path to get wrong**. Two characters dressed alike share a file,
which falls out rather than being built.

That fingerprint is also the **ETag**, which is why the URL can stay stable: an unchanged
character revalidates to `304` with no body, at the cost of a string comparison.

## Two corrections made while building it

**The fingerprint hashed the wrong thing.** It signed `ItemId` while the renderer is handed
`TemplateId` — signing something the picture does not depend on and omitting something it does.
Two items sharing an art id but not a template would have shared a file while rendering
differently.

**The sweep reads last-*write* time, not last access.** Last access is the obvious choice and
the wrong one: `atime` is disabled or coarsened on many mounts, so a picture in daily use could
look untouched for a week and be swept on a host mounted in a way we do not control. The image
service touches the file when it serves one from cache.

## Verification

- 2034 tests. The layer ordering in the fingerprint was watched failing — replacing the sort with
  one that preserves input order dropped exactly that assertion, and nothing else.
- The sweep is tested for **keeping** a fresh file as well as removing a stale one; a sweep that
  deleted everything would pass a test checking only deletion.
- `ui/openapi.json` and `api-types.ts` regenerated — CI's UI job fails on the drift while the
  .NET suite stays green.
- Booted against an isolated root: 21 services.