### PR TITLE
feat(ui): a staff table of every character

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import { MapScreen } from './routes/MapScreen'
 import { CharactersScreen } from './routes/CharactersScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
+import { CharactersAdminScreen } from './routes/admin/CharactersAdminScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
 import { SettingsScreen } from './routes/SettingsScreen'
 import { ConsoleScreen } from './routes/ConsoleScreen'
@@ -76,6 +77,7 @@ export function App() {
             >
               <Route index element={<AdminScreen />} />
               <Route path="accounts" element={<AccountsScreen />} />
+              <Route path="characters" element={<CharactersAdminScreen />} />
               <Route path="plugins" element={<PluginsScreen />} />
               <Route path="settings" element={<SettingsScreen />} />
               <Route path="console" element={<ConsoleScreen />} />

--- a/ui/src/components/characters/CharacterImage.test.tsx
+++ b/ui/src/components/characters/CharacterImage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { fireEvent } from '@testing-library/dom'
+
+import { CharacterImage } from './CharacterImage'
+
+describe('CharacterImage', () => {
+  it('shows the image', () => {
+    render(<CharacterImage src="/a.png" alt="Squid" fallback={<span>none</span>} />)
+
+    expect(screen.getByAltText('Squid')).toHaveAttribute('src', '/a.png')
+  })
+
+  // A body with no animation 404s from the image route, and the browser's broken-image icon is not
+  // an answer on a page whose point is the picture.
+  it('gives way to the fallback when the image fails', () => {
+    render(<CharacterImage src="/missing.png" alt="Squid" fallback={<span>none</span>} />)
+
+    fireEvent.error(screen.getByAltText('Squid'))
+
+    expect(screen.queryByAltText('Squid')).not.toBeInTheDocument()
+    expect(screen.getByText('none')).toBeInTheDocument()
+  })
+
+  // Without this, a row whose image failed keeps its placeholder when the table pages to a
+  // different character in the same position.
+  it('tries again when the src changes', () => {
+    const { rerender } = render(<CharacterImage src="/a.png" alt="One" fallback={<span>none</span>} />)
+
+    fireEvent.error(screen.getByAltText('One'))
+    expect(screen.getByText('none')).toBeInTheDocument()
+
+    rerender(<CharacterImage src="/b.png" alt="Two" fallback={<span>none</span>} />)
+
+    expect(screen.getByAltText('Two')).toHaveAttribute('src', '/b.png')
+  })
+})

--- a/ui/src/components/characters/CharacterImage.tsx
+++ b/ui/src/components/characters/CharacterImage.tsx
@@ -1,0 +1,30 @@
+import { useState, type ReactNode } from 'react'
+
+/**
+ * An image that gives way to something readable when it fails. A character whose body has no
+ * animation legitimately 404s from the image route, and the browser's broken-image icon is not an
+ * answer for a page whose whole point is the picture.
+ *
+ * The failure resets when `src` changes, so a reused row — a table paging to a different character
+ * in the same position — is not stuck with the previous one's placeholder. Storing which src failed
+ * rather than a boolean is what makes that reset free: no effect, no stale flag.
+ */
+export function CharacterImage({
+  src,
+  alt,
+  className,
+  fallback,
+}: {
+  src: string
+  alt: string
+  className?: string
+  fallback: ReactNode
+}) {
+  const [failed, setFailed] = useState<string | null>(null)
+
+  if (failed === src) {
+    return <>{fallback}</>
+  }
+
+  return <img src={src} alt={alt} className={className} onError={() => setFailed(src)} />
+}

--- a/ui/src/components/ui/data-table.test.tsx
+++ b/ui/src/components/ui/data-table.test.tsx
@@ -36,4 +36,70 @@ describe('DataTable', () => {
     // ascending by name puts aelric before althea
     expect(cells.indexOf('aelric')).toBeLessThan(cells.indexOf('althea'))
   })
+
+  it('renders no pager when pagination is not given', () => {
+    render(<DataTable columns={columns} data={rows} />)
+
+    expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument()
+  })
+
+  // The trap the controlled props exist for: with a server-driven search, filtering here would
+  // search only the page in hand and silently hide every match on another page.
+  it('does not filter in the browser when the search is controlled', async () => {
+    const onChange = vi.fn()
+
+    render(<DataTable columns={columns} data={rows} searchPlaceholder="Search" search={{ value: '', onChange }} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Search'), 'alth')
+
+    expect(onChange).toHaveBeenCalled()
+    expect(screen.getByText('aelric')).toBeInTheDocument()
+    expect(screen.getByText('althea')).toBeInTheDocument()
+  })
+
+  it('shows the controlled search value', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={rows}
+        searchPlaceholder="Search"
+        search={{ value: 'typed', onChange: vi.fn() }}
+      />,
+    )
+
+    expect(screen.getByPlaceholderText('Search')).toHaveValue('typed')
+  })
+
+  it('reports which page was asked for', async () => {
+    const onPageChange = vi.fn()
+
+    render(<DataTable columns={columns} data={rows} pagination={{ page: 2, totalPages: 5, onPageChange }} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(onPageChange).toHaveBeenCalledWith(3)
+
+    await userEvent.click(screen.getByRole('button', { name: /previous/i }))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it('cannot page past either end', () => {
+    const { rerender } = render(
+      <DataTable columns={columns} data={rows} pagination={{ page: 1, totalPages: 3, onPageChange: vi.fn() }} />,
+    )
+
+    expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled()
+
+    rerender(<DataTable columns={columns} data={rows} pagination={{ page: 3, totalPages: 3, onPageChange: vi.fn() }} />)
+
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+
+  // Sorting one page of a server-paged list reorders that page alone, which reads as "the strongest
+  // character" while meaning "the strongest on page 3".
+  it('offers no sort buttons while server-paged', () => {
+    render(<DataTable columns={columns} data={rows} pagination={{ page: 1, totalPages: 2, onPageChange: vi.fn() }} />)
+
+    expect(screen.queryByRole('button', { name: /name/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Name')).toBeInTheDocument()
+  })
 })

--- a/ui/src/components/ui/data-table.tsx
+++ b/ui/src/components/ui/data-table.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   type ColumnDef,
   type SortingState,
@@ -10,39 +11,59 @@ import {
 } from '@tanstack/react-table'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './table'
 import { Input } from './input'
+import { Button } from './button'
+
+/** A search box the caller owns, because the server does the filtering. */
+export type DataTableSearch = { value: string; onChange: (value: string) => void }
+
+/** A pager the caller owns, because the server does the paging. */
+export type DataTablePagination = { page: number; totalPages: number; onPageChange: (page: number) => void }
 
 // A searchable, sortable table over the styled primitives. Search is a global filter; each header is a
 // button that toggles that column's sort. Behaviour comes from TanStack Table; the look from the tokens.
+//
+// Pass `search` and/or `pagination` when the SERVER does that work instead. Each switches off the
+// matching client-side behaviour, and that is the point rather than a detail: filtering or sorting a
+// single page of a paged result operates on that page alone, so a search would report "not found"
+// for a row sitting on page 2.
 export function DataTable<T>({
   columns,
   data,
   searchPlaceholder,
+  search,
+  pagination,
 }: {
   columns: ColumnDef<T>[]
   data: T[]
   searchPlaceholder?: string
+  search?: DataTableSearch
+  pagination?: DataTablePagination
 }) {
+  const { t } = useTranslation()
   const [globalFilter, setGlobalFilter] = useState('')
   const [sorting, setSorting] = useState<SortingState>([])
+
+  const serverSearched = search !== undefined
+  const serverPaged = pagination !== undefined
 
   const table = useReactTable({
     data,
     columns,
-    state: { globalFilter, sorting },
+    state: { globalFilter: serverSearched ? '' : globalFilter, sorting: serverPaged ? [] : sorting },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getSortedRowModel: getSortedRowModel(),
+    ...(serverSearched ? {} : { getFilteredRowModel: getFilteredRowModel() }),
+    ...(serverPaged ? {} : { getSortedRowModel: getSortedRowModel() }),
   })
 
   return (
     <div className="flex flex-col gap-3">
       {searchPlaceholder !== undefined && (
         <Input
-          value={globalFilter}
+          value={search ? search.value : globalFilter}
           placeholder={searchPlaceholder}
-          onChange={(e) => setGlobalFilter(e.target.value)}
+          onChange={(e) => (search ? search.onChange(e.target.value) : setGlobalFilter(e.target.value))}
           className="max-w-xs"
         />
       )}
@@ -52,16 +73,22 @@ export function DataTable<T>({
             <TableRow key={group.id}>
               {group.headers.map((header) => (
                 <TableHead key={header.id}>
-                  <button
-                    type="button"
-                    className="flex items-center gap-1 uppercase"
-                    onClick={header.column.getToggleSortingHandler()}
-                  >
-                    {flexRender(header.column.columnDef.header, header.getContext())}
-                    <span className="text-gold">
-                      {{ asc: '▲', desc: '▼' }[header.column.getIsSorted() as string] ?? ''}
+                  {serverPaged ? (
+                    <span className="flex items-center gap-1 uppercase">
+                      {flexRender(header.column.columnDef.header, header.getContext())}
                     </span>
-                  </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="flex items-center gap-1 uppercase"
+                      onClick={header.column.getToggleSortingHandler()}
+                    >
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      <span className="text-gold">
+                        {{ asc: '▲', desc: '▼' }[header.column.getIsSorted() as string] ?? ''}
+                      </span>
+                    </button>
+                  )}
                 </TableHead>
               ))}
             </TableRow>
@@ -81,6 +108,32 @@ export function DataTable<T>({
           ))}
         </TableBody>
       </Table>
+
+      {pagination && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted">
+            {t('common.pageOf', { page: pagination.page, total: Math.max(pagination.totalPages, 1) })}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="default"
+              className="px-3 py-1 text-xs"
+              disabled={pagination.page <= 1}
+              onClick={() => pagination.onPageChange(pagination.page - 1)}
+            >
+              {t('common.previous')}
+            </Button>
+            <Button
+              variant="default"
+              className="px-3 py-1 text-xs"
+              disabled={pagination.page >= pagination.totalPages}
+              onClick={() => pagination.onPageChange(pagination.page + 1)}
+            >
+              {t('common.next')}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/ui/src/lib/characters.test.ts
+++ b/ui/src/lib/characters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { figureUrl, paperdollUrl } from './characters'
+import { charactersQuery, figureUrl, paperdollUrl } from './characters'
 
 // The serial is used verbatim, in the `0x40000001` form the API reports it in. The routes accept
 // that form, so nothing here converts bases -- a conversion is the kind of thing that silently
@@ -24,5 +24,28 @@ describe('character image urls', () => {
   it('never adds a cache-busting parameter', () => {
     expect(figureUrl('0x1')).not.toMatch(/[?&](t|v|_)=/)
     expect(paperdollUrl('0x1')).not.toMatch(/[?&](t|v|_)=/)
+  })
+})
+
+describe('staff characters query', () => {
+  it('asks for the page it was given', () => {
+    expect(charactersQuery({ page: 3, search: '' })).toBe('/api/v1/admin/characters?page=3&pageSize=25')
+  })
+
+  // Blank means no filter; sending `search=` would be a filter on the empty string.
+  it('omits an empty search', () => {
+    expect(charactersQuery({ page: 1, search: '   ' })).toBe('/api/v1/admin/characters?page=1&pageSize=25')
+  })
+
+  it('encodes the search', () => {
+    expect(charactersQuery({ page: 1, search: 'lord blackthorn' })).toBe(
+      '/api/v1/admin/characters?page=1&pageSize=25&search=lord+blackthorn',
+    )
+  })
+
+  // page 0 is a 400 from the server, so a bug that reaches it should be visible here rather than as
+  // a failed request.
+  it('never asks for a page below 1', () => {
+    expect(charactersQuery({ page: 0, search: '' })).toBe('/api/v1/admin/characters?page=1&pageSize=25')
   })
 })

--- a/ui/src/lib/characters.ts
+++ b/ui/src/lib/characters.ts
@@ -26,3 +26,41 @@ export const paperdollUrl = (serial: string, background = true) =>
   background
     ? `/api/v1/images/mobiles/${serial}/paperdoll.png`
     : `/api/v1/images/mobiles/${serial}/paperdoll.png?background=false`
+
+export type CharacterPage = components['schemas']['CharacterResponsePagedResponse']
+
+/** The server's own default. Named here so the pager and the request cannot disagree. */
+export const CHARACTERS_PAGE_SIZE = 25
+
+/**
+ * The staff listing URL. A blank search is omitted rather than sent empty: the server reads a blank
+ * `search` as "no filter" anyway, and leaving it out keeps the query key stable so paging with an
+ * empty box does not miss the cache.
+ */
+export function charactersQuery({ page, search }: { page: number; search: string }): string {
+  const params = new URLSearchParams({
+    page: String(Math.max(page, 1)),
+    pageSize: String(CHARACTERS_PAGE_SIZE),
+  })
+
+  const trimmed = search.trim()
+
+  if (trimmed !== '') {
+    params.set('search', trimmed)
+  }
+
+  return `/api/v1/admin/characters?${params}`
+}
+
+/**
+ * Every character on the shard, paged and searched by the server. Staff only.
+ *
+ * The previous page is held while the next loads: without it the table blanks to its loading state
+ * on every keystroke and every page turn, which reads as a slideshow rather than a table.
+ */
+export const useAllCharacters = (params: { page: number; search: string }) =>
+  useQuery({
+    queryKey: ['admin', 'characters', params.page, params.search.trim()],
+    queryFn: () => apiFetch<CharacterPage>(charactersQuery(params)),
+    placeholderData: (previous: CharacterPage | undefined) => previous,
+  })

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -158,7 +158,8 @@
       "accounts": "Accounts",
       "plugins": "Plugins",
       "settings": "Settings",
-      "console": "Console"
+      "console": "Console",
+      "characters": "Characters"
     },
     "accounts": {
       "title": "Accounts",
@@ -248,6 +249,22 @@
       "empty": "No output yet. Type a command to begin.",
       "hint": "↑ / ↓ for history",
       "snippets": "Quick commands"
+    },
+    "characters": {
+      "title": "Characters",
+      "search": "Search by character or account…",
+      "preview": "Preview",
+      "name": "Name",
+      "account": "Account",
+      "race": "Race",
+      "stats": "Str / Dex / Int",
+      "hits": "Hits",
+      "location": "Location",
+      "total": "{{count}} characters",
+      "empty": "No character matches that search.",
+      "loadFailed": "The characters could not be loaded.",
+      "noImage": "—",
+      "unknownAccount": "Unknown"
     }
   },
   "characters": {

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -119,7 +119,10 @@
   "common": {
     "signOut": "Sign out",
     "loading": "Loading…",
-    "backToLogin": "Back to sign in"
+    "backToLogin": "Back to sign in",
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {{page}} of {{total}}"
   },
   "error": {
     "generic": "Something went wrong. Please try again."

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -119,7 +119,10 @@
   "common": {
     "signOut": "Esci",
     "loading": "Caricamento…",
-    "backToLogin": "Torna all’accesso"
+    "backToLogin": "Torna all’accesso",
+    "previous": "Precedente",
+    "next": "Successiva",
+    "pageOf": "Pagina {{page}} di {{total}}"
   },
   "error": {
     "generic": "Qualcosa è andato storto. Riprova."

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -158,7 +158,8 @@
       "accounts": "Account",
       "plugins": "Plugin",
       "settings": "Impostazioni",
-      "console": "Console"
+      "console": "Console",
+      "characters": "Personaggi"
     },
     "accounts": {
       "title": "Account",
@@ -248,6 +249,22 @@
       "empty": "Nessun output. Scrivi un comando per iniziare.",
       "hint": "↑ / ↓ per la cronologia",
       "snippets": "Comandi rapidi"
+    },
+    "characters": {
+      "title": "Personaggi",
+      "search": "Cerca per personaggio o account…",
+      "preview": "Anteprima",
+      "name": "Nome",
+      "account": "Account",
+      "race": "Razza",
+      "stats": "For / Des / Int",
+      "hits": "Vita",
+      "location": "Posizione",
+      "total": "{{count}} personaggi",
+      "empty": "Nessun personaggio corrisponde alla ricerca.",
+      "loadFailed": "Non è stato possibile caricare i personaggi.",
+      "noImage": "—",
+      "unknownAccount": "Sconosciuto"
     }
   },
   "characters": {

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -21,6 +21,7 @@ describe('AdminLayout', () => {
     renderAt('/admin')
     expect(screen.getByRole('link', { name: /overview/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /characters/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /console/i })).toBeInTheDocument()

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -19,6 +19,9 @@ export function AdminLayout() {
         <NavLink to="/admin/accounts" className={linkClass}>
           {t('admin.nav.accounts')}
         </NavLink>
+        <NavLink to="/admin/characters" className={linkClass}>
+          {t('admin.nav.characters')}
+        </NavLink>
         <NavLink to="/admin/plugins" className={linkClass}>
           {t('admin.nav.plugins')}
         </NavLink>

--- a/ui/src/routes/CharactersScreen.tsx
+++ b/ui/src/routes/CharactersScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Card } from '../components/ui/card'
+import { CharacterImage } from '../components/characters/CharacterImage'
 import { cn } from '../lib/utils'
 import { figureUrl, paperdollUrl, useMyCharacters, type Character } from '../lib/characters'
 
@@ -140,29 +141,4 @@ function Stat({ label, value }: { label: string; value: string | number }) {
       <dd className="font-bold text-ink">{value}</dd>
     </div>
   )
-}
-
-/**
- * An image that gives way to something readable when it fails. A character whose body has no
- * animation legitimately 404s from the image route, and the browser's broken-image icon is not an
- * answer for a page whose whole point is the picture.
- */
-function CharacterImage({
-  src,
-  alt,
-  className,
-  fallback,
-}: {
-  src: string
-  alt: string
-  className?: string
-  fallback: React.ReactNode
-}) {
-  const [failed, setFailed] = useState(false)
-
-  if (failed) {
-    return <>{fallback}</>
-  }
-
-  return <img src={src} alt={alt} className={className} onError={() => setFailed(true)} />
 }

--- a/ui/src/routes/admin/CharactersAdminScreen.test.tsx
+++ b/ui/src/routes/admin/CharactersAdminScreen.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import '../../lib/i18n'
+import { CharactersAdminScreen } from './CharactersAdminScreen'
+import type { Character, CharacterPage } from '../../lib/characters'
+
+const query = vi.hoisted(() => ({
+  data: undefined as CharacterPage | undefined,
+  isPending: false,
+  isError: false,
+  lastParams: null as { page: number; search: string } | null,
+}))
+
+// Only the hook is stubbed; figureUrl is the real one, so the src assertion below checks what the
+// browser would actually request.
+vi.mock('../../lib/characters', async (original) => ({
+  ...(await original<typeof import('../../lib/characters')>()),
+  useAllCharacters: (params: { page: number; search: string }) => {
+    query.lastParams = params
+    return query
+  },
+}))
+
+function character(serial: string, name: string, account: string | null): Character {
+  return {
+    serial,
+    name,
+    accountUsername: account,
+    race: 'Human',
+    gender: 'Male',
+    body: 400,
+    strength: 60,
+    dexterity: 45,
+    intelligence: 30,
+    hits: 55,
+    hitsMax: 60,
+    stamina: 45,
+    staminaMax: 45,
+    mana: 30,
+    manaMax: 30,
+    kills: 0,
+    skinHue: 1002,
+    hairStyle: 8252,
+    hairHue: 1102,
+    mapId: 1,
+    x: 1495,
+    y: 1629,
+    z: 0,
+  } as Character
+}
+
+function page(items: Character[], over: Partial<CharacterPage> = {}): CharacterPage {
+  return { items, total: items.length, page: 1, pageSize: 25, totalPages: 1, ...over } as CharacterPage
+}
+
+function renderWith(data: CharacterPage | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isPending: false, isError: false }, state)
+  return render(<CharactersAdminScreen />)
+}
+
+describe('CharactersAdminScreen', () => {
+  it('lists the characters with their owning account', () => {
+    renderWith(page([character('0x1', 'Squid', 'tom'), character('0x2', 'Vega', 'alice')]))
+
+    expect(screen.getByText('Squid')).toBeInTheDocument()
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+
+  it('shows a preview addressed by the serial the API reported', () => {
+    renderWith(page([character('0x40000001', 'Squid', 'tom')]))
+
+    expect(screen.getByAltText('Squid')).toHaveAttribute('src', '/api/v1/images/mobiles/0x40000001.png')
+  })
+
+  // The search is the server's. If this ever asserts filtered rows instead of the passed-through
+  // term, the screen has started filtering locally and searches a single page.
+  it('hands the typed search to the query', async () => {
+    renderWith(page([character('0x1', 'Squid', 'tom')]))
+
+    await userEvent.type(screen.getByPlaceholderText(/Search by character/), 'veg')
+
+    expect(query.lastParams?.search).toBe('veg')
+  })
+
+  it('asks for the next page', async () => {
+    renderWith(page([character('0x1', 'Squid', 'tom')], { totalPages: 3 }))
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    expect(query.lastParams?.page).toBe(2)
+  })
+
+  // Searching from page 3 would otherwise land on page 3 of a one-page result: an empty table that
+  // reads as "no matches" for a search that in fact matched.
+  it('returns to the first page when the search changes', async () => {
+    renderWith(page([character('0x1', 'Squid', 'tom')], { totalPages: 3 }))
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(query.lastParams?.page).toBe(2)
+
+    await userEvent.type(screen.getByPlaceholderText(/Search by character/), 'v')
+
+    expect(query.lastParams?.page).toBe(1)
+  })
+
+  it('reports the total, which counts every match and not just this page', () => {
+    renderWith(page([character('0x1', 'Squid', 'tom')], { total: 87, totalPages: 4 }))
+
+    expect(screen.getByText('87 characters')).toBeInTheDocument()
+  })
+
+  it('says so when a search matches nothing', () => {
+    renderWith(page([], { total: 0 }))
+
+    expect(screen.getByText('No character matches that search.')).toBeInTheDocument()
+  })
+
+  it('says so when the request failed', () => {
+    renderWith(undefined, { isError: true })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The characters could not be loaded.')
+  })
+
+  it('names a character with no owning account rather than showing a blank', () => {
+    renderWith(page([character('0x1', 'Squid', null)]))
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/admin/CharactersAdminScreen.tsx
+++ b/ui/src/routes/admin/CharactersAdminScreen.tsx
@@ -1,0 +1,95 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { DataTable } from '../../components/ui/data-table'
+import { CharacterImage } from '../../components/characters/CharacterImage'
+import { figureUrl, useAllCharacters, type Character } from '../../lib/characters'
+
+export function CharactersAdminScreen() {
+  const { t } = useTranslation()
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const characters = useAllCharacters({ page, search })
+
+  const columns = useMemo<ColumnDef<Character>[]>(
+    () => [
+      {
+        id: 'preview',
+        header: t('admin.characters.preview'),
+        cell: ({ row }) => (
+          <CharacterImage
+            src={figureUrl(row.original.serial)}
+            alt={row.original.name}
+            className="h-16 w-16 object-contain"
+            fallback={<span className="block h-16 w-16 text-center text-muted">{t('admin.characters.noImage')}</span>}
+          />
+        ),
+      },
+      { accessorKey: 'name', header: t('admin.characters.name') },
+      {
+        accessorKey: 'accountUsername',
+        header: t('admin.characters.account'),
+        cell: ({ getValue }) => (getValue() as string | null) ?? t('admin.characters.unknownAccount'),
+      },
+      {
+        accessorKey: 'race',
+        header: t('admin.characters.race'),
+        cell: ({ row }) => t(`characters.race.${row.original.race}`, { defaultValue: row.original.race }),
+      },
+      {
+        id: 'stats',
+        header: t('admin.characters.stats'),
+        cell: ({ row }) => `${row.original.strength} / ${row.original.dexterity} / ${row.original.intelligence}`,
+      },
+      {
+        id: 'hits',
+        header: t('admin.characters.hits'),
+        cell: ({ row }) => `${row.original.hits} / ${row.original.hitsMax}`,
+      },
+      {
+        id: 'location',
+        header: t('admin.characters.location'),
+        cell: ({ row }) => `${row.original.x}, ${row.original.y}`,
+      },
+    ],
+    [t],
+  )
+
+  // A new search restarts the paging. Without this, searching from page 3 asks the server for page 3
+  // of a result that may have one page, and the empty table reads as "no matches" for a search that
+  // in fact matched.
+  function changeSearch(value: string) {
+    setSearch(value)
+    setPage(1)
+  }
+
+  if (characters.isError) {
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t('admin.characters.loadFailed')}
+      </p>
+    )
+  }
+
+  const result = characters.data
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-xl text-ink">{t('admin.characters.title')}</h1>
+        {result && <span className="text-sm text-muted">{t('admin.characters.total', { count: result.total })}</span>}
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={result?.items ?? []}
+        searchPlaceholder={t('admin.characters.search')}
+        search={{ value: search, onChange: changeSearch }}
+        pagination={{ page, totalPages: result?.totalPages ?? 1, onPageChange: setPage }}
+      />
+
+      {result && result.items.length === 0 && <p className="text-sm text-muted">{t('admin.characters.empty')}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #168 (by hand once merged — this targets `develop`).

The second half of Trello #131: the player screen from #167 covers a player's own characters, staff had no view over the shard. `GET /api/v1/admin/characters` already paged and searched server-side and nothing called it.

## The screen

`/admin/characters`, a fifth tab beside Accounts, inheriting `RequireAuth` + `RequireAdmin` + `AppShell` from the parent route rather than declaring guards that could drift from it. A table with a 64px preview, the name, the owning account, race, stats, hits and location.

## The trap this change is shaped around

The shared `DataTable` filters and sorts **in the browser**, over the array it is handed. Give it one page of 25 rows and its search box searches those 25 rows only — the box appears to work while every match on another page silently disappears. A staff member searching for a player would conclude the character does not exist. The same for its sort headers: sorting one page gives "the strongest character on page 3".

So `DataTable` gained optional `search` and `pagination` props, and passing either switches off the matching client-side behaviour. Omitting them leaves the default path unchanged, which is what keeps `AccountsScreen` working untouched — asserted by a test.

This matters concretely here: the server's search matches the **account username** as well as the character name, and the account is not a value any client-side filter over the visible rows could reach.

## Other decisions worth naming

- **A new search resets the page to 1.** Otherwise searching from page 3 asks for page 3 of a one-page result, and the empty table reads as "no matches" for a search that in fact matched.
- **`CharacterImage` was extracted** out of `CharactersScreen` so both screens share the 404 fallback. It now resets its failure when `src` changes rather than relying on the caller for a fresh `key`, which a table reusing rows across pages would not supply.
- **No column sorting.** The server orders by name; sorting one page would mislead.

## Checks

- UI **255 passed**, production build (`tsc --noEmit && vite build`) and Prettier clean.
- No C# changed, so no .NET run, no packet docs and **no contract regeneration** — `CharacterResponsePagedResponse` was already generated.
- Verified against a running shard, since the tests mock the hook: the URLs the code builds answer 200 on the real route, `search=admin` returns the character owned by that account (the half no client filter could do), and `page=0` is the 400 that `Math.max(page, 1)` exists to prevent.

## Not included

Editing or deleting a character — no endpoint, and world mutation belongs on the game loop.