### PR TITLE
feat(ui): a screen for a player's own characters

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -393,7 +393,9 @@ The same two pictures exist for a **real character** rather than a template:
 `GET /api/v1/images/mobiles/{serial}.png` and
 `GET /api/v1/images/mobiles/{serial}/paperdoll.png` show what that character is
 actually wearing. There are no hue specs to resolve here — a real mobile carries
-hues that are already resolved.
+hues that are already resolved. The serial takes the form the rest of the API
+reports it in, `0x40000001`, so a character's own `serial` field can be fed
+straight back; plain decimal works too.
 
 Their cache is **content-addressed**: the file is named with a fingerprint of the
 appearance, so changing clothes writes a new picture instead of invalidating an

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileCharacterImageEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileCharacterImageEndpoints.cs
@@ -21,12 +21,12 @@ public sealed class MobileCharacterImageEndpoints : IApiEndpointRegistration
 
     public void Register(IEndpointRouteBuilder routes)
     {
-        routes.MapGet("/api/v1/images/mobiles/{serial:long}.png", GetFigure)
+        routes.MapGet("/api/v1/images/mobiles/{serial}.png", GetFigure)
               .WithName("GetMobileCharacterImage")
               .WithTags("mobiles")
               .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
 
-        routes.MapGet("/api/v1/images/mobiles/{serial:long}/paperdoll.png", GetPaperdoll)
+        routes.MapGet("/api/v1/images/mobiles/{serial}/paperdoll.png", GetPaperdoll)
               .WithName("GetMobileCharacterPaperdoll")
               .WithTags("mobiles")
               .Produces<byte[]>(StatusCodes.Status200OK, "image/png");
@@ -34,24 +34,40 @@ public sealed class MobileCharacterImageEndpoints : IApiEndpointRegistration
 
     /// <summary>Serves a character's dressed figure as PNG: body, hair and the items they are wearing.</summary>
     /// <remarks>
+    /// The serial takes the form the rest of the API reports, <c>0x40000001</c>, or plain decimal.
     /// The ETag is a fingerprint of the appearance, so a client that already has the current look gets
     /// 304 without a body. 404 when the serial names no mobile, or when its body has no animation.
     /// </remarks>
-    private async Task<IResult> GetFigure(long serial, HttpRequest request, CancellationToken cancellationToken)
-        => Respond(await _images.GetFigureAsync((Serial)(uint)serial, cancellationToken), request);
+    private async Task<IResult> GetFigure(string serial, HttpRequest request, CancellationToken cancellationToken)
+    {
+        if (!Serial.TryParse(serial, out var parsed))
+        {
+            return NotFound();
+        }
+
+        return Respond(await _images.GetFigureAsync(parsed, cancellationToken), request);
+    }
 
     /// <summary>Serves a character's paperdoll as PNG, with the equipment they are wearing.</summary>
     /// <remarks>
+    /// The serial takes the form the rest of the API reports, <c>0x40000001</c>, or plain decimal.
     /// Pass <c>background=false</c> for the doll without its backdrop. The ETag is a fingerprint of
     /// the appearance, so an unchanged character gets 304 without a body.
     /// </remarks>
     private async Task<IResult> GetPaperdoll(
-        long serial,
+        string serial,
         HttpRequest request,
         CancellationToken cancellationToken,
         bool background = true
     )
-        => Respond(await _images.GetPaperdollAsync((Serial)(uint)serial, background, cancellationToken), request);
+    {
+        if (!Serial.TryParse(serial, out var parsed))
+        {
+            return NotFound();
+        }
+
+        return Respond(await _images.GetPaperdollAsync(parsed, background, cancellationToken), request);
+    }
 
     /// <summary>
     /// The one HTTP decision this endpoint makes: hand back the file, or say the caller already has
@@ -61,7 +77,7 @@ public sealed class MobileCharacterImageEndpoints : IApiEndpointRegistration
     {
         if (image is null)
         {
-            return Results.Problem("No renderable image for that mobile.", statusCode: StatusCodes.Status404NotFound);
+            return NotFound();
         }
 
         var tag = new EntityTagHeaderValue($"\"{image.Hash}\"");
@@ -73,4 +89,11 @@ public sealed class MobileCharacterImageEndpoints : IApiEndpointRegistration
 
         return Results.File(image.Path, "image/png", entityTag: tag);
     }
+
+    /// <summary>
+    /// One answer for "that is not a character" and "that is not even a serial": from outside, both
+    /// mean the picture asked for does not exist.
+    /// </summary>
+    private static IResult NotFound()
+        => Results.Problem("No renderable image for that mobile.", statusCode: StatusCodes.Status404NotFound);
 }

--- a/src/Moongate.Core/Primitives/Serial.cs
+++ b/src/Moongate.Core/Primitives/Serial.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Moongate.Core.Primitives;
 
 /// <summary>
@@ -61,6 +63,38 @@ public readonly struct Serial : IEquatable<Serial>, IComparable<Serial>
 
     public override string ToString()
         => $"0x{Value:X8}";
+
+    /// <summary>
+    /// Reads a serial written the way <see cref="ToString" /> writes it — <c>0x40000001</c> — or as
+    /// plain decimal. The <c>0x</c> prefix is what picks the base: without it the text is decimal,
+    /// so <c>40000001</c> is forty million and not the first item serial.
+    /// </summary>
+    /// <returns>False, with <paramref name="serial" /> set to <see cref="Zero" />, when the text is
+    /// not a serial.</returns>
+    public static bool TryParse(string? text, out Serial serial)
+    {
+        serial = Zero;
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var span = text.AsSpan().Trim();
+
+        var parsed = span.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            ? uint.TryParse(span[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var value)
+            : uint.TryParse(span, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+
+        if (!parsed)
+        {
+            return false;
+        }
+
+        serial = new(value);
+
+        return true;
+    }
 
     public static bool operator ==(Serial left, Serial right)
         => left.Value == right.Value;

--- a/tests/Moongate.Tests/Core/Primitives/SerialTests.cs
+++ b/tests/Moongate.Tests/Core/Primitives/SerialTests.cs
@@ -80,6 +80,58 @@ public class SerialTests
         Assert.Equal("0x00000001", new Serial(1).ToString());
     }
 
+    // The pair that matters: whatever ToString wrote, TryParse must read back. Everything the API
+    // hands out is in that form, so this round trip is what lets a caller feed a serial back to us.
+    [Theory]
+    [InlineData(0x4000000Au)]
+    [InlineData(1u)]
+    [InlineData(0u)]
+    [InlineData(uint.MaxValue)]
+    public void TryParse_ReadsBackWhatToStringWrote(uint value)
+    {
+        var serial = new Serial(value);
+
+        Assert.True(Serial.TryParse(serial.ToString(), out var parsed));
+        Assert.Equal(serial, parsed);
+    }
+
+    [Theory]
+    [InlineData("0x40000001", 0x40000001u)]
+    [InlineData("0X40000001", 0x40000001u)]
+    [InlineData("40000001", 40000001u)]
+    [InlineData("57005", 57005u)]
+    public void TryParse_TakesHexWithThePrefixAndPlainDecimalWithout(string text, uint expected)
+    {
+        Assert.True(Serial.TryParse(text, out var parsed));
+        Assert.Equal(new Serial(expected), parsed);
+    }
+
+    // Without the prefix a bare "40000001" is decimal, so the prefix is what picks the base -- not a
+    // guess at whether the digits look hexadecimal.
+    [Fact]
+    public void TryParse_WithoutThePrefix_DoesNotGuessHex()
+    {
+        Assert.False(Serial.TryParse("4000000A", out _));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("banana")]
+    [InlineData("0x")]
+    [InlineData("-1")]
+    [InlineData("0x100000000")]
+    [InlineData("4294967296")]
+    public void TryParse_RejectsWhatIsNotASerial(string text)
+    {
+        Assert.False(Serial.TryParse(text, out var parsed));
+        Assert.Equal(Serial.Zero, parsed);
+    }
+
+    [Fact]
+    public void TryParse_RejectsNull()
+        => Assert.False(Serial.TryParse(null, out _));
+
     [Fact]
     public void VirtualBand_StartsRightAfterTheLastItem()
         => Assert.Equal(Serial.MaxItem + 1, Serial.MinVirtual);

--- a/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileCharacterImageEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileCharacterImageEndpointsTests.cs
@@ -88,6 +88,56 @@ public class MobileCharacterImageEndpointsTests
         Assert.Equal("\"dollhash\"", response.Headers.ETag?.ToString());
     }
 
+    // The API reports every serial as 0x40000001, so that is the string a caller has in hand when it
+    // wants the picture. A route that only accepted decimal would answer 404 for the API's own value
+    // -- and 404 reads as "no such character", not "wrong number base".
+    [Fact]
+    public async Task Get_WithTheHexSerialTheApiReports_ReachesThatCharacter()
+    {
+        var images = new StubImageService(Png("hexhash1"));
+        await using var server = await StartAsync(images);
+
+        var response = await server.Client.GetAsync("/api/v1/images/mobiles/0x40000001.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal((Serial)0x40000001u, images.LastSerial);
+    }
+
+    [Fact]
+    public async Task GetPaperdoll_WithTheHexSerialTheApiReports_ReachesThatCharacter()
+    {
+        var images = new StubImageService(Png("hexhash2"));
+        await using var server = await StartAsync(images);
+
+        var response = await server.Client.GetAsync("/api/v1/images/mobiles/0x40000001/paperdoll.png");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal((Serial)0x40000001u, images.LastSerial);
+    }
+
+    // Decimal stays valid: it is what the route has always accepted, and dropping it would break
+    // any caller already using it.
+    [Fact]
+    public async Task Get_WithADecimalSerial_ReachesThatCharacter()
+    {
+        var images = new StubImageService(Png("dechash1"));
+        await using var server = await StartAsync(images);
+
+        await server.Client.GetAsync("/api/v1/images/mobiles/57005.png");
+
+        Assert.Equal((Serial)57005u, images.LastSerial);
+    }
+
+    [Fact]
+    public async Task Get_WithASerialThatIsNotANumber_Is404()
+    {
+        await using var server = await StartAsync(new StubImageService(Png("nothash1")));
+
+        var response = await server.Client.GetAsync("/api/v1/images/mobiles/banana.png");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     private static MobileImage Png(string hash)
     {
         var path = Path.Combine(TemporaryDirectory.Create("mg-character-route-"), $"{hash}.png");
@@ -115,14 +165,25 @@ public class MobileCharacterImageEndpointsTests
             _image = image;
         }
 
+        /// <summary>The serial the route asked for, which is how the tests check the parse.</summary>
+        public Serial LastSerial { get; private set; }
+
         public Task<MobileImage?> GetFigureAsync(Serial serial, CancellationToken cancellationToken = default)
-            => Task.FromResult(_image);
+        {
+            LastSerial = serial;
+
+            return Task.FromResult(_image);
+        }
 
         public Task<MobileImage?> GetPaperdollAsync(
             Serial serial,
             bool includeBackground,
             CancellationToken cancellationToken = default
         )
-            => Task.FromResult(_image);
+        {
+            LastSerial = serial;
+
+            return Task.FromResult(_image);
+        }
     }
 }

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -953,7 +953,7 @@
           "mobiles"
         ],
         "summary": "Serves a character's dressed figure as PNG: body, hair and the items they are wearing.",
-        "description": "The ETag is a fingerprint of the appearance, so a client that already has the current look gets\n304 without a body. 404 when the serial names no mobile, or when its body has no animation.",
+        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal.\nThe ETag is a fingerprint of the appearance, so a client that already has the current look gets\n304 without a body. 404 when the serial names no mobile, or when its body has no animation.",
         "operationId": "GetMobileCharacterImage",
         "parameters": [
           {
@@ -961,8 +961,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -987,7 +986,7 @@
           "mobiles"
         ],
         "summary": "Serves a character's paperdoll as PNG, with the equipment they are wearing.",
-        "description": "Pass `background=false` for the doll without its backdrop. The ETag is a fingerprint of\nthe appearance, so an unchanged character gets 304 without a body.",
+        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal.\nPass `background=false` for the doll without its backdrop. The ETag is a fingerprint of\nthe appearance, so an unchanged character gets 304 without a body.",
         "operationId": "GetMobileCharacterPaperdoll",
         "parameters": [
           {
@@ -995,8 +994,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import { VerifyRegistrationScreen } from './routes/VerifyRegistrationScreen'
 import { DashboardScreen } from './routes/DashboardScreen'
 import { AdminScreen } from './routes/AdminScreen'
 import { MapScreen } from './routes/MapScreen'
+import { CharactersScreen } from './routes/CharactersScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
@@ -37,6 +38,16 @@ export function App() {
                 <RequireAuth>
                   <AppShell>
                     <DashboardScreen />
+                  </AppShell>
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/characters"
+              element={
+                <RequireAuth>
+                  <AppShell>
+                    <CharactersScreen />
                   </AppShell>
                 </RequireAuth>
               }

--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -59,6 +59,12 @@ describe('AppShell', () => {
     expect(screen.getByRole('button', { name: /light/i })).toBeInTheDocument()
   })
 
+  // Characters is a player's own page, so unlike Admin right beside it, it is not gated on level.
+  it('shows the Characters tab to a player', async () => {
+    renderWithLevel('Player')
+    expect(await screen.findByRole('link', { name: /characters/i })).toBeInTheDocument()
+  })
+
   it('shows the Admin tab for an admin session', async () => {
     renderWithLevel('Administrator')
     expect(await screen.findByRole('link', { name: /admin/i })).toBeInTheDocument()

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -45,6 +45,17 @@ export function AppShell({ children }: { children: ReactNode }) {
         </NavLink>
 
         <NavLink
+          to="/characters"
+          className={({ isActive }) =>
+            isActive
+              ? 'flex items-center border-b-2 border-gold text-sm font-bold text-gold'
+              : 'flex items-center border-b-2 border-transparent text-sm text-muted hover:text-ink'
+          }
+        >
+          {t('nav.characters')}
+        </NavLink>
+
+        <NavLink
           to="/map"
           className={({ isActive }) =>
             isActive

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -546,7 +546,8 @@ export interface paths {
         };
         /**
          * Serves a character's dressed figure as PNG: body, hair and the items they are wearing.
-         * @description The ETag is a fingerprint of the appearance, so a client that already has the current look gets
+         * @description The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal.
+         *     The ETag is a fingerprint of the appearance, so a client that already has the current look gets
          *     304 without a body. 404 when the serial names no mobile, or when its body has no animation.
          */
         get: operations["GetMobileCharacterImage"];
@@ -567,7 +568,8 @@ export interface paths {
         };
         /**
          * Serves a character's paperdoll as PNG, with the equipment they are wearing.
-         * @description Pass `background=false` for the doll without its backdrop. The ETag is a fingerprint of
+         * @description The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal.
+         *     Pass `background=false` for the doll without its backdrop. The ETag is a fingerprint of
          *     the appearance, so an unchanged character gets 304 without a body.
          */
         get: operations["GetMobileCharacterPaperdoll"];
@@ -2257,7 +2259,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                serial: number;
+                serial: string;
             };
             cookie?: never;
         };
@@ -2281,7 +2283,7 @@ export interface operations {
             };
             header?: never;
             path: {
-                serial: number;
+                serial: string;
             };
             cookie?: never;
         };

--- a/ui/src/lib/characters.test.ts
+++ b/ui/src/lib/characters.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { figureUrl, paperdollUrl } from './characters'
+
+// The serial is used verbatim, in the `0x40000001` form the API reports it in. The routes accept
+// that form, so nothing here converts bases -- a conversion is the kind of thing that silently
+// drifts from what the server accepts.
+describe('character image urls', () => {
+  it('addresses a character by the serial the API reported', () => {
+    expect(figureUrl('0x40000001')).toBe('/api/v1/images/mobiles/0x40000001.png')
+  })
+
+  it('asks for the paperdoll with its backdrop by default', () => {
+    expect(paperdollUrl('0x40000001')).toBe('/api/v1/images/mobiles/0x40000001/paperdoll.png')
+  })
+
+  it('can drop the backdrop', () => {
+    expect(paperdollUrl('0x40000001', false)).toBe('/api/v1/images/mobiles/0x40000001/paperdoll.png?background=false')
+  })
+
+  // The ETag is a fingerprint of the appearance, so the browser revalidates and takes a 304 until
+  // the character changes clothes. A cache-buster would force a full download on every visit --
+  // it is the natural reflex when a picture might look stale, and here it is exactly wrong.
+  it('never adds a cache-busting parameter', () => {
+    expect(figureUrl('0x1')).not.toMatch(/[?&](t|v|_)=/)
+    expect(paperdollUrl('0x1')).not.toMatch(/[?&](t|v|_)=/)
+  })
+})

--- a/ui/src/lib/characters.ts
+++ b/ui/src/lib/characters.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiFetch } from './api'
+import type { components } from './api-types'
+
+export type Character = components['schemas']['CharacterResponse']
+
+const MINE_KEY = ['player', 'characters']
+
+/** The caller's own characters. The API fills in the account, so there is nothing to pass. */
+export const useMyCharacters = () =>
+  useQuery({ queryKey: MINE_KEY, queryFn: () => apiFetch<Character[]>('/api/v1/player/me/characters') })
+
+/**
+ * The in-world figure: body, hair and what the character is wearing.
+ *
+ * Deliberately no cache-busting parameter. The URL is stable and the ETag is a fingerprint of the
+ * appearance, so the browser revalidates and takes a 304 until the character changes clothes.
+ * Appending `?t=` would force a full download on every visit — the opposite of what the route is
+ * built for.
+ */
+export const figureUrl = (serial: string) => `/api/v1/images/mobiles/${serial}.png`
+
+/** The paperdoll, with the classic backdrop unless it is turned off. Cached like {@link figureUrl}. */
+export const paperdollUrl = (serial: string, background = true) =>
+  background
+    ? `/api/v1/images/mobiles/${serial}/paperdoll.png`
+    : `/api/v1/images/mobiles/${serial}/paperdoll.png?background=false`

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -264,6 +264,15 @@
     "mana": "Mana",
     "kills": "Kills",
     "location": "Location",
-    "pool": "{{current}} / {{max}}"
+    "pool": "{{current}} / {{max}}",
+    "race": {
+      "Human": "Human",
+      "Elf": "Elf",
+      "Gargoyle": "Gargoyle"
+    },
+    "gender": {
+      "Male": "Male",
+      "Female": "Female"
+    }
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -10,7 +10,8 @@
   "nav": {
     "dashboard": "Dashboard",
     "map": "Map",
-    "admin": "Admin"
+    "admin": "Admin",
+    "characters": "Characters"
   },
   "login": {
     "title": "MOONGATE",
@@ -245,5 +246,24 @@
       "hint": "↑ / ↓ for history",
       "snippets": "Quick commands"
     }
+  },
+  "characters": {
+    "title": "My Characters",
+    "empty": "No characters yet",
+    "emptyHint": "Create one in the game client, and it will show up here.",
+    "loadFailed": "Your characters could not be loaded.",
+    "noImage": "No picture for this character",
+    "figureAlt": "{{name}} in the world",
+    "paperdollAlt": "{{name}} paperdoll",
+    "identity": "{{race}} · {{gender}}",
+    "strength": "Strength",
+    "dexterity": "Dexterity",
+    "intelligence": "Intelligence",
+    "hits": "Hits",
+    "stamina": "Stamina",
+    "mana": "Mana",
+    "kills": "Kills",
+    "location": "Location",
+    "pool": "{{current}} / {{max}}"
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -264,6 +264,15 @@
     "mana": "Mana",
     "kills": "Uccisioni",
     "location": "Posizione",
-    "pool": "{{current}} / {{max}}"
+    "pool": "{{current}} / {{max}}",
+    "race": {
+      "Human": "Umano",
+      "Elf": "Elfo",
+      "Gargoyle": "Gargoyle"
+    },
+    "gender": {
+      "Male": "Maschio",
+      "Female": "Femmina"
+    }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -10,7 +10,8 @@
   "nav": {
     "dashboard": "Dashboard",
     "map": "Mappa",
-    "admin": "Admin"
+    "admin": "Admin",
+    "characters": "Personaggi"
   },
   "login": {
     "title": "MOONGATE",
@@ -245,5 +246,24 @@
       "hint": "↑ / ↓ per la cronologia",
       "snippets": "Comandi rapidi"
     }
+  },
+  "characters": {
+    "title": "I miei personaggi",
+    "empty": "Nessun personaggio",
+    "emptyHint": "Creane uno dal client di gioco e comparirà qui.",
+    "loadFailed": "Non è stato possibile caricare i tuoi personaggi.",
+    "noImage": "Nessuna immagine per questo personaggio",
+    "figureAlt": "{{name}} nel mondo",
+    "paperdollAlt": "Paperdoll di {{name}}",
+    "identity": "{{race}} · {{gender}}",
+    "strength": "Forza",
+    "dexterity": "Destrezza",
+    "intelligence": "Intelligenza",
+    "hits": "Vita",
+    "stamina": "Stamina",
+    "mana": "Mana",
+    "kills": "Uccisioni",
+    "location": "Posizione",
+    "pool": "{{current}} / {{max}}"
   }
 }

--- a/ui/src/routes/CharactersScreen.test.tsx
+++ b/ui/src/routes/CharactersScreen.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { fireEvent } from '@testing-library/dom'
+import '../lib/i18n'
+import { CharactersScreen } from './CharactersScreen'
+import type { Character } from '../lib/characters'
+
+const query = vi.hoisted(() => ({
+  data: undefined as Character[] | undefined,
+  isPending: false,
+  isError: false,
+}))
+
+// Only the hook is stubbed; the URL builders are the real ones, so the `src` assertions below are
+// checking what the browser would actually request.
+vi.mock('../lib/characters', async (original) => ({
+  ...(await original<typeof import('../lib/characters')>()),
+  useMyCharacters: () => query,
+}))
+
+function character(serial: string, name: string): Character {
+  return {
+    serial,
+    name,
+    race: 'Human',
+    gender: 'Male',
+    body: 400,
+    strength: 60,
+    dexterity: 45,
+    intelligence: 30,
+    hits: 55,
+    hitsMax: 60,
+    stamina: 45,
+    staminaMax: 45,
+    mana: 30,
+    manaMax: 30,
+    kills: 0,
+    skinHue: 1002,
+    hairStyle: 8252,
+    hairHue: 1102,
+    mapId: 1,
+    x: 1495,
+    y: 1629,
+    z: 0,
+  }
+}
+
+function renderWith(data: Character[] | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isPending: false, isError: false }, state)
+  return render(<CharactersScreen />)
+}
+
+describe('CharactersScreen', () => {
+  it('lists every character on the account', () => {
+    renderWith([character('0x1', 'Squid'), character('0x2', 'Vega')])
+
+    expect(screen.getByRole('button', { name: /Squid/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Vega/ })).toBeInTheDocument()
+  })
+
+  // The panel is never empty while the account has characters, so arriving shows one.
+  it('shows the first character on arrival', () => {
+    renderWith([character('0x1', 'Squid'), character('0x2', 'Vega')])
+
+    expect(screen.getByAltText('Squid paperdoll')).toHaveAttribute('src', '/api/v1/images/mobiles/0x1/paperdoll.png')
+  })
+
+  it('shows the character that was chosen', async () => {
+    renderWith([character('0x1', 'Squid'), character('0x2', 'Vega')])
+
+    await userEvent.click(screen.getByRole('button', { name: /Vega/ }))
+
+    expect(screen.getByAltText('Vega paperdoll')).toHaveAttribute('src', '/api/v1/images/mobiles/0x2/paperdoll.png')
+  })
+
+  it('asks for the figure with the serial the API reported', () => {
+    renderWith([character('0x40000001', 'Squid')])
+
+    expect(screen.getByAltText('Squid in the world')).toHaveAttribute('src', '/api/v1/images/mobiles/0x40000001.png')
+  })
+
+  it('shows the pools against their maximum', () => {
+    renderWith([character('0x1', 'Squid')])
+
+    expect(screen.getByText('55 / 60')).toBeInTheDocument()
+  })
+
+  // A body with no animation legitimately 404s from the image route, and a broken-image icon is
+  // not an answer.
+  it('replaces a picture that fails to load', () => {
+    renderWith([character('0x1', 'Squid')])
+
+    fireEvent.error(screen.getByAltText('Squid paperdoll'))
+
+    expect(screen.queryByAltText('Squid paperdoll')).not.toBeInTheDocument()
+    expect(screen.getByText('No picture for this character')).toBeInTheDocument()
+  })
+
+  // The state a freshly registered player sees first.
+  it('says so when the account has no characters', () => {
+    renderWith([])
+
+    expect(screen.getByText('No characters yet')).toBeInTheDocument()
+  })
+
+  it('says so when the request failed', () => {
+    renderWith(undefined, { isError: true })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Your characters could not be loaded.')
+  })
+
+  it('says so while loading', () => {
+    renderWith(undefined, { isPending: true })
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/CharactersScreen.test.tsx
+++ b/ui/src/routes/CharactersScreen.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { fireEvent } from '@testing-library/dom'
-import '../lib/i18n'
+import i18n from '../lib/i18n'
 import { CharactersScreen } from './CharactersScreen'
 import type { Character } from '../lib/characters'
 
@@ -83,6 +83,32 @@ describe('CharactersScreen', () => {
     renderWith([character('0x1', 'Squid')])
 
     expect(screen.getByText('55 / 60')).toBeInTheDocument()
+  })
+
+  // Asserted in Italian on purpose: the API reports race and gender in English, so in English the
+  // translated and untranslated renderings are identical and the test could not fail.
+  it('translates the race and gender', async () => {
+    await i18n.changeLanguage('it')
+    try {
+      renderWith([{ ...character('0x1', 'Squid'), race: 'Gargoyle', gender: 'Female' }])
+
+      expect(screen.getByText('Gargoyle · Femmina')).toBeInTheDocument()
+    } finally {
+      await i18n.changeLanguage('en')
+    }
+  })
+
+  // The races and genders are closed enums today, but a page must not break on a value it has no
+  // word for -- showing the server's own is better than showing a raw translation key.
+  it('shows a race it has no translation for rather than a key', async () => {
+    await i18n.changeLanguage('it')
+    try {
+      renderWith([{ ...character('0x1', 'Squid'), race: 'Daemon' }])
+
+      expect(screen.getByText('Daemon · Maschio')).toBeInTheDocument()
+    } finally {
+      await i18n.changeLanguage('en')
+    }
   })
 
   // A body with no animation legitimately 404s from the image route, and a broken-image icon is

--- a/ui/src/routes/CharactersScreen.tsx
+++ b/ui/src/routes/CharactersScreen.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Card } from '../components/ui/card'
+import { cn } from '../lib/utils'
+import { figureUrl, paperdollUrl, useMyCharacters, type Character } from '../lib/characters'
+
+export function CharactersScreen() {
+  const { t } = useTranslation()
+  const characters = useMyCharacters()
+
+  // The chosen serial rather than the character: resolving it against the current list means a
+  // character that disappears cannot leave a selection pointing at nothing, and arriving needs no
+  // effect to pick the first one.
+  const [chosen, setChosen] = useState<string | null>(null)
+
+  if (characters.isPending) {
+    return <p className="text-sm text-muted">{t('common.loading')}</p>
+  }
+
+  if (characters.isError) {
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t('characters.loadFailed')}
+      </p>
+    )
+  }
+
+  const all = characters.data ?? []
+
+  if (all.length === 0) {
+    return (
+      <section className="space-y-4">
+        <h1 className="text-2xl font-bold text-ink">{t('characters.title')}</h1>
+        <Card className="items-center gap-2 py-12 text-center">
+          <p className="font-bold text-ink">{t('characters.empty')}</p>
+          <p className="text-sm text-muted">{t('characters.emptyHint')}</p>
+        </Card>
+      </section>
+    )
+  }
+
+  const selected = all.find((one) => one.serial === chosen) ?? all[0]
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-2xl font-bold text-ink">{t('characters.title')}</h1>
+
+      <div className="grid gap-6 lg:grid-cols-[16rem_1fr]">
+        <Card className="gap-0 p-2">
+          {all.map((one) => (
+            <button
+              key={one.serial}
+              type="button"
+              onClick={() => setChosen(one.serial)}
+              className={cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors',
+                one.serial === selected.serial ? 'bg-gold/10 text-gold' : 'text-ink hover:bg-ink/5',
+              )}
+            >
+              <CharacterImage
+                src={figureUrl(one.serial)}
+                alt={t('characters.figureAlt', { name: one.name })}
+                className="h-12 w-10 object-contain"
+                fallback={<span className="h-12 w-10" aria-hidden="true" />}
+              />
+              <span className="min-w-0">
+                <span className="block truncate font-bold">{one.name}</span>
+                <span className="block truncate text-xs text-muted">{one.race}</span>
+              </span>
+            </button>
+          ))}
+        </Card>
+
+        <CharacterPanel character={selected} />
+      </div>
+    </section>
+  )
+}
+
+function CharacterPanel({ character }: { character: Character }) {
+  const { t } = useTranslation()
+
+  return (
+    <Card className="items-center gap-4 py-8">
+      <header className="text-center">
+        <h2 className="text-xl font-bold text-ink">{character.name}</h2>
+        <p className="text-sm text-muted">
+          {t('characters.identity', { race: character.race, gender: character.gender })}
+        </p>
+      </header>
+
+      {/* A fixed box so the panel does not jump while the picture loads. */}
+      <div className="flex h-[260px] w-[210px] items-center justify-center">
+        <CharacterImage
+          // Keyed by serial so switching characters remounts the image: without it a picture that
+          // failed once would keep its placeholder for the next character too.
+          key={character.serial}
+          src={paperdollUrl(character.serial)}
+          alt={t('characters.paperdollAlt', { name: character.name })}
+          className="max-h-full max-w-full object-contain"
+          fallback={<p className="text-center text-sm text-muted">{t('characters.noImage')}</p>}
+        />
+      </div>
+
+      <dl className="grid w-full max-w-sm grid-cols-2 gap-x-6 gap-y-2 px-6 text-sm">
+        <Stat label={t('characters.strength')} value={character.strength} />
+        <Stat label={t('characters.dexterity')} value={character.dexterity} />
+        <Stat label={t('characters.intelligence')} value={character.intelligence} />
+        <Stat label={t('characters.kills')} value={character.kills} />
+        <Stat
+          label={t('characters.hits')}
+          value={t('characters.pool', { current: character.hits, max: character.hitsMax })}
+        />
+        <Stat
+          label={t('characters.stamina')}
+          value={t('characters.pool', { current: character.stamina, max: character.staminaMax })}
+        />
+        <Stat
+          label={t('characters.mana')}
+          value={t('characters.pool', { current: character.mana, max: character.manaMax })}
+        />
+        <Stat label={t('characters.location')} value={`${character.x}, ${character.y}`} />
+      </dl>
+    </Card>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <dt className="text-muted">{label}</dt>
+      <dd className="font-bold text-ink">{value}</dd>
+    </div>
+  )
+}
+
+/**
+ * An image that gives way to something readable when it fails. A character whose body has no
+ * animation legitimately 404s from the image route, and the browser's broken-image icon is not an
+ * answer for a page whose whole point is the picture.
+ */
+function CharacterImage({
+  src,
+  alt,
+  className,
+  fallback,
+}: {
+  src: string
+  alt: string
+  className?: string
+  fallback: React.ReactNode
+}) {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return <>{fallback}</>
+  }
+
+  return <img src={src} alt={alt} className={className} onError={() => setFailed(true)} />
+}

--- a/ui/src/routes/CharactersScreen.tsx
+++ b/ui/src/routes/CharactersScreen.tsx
@@ -66,7 +66,9 @@ export function CharactersScreen() {
               />
               <span className="min-w-0">
                 <span className="block truncate font-bold">{one.name}</span>
-                <span className="block truncate text-xs text-muted">{one.race}</span>
+                <span className="block truncate text-xs text-muted">
+                  {t(`characters.race.${one.race}`, { defaultValue: one.race })}
+                </span>
               </span>
             </button>
           ))}
@@ -86,7 +88,12 @@ function CharacterPanel({ character }: { character: Character }) {
       <header className="text-center">
         <h2 className="text-xl font-bold text-ink">{character.name}</h2>
         <p className="text-sm text-muted">
-          {t('characters.identity', { race: character.race, gender: character.gender })}
+          {t('characters.identity', {
+            // The server reports these as its own enum names. Falling back to that name means a
+            // race the portal has no word for still reads as something, rather than as a raw key.
+            race: t(`characters.race.${character.race}`, { defaultValue: character.race }),
+            gender: t(`characters.gender.${character.gender}`, { defaultValue: character.gender }),
+          })}
         </p>
       </header>
 


### PR DESCRIPTION
Closes #166 (by hand once merged — this targets `develop`).

The character image routes merged this afternoon in #165 served a real character's figure and paperdoll, and nothing in the portal looked at them. No screen showed a character at all: they appeared only as the `characterCount` column on the accounts table. This is the screen they were built for.

## The screen

`/characters`, beside `/map` under `RequireAuth` + `AppShell`. Master–detail: the list on the left carries each character's small in-world figure, and the panel on the right carries the paperdoll, the stats and the pools. Two columns on wide viewports, stacked on narrow ones.

The selection is held as a **serial** and resolved against the current list, so arriving needs no effect to pick the first character, and one disappearing cannot leave a selection pointing at nothing.

Empty, error, loading and failed-picture states are all real cases, not decoration: an account can exist with no characters, and a body with no animation legitimately 404s from the image route — a broken-image icon is not an answer for a page whose whole point is the picture.

**No cache-busting parameter on the image URLs**, deliberately. The URL is stable and the ETag fingerprints the appearance, so the browser revalidates and takes a 304 until the character changes clothes; a `?t=` would force a full download on every visit. A test asserts its absence, because appending one is the natural reflex.

## A defect found on the way

The image routes constrained their serial to `{serial:long}`, so they matched **only decimal**, while every other part of the API reports a serial as `0x40000001` — `CharacterResponse.Serial` is documented in exactly that form. Feeding the API's own value to its own image route answered **404**, which reads as "no such character" rather than "wrong number base", and made the base conversion every consumer's problem.

Fixed at the route rather than in the frontend: both routes now take the serial as a string and parse it. `Serial.TryParse` is the mirror of `Serial.ToString`, with the `0x` prefix picking the base so a bare `40000001` stays decimal instead of being guessed at. An unparsable serial is the same 404 as an unknown one — from outside, both mean the picture does not exist.

## Checks

- .NET **2055 passed**; UI **230 passed**, production build clean, Prettier clean.
- DocFX **0 warnings**.
- UI contract regenerated (`openapi:sync` + `openapi:types`): the path parameter turns from integer into string.
- No packet classes changed, so no packet-docs regeneration.

## Not in this pass

The staff view over every character (the rest of Trello #130) — a showcase and an admin tool want different layouts. Nothing here changes a character; skills and inventory are a different screen; race-aware bodies (#78) will improve these pictures without touching this page.