### PR TITLE
feat: a character detail page with equipment and backpack

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -110,6 +110,7 @@ good token that is simply not staff.
 | `DELETE` | `/api/v1/admin/accounts/{username}`  | `admin`  | 204, or 404 / 409 / 503            |
 | `GET`    | `/api/v1/player/me/characters`       | `player` | the caller's own characters        |
 | `GET`    | `/api/v1/admin/characters`           | `admin`  | every character, paged             |
+| `GET`    | `/api/v1/characters/{serial}`        | `player` | one character in full, or 403 / 404 |
 | `GET`    | `/api/v1/admin/players/online`       | `admin`  | players currently in the world     |
 | `GET`    | `/api/v1/images/items/{id}.png`      | none     | item art as PNG, or 400 / 404 / 503 |
 | `POST`   | `/api/v1/admin/images/items`         | `admin`  | 202, or 409 / 503                  |
@@ -201,7 +202,30 @@ account's `MobileIds`. The admin route therefore reads the accounts first, which
 it must do anyway to name each character's owner, and uses that to tell characters
 from the NPCs sharing the mobile store.
 
-Neither route returns `MobileEntity`. It carries `BrainScriptId`, `LootTableId`
+`GET /api/v1/characters/{serial}` is one character in full, and the one route
+both audiences use: an account reads its own characters, staff read anyone's, and
+anything else is a 403. Ownership is checked against the account the **token**
+names — an id the caller could supply would let anyone read anyone's character by
+changing a number. The serial takes the form the rest of the API reports it in,
+`0x40000001`, or plain decimal; a serial naming no character and one that is not
+a number are the same 404.
+
+It returns the character in the shape the lists already use, the worn items by
+layer — the backpack and the bank box among them — and the backpack's contents as
+a **tree**, nested containers expanded to a depth of 10.
+
+That depth is a guard, not a preference. Containment is a plain list of serials
+with nothing preventing a bag from containing an ancestor, and the walk is
+recursive on a request thread: a cycle there is a hung request rather than a
+wrong answer. A visited set stops one, and the depth limit stops anything the
+visited set misses.
+
+Like the online-player route, this reads world state off the game loop. An item
+the loop moves mid-read may appear in neither place or in both; the next request
+settles it. That trade-off is local to read-only views — world mutations still
+belong on the loop.
+
+Neither list route returns `MobileEntity`. It carries `BrainScriptId`, `LootTableId`
 and `BackpackId`, and a field added to it later would publish itself; the DTO
 names its fields for the same reason `AccountResponse` does.
 

--- a/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterDetailResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterDetailResponse.cs
@@ -1,0 +1,11 @@
+namespace Moongate.Http.Plugin.Data.Api.Characters;
+
+/// <summary>Everything one character is: who they are, what they wear, what they carry.</summary>
+/// <param name="Character">The same shape the character lists report, so the two cannot disagree.</param>
+/// <param name="Equipment">Worn items by layer, the backpack and the bank box among them.</param>
+/// <param name="Backpack">The backpack's contents, nested containers expanded.</param>
+public sealed record CharacterDetailResponse(
+    CharacterResponse Character,
+    IReadOnlyList<CharacterItemResponse> Equipment,
+    IReadOnlyList<CharacterItemResponse> Backpack
+);

--- a/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterItemResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterItemResponse.cs
@@ -1,0 +1,24 @@
+namespace Moongate.Http.Plugin.Data.Api.Characters;
+
+/// <summary>
+/// One item as the API reports it, with whatever it contains. Deliberately not <c>ItemEntity</c>, which
+/// carries script and loot ids: a field added to the entity later would publish itself.
+/// </summary>
+/// <param name="Serial">The item's serial, as <c>0x40000001</c>.</param>
+/// <param name="Name">The item's name. Blank when the item is named by cliloc rather than stored text.</param>
+/// <param name="TemplateId">The template it was built from.</param>
+/// <param name="ItemId">The art id, which addresses <c>/api/v1/images/items/{id}.png</c>.</param>
+/// <param name="Hue">0 for the raw art.</param>
+/// <param name="Amount">How many, for a stack.</param>
+/// <param name="Layer">The layer it is worn on, or null when it sits inside a container.</param>
+/// <param name="Contents">What it contains. Empty for anything that is not a container.</param>
+public sealed record CharacterItemResponse(
+    string Serial,
+    string Name,
+    string TemplateId,
+    int ItemId,
+    int Hue,
+    int Amount,
+    string? Layer,
+    IReadOnlyList<CharacterItemResponse> Contents
+);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
@@ -1,0 +1,110 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+
+namespace Moongate.Http.Plugin.Endpoints.Characters;
+
+/// <summary>One character in full, for its owner or for staff.</summary>
+public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
+{
+    private readonly IAccountService _accounts;
+    private readonly ICharacterQueryService _characters;
+    private readonly CharacterInventoryReader _inventory;
+
+    public CharacterDetailEndpoints(
+        IAccountService accounts,
+        ICharacterQueryService characters,
+        CharacterInventoryReader inventory
+    )
+    {
+        _accounts = accounts;
+        _characters = characters;
+        _inventory = inventory;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+        => routes.MapGet("/api/v1/characters/{serial}", GetOne)
+                 .WithName("GetCharacter")
+                 .WithTags("characters")
+                 .Produces<CharacterDetailResponse>()
+                 .RequireAuthorization(HttpServerService.PlayerPolicy);
+
+    /// <summary>One character in full: stats, appearance, what they wear and what they carry.</summary>
+    /// <remarks>
+    /// The serial takes the form the rest of the API reports, <c>0x40000001</c>, or plain decimal. An
+    /// account may read its own characters; staff may read anyone's, and everyone else gets 403. A
+    /// serial naming no character is 404, and so is one that is not a number.
+    ///
+    /// The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the
+    /// worn items by layer, the backpack and the bank box among them, without expanding them.
+    ///
+    /// Read off the game loop, so an item the loop moves mid-read may appear in neither place or in
+    /// both. The next request settles it: this is a view, not a ledger.
+    /// </remarks>
+    private IResult GetOne(string serial, ClaimsPrincipal user)
+    {
+        if (!Serial.TryParse(serial, out var characterId))
+        {
+            return NotFound();
+        }
+
+        var found = _characters.Find(characterId);
+
+        if (found is null)
+        {
+            return NotFound();
+        }
+
+        // The account comes from the token, never from the request: an id a caller could supply would
+        // let anyone read anyone's character by changing a number.
+        if (!CharacterEndpoints.TryReadAccountId(user, out var accountId))
+        {
+            return Results.Problem("The token carries no account id.", statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var caller = _accounts.GetById(accountId);
+
+        if (caller is null)
+        {
+            return Results.Problem(
+                "The account this token belongs to no longer exists.",
+                statusCode: StatusCodes.Status401Unauthorized
+            );
+        }
+
+        if (!IsStaff(caller.AccountLevel) && !caller.MobileIds.Contains(characterId))
+        {
+            return Results.Problem(
+                "That character belongs to another account.",
+                statusCode: StatusCodes.Status403Forbidden
+            );
+        }
+
+        return Results.Ok(
+            new CharacterDetailResponse(
+                CharacterResponse.From(found.Mobile, found.AccountUsername),
+                _inventory.ReadEquipment(found.Mobile),
+                _inventory.ReadBackpack(found.Mobile)
+            )
+        );
+    }
+
+    /// <summary>The same two levels the admin policy admits, so the two cannot drift apart.</summary>
+    private static bool IsStaff(AccountLevelType level)
+        => level is AccountLevelType.Administrator or AccountLevelType.GrandMaster;
+
+    /// <summary>
+    /// One answer for "no such character" and "that is not even a serial": from outside, both mean
+    /// there is nothing at that address.
+    /// </summary>
+    private static IResult NotFound()
+        => Results.Problem("No character with that serial.", statusCode: StatusCodes.Status404NotFound);
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -27,6 +27,7 @@ using Moongate.Http.Plugin.Interfaces.Registration;
 using Moongate.Http.Plugin.Interfaces.Ultima;
 using Moongate.Http.Plugin.Services.Assets;
 using Moongate.Http.Plugin.Services.Auth;
+using Moongate.Http.Plugin.Services.Characters;
 using Moongate.Http.Plugin.Services.Console;
 using Moongate.Http.Plugin.Services.Hosting;
 using Moongate.Http.Plugin.Services.Images;
@@ -117,6 +118,11 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<OnlinePlayerAdminEndpoints>();
         container.RegisterApiEndpoint<CharacterEndpoints>();
         container.RegisterApiEndpoint<CharacterAdminEndpoints>();
+
+        // The detail route's reader walks containers; it takes IItemService and nothing else, so it
+        // is a plain singleton beside the endpoint group that uses it.
+        container.Register<CharacterInventoryReader>(Reuse.Singleton);
+        container.RegisterApiEndpoint<CharacterDetailEndpoints>();
         container.RegisterApiEndpoint<ItemTemplateEndpoints>();
 
         // A REST web-terminal onto the admin command set: the registry holds the open SSE feeds,

--- a/plugins/Moongate.Http.Plugin/Services/Characters/CharacterInventoryReader.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Characters/CharacterInventoryReader.cs
@@ -1,0 +1,73 @@
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Items;
+
+namespace Moongate.Http.Plugin.Services.Characters;
+
+/// <summary>
+/// Turns a character's worn items and backpack into the API's item tree.
+///
+/// The walk is recursive over a containment graph nothing validates, and it runs on a request thread —
+/// so it carries two guards. A visited set stops a container holding an ancestor from looping forever,
+/// and a depth limit stops anything the visited set somehow misses. Neither is defensive padding:
+/// without them a cycle hangs the request rather than answering wrongly.
+/// </summary>
+public sealed class CharacterInventoryReader
+{
+    /// <summary>Deep enough that no real bag tree reaches it, shallow enough that a cycle costs nothing.</summary>
+    public const int MaxDepth = 10;
+
+    private readonly IItemService _items;
+
+    public CharacterInventoryReader(IItemService items)
+    {
+        _items = items;
+    }
+
+    /// <summary>The items worn on each layer, the backpack and the bank box among them.</summary>
+    public IReadOnlyList<CharacterItemResponse> ReadEquipment(MobileEntity mobile)
+    {
+        var visited = new HashSet<Serial>();
+
+        return [.. _items.GetEquipped(mobile).Select(item => Read(item, visited, 1))];
+    }
+
+    /// <summary>The backpack's contents as a tree. Empty when the character has no backpack.</summary>
+    public IReadOnlyList<CharacterItemResponse> ReadBackpack(MobileEntity mobile)
+    {
+        if (!mobile.BackpackId.IsValid || _items.GetById(mobile.BackpackId) is null)
+        {
+            return [];
+        }
+
+        // The backpack counts as visited before the walk starts, so an item inside it that points back
+        // at it stops there instead of listing the whole bag again one level down.
+        var visited = new HashSet<Serial> { mobile.BackpackId };
+
+        return [.. _items.GetContents(mobile.BackpackId).Select(item => Read(item, visited, 1))];
+    }
+
+    private CharacterItemResponse Read(ItemEntity item, HashSet<Serial> visited, int depth)
+    {
+        IReadOnlyList<CharacterItemResponse> contents = [];
+
+        // Add returns false when this item has already been reported on this walk, which is the cycle
+        // case: descending again would repeat everything under it, forever.
+        if (depth < MaxDepth && visited.Add(item.Id))
+        {
+            contents = [.. _items.GetContents(item.Id).Select(child => Read(child, visited, depth + 1))];
+        }
+
+        return new(
+            item.Id.ToString(),
+            item.Name,
+            item.TemplateId,
+            item.ItemId,
+            item.Hue.Value,
+            item.Amount,
+            item.EquippedLayer?.ToString(),
+            contents
+        );
+    }
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Accounts/ICharacterQueryService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Accounts/ICharacterQueryService.cs
@@ -1,3 +1,4 @@
+using Moongate.Core.Primitives;
 using Moongate.Server.Abstractions.Data.Internal;
 using SquidStd.Persistence.Abstractions.Data;
 
@@ -14,4 +15,10 @@ public interface ICharacterQueryService
     /// <param name="skip">Characters to skip. Past the end yields an empty page and the true total.</param>
     /// <param name="take">Page size.</param>
     PagedResult<OwnedCharacter> Search(string? search, int skip, int take);
+
+    /// <summary>
+    /// One character by serial, with its owner's username. Null when no account owns that mobile —
+    /// which is what tells a player character from the NPCs sharing the mobile store.
+    /// </summary>
+    OwnedCharacter? Find(Serial characterId);
 }

--- a/src/Moongate.Server/Services/Accounts/CharacterQueryService.cs
+++ b/src/Moongate.Server/Services/Accounts/CharacterQueryService.cs
@@ -23,6 +23,28 @@ public sealed class CharacterQueryService : ICharacterQueryService
         _mobileStore = persistenceService.GetStore<MobileEntity, Serial>();
     }
 
+    public OwnedCharacter? Find(Serial characterId)
+    {
+        var mobile = _mobileStore.GetById(characterId);
+
+        if (mobile is null)
+        {
+            return null;
+        }
+
+        // Same rule as Search: an account's MobileIds is the only thing marking a mobile as a player
+        // character, so a mobile nobody owns is an NPC and not addressable here.
+        foreach (var account in _accounts.GetAll())
+        {
+            if (account.MobileIds.Contains(characterId))
+            {
+                return new(mobile, account.Username);
+            }
+        }
+
+        return null;
+    }
+
     public PagedResult<OwnedCharacter> Search(string? search, int skip, int take)
     {
         // One pass over the accounts, needed either way: it is what tells a character from an NPC, and the

--- a/tests/Moongate.Tests/Http/Characters/CharacterInventoryReaderTests.cs
+++ b/tests/Moongate.Tests/Http/Characters/CharacterInventoryReaderTests.cs
@@ -1,0 +1,150 @@
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Persistence.Entities;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Http.Characters;
+
+/// <summary>
+/// The walk is recursive over a containment graph nothing validates, and it runs on a request thread.
+/// Its guards are the point of the class: without them a bag containing an ancestor is not a wrong
+/// answer, it is a hung request.
+/// </summary>
+public class CharacterInventoryReaderTests
+{
+    [Fact]
+    public void ReadBackpack_ReturnsWhatIsDirectlyInside()
+    {
+        var items = new StubItemService([]);
+        var backpack = Container(items, 100);
+
+        Put(items, backpack, Item(items, 1, "sword"));
+        Put(items, backpack, Item(items, 2, "gold"));
+
+        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+
+        Assert.Equal(["sword", "gold"], contents.Select(item => item.Name));
+    }
+
+    [Fact]
+    public void ReadBackpack_DescendsIntoNestedContainers()
+    {
+        var items = new StubItemService([]);
+        var backpack = Container(items, 100);
+        var bag = Container(items, 101, "bag");
+
+        Put(items, backpack, bag);
+        Put(items, bag, Item(items, 1, "potion"));
+
+        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+
+        var found = Assert.Single(contents);
+
+        Assert.Equal("bag", found.Name);
+        Assert.Equal("potion", Assert.Single(found.Contents).Name);
+    }
+
+    // Nothing stops a bag from containing an ancestor, and the walk runs on a request thread: a cycle
+    // without this guard hangs the request rather than answering wrongly.
+    [Fact]
+    public void ReadBackpack_SurvivesAContainerThatContainsAnAncestor()
+    {
+        var items = new StubItemService([]);
+        var backpack = Container(items, 100);
+        var bag = Container(items, 101, "bag");
+
+        Put(items, backpack, bag);
+        Put(items, bag, backpack); // the cycle
+
+        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+
+        // It returns rather than hanging, and stops where it would repeat itself.
+        var bagNode = Assert.Single(contents);
+
+        Assert.Equal("bag", bagNode.Name);
+        Assert.Empty(Assert.Single(bagNode.Contents).Contents);
+    }
+
+    [Fact]
+    public void ReadBackpack_StopsAtTheDepthLimit()
+    {
+        var items = new StubItemService([]);
+        var backpack = Container(items, 100);
+        var current = backpack;
+
+        for (var depth = 0; depth < 25; depth++)
+        {
+            var bag = Container(items, (uint)(200 + depth), $"bag{depth}");
+
+            Put(items, current, bag);
+            current = bag;
+        }
+
+        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+
+        Assert.Equal(CharacterInventoryReader.MaxDepth, Depth(contents));
+    }
+
+    [Fact]
+    public void ReadBackpack_IsEmptyWhenTheCharacterHasNoBackpack()
+    {
+        var reader = new CharacterInventoryReader(new StubItemService([]));
+
+        Assert.Empty(reader.ReadBackpack(new MobileEntity { Id = new(1) }));
+    }
+
+    [Fact]
+    public void ReadEquipment_NamesTheLayerOfEachWornItem()
+    {
+        var robe = Item(new StubItemService([]), 5, "robe");
+
+        robe.EquippedLayer = LayerType.OuterTorso;
+
+        var worn = new CharacterInventoryReader(new StubItemService([robe])).ReadEquipment(new() { Id = new(1) });
+
+        var found = Assert.Single(worn);
+
+        Assert.Equal("robe", found.Name);
+        Assert.Equal("OuterTorso", found.Layer);
+    }
+
+    // The serial form the rest of the API reports, so a caller can feed it straight back.
+    [Fact]
+    public void Items_CarryTheSerialInTheApiForm()
+    {
+        var items = new StubItemService([]);
+        var backpack = Container(items, 100);
+
+        Put(items, backpack, Item(items, 0x40000001, "sword"));
+
+        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+
+        Assert.Equal("0x40000001", Assert.Single(contents).Serial);
+    }
+
+    private static int Depth(IReadOnlyList<CharacterItemResponse> nodes)
+        => nodes.Count == 0 ? 0 : 1 + nodes.Max(node => Depth(node.Contents));
+
+    private static ItemEntity Item(StubItemService items, uint serial, string name)
+        => items.Track(new() { Id = new(serial), Name = name, TemplateId = name, ItemId = 0x13B9, Amount = 1 });
+
+    private static ItemEntity Container(StubItemService items, uint serial, string name = "backpack")
+        => Item(items, serial, name);
+
+    private static void Put(StubItemService items, ItemEntity container, ItemEntity item)
+    {
+        container.ContainedItemIds.Add(item.Id);
+        items.Track(item);
+    }
+
+    private static MobileEntity MobileWith(ItemEntity backpack)
+    {
+        var mobile = new MobileEntity { Id = new(1), BackpackId = backpack.Id };
+
+        mobile.EquippedItemIds[LayerType.Backpack] = backpack.Id;
+
+        return mobile;
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
@@ -1,0 +1,176 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Http.Plugin.Endpoints.Characters;
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Services.Accounts;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http.Endpoints.Characters;
+
+/// <summary>
+/// One route serving two audiences, so what it owns is the decision of who may read what: your own
+/// always, anyone's for staff, and nothing at all for a character on someone else's account.
+/// </summary>
+public class CharacterDetailEndpointsTests
+{
+    [Fact]
+    public async Task Get_TheCallersOwnCharacter_ReturnsItWithEquipmentAndBackpack()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        var character = Create(server, "tom", "Freydis");
+
+        await server.AuthenticateAsync();
+
+        var detail = await server.Client.GetFromJsonAsync<CharacterDetailResponse>($"/api/v1/characters/{character}");
+
+        Assert.Equal("Freydis", detail!.Character.Name);
+        Assert.NotNull(detail.Equipment);
+        Assert.NotNull(detail.Backpack);
+    }
+
+    // The account comes from the token. A player who could read another account's character by
+    // changing a number in the URL is the whole reason this check exists.
+    [Fact]
+    public async Task Get_AnotherAccountsCharacter_AsAPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+
+        var hers = Create(server, "alice", "Aramis");
+
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync($"/api/v1/characters/{hers}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AnotherAccountsCharacter_AsStaff_ReturnsIt()
+    {
+        await using var server = await StartAsync(AccountLevelType.Administrator);
+
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+
+        var hers = Create(server, "alice", "Aramis");
+
+        await server.AuthenticateAsync();
+
+        var detail = await server.Client.GetFromJsonAsync<CharacterDetailResponse>($"/api/v1/characters/{hers}");
+
+        Assert.Equal("Aramis", detail!.Character.Name);
+        Assert.Equal("alice", detail.Character.AccountUsername);
+    }
+
+    [Fact]
+    public async Task Get_AnUnknownSerial_IsNotFound()
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await server.Client.GetAsync("/api/v1/characters/0x0000DEAD")).StatusCode
+        );
+    }
+
+    // The API reports serials as 0x40000001, so its own value must address its own route -- the exact
+    // defect fixed on the image routes in PR #167.
+    [Fact]
+    public async Task Get_AcceptsTheHexSerialTheApiReports()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        var character = Create(server, "tom", "Freydis");
+
+        await server.AuthenticateAsync();
+
+        // Create returns the serial already in the API's own form; asserting that keeps this test
+        // honest if that form ever changes.
+        Assert.StartsWith("0x", character);
+
+        var response = await server.Client.GetAsync($"/api/v1/characters/{character}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithASerialThatIsNotANumber_IsNotFound()
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, (await server.Client.GetAsync("/api/v1/characters/banana")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            (await server.Client.GetAsync("/api/v1/characters/0x00000001")).StatusCode
+        );
+    }
+
+    private static string Create(TestApiServer server, string username, string name)
+    {
+        var accountId = server.Accounts.GetByUsername(username)!.Id;
+
+        server.Characters.CreateCharacter(accountId, Packet(name));
+
+        return server.Accounts.GetByUsername(username)!.MobileIds[^1].ToString();
+    }
+
+    private static CharacterCreationPacket Packet(string name)
+        => new(
+            0,
+            name,
+            0,
+            4,
+            GenderType.Female,
+            RaceType.Elf,
+            45,
+            20,
+            25,
+            [new(1, 50)],
+            0x03EA,
+            0x203C,
+            0x044E,
+            0x2040,
+            0x0450,
+            0,
+            0x0765,
+            0x0766
+        );
+
+    private static async Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+        => await TestApiServer.StartAsync(
+               level,
+               configure: container =>
+                          {
+                              // What this route owns is who may read what; the walk over equipment and
+                              // containers has its own tests, so an empty item world is enough here.
+                              container.RegisterInstance<IItemService>(new StubItemService([]));
+                              container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
+                              container.Register<CharacterInventoryReader>(Reuse.Singleton);
+                              container.RegisterApiEndpointInstance(
+                                  new CharacterDetailEndpoints(
+                                      container.Resolve<IAccountService>(),
+                                      container.Resolve<ICharacterQueryService>(),
+                                      container.Resolve<CharacterInventoryReader>()
+                                  )
+                              );
+                          }
+           );
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -47,6 +47,7 @@ public class MoongateHttpPluginTests
                 typeof(AuthEndpoints),
                 typeof(BodyImageEndpoints),
                 typeof(CharacterAdminEndpoints),
+                typeof(CharacterDetailEndpoints),
                 typeof(CharacterEndpoints),
                 typeof(ConsoleEndpoints),
                 typeof(HairImageEndpoints),

--- a/tests/Moongate.Tests/Server/Accounts/CharacterQueryServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Accounts/CharacterQueryServiceTests.cs
@@ -1,0 +1,128 @@
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Network.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.Accounts;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Accounts;
+
+/// <summary>
+/// Nothing on a mobile says it is a player character — the only link is the owning account's id list.
+/// That rule is this service's whole reason to exist, and every case here is about it.
+/// </summary>
+public class CharacterQueryServiceTests
+{
+    [Fact]
+    public void Find_ReturnsTheCharacterAndItsOwner()
+    {
+        var persistence = new FakePersistenceService();
+        var character = Mobile(1, "Squid");
+
+        persistence.Store<MobileEntity>().UpsertAsync(character);
+
+        var service = new CharacterQueryService(Owning("tom", character.Id), persistence);
+
+        var found = service.Find(character.Id);
+
+        Assert.NotNull(found);
+        Assert.Equal("tom", found.AccountUsername);
+        Assert.Equal(character.Id, found.Mobile.Id);
+    }
+
+    // An NPC addressable by serial would turn a route meant for characters into a window onto every
+    // mobile on the shard.
+    [Fact]
+    public void Find_IgnoresAMobileNoAccountOwns()
+    {
+        var persistence = new FakePersistenceService();
+        var npc = Mobile(2, "a wandering healer");
+
+        persistence.Store<MobileEntity>().UpsertAsync(npc);
+
+        var service = new CharacterQueryService(Owning("tom"), persistence);
+
+        Assert.Null(service.Find(npc.Id));
+    }
+
+    [Fact]
+    public void Find_ReturnsNullForAnUnknownSerial()
+    {
+        var service = new CharacterQueryService(Owning("tom"), new FakePersistenceService());
+
+        Assert.Null(service.Find(new(0xDEAD)));
+    }
+
+    private static MobileEntity Mobile(uint serial, string name)
+        => new() { Id = new(serial), Name = name };
+
+    private static IAccountService Owning(string username, params Serial[] characters)
+        => new AccountsStub(username, characters);
+
+    /// <summary>
+    /// One account owning the given characters. Only <see cref="GetAll" /> is real — it is the single
+    /// thing the service under test asks for, and everything else throwing is what makes a test that
+    /// wandered off say so.
+    /// </summary>
+    private sealed class AccountsStub : IAccountService
+    {
+        private readonly AccountEntity _account;
+
+        public AccountsStub(string username, IEnumerable<Serial> characters)
+        {
+            _account = new()
+            {
+                Id = new(1),
+                Username = username,
+                AccountLevel = AccountLevelType.Player,
+                IsActive = true,
+                MobileIds = [.. characters],
+            };
+        }
+
+        public IReadOnlyList<AccountEntity> GetAll()
+            => [_account];
+
+        public AccountAuthResult Authenticate(string username, string password)
+            => throw new NotSupportedException();
+
+        public AccountCreateResultType Create(string username, string password, string? email, AccountLevelType level)
+            => throw new NotSupportedException();
+
+        public AccountDeleteResultType Delete(string username)
+            => throw new NotSupportedException();
+
+        public Serial? GetAccountIdByUsername(string username)
+            => throw new NotSupportedException();
+
+        public AccountEntity? GetById(Serial accountId)
+            => throw new NotSupportedException();
+
+        public AccountEntity? GetByUsername(string username)
+            => throw new NotSupportedException();
+
+        public IReadOnlyList<string> GetUsernames()
+            => throw new NotSupportedException();
+
+        public AccountRegisterResult RegisterPending(string username, string password, string email)
+            => throw new NotSupportedException();
+
+        public AccountResendResultType ResendVerification(string username, string email)
+            => throw new NotSupportedException();
+
+        public bool SetActive(string username, bool isActive)
+            => throw new NotSupportedException();
+
+        public bool SetLevel(string username, AccountLevelType level)
+            => throw new NotSupportedException();
+
+        public bool SetPassword(string username, string password)
+            => throw new NotSupportedException();
+
+        public AccountVerifyResultType VerifyEmail(string token)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Moongate.Tests/Support/StubItemService.cs
+++ b/tests/Moongate.Tests/Support/StubItemService.cs
@@ -7,16 +7,32 @@ using Moongate.Ultima.Types;
 namespace Moongate.Tests.Support;
 
 /// <summary>
-/// Minimal <see cref="IItemService" /> test double that only answers <see cref="GetEquipped" /> with a
-/// fixed list; every other member is unused by the systems under test and throws if called.
+/// Minimal <see cref="IItemService" /> test double for the read side. <see cref="GetEquipped" /> answers
+/// with a fixed list; <see cref="GetById" /> and <see cref="GetContents" /> answer from items handed to
+/// <see cref="Track" />, resolving containment through each entity's own <c>ContainedItemIds</c> exactly
+/// as the real service does. Every mutating member throws, so a test that reaches one says so.
 /// </summary>
 public sealed class StubItemService : IItemService
 {
     private readonly IReadOnlyList<ItemEntity> _equipped;
+    private readonly Dictionary<Serial, ItemEntity> _items = new();
 
     public StubItemService(IReadOnlyList<ItemEntity> equipped)
     {
         _equipped = equipped;
+
+        foreach (var item in equipped)
+        {
+            _items[item.Id] = item;
+        }
+    }
+
+    /// <summary>Makes an item findable by serial, so a container listing it can resolve it.</summary>
+    public ItemEntity Track(ItemEntity item)
+    {
+        _items[item.Id] = item;
+
+        return item;
     }
 
     public void AddToContainer(ItemEntity container, ItemEntity item, Point2D position)
@@ -38,10 +54,12 @@ public sealed class StubItemService : IItemService
         => throw new NotSupportedException();
 
     public ItemEntity? GetById(Serial itemId)
-        => throw new NotSupportedException();
+        => _items.GetValueOrDefault(itemId);
 
     public IReadOnlyList<ItemEntity> GetContents(Serial containerId)
-        => throw new NotSupportedException();
+        => GetById(containerId) is { } container
+               ? [.. container.ContainedItemIds.Select(GetById).OfType<ItemEntity>()]
+               : [];
 
     public IReadOnlyList<ItemEntity> GetEquipped(MobileEntity mobile)
         => _equipped;

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -301,6 +301,38 @@
         }
       }
     },
+    "/api/v1/characters/{serial}": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "One character in full: stats, appearance, what they wear and what they carry.",
+        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An\naccount may read its own characters; staff may read anyone's, and everyone else gets 403. A\nserial naming no character is 404, and so is one that is not a number.\n            \nThe backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the\nworn items by layer, the backpack and the bank box among them, without expanding them.\n            \nRead off the game loop, so an item the loop moves mid-read may appear in neither place or in\nboth. The next request settles it: this is a view, not a ledger.",
+        "operationId": "GetCharacter",
+        "parameters": [
+          {
+            "name": "serial",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharacterDetailResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/admin/console/stream": {
       "get": {
         "tags": [
@@ -1958,6 +1990,90 @@
           }
         },
         "additionalProperties": false
+      },
+      "CharacterDetailResponse": {
+        "required": [
+          "backpack",
+          "character",
+          "equipment"
+        ],
+        "type": "object",
+        "properties": {
+          "character": {
+            "$ref": "#/components/schemas/CharacterResponse"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CharacterItemResponse"
+            },
+            "description": "Worn items by layer, the backpack and the bank box among them."
+          },
+          "backpack": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CharacterItemResponse"
+            },
+            "description": "The backpack's contents, nested containers expanded."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Everything one character is: who they are, what they wear, what they carry."
+      },
+      "CharacterItemResponse": {
+        "required": [
+          "amount",
+          "contents",
+          "hue",
+          "itemId",
+          "name",
+          "serial",
+          "templateId"
+        ],
+        "type": "object",
+        "properties": {
+          "serial": {
+            "type": "string",
+            "description": "The item's serial, as `0x40000001`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The item's name. Blank when the item is named by cliloc rather than stored text."
+          },
+          "templateId": {
+            "type": "string",
+            "description": "The template it was built from."
+          },
+          "itemId": {
+            "type": "integer",
+            "description": "The art id, which addresses `/api/v1/images/items/{id}.png`.",
+            "format": "int32"
+          },
+          "hue": {
+            "type": "integer",
+            "description": "0 for the raw art.",
+            "format": "int32"
+          },
+          "amount": {
+            "type": "integer",
+            "description": "How many, for a stack.",
+            "format": "int32"
+          },
+          "layer": {
+            "type": "string",
+            "description": "The layer it is worn on, or null when it sits inside a container.",
+            "nullable": true
+          },
+          "contents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CharacterItemResponse"
+            },
+            "description": "What it contains. Empty for anything that is not a container."
+          }
+        },
+        "additionalProperties": false,
+        "description": "One item as the API reports it, with whatever it contains. Deliberately not `ItemEntity`, which\ncarries script and loot ids: a field added to the entity later would publish itself."
       },
       "CharacterResponse": {
         "required": [

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -12,6 +12,7 @@ import { DashboardScreen } from './routes/DashboardScreen'
 import { AdminScreen } from './routes/AdminScreen'
 import { MapScreen } from './routes/MapScreen'
 import { CharactersScreen } from './routes/CharactersScreen'
+import { CharacterDetailScreen } from './routes/CharacterDetailScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
 import { CharactersAdminScreen } from './routes/admin/CharactersAdminScreen'
@@ -49,6 +50,16 @@ export function App() {
                 <RequireAuth>
                   <AppShell>
                     <CharactersScreen />
+                  </AppShell>
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/characters/:serial"
+              element={
+                <RequireAuth>
+                  <AppShell>
+                    <CharacterDetailScreen />
                   </AppShell>
                 </RequireAuth>
               }

--- a/ui/src/components/characters/InventoryTree.test.tsx
+++ b/ui/src/components/characters/InventoryTree.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+
+import '../../lib/i18n'
+import { InventoryTree } from './InventoryTree'
+import type { CharacterItem } from '../../lib/characters'
+
+function item(name: string, over: Partial<CharacterItem> = {}): CharacterItem {
+  return {
+    serial: '0x1',
+    name,
+    templateId: 'sword',
+    itemId: 0x13b9,
+    hue: 0,
+    amount: 1,
+    layer: null,
+    contents: [],
+    ...over,
+  } as CharacterItem
+}
+
+describe('InventoryTree', () => {
+  it('shows each item with its art', () => {
+    render(<InventoryTree items={[item('Sword')]} emptyLabel="empty" />)
+
+    expect(screen.getByAltText('Sword')).toHaveAttribute('src', '/api/v1/images/items/0x13b9.png')
+  })
+
+  it('hues the art when the item is dyed', () => {
+    render(<InventoryTree items={[item('Robe', { serial: '0x2', itemId: 0x1f03, hue: 0x21 })]} emptyLabel="empty" />)
+
+    expect(screen.getByAltText('Robe')).toHaveAttribute('src', '/api/v1/images/items/0x1f03.png?hue=0x21')
+  })
+
+  it('shows what a container holds', () => {
+    render(
+      <InventoryTree
+        items={[item('Bag', { serial: '0x2', contents: [item('Potion', { serial: '0x3' })] })]}
+        emptyLabel="empty"
+      />,
+    )
+
+    expect(screen.getByText('Bag')).toBeInTheDocument()
+    expect(screen.getByText('Potion')).toBeInTheDocument()
+  })
+
+  it('shows the amount only when there is more than one', () => {
+    render(
+      <InventoryTree
+        items={[item('Gold', { serial: '0x2', amount: 250 }), item('Sword', { serial: '0x3' })]}
+        emptyLabel="empty"
+      />,
+    )
+
+    expect(screen.getByText('×250')).toBeInTheDocument()
+    expect(screen.queryByText('×1')).not.toBeInTheDocument()
+  })
+
+  // UO names most items by cliloc rather than by stored text, so a blank name is normal here and
+  // must not render as an empty row.
+  it('labels an item with no stored name', () => {
+    render(<InventoryTree items={[item('')]} emptyLabel="empty" />)
+
+    expect(screen.getByText('Unnamed item')).toBeInTheDocument()
+  })
+
+  it('names the layer of a worn item', () => {
+    render(<InventoryTree items={[item('Robe', { layer: 'OuterTorso' })]} emptyLabel="empty" />)
+
+    expect(screen.getByText('OuterTorso')).toBeInTheDocument()
+  })
+
+  it('says so when there is nothing', () => {
+    render(<InventoryTree items={[]} emptyLabel="Nothing here" />)
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/characters/InventoryTree.tsx
+++ b/ui/src/components/characters/InventoryTree.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+
+import { CharacterImage } from './CharacterImage'
+import { itemImageUrl, type CharacterItem } from '../../lib/characters'
+
+/**
+ * A character's items as a nested list rather than a table: the data is a tree, and a flat table
+ * cannot say what is inside what. Each row carries the item's art, so an item named only by cliloc —
+ * which is most of them — is still recognisable.
+ */
+export function InventoryTree({ items, emptyLabel }: { items: CharacterItem[]; emptyLabel: string }) {
+  const { t } = useTranslation()
+
+  if (items.length === 0) {
+    return <p className="text-sm text-muted">{emptyLabel}</p>
+  }
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {items.map((item) => (
+        <li key={item.serial}>
+          <div className="flex items-center gap-3 rounded-lg px-2 py-1">
+            <CharacterImage
+              src={itemImageUrl(item.itemId, item.hue)}
+              alt={item.name === '' ? t('characters.inventory.unnamed') : item.name}
+              className="h-16 w-16 shrink-0 object-contain"
+              fallback={
+                <span className="flex h-16 w-16 shrink-0 items-center justify-center text-muted">
+                  {t('characters.inventory.noImage')}
+                </span>
+              }
+            />
+
+            <span className="min-w-0">
+              <span className="block truncate text-ink">
+                {item.name === '' ? t('characters.inventory.unnamed') : item.name}
+              </span>
+              <span className="flex gap-2 text-xs text-muted">
+                {item.amount > 1 && <span>{t('characters.inventory.amount', { count: item.amount })}</span>}
+                {item.layer !== null && <span>{item.layer}</span>}
+              </span>
+            </span>
+          </div>
+
+          {item.contents.length > 0 && (
+            <div className="ml-8 border-l border-ink/10 pl-2">
+              <InventoryTree items={item.contents} emptyLabel={emptyLabel} />
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -173,6 +173,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/characters/{serial}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * One character in full: stats, appearance, what they wear and what they carry.
+         * @description The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An
+         *     account may read its own characters; staff may read anyone's, and everyone else gets 403. A
+         *     serial naming no character is 404, and so is one that is not a number.
+         *
+         *     The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the
+         *     worn items by layer, the backpack and the bank box among them, without expanding them.
+         *
+         *     Read off the game loop, so an item the loop moves mid-read may appear in neither place or in
+         *     both. The next request settles it: this is a view, not a ledger.
+         */
+        get: operations["GetCharacter"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/console/stream": {
         parameters: {
             query?: never;
@@ -1015,6 +1043,45 @@ export interface components {
         BookSpec: {
             bookId: string;
         };
+        /** @description Everything one character is: who they are, what they wear, what they carry. */
+        CharacterDetailResponse: {
+            character: components["schemas"]["CharacterResponse"];
+            /** @description Worn items by layer, the backpack and the bank box among them. */
+            equipment: components["schemas"]["CharacterItemResponse"][];
+            /** @description The backpack's contents, nested containers expanded. */
+            backpack: components["schemas"]["CharacterItemResponse"][];
+        };
+        /**
+         * @description One item as the API reports it, with whatever it contains. Deliberately not `ItemEntity`, which
+         *     carries script and loot ids: a field added to the entity later would publish itself.
+         */
+        CharacterItemResponse: {
+            /** @description The item's serial, as `0x40000001`. */
+            serial: string;
+            /** @description The item's name. Blank when the item is named by cliloc rather than stored text. */
+            name: string;
+            /** @description The template it was built from. */
+            templateId: string;
+            /**
+             * Format: int32
+             * @description The art id, which addresses `/api/v1/images/items/{id}.png`.
+             */
+            itemId: number;
+            /**
+             * Format: int32
+             * @description 0 for the raw art.
+             */
+            hue: number;
+            /**
+             * Format: int32
+             * @description How many, for a stack.
+             */
+            amount: number;
+            /** @description The layer it is worn on, or null when it sits inside a container. */
+            layer?: string | null;
+            /** @description What it contains. Empty for anything that is not a container. */
+            contents: components["schemas"]["CharacterItemResponse"][];
+        };
         /**
          * @description A character as the API reports it. Deliberately not `MobileEntity`, which carries BrainScriptId,
          *     LootTableId and BackpackId: returning the entity would publish the shard's internals to every caller,
@@ -1842,6 +1909,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CharacterResponsePagedResponse"];
+                };
+            };
+        };
+    };
+    GetCharacter: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serial: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CharacterDetailResponse"];
                 };
             };
         };

--- a/ui/src/lib/characters.test.ts
+++ b/ui/src/lib/characters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { charactersQuery, figureUrl, paperdollUrl } from './characters'
+import { charactersQuery, figureUrl, itemImageUrl, paperdollUrl } from './characters'
 
 // The serial is used verbatim, in the `0x40000001` form the API reports it in. The routes accept
 // that form, so nothing here converts bases -- a conversion is the kind of thing that silently
@@ -47,5 +47,25 @@ describe('staff characters query', () => {
   // a failed request.
   it('never asks for a page below 1', () => {
     expect(charactersQuery({ page: 0, search: '' })).toBe('/api/v1/admin/characters?page=1&pageSize=25')
+  })
+})
+
+describe('item art urls', () => {
+  // The route takes the ART id in hex, with or without the prefix -- not the item's serial.
+  it('addresses the art by its hex id', () => {
+    expect(itemImageUrl(0x1234)).toBe('/api/v1/images/items/0x1234.png')
+  })
+
+  it('asks for the hue when the item is dyed', () => {
+    expect(itemImageUrl(0x1234, 0x21)).toBe('/api/v1/images/items/0x1234.png?hue=0x21')
+  })
+
+  // Hue 0 IS the raw art, so sending it is noise that keeps two spellings of one picture in the cache.
+  it('omits hue 0', () => {
+    expect(itemImageUrl(0x1234, 0)).toBe('/api/v1/images/items/0x1234.png')
+  })
+
+  it('never adds a cache-busting parameter', () => {
+    expect(itemImageUrl(0x1234, 0x21)).not.toMatch(/[?&](t|v|_)=/)
   })
 })

--- a/ui/src/lib/characters.ts
+++ b/ui/src/lib/characters.ts
@@ -64,3 +64,24 @@ export const useAllCharacters = (params: { page: number; search: string }) =>
     queryFn: () => apiFetch<CharacterPage>(charactersQuery(params)),
     placeholderData: (previous: CharacterPage | undefined) => previous,
   })
+
+export type CharacterDetail = components['schemas']['CharacterDetailResponse']
+export type CharacterItem = components['schemas']['CharacterItemResponse']
+
+/** One character in full — your own, or anyone's for staff. The server decides which. */
+export const useCharacter = (serial: string) =>
+  useQuery({
+    queryKey: ['characters', serial],
+    queryFn: () => apiFetch<CharacterDetail>(`/api/v1/characters/${serial}`),
+  })
+
+/**
+ * An item's art. The id is the ART id in hex — not the item's serial — and hue 0 is the raw art, so
+ * it is omitted rather than sent: two spellings of one picture would sit in the cache as two.
+ * No cache-busting parameter, for the same reason as {@link figureUrl}.
+ */
+export function itemImageUrl(itemId: number, hue = 0): string {
+  const id = `0x${itemId.toString(16)}`
+
+  return hue === 0 ? `/api/v1/images/items/${id}.png` : `/api/v1/images/items/${id}.png?hue=0x${hue.toString(16)}`
+}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -293,6 +293,12 @@
     "gender": {
       "Male": "Male",
       "Female": "Female"
+    },
+    "inventory": {
+      "empty": "Nothing here",
+      "unnamed": "Unnamed item",
+      "amount": "×{{count}}",
+      "noImage": "—"
     }
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -299,6 +299,16 @@
       "unnamed": "Unnamed item",
       "amount": "×{{count}}",
       "noImage": "—"
+    },
+    "detail": {
+      "equipment": "Equipment",
+      "backpack": "Backpack",
+      "equipmentEmpty": "Wearing nothing",
+      "backpackEmpty": "The backpack is empty",
+      "back": "Back to characters",
+      "notFound": "That character could not be found.",
+      "forbidden": "That character belongs to another account.",
+      "loadFailed": "That character could not be loaded."
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -299,6 +299,16 @@
       "unnamed": "Oggetto senza nome",
       "amount": "×{{count}}",
       "noImage": "—"
+    },
+    "detail": {
+      "equipment": "Equipaggiamento",
+      "backpack": "Zaino",
+      "equipmentEmpty": "Non indossa nulla",
+      "backpackEmpty": "Lo zaino è vuoto",
+      "back": "Torna ai personaggi",
+      "notFound": "Personaggio non trovato.",
+      "forbidden": "Quel personaggio appartiene a un altro account.",
+      "loadFailed": "Non è stato possibile caricare il personaggio."
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -293,6 +293,12 @@
     "gender": {
       "Male": "Maschio",
       "Female": "Femmina"
+    },
+    "inventory": {
+      "empty": "Niente qui",
+      "unnamed": "Oggetto senza nome",
+      "amount": "×{{count}}",
+      "noImage": "—"
     }
   }
 }

--- a/ui/src/routes/CharacterDetailScreen.test.tsx
+++ b/ui/src/routes/CharacterDetailScreen.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+
+import '../lib/i18n'
+import { ApiError } from '../lib/api'
+import { CharacterDetailScreen } from './CharacterDetailScreen'
+import type { CharacterDetail, CharacterItem } from '../lib/characters'
+
+const query = vi.hoisted(() => ({
+  data: undefined as CharacterDetail | undefined,
+  isPending: false,
+  isError: false,
+  error: null as unknown,
+  lastSerial: '' as string,
+}))
+
+vi.mock('../lib/characters', async (original) => ({
+  ...(await original<typeof import('../lib/characters')>()),
+  useCharacter: (serial: string) => {
+    query.lastSerial = serial
+    return query
+  },
+}))
+
+function item(name: string, over: Partial<CharacterItem> = {}): CharacterItem {
+  return {
+    serial: '0xA',
+    name,
+    templateId: name,
+    itemId: 0x13b9,
+    hue: 0,
+    amount: 1,
+    layer: null,
+    contents: [],
+    ...over,
+  } as CharacterItem
+}
+
+function detail(over: Partial<CharacterDetail> = {}): CharacterDetail {
+  return {
+    character: {
+      serial: '0x40000001',
+      name: 'Squid',
+      accountUsername: 'tom',
+      race: 'Human',
+      gender: 'Male',
+      body: 400,
+      strength: 60,
+      dexterity: 45,
+      intelligence: 30,
+      hits: 55,
+      hitsMax: 60,
+      stamina: 45,
+      staminaMax: 45,
+      mana: 30,
+      manaMax: 30,
+      kills: 0,
+      skinHue: 1002,
+      hairStyle: 8252,
+      hairHue: 1102,
+      mapId: 1,
+      x: 1495,
+      y: 1629,
+      z: 0,
+    },
+    equipment: [],
+    backpack: [],
+    ...over,
+  } as CharacterDetail
+}
+
+function renderAt(serial: string, data: CharacterDetail | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isPending: false, isError: false, error: null }, state)
+
+  return render(
+    <MemoryRouter initialEntries={[`/characters/${serial}`]}>
+      <Routes>
+        <Route path="/characters/:serial" element={<CharacterDetailScreen />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('CharacterDetailScreen', () => {
+  it('asks for the character named in the route', () => {
+    renderAt('0x40000001', detail())
+
+    expect(query.lastSerial).toBe('0x40000001')
+  })
+
+  it('shows the paperdoll of that character', () => {
+    renderAt('0x40000001', detail())
+
+    expect(screen.getByAltText('Squid paperdoll')).toHaveAttribute(
+      'src',
+      '/api/v1/images/mobiles/0x40000001/paperdoll.png',
+    )
+  })
+
+  it('shows what the character wears and what they carry', () => {
+    renderAt('0x40000001', detail({ equipment: [item('Robe', { layer: 'OuterTorso' })], backpack: [item('Dagger')] }))
+
+    expect(screen.getByText('Robe')).toBeInTheDocument()
+    expect(screen.getByText('Dagger')).toBeInTheDocument()
+  })
+
+  it('shows the stats', () => {
+    renderAt('0x40000001', detail())
+
+    expect(screen.getByText('55 / 60')).toBeInTheDocument()
+  })
+
+  // "Not yours" and "does not exist" are different answers, and telling them apart is the reason
+  // both messages exist.
+  it('says a character belongs to someone else', () => {
+    renderAt('0x2', undefined, { isError: true, error: new ApiError(403, 'forbidden') })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('That character belongs to another account.')
+  })
+
+  it('says a character does not exist', () => {
+    renderAt('0xDEAD', undefined, { isError: true, error: new ApiError(404, 'not found') })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('That character could not be found.')
+  })
+
+  it('falls back to a generic failure for anything else', () => {
+    renderAt('0x1', undefined, { isError: true, error: new Error('network') })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('That character could not be loaded.')
+  })
+
+  it('offers the way back to the list', () => {
+    renderAt('0x40000001', detail())
+
+    expect(screen.getByRole('link', { name: /back to characters/i })).toHaveAttribute('href', '/characters')
+  })
+})

--- a/ui/src/routes/CharacterDetailScreen.tsx
+++ b/ui/src/routes/CharacterDetailScreen.tsx
@@ -1,0 +1,122 @@
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router'
+
+import { Card } from '../components/ui/card'
+import { CharacterImage } from '../components/characters/CharacterImage'
+import { InventoryTree } from '../components/characters/InventoryTree'
+import { ApiError } from '../lib/api'
+import { paperdollUrl, useCharacter, type CharacterDetail } from '../lib/characters'
+
+export function CharacterDetailScreen() {
+  const { t } = useTranslation()
+  const { serial = '' } = useParams()
+  const character = useCharacter(serial)
+
+  if (character.isError) {
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t(failureKey(character.error))}
+      </p>
+    )
+  }
+
+  if (character.data === undefined) {
+    return <p className="text-sm text-muted">{t('common.loading')}</p>
+  }
+
+  return <Detail detail={character.data} />
+}
+
+/**
+ * Which failure to name. "Not yours" and "does not exist" are different answers to the reader, and
+ * collapsing them into one message would leave a player wondering which they hit.
+ */
+function failureKey(error: unknown): string {
+  if (error instanceof ApiError && error.status === 403) {
+    return 'characters.detail.forbidden'
+  }
+
+  if (error instanceof ApiError && error.status === 404) {
+    return 'characters.detail.notFound'
+  }
+
+  return 'characters.detail.loadFailed'
+}
+
+function Detail({ detail }: { detail: CharacterDetail }) {
+  const { t } = useTranslation()
+  const character = detail.character
+
+  return (
+    <section className="space-y-4">
+      <Link to="/characters" className="text-sm text-muted hover:text-ink">
+        {t('characters.detail.back')}
+      </Link>
+
+      <div className="grid gap-6 lg:grid-cols-[20rem_1fr]">
+        <Card className="items-center gap-4 py-8">
+          <header className="text-center">
+            <h1 className="text-xl font-bold text-ink">{character.name}</h1>
+            <p className="text-sm text-muted">
+              {t('characters.identity', {
+                race: t(`characters.race.${character.race}`, { defaultValue: character.race }),
+                gender: t(`characters.gender.${character.gender}`, { defaultValue: character.gender }),
+              })}
+            </p>
+          </header>
+
+          {/* A fixed box so the panel does not jump while the picture loads. */}
+          <div className="flex h-[260px] w-[210px] items-center justify-center">
+            <CharacterImage
+              src={paperdollUrl(character.serial)}
+              alt={t('characters.paperdollAlt', { name: character.name })}
+              className="max-h-full max-w-full object-contain"
+              fallback={<p className="text-center text-sm text-muted">{t('characters.noImage')}</p>}
+            />
+          </div>
+
+          <dl className="grid w-full grid-cols-2 gap-x-6 gap-y-2 px-6 text-sm">
+            <Stat label={t('characters.strength')} value={character.strength} />
+            <Stat label={t('characters.dexterity')} value={character.dexterity} />
+            <Stat label={t('characters.intelligence')} value={character.intelligence} />
+            <Stat label={t('characters.kills')} value={character.kills} />
+            <Stat
+              label={t('characters.hits')}
+              value={t('characters.pool', { current: character.hits, max: character.hitsMax })}
+            />
+            <Stat
+              label={t('characters.stamina')}
+              value={t('characters.pool', { current: character.stamina, max: character.staminaMax })}
+            />
+            <Stat
+              label={t('characters.mana')}
+              value={t('characters.pool', { current: character.mana, max: character.manaMax })}
+            />
+            <Stat label={t('characters.location')} value={`${character.x}, ${character.y}`} />
+          </dl>
+        </Card>
+
+        <div className="flex flex-col gap-6">
+          <Card className="gap-3 p-4">
+            <h2 className="font-bold text-ink">{t('characters.detail.equipment')}</h2>
+            <InventoryTree items={detail.equipment} emptyLabel={t('characters.detail.equipmentEmpty')} />
+          </Card>
+
+          <Card className="gap-3 p-4">
+            <h2 className="font-bold text-ink">{t('characters.detail.backpack')}</h2>
+            <InventoryTree items={detail.backpack} emptyLabel={t('characters.detail.backpackEmpty')} />
+          </Card>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <dt className="text-muted">{label}</dt>
+      <dd className="font-bold text-ink">{value}</dd>
+    </div>
+  )
+}

--- a/ui/src/routes/CharactersScreen.test.tsx
+++ b/ui/src/routes/CharactersScreen.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { fireEvent } from '@testing-library/dom'
+import { MemoryRouter } from 'react-router'
 import i18n from '../lib/i18n'
 import { CharactersScreen } from './CharactersScreen'
 import type { Character } from '../lib/characters'
@@ -47,30 +46,26 @@ function character(serial: string, name: string): Character {
 
 function renderWith(data: Character[] | undefined, state: Partial<typeof query> = {}) {
   Object.assign(query, { data, isPending: false, isError: false }, state)
-  return render(<CharactersScreen />)
+  return render(
+    <MemoryRouter>
+      <CharactersScreen />
+    </MemoryRouter>,
+  )
 }
 
 describe('CharactersScreen', () => {
   it('lists every character on the account', () => {
     renderWith([character('0x1', 'Squid'), character('0x2', 'Vega')])
 
-    expect(screen.getByRole('button', { name: /Squid/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Vega/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Squid/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Vega/ })).toBeInTheDocument()
   })
 
-  // The panel is never empty while the account has characters, so arriving shows one.
-  it('shows the first character on arrival', () => {
-    renderWith([character('0x1', 'Squid'), character('0x2', 'Vega')])
+  // The list is the way into the detail page, which is where a character is actually shown.
+  it('links each character to its detail page', () => {
+    renderWith([character('0x40000001', 'Squid')])
 
-    expect(screen.getByAltText('Squid paperdoll')).toHaveAttribute('src', '/api/v1/images/mobiles/0x1/paperdoll.png')
-  })
-
-  it('shows the character that was chosen', async () => {
-    renderWith([character('0x1', 'Squid'), character('0x2', 'Vega')])
-
-    await userEvent.click(screen.getByRole('button', { name: /Vega/ }))
-
-    expect(screen.getByAltText('Vega paperdoll')).toHaveAttribute('src', '/api/v1/images/mobiles/0x2/paperdoll.png')
+    expect(screen.getByRole('link', { name: /Squid/ })).toHaveAttribute('href', '/characters/0x40000001')
   })
 
   it('asks for the figure with the serial the API reported', () => {
@@ -79,47 +74,30 @@ describe('CharactersScreen', () => {
     expect(screen.getByAltText('Squid in the world')).toHaveAttribute('src', '/api/v1/images/mobiles/0x40000001.png')
   })
 
-  it('shows the pools against their maximum', () => {
-    renderWith([character('0x1', 'Squid')])
-
-    expect(screen.getByText('55 / 60')).toBeInTheDocument()
-  })
-
-  // Asserted in Italian on purpose: the API reports race and gender in English, so in English the
+  // Asserted in Italian on purpose: the API reports the race in English, so in English the
   // translated and untranslated renderings are identical and the test could not fail.
-  it('translates the race and gender', async () => {
+  it('translates the race', async () => {
     await i18n.changeLanguage('it')
     try {
-      renderWith([{ ...character('0x1', 'Squid'), race: 'Gargoyle', gender: 'Female' }])
+      renderWith([{ ...character('0x1', 'Squid'), race: 'Elf' }])
 
-      expect(screen.getByText('Gargoyle · Femmina')).toBeInTheDocument()
+      expect(screen.getByText('Elfo')).toBeInTheDocument()
     } finally {
       await i18n.changeLanguage('en')
     }
   })
 
-  // The races and genders are closed enums today, but a page must not break on a value it has no
-  // word for -- showing the server's own is better than showing a raw translation key.
+  // The races are a closed enum today, but a list must not break on a value it has no word for --
+  // showing the server's own is better than showing a raw translation key.
   it('shows a race it has no translation for rather than a key', async () => {
     await i18n.changeLanguage('it')
     try {
       renderWith([{ ...character('0x1', 'Squid'), race: 'Daemon' }])
 
-      expect(screen.getByText('Daemon · Maschio')).toBeInTheDocument()
+      expect(screen.getByText('Daemon')).toBeInTheDocument()
     } finally {
       await i18n.changeLanguage('en')
     }
-  })
-
-  // A body with no animation legitimately 404s from the image route, and a broken-image icon is
-  // not an answer.
-  it('replaces a picture that fails to load', () => {
-    renderWith([character('0x1', 'Squid')])
-
-    fireEvent.error(screen.getByAltText('Squid paperdoll'))
-
-    expect(screen.queryByAltText('Squid paperdoll')).not.toBeInTheDocument()
-    expect(screen.getByText('No picture for this character')).toBeInTheDocument()
   })
 
   // The state a freshly registered player sees first.

--- a/ui/src/routes/CharactersScreen.tsx
+++ b/ui/src/routes/CharactersScreen.tsx
@@ -1,19 +1,13 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router'
 
 import { Card } from '../components/ui/card'
 import { CharacterImage } from '../components/characters/CharacterImage'
-import { cn } from '../lib/utils'
-import { figureUrl, paperdollUrl, useMyCharacters, type Character } from '../lib/characters'
+import { figureUrl, useMyCharacters } from '../lib/characters'
 
 export function CharactersScreen() {
   const { t } = useTranslation()
   const characters = useMyCharacters()
-
-  // The chosen serial rather than the character: resolving it against the current list means a
-  // character that disappears cannot leave a selection pointing at nothing, and arriving needs no
-  // effect to pick the first one.
-  const [chosen, setChosen] = useState<string | null>(null)
 
   if (characters.isPending) {
     return <p className="text-sm text-muted">{t('common.loading')}</p>
@@ -41,104 +35,32 @@ export function CharactersScreen() {
     )
   }
 
-  const selected = all.find((one) => one.serial === chosen) ?? all[0]
-
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-bold text-ink">{t('characters.title')}</h1>
 
-      <div className="grid gap-6 lg:grid-cols-[16rem_1fr]">
-        <Card className="gap-0 p-2">
-          {all.map((one) => (
-            <button
-              key={one.serial}
-              type="button"
-              onClick={() => setChosen(one.serial)}
-              className={cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors',
-                one.serial === selected.serial ? 'bg-gold/10 text-gold' : 'text-ink hover:bg-ink/5',
-              )}
-            >
-              <CharacterImage
-                src={figureUrl(one.serial)}
-                alt={t('characters.figureAlt', { name: one.name })}
-                className="h-12 w-10 object-contain"
-                fallback={<span className="h-12 w-10" aria-hidden="true" />}
-              />
-              <span className="min-w-0">
-                <span className="block truncate font-bold">{one.name}</span>
-                <span className="block truncate text-xs text-muted">
-                  {t(`characters.race.${one.race}`, { defaultValue: one.race })}
-                </span>
+      <Card className="gap-0 p-2">
+        {all.map((one) => (
+          <Link
+            key={one.serial}
+            to={`/characters/${one.serial}`}
+            className="flex items-center gap-3 rounded-lg px-3 py-2 text-ink transition-colors hover:bg-ink/5"
+          >
+            <CharacterImage
+              src={figureUrl(one.serial)}
+              alt={t('characters.figureAlt', { name: one.name })}
+              className="h-12 w-10 object-contain"
+              fallback={<span className="h-12 w-10" aria-hidden="true" />}
+            />
+            <span className="min-w-0">
+              <span className="block truncate font-bold">{one.name}</span>
+              <span className="block truncate text-xs text-muted">
+                {t(`characters.race.${one.race}`, { defaultValue: one.race })}
               </span>
-            </button>
-          ))}
-        </Card>
-
-        <CharacterPanel character={selected} />
-      </div>
+            </span>
+          </Link>
+        ))}
+      </Card>
     </section>
-  )
-}
-
-function CharacterPanel({ character }: { character: Character }) {
-  const { t } = useTranslation()
-
-  return (
-    <Card className="items-center gap-4 py-8">
-      <header className="text-center">
-        <h2 className="text-xl font-bold text-ink">{character.name}</h2>
-        <p className="text-sm text-muted">
-          {t('characters.identity', {
-            // The server reports these as its own enum names. Falling back to that name means a
-            // race the portal has no word for still reads as something, rather than as a raw key.
-            race: t(`characters.race.${character.race}`, { defaultValue: character.race }),
-            gender: t(`characters.gender.${character.gender}`, { defaultValue: character.gender }),
-          })}
-        </p>
-      </header>
-
-      {/* A fixed box so the panel does not jump while the picture loads. */}
-      <div className="flex h-[260px] w-[210px] items-center justify-center">
-        <CharacterImage
-          // Keyed by serial so switching characters remounts the image: without it a picture that
-          // failed once would keep its placeholder for the next character too.
-          key={character.serial}
-          src={paperdollUrl(character.serial)}
-          alt={t('characters.paperdollAlt', { name: character.name })}
-          className="max-h-full max-w-full object-contain"
-          fallback={<p className="text-center text-sm text-muted">{t('characters.noImage')}</p>}
-        />
-      </div>
-
-      <dl className="grid w-full max-w-sm grid-cols-2 gap-x-6 gap-y-2 px-6 text-sm">
-        <Stat label={t('characters.strength')} value={character.strength} />
-        <Stat label={t('characters.dexterity')} value={character.dexterity} />
-        <Stat label={t('characters.intelligence')} value={character.intelligence} />
-        <Stat label={t('characters.kills')} value={character.kills} />
-        <Stat
-          label={t('characters.hits')}
-          value={t('characters.pool', { current: character.hits, max: character.hitsMax })}
-        />
-        <Stat
-          label={t('characters.stamina')}
-          value={t('characters.pool', { current: character.stamina, max: character.staminaMax })}
-        />
-        <Stat
-          label={t('characters.mana')}
-          value={t('characters.pool', { current: character.mana, max: character.manaMax })}
-        />
-        <Stat label={t('characters.location')} value={`${character.x}, ${character.y}`} />
-      </dl>
-    </Card>
-  )
-}
-
-function Stat({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex justify-between gap-2">
-      <dt className="text-muted">{label}</dt>
-      <dd className="font-bold text-ink">{value}</dd>
-    </div>
   )
 }

--- a/ui/src/routes/admin/CharactersAdminScreen.test.tsx
+++ b/ui/src/routes/admin/CharactersAdminScreen.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
 
 import '../../lib/i18n'
 import { CharactersAdminScreen } from './CharactersAdminScreen'
@@ -56,7 +57,11 @@ function page(items: Character[], over: Partial<CharacterPage> = {}): CharacterP
 
 function renderWith(data: CharacterPage | undefined, state: Partial<typeof query> = {}) {
   Object.assign(query, { data, isPending: false, isError: false }, state)
-  return render(<CharactersAdminScreen />)
+  return render(
+    <MemoryRouter>
+      <CharactersAdminScreen />
+    </MemoryRouter>,
+  )
 }
 
 describe('CharactersAdminScreen', () => {

--- a/ui/src/routes/admin/CharactersAdminScreen.tsx
+++ b/ui/src/routes/admin/CharactersAdminScreen.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ColumnDef } from '@tanstack/react-table'
+import { Link } from 'react-router'
 
 import { DataTable } from '../../components/ui/data-table'
 import { CharacterImage } from '../../components/characters/CharacterImage'
@@ -26,7 +27,15 @@ export function CharactersAdminScreen() {
           />
         ),
       },
-      { accessorKey: 'name', header: t('admin.characters.name') },
+      {
+        accessorKey: 'name',
+        header: t('admin.characters.name'),
+        cell: ({ row }) => (
+          <Link to={`/characters/${row.original.serial}`} className="font-bold text-gold hover:underline">
+            {row.original.name}
+          </Link>
+        ),
+      },
       {
         accessorKey: 'accountUsername',
         header: t('admin.characters.account'),


### PR DESCRIPTION
Closes #170 (by hand once merged — this targets `develop`).

Clicking a character now opens a page showing everything it is. **This was not a frontend job**: no endpoint returned a single character, and none returned any inventory — only the two list routes.

## The endpoint

`GET /api/v1/characters/{serial}`, one route for both audiences: an account reads its own characters, staff read anyone's, everyone else gets 403, and a serial naming no character — or one that is not a number — is 404.

Ownership is checked against the account the **token** names, never against a value the caller supplied. An id from the request would let anyone read anyone's character by changing a number.

It returns the character in the shape the lists already use — so the detail and the lists cannot disagree about what a character is — plus the worn items by layer and the backpack as a nested tree.

## The guard that is the point of the reader

Containment is a plain list of serials (`ItemEntity.ContainedItemIds`) with nothing preventing a bag from containing an ancestor, and the walk is recursive **on a request thread**. A cycle there is not a wrong answer, it is a hung request. The reader carries a visited set and a depth limit of 10, both tested — including a container that contains its own ancestor.

Reads need no game loop (only the mutating methods on `ItemService` assert loop affinity), so this reads from the HTTP thread like the existing character list, with the same staleness caveat the online-player route documents. That is said in the endpoint's `<remarks>` and in the REST reference.

## The page

`/characters/:serial`, under `RequireAuth` and **not** `RequireAdmin` — the endpoint decides, so a second guard here could only drift from it. Paperdoll, stats, equipment and the backpack tree, with each item's art at 64px. A 403 and a 404 say different things, because "not yours" and "does not exist" are different answers to the reader.

Both lists link to it. **`/characters` loses its master–detail panel**: it had no reason to exist once the detail page is shared, so the panel's tests moved to the new page and the list kept its own.

## Checks

- .NET **2072 passed**; UI **271 passed**, build and Prettier clean; DocFX **0 warnings**; UI contract regenerated (new path + two schemas).
- Verified at **real boot**, which is the only place an unresolvable service shows: the route answers with the shard's character, its seven worn items and its backpack, and every item-art URL the page builds returns a real PNG — including the hued ones.

## Known trade-off

Serials are sequential from `0x00000001`, so answering 403 rather than 404 for someone else's character lets a player probe which serials exist. Taken deliberately; switching to 404 for anything not the caller's own is a two-line change in `GetOne`.

## Not included

The bank box appears as a worn item but is not expanded — only the backpack is walked. Nothing here mutates a character or its items.