### PR TITLE
feat: show a character's skills on the detail page

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -211,8 +211,17 @@ changing a number. The serial takes the form the rest of the API reports it in,
 a number are the same 404.
 
 It returns the character in the shape the lists already use, the worn items by
-layer — the backpack and the bank box among them — and the backpack's contents as
-a **tree**, nested containers expanded to a depth of 10.
+layer — the backpack and the bank box among them — the backpack's contents as a
+**tree**, nested containers expanded to a depth of 10, and the character's
+skills.
+
+Skills are reported in **points**, not the tenths the entity stores: 500 becomes
+50.0, so no consumer has to remember the division. Each carries its name from the
+skill registry — its id when nothing defines it, since the catalogue is data and
+can lag the world — its personal cap, and its lock, the up/down/locked arrow the
+client shows beside each entry. The list is sparse and alphabetical: a mobile
+never stores a skill left at zero, so it reports what the character trained
+rather than the whole catalogue padded with noughts.
 
 That depth is a guard, not a preference. Containment is a plain list of serials
 with nothing preventing a bag from containing an ancestor, and the walk is

--- a/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterDetailResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterDetailResponse.cs
@@ -4,8 +4,13 @@ namespace Moongate.Http.Plugin.Data.Api.Characters;
 /// <param name="Character">The same shape the character lists report, so the two cannot disagree.</param>
 /// <param name="Equipment">Worn items by layer, the backpack and the bank box among them.</param>
 /// <param name="Backpack">The backpack's contents, nested containers expanded.</param>
+/// <param name="Skills">
+/// The skills the character has, by name. Sparse on purpose: a mobile never stores a skill left at
+/// zero, so this is what the character actually trained rather than the whole catalogue.
+/// </param>
 public sealed record CharacterDetailResponse(
     CharacterResponse Character,
     IReadOnlyList<CharacterItemResponse> Equipment,
-    IReadOnlyList<CharacterItemResponse> Backpack
+    IReadOnlyList<CharacterItemResponse> Backpack,
+    IReadOnlyList<CharacterSkillResponse> Skills
 );

--- a/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterSkillResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterSkillResponse.cs
@@ -1,0 +1,15 @@
+namespace Moongate.Http.Plugin.Data.Api.Characters;
+
+/// <summary>One skill a character has, as the API reports it.</summary>
+/// <param name="Id">The skill id, which is what the mobile stores it under.</param>
+/// <param name="Name">The skill's name, or its id when no definition is registered for it.</param>
+/// <param name="Value">
+/// The skill's value in points — 50.0, not the 500 tenths the entity stores. The tenths are a storage
+/// detail, and reporting them would leave every consumer to remember to divide.
+/// </param>
+/// <param name="Cap">That skill's personal ceiling, in points. 100.0 unless something raised it.</param>
+/// <param name="Lock">
+/// Whether the skill may drift as it is used: <c>Up</c>, <c>Down</c> or <c>Locked</c> — the arrow the
+/// client shows beside each entry.
+/// </param>
+public sealed record CharacterSkillResponse(int Id, string Name, double Value, double Cap, string Lock);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
@@ -18,16 +18,19 @@ public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
     private readonly IAccountService _accounts;
     private readonly ICharacterQueryService _characters;
     private readonly CharacterInventoryReader _inventory;
+    private readonly CharacterSkillReader _skills;
 
     public CharacterDetailEndpoints(
         IAccountService accounts,
         ICharacterQueryService characters,
-        CharacterInventoryReader inventory
+        CharacterInventoryReader inventory,
+        CharacterSkillReader skills
     )
     {
         _accounts = accounts;
         _characters = characters;
         _inventory = inventory;
+        _skills = skills;
     }
 
     public void Register(IEndpointRouteBuilder routes)
@@ -44,7 +47,8 @@ public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
     /// serial naming no character is 404, and so is one that is not a number.
     ///
     /// The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the
-    /// worn items by layer, the backpack and the bank box among them, without expanding them.
+    /// worn items by layer, the backpack and the bank box among them, without expanding them. Skills
+    /// are the ones the character has, by name, in points rather than the tenths the entity stores.
     ///
     /// Read off the game loop, so an item the loop moves mid-read may appear in neither place or in
     /// both. The next request settles it: this is a view, not a ledger.
@@ -92,7 +96,8 @@ public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
             new CharacterDetailResponse(
                 CharacterResponse.From(found.Mobile, found.AccountUsername),
                 _inventory.ReadEquipment(found.Mobile),
-                _inventory.ReadBackpack(found.Mobile)
+                _inventory.ReadBackpack(found.Mobile),
+                _skills.Read(found.Mobile)
             )
         );
     }

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -122,6 +122,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         // The detail route's reader walks containers; it takes IItemService and nothing else, so it
         // is a plain singleton beside the endpoint group that uses it.
         container.Register<CharacterInventoryReader>(Reuse.Singleton);
+        container.Register<CharacterSkillReader>(Reuse.Singleton);
         container.RegisterApiEndpoint<CharacterDetailEndpoints>();
         container.RegisterApiEndpoint<ItemTemplateEndpoints>();
 

--- a/plugins/Moongate.Http.Plugin/Services/Characters/CharacterSkillReader.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Characters/CharacterSkillReader.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+
+namespace Moongate.Http.Plugin.Services.Characters;
+
+/// <summary>
+/// Turns a mobile's skill dictionary into something a reader can use. The entity stores tenths under a
+/// bare id, which is right for the wire and wrong for anyone looking at it: this names each skill from
+/// the registry and reports points.
+/// </summary>
+public sealed class CharacterSkillReader
+{
+    private readonly ISkillService _skills;
+
+    public CharacterSkillReader(ISkillService skills)
+    {
+        _skills = skills;
+    }
+
+    /// <summary>
+    /// The skills the character has, by name. The dictionary is sparse — a starting-skill slot left at
+    /// zero is never written — so this reports what is there rather than padding out the catalogue.
+    /// </summary>
+    public IReadOnlyList<CharacterSkillResponse> Read(MobileEntity mobile)
+        => [.. mobile.Skills
+                     .Select(entry => Describe(entry.Key, entry.Value))
+                     .OrderBy(skill => skill.Name, StringComparer.OrdinalIgnoreCase)];
+
+    private CharacterSkillResponse Describe(int id, MobileSkill skill)
+    {
+        // The catalogue is data and can lag the world, so a character may hold a skill nothing defines.
+        // Its id reads worse than a name and far better than a blank row.
+        var name = _skills.GetById(id)?.Name ?? id.ToString(CultureInfo.InvariantCulture);
+
+        return new(id, name, skill.Value / 10.0, skill.Cap / 10.0, skill.Lock.ToString());
+    }
+}

--- a/tests/Moongate.Tests/Http/Characters/CharacterSkillReaderTests.cs
+++ b/tests/Moongate.Tests/Http/Characters/CharacterSkillReaderTests.cs
@@ -1,0 +1,114 @@
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.UO.Data.Skills;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http.Characters;
+
+/// <summary>
+/// The mobile stores skills in tenths under a bare id. What this reader owns is turning that into
+/// something a reader can use: a name, and a value in points.
+/// </summary>
+public class CharacterSkillReaderTests
+{
+    [Fact]
+    public void Read_NamesEachSkillFromTheRegistry()
+    {
+        var mobile = With((1, 500, 1000, SkillLockType.Up));
+
+        var skills = new CharacterSkillReader(Registry((1, "Swordsmanship"))).Read(mobile);
+
+        Assert.Equal("Swordsmanship", Assert.Single(skills).Name);
+    }
+
+    // 500 tenths is 50.0 points. Reporting the tenths would leave every consumer to remember the
+    // division, and the first one to forget publishes a character with 500.0 swordsmanship.
+    [Fact]
+    public void Read_ReportsPointsRatherThanTheStoredTenths()
+    {
+        var mobile = With((1, 500, 1000, SkillLockType.Up));
+
+        var skill = Assert.Single(new CharacterSkillReader(Registry((1, "Swordsmanship"))).Read(mobile));
+
+        Assert.Equal(50.0, skill.Value);
+        Assert.Equal(100.0, skill.Cap);
+    }
+
+    [Fact]
+    public void Read_ReportsTheLock()
+    {
+        var mobile = With((1, 500, 1000, SkillLockType.Locked));
+
+        Assert.Equal("Locked", Assert.Single(new CharacterSkillReader(Registry((1, "Swordsmanship"))).Read(mobile)).Lock);
+    }
+
+    // The skill catalogue is data, so it can lag the world: a character can hold a skill nothing
+    // defines. Its id is worse than a name and far better than a blank row.
+    [Fact]
+    public void Read_FallsBackToTheIdWhenNoDefinitionIsRegistered()
+    {
+        var mobile = With((42, 300, 1000, SkillLockType.Up));
+
+        Assert.Equal("42", Assert.Single(new CharacterSkillReader(Registry()).Read(mobile)).Name);
+    }
+
+    // The dictionary is keyed by id and iterates in insertion order, which is whatever order the
+    // creation packet happened to use. A list a human reads should be alphabetical.
+    [Fact]
+    public void Read_OrdersByName()
+    {
+        var mobile = With((1, 500, 1000, SkillLockType.Up), (2, 400, 1000, SkillLockType.Up));
+
+        var skills = new CharacterSkillReader(Registry((1, "Swordsmanship"), (2, "Alchemy"))).Read(mobile);
+
+        Assert.Equal(["Alchemy", "Swordsmanship"], skills.Select(skill => skill.Name));
+    }
+
+    [Fact]
+    public void Read_IsEmptyForACharacterWithNoSkills()
+        => Assert.Empty(new CharacterSkillReader(Registry()).Read(new MobileEntity { Id = new(1) }));
+
+    private static MobileEntity With(params (int Id, int Value, int Cap, SkillLockType Lock)[] skills)
+    {
+        var mobile = new MobileEntity { Id = new(1) };
+
+        foreach (var (id, value, cap, locked) in skills)
+        {
+            mobile.Skills[id] = new() { Value = value, Cap = cap, Lock = locked };
+        }
+
+        return mobile;
+    }
+
+    private static ISkillService Registry(params (int Id, string Name)[] definitions)
+        => new SkillRegistryStub(definitions);
+
+    private sealed class SkillRegistryStub : ISkillService
+    {
+        private readonly Dictionary<int, SkillDefinition> _definitions;
+
+        public SkillRegistryStub(IEnumerable<(int Id, string Name)> definitions)
+        {
+            _definitions = definitions.ToDictionary(
+                definition => definition.Id,
+                definition => new SkillDefinition { Id = definition.Id, Name = definition.Name }
+            );
+        }
+
+        public IReadOnlyList<SkillDefinition> All
+            => [.. _definitions.Values];
+
+        public int Count
+            => _definitions.Count;
+
+        public SkillDefinition? GetById(int id)
+            => _definitions.GetValueOrDefault(id);
+
+        public SkillDefinition? GetByName(string name)
+            => throw new NotSupportedException();
+
+        public void Register(SkillDefinition definition)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
@@ -8,7 +8,10 @@ using Moongate.Http.Plugin.Services.Characters;
 using Moongate.Network.Packets.Incoming;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
 using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Services.Accounts;
+using Moongate.Server.Services.Mobiles;
+using Moongate.UO.Data.Skills;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Types;
 
@@ -33,6 +36,25 @@ public class CharacterDetailEndpointsTests
         Assert.Equal("Freydis", detail!.Character.Name);
         Assert.NotNull(detail.Equipment);
         Assert.NotNull(detail.Backpack);
+    }
+
+    // The entity stores 500 tenths; the API reports 50 points. A consumer that forgot the division
+    // would publish a character with 500.0 alchemy, so the route is asserted in the reported unit.
+    [Fact]
+    public async Task Get_ReportsTheCharactersSkillsInPoints()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+        var character = Create(server, "tom", "Freydis");
+
+        await server.AuthenticateAsync();
+
+        var detail = await server.Client.GetFromJsonAsync<CharacterDetailResponse>($"/api/v1/characters/{character}");
+
+        var skill = Assert.Single(detail!.Skills);
+
+        Assert.Equal("Alchemy", skill.Name);
+        Assert.Equal(50.0, skill.Value);
+        Assert.Equal("Up", skill.Lock);
     }
 
     // The account comes from the token. A player who could read another account's character by
@@ -132,6 +154,16 @@ public class CharacterDetailEndpointsTests
         return server.Accounts.GetByUsername(username)!.MobileIds[^1].ToString();
     }
 
+    /// <summary>The two skills the creation packet below hands out, so the route can name them.</summary>
+    private static ISkillService SkillRegistry()
+    {
+        var skills = new SkillService();
+
+        skills.Register(new() { Id = 1, Name = "Alchemy" });
+
+        return skills;
+    }
+
     private static CharacterCreationPacket Packet(string name)
         => new(
             0,
@@ -164,11 +196,14 @@ public class CharacterDetailEndpointsTests
                               container.RegisterInstance<IItemService>(new StubItemService([]));
                               container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
                               container.Register<CharacterInventoryReader>(Reuse.Singleton);
+                              container.RegisterInstance<ISkillService>(SkillRegistry());
+                              container.Register<CharacterSkillReader>(Reuse.Singleton);
                               container.RegisterApiEndpointInstance(
                                   new CharacterDetailEndpoints(
                                       container.Resolve<IAccountService>(),
                                       container.Resolve<ICharacterQueryService>(),
-                                      container.Resolve<CharacterInventoryReader>()
+                                      container.Resolve<CharacterInventoryReader>(),
+                                      container.Resolve<CharacterSkillReader>()
                                   )
                               );
                           }

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -307,7 +307,7 @@
           "characters"
         ],
         "summary": "One character in full: stats, appearance, what they wear and what they carry.",
-        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An\naccount may read its own characters; staff may read anyone's, and everyone else gets 403. A\nserial naming no character is 404, and so is one that is not a number.\n            \nThe backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the\nworn items by layer, the backpack and the bank box among them, without expanding them.\n            \nRead off the game loop, so an item the loop moves mid-read may appear in neither place or in\nboth. The next request settles it: this is a view, not a ledger.",
+        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An\naccount may read its own characters; staff may read anyone's, and everyone else gets 403. A\nserial naming no character is 404, and so is one that is not a number.\n            \nThe backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the\nworn items by layer, the backpack and the bank box among them, without expanding them. Skills\nare the ones the character has, by name, in points rather than the tenths the entity stores.\n            \nRead off the game loop, so an item the loop moves mid-read may appear in neither place or in\nboth. The next request settles it: this is a view, not a ledger.",
         "operationId": "GetCharacter",
         "parameters": [
           {
@@ -1995,7 +1995,8 @@
         "required": [
           "backpack",
           "character",
-          "equipment"
+          "equipment",
+          "skills"
         ],
         "type": "object",
         "properties": {
@@ -2015,6 +2016,13 @@
               "$ref": "#/components/schemas/CharacterItemResponse"
             },
             "description": "The backpack's contents, nested containers expanded."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CharacterSkillResponse"
+            },
+            "description": "The skills the character has, by name. Sparse on purpose: a mobile never stores a skill left at\nzero, so this is what the character actually trained rather than the whole catalogue."
           }
         },
         "additionalProperties": false,
@@ -2236,6 +2244,43 @@
         },
         "additionalProperties": false,
         "description": "One page of results, and what a caller needs to walk the rest."
+      },
+      "CharacterSkillResponse": {
+        "required": [
+          "cap",
+          "id",
+          "lock",
+          "name",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The skill id, which is what the mobile stores it under.",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "description": "The skill's name, or its id when no definition is registered for it."
+          },
+          "value": {
+            "type": "number",
+            "description": "The skill's value in points — 50.0, not the 500 tenths the entity stores. The tenths are a storage\ndetail, and reporting them would leave every consumer to remember to divide.",
+            "format": "double"
+          },
+          "cap": {
+            "type": "number",
+            "description": "That skill's personal ceiling, in points. 100.0 unless something raised it.",
+            "format": "double"
+          },
+          "lock": {
+            "type": "string",
+            "description": "Whether the skill may drift as it is used: `Up`, `Down` or `Locked` — the arrow the\nclient shows beside each entry."
+          }
+        },
+        "additionalProperties": false,
+        "description": "One skill a character has, as the API reports it."
       },
       "ConsoleCommandRequest": {
         "required": [

--- a/ui/src/components/characters/SkillList.test.tsx
+++ b/ui/src/components/characters/SkillList.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+
+import '../../lib/i18n'
+import { SkillList } from './SkillList'
+import type { CharacterSkill } from '../../lib/characters'
+
+function skill(name: string, over: Partial<CharacterSkill> = {}): CharacterSkill {
+  return { id: 1, name, value: 50, cap: 100, lock: 'Up', ...over } as CharacterSkill
+}
+
+describe('SkillList', () => {
+  it('shows each skill with its value and cap', () => {
+    render(<SkillList skills={[skill('Alchemy', { value: 62.5 })]} />)
+
+    expect(screen.getByText('Alchemy')).toBeInTheDocument()
+    expect(screen.getByText('62.5')).toBeInTheDocument()
+    expect(screen.getByText('100')).toBeInTheDocument()
+  })
+
+  // A value with no decimal reads better as 50 than 50.0, and one with a decimal must keep it: the
+  // server reports tenths of a point, so 62.5 is a real value and not a rounding artefact.
+  it('keeps the tenth only when there is one', () => {
+    render(<SkillList skills={[skill('Alchemy', { id: 1, value: 50 }), skill('Mining', { id: 2, value: 62.5 })]} />)
+
+    expect(screen.getByText('50')).toBeInTheDocument()
+    expect(screen.getByText('62.5')).toBeInTheDocument()
+  })
+
+  it('names the lock in words', () => {
+    render(
+      <SkillList
+        skills={[
+          skill('Alchemy', { id: 1, lock: 'Up' }),
+          skill('Mining', { id: 2, lock: 'Down' }),
+          skill('Tailoring', { id: 3, lock: 'Locked' }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Rising')).toBeInTheDocument()
+    expect(screen.getByText('Falling')).toBeInTheDocument()
+    expect(screen.getByText('Locked')).toBeInTheDocument()
+  })
+
+  // The registry can lag the world, so the server may report a lock it has no word for. Showing the
+  // server's own value beats showing a raw translation key.
+  it('shows a lock it has no word for rather than a key', () => {
+    render(<SkillList skills={[skill('Alchemy', { lock: 'Sideways' })]} />)
+
+    expect(screen.getByText('Sideways')).toBeInTheDocument()
+  })
+
+  it('reports the total of every skill', () => {
+    render(<SkillList skills={[skill('Alchemy', { id: 1, value: 50 }), skill('Mining', { id: 2, value: 32.5 })]} />)
+
+    expect(screen.getByText('82.5 total')).toBeInTheDocument()
+  })
+
+  // A brand-new character can have none, and an empty frame says nothing.
+  it('says so when the character has trained nothing', () => {
+    render(<SkillList skills={[]} />)
+
+    expect(screen.getByText('No skills trained')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/characters/SkillList.tsx
+++ b/ui/src/components/characters/SkillList.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+
+import type { CharacterSkill } from '../../lib/characters'
+
+/**
+ * A character's trained skills. The list is what the server reports — sparse and alphabetical, since
+ * a mobile never stores a skill left at zero — so there are no rows of noughts to scroll past.
+ */
+export function SkillList({ skills }: { skills: CharacterSkill[] }) {
+  const { t } = useTranslation()
+
+  if (skills.length === 0) {
+    return <p className="text-sm text-muted">{t('characters.skills.empty')}</p>
+  }
+
+  const total = skills.reduce((sum, skill) => sum + skill.value, 0)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ul className="flex flex-col">
+        {skills.map((skill) => (
+          <li key={skill.id} className="flex items-baseline justify-between gap-3 border-b border-ink/5 py-1 text-sm">
+            <span className="min-w-0 truncate text-ink">{skill.name}</span>
+
+            <span className="flex shrink-0 items-baseline gap-3">
+              {/*
+                Falls back to the server's own value: the arrow set could gain a member the portal
+                has no word for, and a raw translation key is worse than an English one.
+              */}
+              <span className="text-xs text-muted">
+                {t(`characters.skills.lock${skill.lock}`, { defaultValue: skill.lock })}
+              </span>
+              <span className="font-bold text-ink tabular-nums">{points(skill.value)}</span>
+              <span className="w-10 text-right text-xs text-muted tabular-nums">{points(skill.cap)}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="text-right text-xs text-muted">{t('characters.skills.total', { total: points(total) })}</p>
+    </div>
+  )
+}
+
+/**
+ * The server reports tenths of a point, so 62.5 is a real value rather than a rounding artefact — but
+ * a whole number reads better as 50 than as 50.0.
+ */
+function points(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -187,7 +187,8 @@ export interface paths {
          *     serial naming no character is 404, and so is one that is not a number.
          *
          *     The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the
-         *     worn items by layer, the backpack and the bank box among them, without expanding them.
+         *     worn items by layer, the backpack and the bank box among them, without expanding them. Skills
+         *     are the ones the character has, by name, in points rather than the tenths the entity stores.
          *
          *     Read off the game loop, so an item the loop moves mid-read may appear in neither place or in
          *     both. The next request settles it: this is a view, not a ledger.
@@ -1050,6 +1051,11 @@ export interface components {
             equipment: components["schemas"]["CharacterItemResponse"][];
             /** @description The backpack's contents, nested containers expanded. */
             backpack: components["schemas"]["CharacterItemResponse"][];
+            /**
+             * @description The skills the character has, by name. Sparse on purpose: a mobile never stores a skill left at
+             *     zero, so this is what the character actually trained rather than the whole catalogue.
+             */
+            skills: components["schemas"]["CharacterSkillResponse"][];
         };
         /**
          * @description One item as the API reports it, with whatever it contains. Deliberately not `ItemEntity`, which
@@ -1158,6 +1164,32 @@ export interface components {
              * @description How many pages exist at this page size. 0 when nothing matched.
              */
             totalPages: number;
+        };
+        /** @description One skill a character has, as the API reports it. */
+        CharacterSkillResponse: {
+            /**
+             * Format: int32
+             * @description The skill id, which is what the mobile stores it under.
+             */
+            id: number;
+            /** @description The skill's name, or its id when no definition is registered for it. */
+            name: string;
+            /**
+             * Format: double
+             * @description The skill's value in points — 50.0, not the 500 tenths the entity stores. The tenths are a storage
+             *     detail, and reporting them would leave every consumer to remember to divide.
+             */
+            value: number;
+            /**
+             * Format: double
+             * @description That skill's personal ceiling, in points. 100.0 unless something raised it.
+             */
+            cap: number;
+            /**
+             * @description Whether the skill may drift as it is used: `Up`, `Down` or `Locked` — the arrow the
+             *     client shows beside each entry.
+             */
+            lock: string;
         };
         /** @description A console command to run and the SSE connection its output should stream to. */
         ConsoleCommandRequest: {

--- a/ui/src/lib/characters.ts
+++ b/ui/src/lib/characters.ts
@@ -67,6 +67,7 @@ export const useAllCharacters = (params: { page: number; search: string }) =>
 
 export type CharacterDetail = components['schemas']['CharacterDetailResponse']
 export type CharacterItem = components['schemas']['CharacterItemResponse']
+export type CharacterSkill = components['schemas']['CharacterSkillResponse']
 
 /** One character in full — your own, or anyone's for staff. The server decides which. */
 export const useCharacter = (serial: string) =>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -309,6 +309,18 @@
       "notFound": "That character could not be found.",
       "forbidden": "That character belongs to another account.",
       "loadFailed": "That character could not be loaded."
+    },
+    "skills": {
+      "title": "Skills",
+      "empty": "No skills trained",
+      "skill": "Skill",
+      "value": "Value",
+      "cap": "Cap",
+      "lock": "Lock",
+      "total": "{{total}} total",
+      "lockUp": "Rising",
+      "lockDown": "Falling",
+      "lockLocked": "Locked"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -309,6 +309,18 @@
       "notFound": "Personaggio non trovato.",
       "forbidden": "Quel personaggio appartiene a un altro account.",
       "loadFailed": "Non è stato possibile caricare il personaggio."
+    },
+    "skills": {
+      "title": "Abilità",
+      "empty": "Nessuna abilità allenata",
+      "skill": "Abilità",
+      "value": "Valore",
+      "cap": "Limite",
+      "lock": "Blocco",
+      "total": "{{total}} in totale",
+      "lockUp": "In crescita",
+      "lockDown": "In calo",
+      "lockLocked": "Bloccata"
     }
   }
 }

--- a/ui/src/routes/CharacterDetailScreen.test.tsx
+++ b/ui/src/routes/CharacterDetailScreen.test.tsx
@@ -65,6 +65,7 @@ function detail(over: Partial<CharacterDetail> = {}): CharacterDetail {
     },
     equipment: [],
     backpack: [],
+    skills: [],
     ...over,
   } as CharacterDetail
 }
@@ -102,6 +103,16 @@ describe('CharacterDetailScreen', () => {
 
     expect(screen.getByText('Robe')).toBeInTheDocument()
     expect(screen.getByText('Dagger')).toBeInTheDocument()
+  })
+
+  it('shows the skills the character trained', () => {
+    renderAt(
+      '0x40000001',
+      detail({ skills: [{ id: 1, name: 'Alchemy', value: 62.5, cap: 100, lock: 'Up' }] } as Partial<CharacterDetail>),
+    )
+
+    expect(screen.getByText('Alchemy')).toBeInTheDocument()
+    expect(screen.getByText('62.5')).toBeInTheDocument()
   })
 
   it('shows the stats', () => {

--- a/ui/src/routes/CharacterDetailScreen.tsx
+++ b/ui/src/routes/CharacterDetailScreen.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from 'react-router'
 import { Card } from '../components/ui/card'
 import { CharacterImage } from '../components/characters/CharacterImage'
 import { InventoryTree } from '../components/characters/InventoryTree'
+import { SkillList } from '../components/characters/SkillList'
 import { ApiError } from '../lib/api'
 import { paperdollUrl, useCharacter, type CharacterDetail } from '../lib/characters'
 
@@ -100,6 +101,11 @@ function Detail({ detail }: { detail: CharacterDetail }) {
           <Card className="gap-3 p-4">
             <h2 className="font-bold text-ink">{t('characters.detail.equipment')}</h2>
             <InventoryTree items={detail.equipment} emptyLabel={t('characters.detail.equipmentEmpty')} />
+          </Card>
+
+          <Card className="gap-3 p-4">
+            <h2 className="font-bold text-ink">{t('characters.skills.title')}</h2>
+            <SkillList skills={detail.skills} />
           </Card>
 
           <Card className="gap-3 p-4">


### PR DESCRIPTION
Closes #172 (by hand once merged — this targets `develop`).

The detail page showed stats, equipment and the backpack. Skills were on the mobile and nothing reported them.

## The unit is the point

The entity stores skills in **tenths** under a bare id — right for the wire, unreadable everywhere else. The API names each one from `ISkillService` and reports **points**: 500 becomes 50.0, so no consumer has to remember the division, and the first one to forget cannot publish a character with 500.0 alchemy. The endpoint test asserts the reported unit end to end.

## Sparse on purpose

`MobileFactoryService` skips a starting-skill slot left at zero, so the dictionary holds only what the character actually trained. The API reports that rather than padding the catalogue with noughts, and the list is alphabetical — the dictionary iterates in whatever order the creation packet happened to use.

A skill with no registered definition falls back to its **id**. The catalogue is data and can lag the world; an id reads worse than a name and far better than a blank row. Same reasoning for the lock: the UI falls back to the server's own value for an arrow it has no word for.

## The page

A skills section beside equipment and backpack, each row carrying the value, the cap and the lock in words, with the total underneath. A whole number renders as `50` and a real tenth keeps its decimal — `62.5` is a value, not a rounding artefact.

## Checks

- .NET **2079 passed**; UI **278 passed**, build and Prettier clean; DocFX **0 warnings**; contract regenerated.
- Verified at real boot: the shard's character reports Magery, Meditation and Wrestling at 30/100 with lock `Up` — named from the registry, in points, alphabetical.

One thing the typecheck caught that the tests did not: a hand-written signature for i18next's `t` passed every test and failed `tsc`. The helper is gone and the lookup is inline.

## Not included

Nothing changes a skill. That is the game's business, not the portal's.