### PR TITLE
feat: item tooltips from the game's own property list

### DIFF
--- a/docs/under-the-hood/rest-api.md
+++ b/docs/under-the-hood/rest-api.md
@@ -111,6 +111,7 @@ good token that is simply not staff.
 | `GET`    | `/api/v1/player/me/characters`       | `player` | the caller's own characters        |
 | `GET`    | `/api/v1/admin/characters`           | `admin`  | every character, paged             |
 | `GET`    | `/api/v1/characters/{serial}`        | `player` | one character in full, or 403 / 404 |
+| `GET`    | `/api/v1/characters/{serial}/items/{itemSerial}/tooltip` | `player` | what the game says about one of its items |
 | `GET`    | `/api/v1/admin/players/online`       | `admin`  | players currently in the world     |
 | `GET`    | `/api/v1/images/items/{id}.png`      | none     | item art as PNG, or 400 / 404 / 503 |
 | `POST`   | `/api/v1/admin/images/items`         | `admin`  | 202, or 409 / 503                  |
@@ -229,7 +230,27 @@ recursive on a request thread: a cycle there is a hung request rather than a
 wrong answer. A visited set stops one, and the depth limit stops anything the
 visited set misses.
 
-Like the online-player route, this reads world state off the game loop. An item
+`GET /api/v1/characters/{serial}/items/{itemSerial}/tooltip` is what the game
+itself says about one item — the object property list the client renders,
+resolved to text. Resolving it means following UO's own grammar: a cliloc
+number, TAB-separated arguments, `~1_NUMBER~` placeholders, and an argument that
+may itself be a `#cliloc`. That happens here so a caller receives finished
+sentences rather than a numbering scheme to decode. An entry the string table
+cannot describe is dropped, so a shard with no client files answers with fewer
+lines — or none — rather than with raw clilocs or an error.
+
+The route is nested under the character deliberately. An item knows its parent
+container, not whose it is, so there is no ownership chain from an item up to an
+account: authorization is the character's, and the item must actually be in that
+character's equipment or backpack. A serial cannot be probed here.
+
+Unlike the reads above, this one **goes through the game loop**. `IOplService`
+caches its snapshots without synchronization by design, so building one from a
+request thread would race the loop that owns it. A loop that does not answer
+within two seconds is a 503: nobody hovering an item wants to watch a spinner,
+and a loop that busy has a worse problem than a missing tooltip.
+
+Like the online-player route, the rest of this reads world state off the game loop. An item
 the loop moves mid-read may appear in neither place or in both; the next request
 settles it. That trade-off is local to read-only views — world mutations still
 belong on the loop.

--- a/plugins/Moongate.Http.Plugin/Data/Api/Characters/ItemTooltipResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Characters/ItemTooltipResponse.cs
@@ -1,0 +1,20 @@
+namespace Moongate.Http.Plugin.Data.Api.Characters;
+
+/// <summary>What the game itself says about one item, plus what the portal knows about it.</summary>
+/// <param name="Serial">The item's serial, as <c>0x40000001</c>.</param>
+/// <param name="Lines">
+/// The object property list as the game client renders it, resolved to text. Empty when the shard's
+/// string table is not loaded — the technical fields are still worth showing, so that is not an error.
+/// </param>
+/// <param name="TemplateId">The template it was built from.</param>
+/// <param name="ItemId">The art id.</param>
+/// <param name="Hue">0 for the raw art.</param>
+/// <param name="Amount">How many, for a stack.</param>
+public sealed record ItemTooltipResponse(
+    string Serial,
+    IReadOnlyList<string> Lines,
+    string TemplateId,
+    int ItemId,
+    int Hue,
+    int Amount
+);

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
@@ -15,20 +15,17 @@ namespace Moongate.Http.Plugin.Endpoints.Characters;
 /// <summary>One character in full, for its owner or for staff.</summary>
 public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
 {
-    private readonly IAccountService _accounts;
-    private readonly ICharacterQueryService _characters;
+    private readonly CharacterAccessService _access;
     private readonly CharacterInventoryReader _inventory;
     private readonly CharacterSkillReader _skills;
 
     public CharacterDetailEndpoints(
-        IAccountService accounts,
-        ICharacterQueryService characters,
+        CharacterAccessService access,
         CharacterInventoryReader inventory,
         CharacterSkillReader skills
     )
     {
-        _accounts = accounts;
-        _characters = characters;
+        _access = access;
         _inventory = inventory;
         _skills = skills;
     }
@@ -55,61 +52,22 @@ public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
     /// </remarks>
     private IResult GetOne(string serial, ClaimsPrincipal user)
     {
-        if (!Serial.TryParse(serial, out var characterId))
+        // Who may read which character is one rule, and it lives in one place: two copies of an
+        // authorization check are two rules, and the second one drifts.
+        var (found, denial) = _access.Resolve(serial, user);
+
+        if (denial is not null)
         {
-            return NotFound();
-        }
-
-        var found = _characters.Find(characterId);
-
-        if (found is null)
-        {
-            return NotFound();
-        }
-
-        // The account comes from the token, never from the request: an id a caller could supply would
-        // let anyone read anyone's character by changing a number.
-        if (!CharacterEndpoints.TryReadAccountId(user, out var accountId))
-        {
-            return Results.Problem("The token carries no account id.", statusCode: StatusCodes.Status401Unauthorized);
-        }
-
-        var caller = _accounts.GetById(accountId);
-
-        if (caller is null)
-        {
-            return Results.Problem(
-                "The account this token belongs to no longer exists.",
-                statusCode: StatusCodes.Status401Unauthorized
-            );
-        }
-
-        if (!IsStaff(caller.AccountLevel) && !caller.MobileIds.Contains(characterId))
-        {
-            return Results.Problem(
-                "That character belongs to another account.",
-                statusCode: StatusCodes.Status403Forbidden
-            );
+            return denial;
         }
 
         return Results.Ok(
             new CharacterDetailResponse(
-                CharacterResponse.From(found.Mobile, found.AccountUsername),
+                CharacterResponse.From(found!.Mobile, found.AccountUsername),
                 _inventory.ReadEquipment(found.Mobile),
                 _inventory.ReadBackpack(found.Mobile),
                 _skills.Read(found.Mobile)
             )
         );
     }
-
-    /// <summary>The same two levels the admin policy admits, so the two cannot drift apart.</summary>
-    private static bool IsStaff(AccountLevelType level)
-        => level is AccountLevelType.Administrator or AccountLevelType.GrandMaster;
-
-    /// <summary>
-    /// One answer for "no such character" and "that is not even a serial": from outside, both mean
-    /// there is nothing at that address.
-    /// </summary>
-    private static IResult NotFound()
-        => Results.Problem("No character with that serial.", statusCode: StatusCodes.Status404NotFound);
 }

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/ItemTooltipEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/ItemTooltipEndpoints.cs
@@ -1,0 +1,148 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Http.Plugin.Endpoints.Characters;
+
+/// <summary>What the game says about one item a character is carrying or wearing.</summary>
+public sealed class ItemTooltipEndpoints : IApiEndpointRegistration
+{
+    /// <summary>
+    /// How long a tooltip waits for the game loop. Short on purpose: nobody hovering an item wants to
+    /// watch a spinner, and a loop this busy has a worse problem than a missing tooltip.
+    /// </summary>
+    private static readonly TimeSpan _loopTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly CharacterAccessService _access;
+    private readonly CharacterInventoryReader _inventory;
+    private readonly IItemService _items;
+    private readonly IOplService _opl;
+    private readonly OplTextRenderer _renderer;
+    private readonly IGameLoopContext _loop;
+
+    public ItemTooltipEndpoints(
+        CharacterAccessService access,
+        CharacterInventoryReader inventory,
+        IItemService items,
+        IOplService opl,
+        OplTextRenderer renderer,
+        IGameLoopContext loop
+    )
+    {
+        _access = access;
+        _inventory = inventory;
+        _items = items;
+        _opl = opl;
+        _renderer = renderer;
+        _loop = loop;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+        => routes.MapGet("/api/v1/characters/{serial}/items/{itemSerial}/tooltip", GetTooltip)
+                 .WithName("GetItemTooltip")
+                 .WithTags("characters")
+                 .Produces<ItemTooltipResponse>()
+                 .RequireAuthorization(HttpServerService.PlayerPolicy);
+
+    /// <summary>What the game says about one item the character is carrying or wearing.</summary>
+    /// <remarks>
+    /// The lines are the object property list the game client renders, resolved to text — the item's
+    /// name, its weight, and whatever else the shard describes. A shard whose string table is not
+    /// loaded gets an **empty** list rather than an error: the technical fields are still worth having.
+    ///
+    /// The route is nested under the character because an item knows its container, not whose it is.
+    /// Authorization is the character's — an account reads its own, staff read anyone's — and the item
+    /// must actually be in that character's equipment or backpack, so a serial cannot be probed here.
+    ///
+    /// Answers 503 when the game loop does not respond: the property list is built on the loop, whose
+    /// cache is deliberately unsynchronized.
+    /// </remarks>
+    private async Task<IResult> GetTooltip(string serial, string itemSerial, ClaimsPrincipal user)
+    {
+        var (character, denial) = _access.Resolve(serial, user);
+
+        if (denial is not null)
+        {
+            return denial;
+        }
+
+        if (!Serial.TryParse(itemSerial, out var itemId))
+        {
+            return NotFound();
+        }
+
+        // The item must be the character's. This is what nesting the route buys: no ownership chain
+        // from an item up to an account exists, so the character's own tree is the check.
+        if (!Carries(character!.Mobile, itemId))
+        {
+            return NotFound();
+        }
+
+        var item = _items.GetById(itemId);
+
+        if (item is null)
+        {
+            return NotFound();
+        }
+
+        IReadOnlyList<string> lines;
+
+        try
+        {
+            // On the loop: IOplService caches its snapshots without synchronization, by design, so
+            // building one from a request thread would race the loop that owns it.
+            lines = await _loop.InvokeAsync(() => Render(itemId), _loopTimeout);
+        }
+        catch (TimeoutException)
+        {
+            return Results.Problem(
+                "The game loop did not respond; the tooltip is unavailable.",
+                statusCode: StatusCodes.Status503ServiceUnavailable
+            );
+        }
+
+        return Results.Ok(
+            new ItemTooltipResponse(item.Id.ToString(), lines, item.TemplateId, item.ItemId, item.Hue.Value, item.Amount)
+        );
+    }
+
+    /// <summary>
+    /// The property list as text. Entries the string table cannot describe are dropped rather than
+    /// rendered as their raw cliloc, so a partially loaded table shows fewer lines instead of noise.
+    /// </summary>
+    private IReadOnlyList<string> Render(Serial itemId)
+        => [.. _opl.GetOrBuild(itemId).Entries.Select(_renderer.Render).OfType<string>()];
+
+    /// <summary>
+    /// Whether the item is worn by the character or sits somewhere in its backpack. Reuses the reader
+    /// that already walks containers with a cycle guard, rather than walking them again here.
+    /// </summary>
+    private bool Carries(MobileEntity mobile, Serial itemId)
+    {
+        var worn = _inventory.ReadEquipment(mobile);
+        var carried = _inventory.ReadBackpack(mobile);
+        var wanted = itemId.ToString();
+
+        return Contains(worn, wanted) || Contains(carried, wanted);
+    }
+
+    private static bool Contains(IReadOnlyList<CharacterItemResponse> items, string serial)
+        => items.Any(item => item.Serial == serial || Contains(item.Contents, serial));
+
+    /// <summary>
+    /// One answer for an item that is not the character's, one that does not exist, and one whose
+    /// serial is not a number: from outside, all three mean there is nothing to describe.
+    /// </summary>
+    private static IResult NotFound()
+        => Results.Problem("No such item on that character.", statusCode: StatusCodes.Status404NotFound);
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -121,9 +121,14 @@ public class MoongateHttpPlugin : ISquidStdPlugin
 
         // The detail route's reader walks containers; it takes IItemService and nothing else, so it
         // is a plain singleton beside the endpoint group that uses it.
+        container.Register<CharacterAccessService>(Reuse.Singleton);
         container.Register<CharacterInventoryReader>(Reuse.Singleton);
         container.Register<CharacterSkillReader>(Reuse.Singleton);
         container.RegisterApiEndpoint<CharacterDetailEndpoints>();
+
+        // Tooltips render the game's own property list, so they need the cliloc grammar resolved.
+        container.Register<OplTextRenderer>(Reuse.Singleton);
+        container.RegisterApiEndpoint<ItemTooltipEndpoints>();
         container.RegisterApiEndpoint<ItemTemplateEndpoints>();
 
         // A REST web-terminal onto the admin command set: the registry holds the open SSE feeds,

--- a/plugins/Moongate.Http.Plugin/Services/Characters/CharacterAccessService.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Characters/CharacterAccessService.cs
@@ -1,0 +1,90 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Endpoints.Characters;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+
+namespace Moongate.Http.Plugin.Services.Characters;
+
+/// <summary>
+/// Answers one question for every route about a named character: may this caller read it?
+///
+/// It lives in one place because two copies of an authorization rule are two rules, and the second
+/// one drifts. Every route that addresses a character by serial resolves it through here.
+/// </summary>
+public sealed class CharacterAccessService
+{
+    private readonly IAccountService _accounts;
+    private readonly ICharacterQueryService _characters;
+
+    public CharacterAccessService(IAccountService accounts, ICharacterQueryService characters)
+    {
+        _accounts = accounts;
+        _characters = characters;
+    }
+
+    /// <summary>
+    /// The character the caller may read, or the response saying why they may not. Exactly one of the
+    /// two is non-null.
+    /// </summary>
+    /// <remarks>
+    /// An account reads its own characters and staff read anyone's. Ownership is checked against the
+    /// account the token names, never against a value the caller supplied: an id from the request
+    /// would let anyone read anyone's character by changing a number.
+    /// </remarks>
+    public (OwnedCharacter? Character, IResult? Denial) Resolve(string serial, ClaimsPrincipal user)
+    {
+        if (!Serial.TryParse(serial, out var characterId))
+        {
+            return (null, NotFound());
+        }
+
+        var found = _characters.Find(characterId);
+
+        if (found is null)
+        {
+            return (null, NotFound());
+        }
+
+        if (!CharacterEndpoints.TryReadAccountId(user, out var accountId))
+        {
+            return (null, Results.Problem(
+                        "The token carries no account id.",
+                        statusCode: StatusCodes.Status401Unauthorized
+                    ));
+        }
+
+        var caller = _accounts.GetById(accountId);
+
+        if (caller is null)
+        {
+            return (null, Results.Problem(
+                        "The account this token belongs to no longer exists.",
+                        statusCode: StatusCodes.Status401Unauthorized
+                    ));
+        }
+
+        if (!IsStaff(caller.AccountLevel) && !caller.MobileIds.Contains(characterId))
+        {
+            return (null, Results.Problem(
+                        "That character belongs to another account.",
+                        statusCode: StatusCodes.Status403Forbidden
+                    ));
+        }
+
+        return (found, null);
+    }
+
+    /// <summary>
+    /// One answer for "no such character" and "that is not even a serial": from outside, both mean
+    /// there is nothing at that address.
+    /// </summary>
+    public static IResult NotFound()
+        => Results.Problem("No character with that serial.", statusCode: StatusCodes.Status404NotFound);
+
+    /// <summary>The same two levels the admin policy admits, so the two cannot drift apart.</summary>
+    private static bool IsStaff(AccountLevelType level)
+        => level is AccountLevelType.Administrator or AccountLevelType.GrandMaster;
+}

--- a/plugins/Moongate.Http.Plugin/Services/Characters/OplTextRenderer.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Characters/OplTextRenderer.cs
@@ -1,0 +1,70 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Moongate.Network.Data;
+using Moongate.Server.Abstractions.Interfaces.Localization;
+
+namespace Moongate.Http.Plugin.Services.Characters;
+
+/// <summary>
+/// Turns one object-property entry into a line of text: the cliloc's own string with its arguments
+/// substituted. This lives on the server because the grammar is UO's — TAB-separated slots,
+/// <c>~N_X~</c> placeholders, and an argument that may itself be a <c>#cliloc</c> reference. A browser
+/// should receive finished sentences, not a numbering scheme to decode.
+/// </summary>
+public sealed partial class OplTextRenderer
+{
+    private readonly IClilocService _clilocs;
+
+    public OplTextRenderer(IClilocService clilocs)
+    {
+        _clilocs = clilocs;
+    }
+
+    /// <summary>
+    /// The entry as a line, or null when the string table cannot describe its cliloc — which is the
+    /// normal case on a shard whose client files are absent, and a reason to show no line rather than
+    /// to fail.
+    /// </summary>
+    public string? Render(OplEntry entry)
+    {
+        var text = _clilocs.Text(entry.Cliloc);
+
+        if (text is null)
+        {
+            return null;
+        }
+
+        var arguments = entry.Arguments.Split('\t');
+
+        // Slots are 1-based in the placeholder and positional in the argument list. A slot with no
+        // argument — malformed data, or a cliloc declaring more than it was given — collapses to
+        // nothing rather than leaving "~2_ITEMNAME~" in a sentence someone reads.
+        return Placeholder()
+               .Replace(
+                   text,
+                   match =>
+                   {
+                       var slot = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+
+                       return slot <= arguments.Length ? Resolve(arguments[slot - 1]) : string.Empty;
+                   }
+               )
+               .Trim();
+    }
+
+    /// <summary>An argument prefixed with # is a cliloc of its own; anything else is already text.</summary>
+    private string Resolve(string argument)
+    {
+        if (!argument.StartsWith('#'))
+        {
+            return argument;
+        }
+
+        return int.TryParse(argument[1..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var cliloc)
+                   ? _clilocs.Text(cliloc) ?? string.Empty
+                   : string.Empty;
+    }
+
+    [GeneratedRegex(@"~(\d+)_[^~]*~")]
+    private static partial Regex Placeholder();
+}

--- a/tests/Moongate.Tests/Http/Characters/OplTextRendererTests.cs
+++ b/tests/Moongate.Tests/Http/Characters/OplTextRendererTests.cs
@@ -1,0 +1,103 @@
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Network.Data;
+using Moongate.Server.Abstractions.Interfaces.Localization;
+
+namespace Moongate.Tests.Http.Characters;
+
+/// <summary>
+/// A property line is a cliloc plus TAB-separated arguments, and an argument may itself be a cliloc.
+/// Rendering that is UO's grammar, which is exactly why it happens here and not in the browser.
+/// </summary>
+public class OplTextRendererTests
+{
+    [Fact]
+    public void Render_AClilocWithNoArguments_IsItsText()
+    {
+        var renderer = new OplTextRenderer(Clilocs((500000, "a dagger")));
+
+        Assert.Equal("a dagger", renderer.Render(new(500000, "")));
+    }
+
+    [Fact]
+    public void Render_SubstitutesASingleArgument()
+    {
+        var renderer = new OplTextRenderer(Clilocs((1072788, "Weight: ~1_WEIGHT~ stone")));
+
+        Assert.Equal("Weight: 3 stone", renderer.Render(new(1072788, "3")));
+    }
+
+    // Multi-slot arguments arrive TAB-separated, in slot order.
+    [Fact]
+    public void Render_SubstitutesEachSlotInTurn()
+    {
+        var renderer = new OplTextRenderer(Clilocs((1050039, "~1_NUMBER~ ~2_ITEMNAME~")));
+
+        Assert.Equal("500 gold coins", renderer.Render(new(1050039, "500\tgold coins")));
+    }
+
+    // An argument starting with # is itself a cliloc: the stack line names its item that way, and the
+    // prefix is load-bearing rather than decoration.
+    [Fact]
+    public void Render_ResolvesAnArgumentThatIsItselfACliloc()
+    {
+        var renderer = new OplTextRenderer(Clilocs((1050039, "~1_NUMBER~ ~2_ITEMNAME~"), (1020001, "gold coins")));
+
+        Assert.Equal("500 gold coins", renderer.Render(new(1050039, "500\t#1020001")));
+    }
+
+    // The string table is client data and may be absent or incomplete. A line nothing describes is
+    // dropped by the caller, so null says "no line" rather than showing "~1_WEIGHT~" to a reader.
+    [Fact]
+    public void Render_IsNullWhenTheTableDoesNotDescribeTheCliloc()
+        => Assert.Null(new OplTextRenderer(Clilocs()).Render(new(1072788, "3")));
+
+    // An unresolvable nested cliloc must not leave "#1020001" in the sentence.
+    [Fact]
+    public void Render_LeavesNoPlaceholderWhenAnArgumentCannotBeResolved()
+    {
+        var renderer = new OplTextRenderer(Clilocs((1050039, "~1_NUMBER~ ~2_ITEMNAME~")));
+
+        var line = renderer.Render(new(1050039, "500\t#1020001"));
+
+        Assert.DoesNotContain("#", line);
+        Assert.DoesNotContain("~", line);
+    }
+
+    // Fewer arguments than slots is malformed data, not a crash.
+    [Fact]
+    public void Render_ToleratesMissingArguments()
+    {
+        var renderer = new OplTextRenderer(Clilocs((1050039, "~1_NUMBER~ ~2_ITEMNAME~")));
+
+        var line = renderer.Render(new(1050039, "500"));
+
+        Assert.NotNull(line);
+        Assert.DoesNotContain("~", line);
+    }
+
+    // How OplService emits free text: a string cliloc whose whole body is one slot.
+    [Fact]
+    public void Render_AStringClilocIsItsArgument()
+    {
+        var renderer = new OplTextRenderer(Clilocs((1042971, "~1_val~")));
+
+        Assert.Equal("Tommy's spellbook", renderer.Render(new(1042971, "Tommy's spellbook")));
+    }
+
+    private static IClilocService Clilocs(params (int Cliloc, string Text)[] entries)
+        => new ClilocStub(entries.ToDictionary(entry => entry.Cliloc, entry => entry.Text));
+
+    /// <summary>The client's string table, reduced to the entries a test cares about.</summary>
+    private sealed class ClilocStub : IClilocService
+    {
+        private readonly Dictionary<int, string> _text;
+
+        public ClilocStub(Dictionary<int, string> text)
+        {
+            _text = text;
+        }
+
+        public string? Text(int cliloc)
+            => _text.GetValueOrDefault(cliloc);
+    }
+}

--- a/tests/Moongate.Tests/Http/Characters/OplTextRendererTests.cs
+++ b/tests/Moongate.Tests/Http/Characters/OplTextRendererTests.cs
@@ -1,6 +1,6 @@
 using Moongate.Http.Plugin.Services.Characters;
 using Moongate.Network.Data;
-using Moongate.Server.Abstractions.Interfaces.Localization;
+using Moongate.Tests.Support;
 
 namespace Moongate.Tests.Http.Characters;
 
@@ -84,20 +84,6 @@ public class OplTextRendererTests
         Assert.Equal("Tommy's spellbook", renderer.Render(new(1042971, "Tommy's spellbook")));
     }
 
-    private static IClilocService Clilocs(params (int Cliloc, string Text)[] entries)
-        => new ClilocStub(entries.ToDictionary(entry => entry.Cliloc, entry => entry.Text));
-
-    /// <summary>The client's string table, reduced to the entries a test cares about.</summary>
-    private sealed class ClilocStub : IClilocService
-    {
-        private readonly Dictionary<int, string> _text;
-
-        public ClilocStub(Dictionary<int, string> text)
-        {
-            _text = text;
-        }
-
-        public string? Text(int cliloc)
-            => _text.GetValueOrDefault(cliloc);
-    }
+    private static StubClilocService Clilocs(params (int Cliloc, string Text)[] entries)
+        => StubClilocService.Entries(entries);
 }

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
@@ -195,13 +195,13 @@ public class CharacterDetailEndpointsTests
                               // containers has its own tests, so an empty item world is enough here.
                               container.RegisterInstance<IItemService>(new StubItemService([]));
                               container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
+                              container.Register<CharacterAccessService>(Reuse.Singleton);
                               container.Register<CharacterInventoryReader>(Reuse.Singleton);
                               container.RegisterInstance<ISkillService>(SkillRegistry());
                               container.Register<CharacterSkillReader>(Reuse.Singleton);
                               container.RegisterApiEndpointInstance(
                                   new CharacterDetailEndpoints(
-                                      container.Resolve<IAccountService>(),
-                                      container.Resolve<ICharacterQueryService>(),
+                                      container.Resolve<CharacterAccessService>(),
                                       container.Resolve<CharacterInventoryReader>(),
                                       container.Resolve<CharacterSkillReader>()
                                   )

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/ItemTooltipEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/ItemTooltipEndpointsTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Interfaces;
+using Moongate.Core.Primitives;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data.Api.Characters;
+using Moongate.Http.Plugin.Endpoints.Characters;
+using Moongate.Http.Plugin.Services.Characters;
+using Moongate.Network.Packets.Incoming;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Localization;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Services.Accounts;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Types;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Http.Endpoints.Characters;
+
+/// <summary>
+/// The route is nested under the character on purpose: an item knows its container, not whose it is,
+/// so authorization comes from the character and the item must actually be in that character's tree.
+/// That pairing is what these tests are about.
+/// </summary>
+public class ItemTooltipEndpointsTests
+{
+    private const int WeightCliloc = 1072788;
+
+    [Fact]
+    public async Task Get_AnItemInTheBackpack_ReturnsItsRenderedLines()
+    {
+        var world = new StubItemService([]);
+        await using var server = await StartAsync(world, AccountLevelType.Player);
+        var character = Create(server, "tom", "Freydis");
+        var dagger = Backpack(server, world, character, "a dagger");
+
+        await server.AuthenticateAsync();
+
+        var tooltip = await server.Client.GetFromJsonAsync<ItemTooltipResponse>(Route(character, dagger));
+
+        Assert.Equal("Weight: 3 stone", Assert.Single(tooltip!.Lines));
+        Assert.Equal("dagger", tooltip.TemplateId);
+    }
+
+    // Equipment is as much the character's as the backpack is, and a worn item is exactly what someone
+    // hovers a paperdoll layer to ask about.
+    [Fact]
+    public async Task Get_AWornItem_ReturnsItsLines()
+    {
+        var world = new StubItemService([]);
+        await using var server = await StartAsync(world, AccountLevelType.Player);
+        var character = Create(server, "tom", "Freydis");
+        var robe = Worn(server, world, character, "a robe");
+
+        await server.AuthenticateAsync();
+
+        var tooltip = await server.Client.GetFromJsonAsync<ItemTooltipResponse>(Route(character, robe));
+
+        Assert.Single(tooltip!.Lines);
+    }
+
+    // The check that makes nesting worth doing: an item that exists, but not on this character.
+    [Fact]
+    public async Task Get_AnItemNotInThatCharactersTree_IsNotFound()
+    {
+        var world = new StubItemService([]);
+        await using var server = await StartAsync(world, AccountLevelType.Player);
+        var character = Create(server, "tom", "Freydis");
+
+        Backpack(server, world, character, "a dagger");
+
+        // A real item, owned by nobody in this character's tree.
+        var loose = world.Track(Item(0x40009999, "a loose sword"));
+
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync(Route(character, loose.Id.ToString()));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AnotherAccountsCharacter_AsAPlayer_IsForbidden()
+    {
+        var world = new StubItemService([]);
+        await using var server = await StartAsync(world, AccountLevelType.Player);
+
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+
+        var hers = Create(server, "alice", "Aramis");
+        var dagger = Backpack(server, world, hers, "a dagger");
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route(hers, dagger))).StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AnotherAccountsCharacter_AsStaff_ReturnsIt()
+    {
+        var world = new StubItemService([]);
+        await using var server = await StartAsync(world, AccountLevelType.Administrator);
+
+        server.Accounts.Create("alice", "secret", null, AccountLevelType.Player);
+
+        var hers = Create(server, "alice", "Aramis");
+        var dagger = Backpack(server, world, hers, "a dagger");
+
+        await server.AuthenticateAsync();
+
+        var tooltip = await server.Client.GetFromJsonAsync<ItemTooltipResponse>(Route(hers, dagger));
+
+        Assert.Equal(dagger, tooltip!.Serial);
+    }
+
+    [Fact]
+    public async Task Get_AnUnknownCharacter_IsNotFound()
+    {
+        await using var server = await StartAsync(new StubItemService([]));
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await server.Client.GetAsync(Route("0x0000DEAD", "0x40000001"))).StatusCode
+        );
+    }
+
+    [Fact]
+    public async Task Get_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync(new StubItemService([]));
+
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            (await server.Client.GetAsync(Route("0x00000001", "0x40000001"))).StatusCode
+        );
+    }
+
+    // A shard with no client files describes no cliloc. The technical fields are still worth showing,
+    // so an empty list beats a 500.
+    [Fact]
+    public async Task Get_WithNoStringTable_ReturnsNoLinesRatherThanFailing()
+    {
+        var world = new StubItemService([]);
+        await using var server = await StartAsync(world, AccountLevelType.Player, clilocs: new StubClilocService());
+        var character = Create(server, "tom", "Freydis");
+        var dagger = Backpack(server, world, character, "a dagger");
+
+        await server.AuthenticateAsync();
+
+        var tooltip = await server.Client.GetFromJsonAsync<ItemTooltipResponse>(Route(character, dagger));
+
+        Assert.Empty(tooltip!.Lines);
+        Assert.Equal("dagger", tooltip.TemplateId);
+    }
+
+    private static string Route(string character, string item)
+        => $"/api/v1/characters/{character}/items/{item}/tooltip";
+
+    /// <summary>Puts an item in the character's backpack, creating the backpack if it has none.</summary>
+    private static string Backpack(TestApiServer server, StubItemService world, string character, string name)
+    {
+        var mobile = Mobile(server, character);
+
+        // Character creation already sets a BackpackId, but it names an item this stub world does not
+        // hold — so the test gives the mobile a backpack it can actually resolve.
+        if (world.GetById(mobile.BackpackId) is null)
+        {
+            var pack = world.Track(Item(0x40000100, "a backpack"));
+
+            mobile.BackpackId = pack.Id;
+            mobile.EquippedItemIds[LayerType.Backpack] = pack.Id;
+        }
+
+        var item = world.Track(Item((uint)(0x40000200 + world.TrackedCount), name));
+
+        world.GetById(mobile.BackpackId)!.ContainedItemIds.Add(item.Id);
+
+        return item.Id.ToString();
+    }
+
+    private static string Worn(TestApiServer server, StubItemService world, string character, string name)
+    {
+        var mobile = Mobile(server, character);
+        var item = world.Track(Item((uint)(0x40000300 + world.TrackedCount), name));
+
+        item.EquippedLayer = LayerType.OuterTorso;
+        mobile.EquippedItemIds[LayerType.OuterTorso] = item.Id;
+        world.Equipped.Add(item);
+
+        return item.Id.ToString();
+    }
+
+    private static MobileEntity Mobile(TestApiServer server, string character)
+    {
+        Serial.TryParse(character, out var serial);
+
+        return server.Persistence.Store<MobileEntity>().GetById(serial)!;
+    }
+
+    private static ItemEntity Item(uint serial, string name)
+        => new()
+        {
+            Id = new(serial),
+            Name = name,
+            TemplateId = "dagger",
+            ItemId = 0x13B9,
+            Amount = 1,
+        };
+
+    private static string Create(TestApiServer server, string username, string name)
+    {
+        var accountId = server.Accounts.GetByUsername(username)!.Id;
+
+        server.Characters.CreateCharacter(accountId, Packet(name));
+
+        return server.Accounts.GetByUsername(username)!.MobileIds[^1].ToString();
+    }
+
+    private static CharacterCreationPacket Packet(string name)
+        => new(
+            0,
+            name,
+            0,
+            4,
+            GenderType.Female,
+            RaceType.Elf,
+            45,
+            20,
+            25,
+            [new(1, 50)],
+            0x03EA,
+            0x203C,
+            0x044E,
+            0x2040,
+            0x0450,
+            0,
+            0x0765,
+            0x0766
+        );
+
+    private static async Task<TestApiServer> StartAsync(
+        StubItemService world,
+        AccountLevelType level = AccountLevelType.Administrator,
+        IClilocService? clilocs = null
+    )
+        => await TestApiServer.StartAsync(
+               level,
+               configure: container =>
+                          {
+                              container.RegisterInstance<IItemService>(world);
+                              container.RegisterInstance(
+                                  clilocs ?? StubClilocService.Entries((WeightCliloc, "Weight: ~1_WEIGHT~ stone"))
+                              );
+                              container.RegisterInstance<IOplService>(new StubOplService(WeightCliloc));
+                              container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
+                              container.Register<CharacterAccessService>(Reuse.Singleton);
+                              container.Register<CharacterInventoryReader>(Reuse.Singleton);
+                              container.Register<OplTextRenderer>(Reuse.Singleton);
+                              container.RegisterApiEndpointInstance(
+                                  new ItemTooltipEndpoints(
+                                      container.Resolve<CharacterAccessService>(),
+                                      container.Resolve<CharacterInventoryReader>(),
+                                      container.Resolve<IItemService>(),
+                                      container.Resolve<IOplService>(),
+                                      container.Resolve<OplTextRenderer>(),
+                                      container.Resolve<IGameLoopContext>()
+                                  )
+                              );
+                          }
+           );
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -54,6 +54,7 @@ public class MoongateHttpPluginTests
                 typeof(ItemImageAdminEndpoints),
                 typeof(ItemImageEndpoints),
                 typeof(ItemTemplateEndpoints),
+                typeof(ItemTooltipEndpoints),
                 typeof(MapImageAdminEndpoints),
                 typeof(MapImageEndpoints),
                 typeof(MobileCharacterImageEndpoints),

--- a/tests/Moongate.Tests/Support/StubClilocService.cs
+++ b/tests/Moongate.Tests/Support/StubClilocService.cs
@@ -4,17 +4,30 @@ namespace Moongate.Tests.Support;
 
 /// <summary>
 /// Answers with a fixed text for any cliloc, or null for every one when constructed empty — which is
-/// what a shard with no client files looks like.
+/// what a shard with no client files looks like. Seed <see cref="Entries" /> instead when a test cares
+/// which cliloc says what.
 /// </summary>
 public sealed class StubClilocService : IClilocService
 {
     private readonly string? _text;
+    private readonly Dictionary<int, string> _entries;
 
     public StubClilocService(string? text = null)
     {
         _text = text;
+        _entries = [];
+    }
+
+    /// <summary>A table of its own: only the seeded clilocs answer, every other one is null.</summary>
+    public static StubClilocService Entries(params (int Cliloc, string Text)[] entries)
+        => new(entries);
+
+    private StubClilocService((int Cliloc, string Text)[] entries)
+    {
+        _text = null;
+        _entries = entries.ToDictionary(entry => entry.Cliloc, entry => entry.Text);
     }
 
     public string? Text(int cliloc)
-        => _text;
+        => _entries.TryGetValue(cliloc, out var text) ? text : _text;
 }

--- a/tests/Moongate.Tests/Support/StubItemService.cs
+++ b/tests/Moongate.Tests/Support/StubItemService.cs
@@ -14,18 +14,23 @@ namespace Moongate.Tests.Support;
 /// </summary>
 public sealed class StubItemService : IItemService
 {
-    private readonly IReadOnlyList<ItemEntity> _equipped;
     private readonly Dictionary<Serial, ItemEntity> _items = new();
 
     public StubItemService(IReadOnlyList<ItemEntity> equipped)
     {
-        _equipped = equipped;
+        Equipped = [.. equipped];
 
         foreach (var item in equipped)
         {
             _items[item.Id] = item;
         }
     }
+
+    /// <summary>What <see cref="GetEquipped" /> answers with. Mutable, so a test can dress a mobile.</summary>
+    public List<ItemEntity> Equipped { get; }
+
+    /// <summary>How many items are findable, which a test can use to mint distinct serials.</summary>
+    public int TrackedCount => _items.Count;
 
     /// <summary>Makes an item findable by serial, so a container listing it can resolve it.</summary>
     public ItemEntity Track(ItemEntity item)
@@ -62,7 +67,7 @@ public sealed class StubItemService : IItemService
                : [];
 
     public IReadOnlyList<ItemEntity> GetEquipped(MobileEntity mobile)
-        => _equipped;
+        => Equipped;
 
     public void MoveToWorld(ItemEntity item, int mapId, Point3D position)
         => throw new NotSupportedException();

--- a/tests/Moongate.Tests/Support/StubOplService.cs
+++ b/tests/Moongate.Tests/Support/StubOplService.cs
@@ -1,0 +1,29 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Data;
+using Moongate.Server.Abstractions.Data.World;
+using Moongate.Server.Abstractions.Interfaces.World;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Answers every serial with one property entry carrying a fixed cliloc and argument — enough for a
+/// route test, which is about who may read a tooltip rather than about what it says.
+/// </summary>
+public sealed class StubOplService : IOplService
+{
+    private readonly int _cliloc;
+    private readonly string _arguments;
+
+    public StubOplService(int cliloc, string arguments = "3")
+    {
+        _cliloc = cliloc;
+        _arguments = arguments;
+    }
+
+    public OplSnapshot GetOrBuild(Serial serial)
+        => new(1, [new OplEntry(_cliloc, _arguments)]);
+
+    public void Invalidate(Serial serial)
+    {
+    }
+}

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -333,6 +333,46 @@
         }
       }
     },
+    "/api/v1/characters/{serial}/items/{itemSerial}/tooltip": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "What the game says about one item the character is carrying or wearing.",
+        "description": "The lines are the object property list the game client renders, resolved to text — the item's\nname, its weight, and whatever else the shard describes. A shard whose string table is not\nloaded gets an **empty** list rather than an error: the technical fields are still worth having.\n            \nThe route is nested under the character because an item knows its container, not whose it is.\nAuthorization is the character's — an account reads its own, staff read anyone's — and the item\nmust actually be in that character's equipment or backpack, so a serial cannot be probed here.\n            \nAnswers 503 when the game loop does not respond: the property list is built on the loop, whose\ncache is deliberately unsynchronized.",
+        "operationId": "GetItemTooltip",
+        "parameters": [
+          {
+            "name": "serial",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "itemSerial",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemTooltipResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/admin/console/stream": {
       "get": {
         "tags": [
@@ -2811,6 +2851,51 @@
         },
         "additionalProperties": false,
         "description": "One page of results, and what a caller needs to walk the rest."
+      },
+      "ItemTooltipResponse": {
+        "required": [
+          "amount",
+          "hue",
+          "itemId",
+          "lines",
+          "serial",
+          "templateId"
+        ],
+        "type": "object",
+        "properties": {
+          "serial": {
+            "type": "string",
+            "description": "The item's serial, as `0x40000001`."
+          },
+          "lines": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The object property list as the game client renders it, resolved to text. Empty when the shard's\nstring table is not loaded — the technical fields are still worth showing, so that is not an error."
+          },
+          "templateId": {
+            "type": "string",
+            "description": "The template it was built from."
+          },
+          "itemId": {
+            "type": "integer",
+            "description": "The art id.",
+            "format": "int32"
+          },
+          "hue": {
+            "type": "integer",
+            "description": "0 for the raw art.",
+            "format": "int32"
+          },
+          "amount": {
+            "type": "integer",
+            "description": "How many, for a stack.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "What the game itself says about one item, plus what the portal knows about it."
       },
       "LayerType": {
         "enum": [

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,82 +20,85 @@ import { PluginsScreen } from './routes/PluginsScreen'
 import { SettingsScreen } from './routes/SettingsScreen'
 import { ConsoleScreen } from './routes/ConsoleScreen'
 import { Toaster } from './components/ui/sonner'
+import { TooltipProvider } from './components/ui/tooltip'
 
 const queryClient = new QueryClient()
 
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Toaster />
-      <BrowserRouter>
-        <AuthProvider>
-          <Routes>
-            <Route path="/login" element={<LoginScreen />} />
-            <Route path="/register" element={<RegisterScreen />} />
-            <Route path="/register/pending" element={<RegistrationPendingScreen />} />
-            <Route path="/verify" element={<VerifyRegistrationScreen />} />
-            <Route
-              path="/"
-              element={
-                <RequireAuth>
-                  <AppShell>
-                    <DashboardScreen />
-                  </AppShell>
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/characters"
-              element={
-                <RequireAuth>
-                  <AppShell>
-                    <CharactersScreen />
-                  </AppShell>
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/characters/:serial"
-              element={
-                <RequireAuth>
-                  <AppShell>
-                    <CharacterDetailScreen />
-                  </AppShell>
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/map"
-              element={
-                <RequireAuth>
-                  <AppShell>
-                    <MapScreen />
-                  </AppShell>
-                </RequireAuth>
-              }
-            />
-            <Route
-              path="/admin"
-              element={
-                <RequireAuth>
-                  <RequireAdmin>
+      <TooltipProvider>
+        <Toaster />
+        <BrowserRouter>
+          <AuthProvider>
+            <Routes>
+              <Route path="/login" element={<LoginScreen />} />
+              <Route path="/register" element={<RegisterScreen />} />
+              <Route path="/register/pending" element={<RegistrationPendingScreen />} />
+              <Route path="/verify" element={<VerifyRegistrationScreen />} />
+              <Route
+                path="/"
+                element={
+                  <RequireAuth>
                     <AppShell>
-                      <AdminLayout />
+                      <DashboardScreen />
                     </AppShell>
-                  </RequireAdmin>
-                </RequireAuth>
-              }
-            >
-              <Route index element={<AdminScreen />} />
-              <Route path="accounts" element={<AccountsScreen />} />
-              <Route path="characters" element={<CharactersAdminScreen />} />
-              <Route path="plugins" element={<PluginsScreen />} />
-              <Route path="settings" element={<SettingsScreen />} />
-              <Route path="console" element={<ConsoleScreen />} />
-            </Route>
-          </Routes>
-        </AuthProvider>
-      </BrowserRouter>
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/characters"
+                element={
+                  <RequireAuth>
+                    <AppShell>
+                      <CharactersScreen />
+                    </AppShell>
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/characters/:serial"
+                element={
+                  <RequireAuth>
+                    <AppShell>
+                      <CharacterDetailScreen />
+                    </AppShell>
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/map"
+                element={
+                  <RequireAuth>
+                    <AppShell>
+                      <MapScreen />
+                    </AppShell>
+                  </RequireAuth>
+                }
+              />
+              <Route
+                path="/admin"
+                element={
+                  <RequireAuth>
+                    <RequireAdmin>
+                      <AppShell>
+                        <AdminLayout />
+                      </AppShell>
+                    </RequireAdmin>
+                  </RequireAuth>
+                }
+              >
+                <Route index element={<AdminScreen />} />
+                <Route path="accounts" element={<AccountsScreen />} />
+                <Route path="characters" element={<CharactersAdminScreen />} />
+                <Route path="plugins" element={<PluginsScreen />} />
+                <Route path="settings" element={<SettingsScreen />} />
+                <Route path="console" element={<ConsoleScreen />} />
+              </Route>
+            </Routes>
+          </AuthProvider>
+        </BrowserRouter>
+      </TooltipProvider>
     </QueryClientProvider>
   )
 }

--- a/ui/src/components/characters/InventoryTree.test.tsx
+++ b/ui/src/components/characters/InventoryTree.test.tsx
@@ -91,6 +91,17 @@ describe('InventoryTree', () => {
     expect(screen.getByText('OuterTorso')).toBeInTheDocument()
   })
 
+  // The trigger is the picture, not the row. Anchored to a full-width row, the tooltip lands
+  // somewhere in the middle of it instead of beside the thing being pointed at.
+  it('hangs the tooltip off the picture rather than the whole row', () => {
+    renderTree(<InventoryTree characterSerial="0x1" items={[item('Sword')]} emptyLabel="empty" />)
+
+    const trigger = screen.getByAltText('Sword').closest('[data-slot="tooltip-trigger"]')
+
+    expect(trigger).not.toBeNull()
+    expect(trigger).not.toHaveTextContent('Sword')
+  })
+
   it('says so when there is nothing', () => {
     renderTree(<InventoryTree characterSerial="0x1" items={[]} emptyLabel="Nothing here" />)
 

--- a/ui/src/components/characters/InventoryTree.test.tsx
+++ b/ui/src/components/characters/InventoryTree.test.tsx
@@ -1,6 +1,9 @@
+import type { ReactElement } from 'react'
 import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import '../../lib/i18n'
+import { TooltipProvider } from '../ui/tooltip'
 import { InventoryTree } from './InventoryTree'
 import type { CharacterItem } from '../../lib/characters'
 
@@ -18,22 +21,38 @@ function item(name: string, over: Partial<CharacterItem> = {}): CharacterItem {
   } as CharacterItem
 }
 
+// The rows now hold a query hook and a tooltip, so they need both providers around them.
+function renderTree(ui: ReactElement) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </QueryClientProvider>,
+  )
+}
+
 describe('InventoryTree', () => {
   it('shows each item with its art', () => {
-    render(<InventoryTree items={[item('Sword')]} emptyLabel="empty" />)
+    renderTree(<InventoryTree characterSerial="0x1" items={[item('Sword')]} emptyLabel="empty" />)
 
     expect(screen.getByAltText('Sword')).toHaveAttribute('src', '/api/v1/images/items/0x13b9.png')
   })
 
   it('hues the art when the item is dyed', () => {
-    render(<InventoryTree items={[item('Robe', { serial: '0x2', itemId: 0x1f03, hue: 0x21 })]} emptyLabel="empty" />)
+    renderTree(
+      <InventoryTree
+        characterSerial="0x1"
+        items={[item('Robe', { serial: '0x2', itemId: 0x1f03, hue: 0x21 })]}
+        emptyLabel="empty"
+      />,
+    )
 
     expect(screen.getByAltText('Robe')).toHaveAttribute('src', '/api/v1/images/items/0x1f03.png?hue=0x21')
   })
 
   it('shows what a container holds', () => {
-    render(
+    renderTree(
       <InventoryTree
+        characterSerial="0x1"
         items={[item('Bag', { serial: '0x2', contents: [item('Potion', { serial: '0x3' })] })]}
         emptyLabel="empty"
       />,
@@ -44,8 +63,9 @@ describe('InventoryTree', () => {
   })
 
   it('shows the amount only when there is more than one', () => {
-    render(
+    renderTree(
       <InventoryTree
+        characterSerial="0x1"
         items={[item('Gold', { serial: '0x2', amount: 250 }), item('Sword', { serial: '0x3' })]}
         emptyLabel="empty"
       />,
@@ -58,19 +78,21 @@ describe('InventoryTree', () => {
   // UO names most items by cliloc rather than by stored text, so a blank name is normal here and
   // must not render as an empty row.
   it('labels an item with no stored name', () => {
-    render(<InventoryTree items={[item('')]} emptyLabel="empty" />)
+    renderTree(<InventoryTree characterSerial="0x1" items={[item('')]} emptyLabel="empty" />)
 
     expect(screen.getByText('Unnamed item')).toBeInTheDocument()
   })
 
   it('names the layer of a worn item', () => {
-    render(<InventoryTree items={[item('Robe', { layer: 'OuterTorso' })]} emptyLabel="empty" />)
+    renderTree(
+      <InventoryTree characterSerial="0x1" items={[item('Robe', { layer: 'OuterTorso' })]} emptyLabel="empty" />,
+    )
 
     expect(screen.getByText('OuterTorso')).toBeInTheDocument()
   })
 
   it('says so when there is nothing', () => {
-    render(<InventoryTree items={[]} emptyLabel="Nothing here" />)
+    renderTree(<InventoryTree characterSerial="0x1" items={[]} emptyLabel="Nothing here" />)
 
     expect(screen.getByText('Nothing here')).toBeInTheDocument()
   })

--- a/ui/src/components/characters/InventoryTree.tsx
+++ b/ui/src/components/characters/InventoryTree.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 import { CharacterImage } from './CharacterImage'
+import { ItemTooltip } from './ItemTooltip'
 import { itemImageUrl, type CharacterItem } from '../../lib/characters'
 
 /**
@@ -8,7 +9,15 @@ import { itemImageUrl, type CharacterItem } from '../../lib/characters'
  * cannot say what is inside what. Each row carries the item's art, so an item named only by cliloc —
  * which is most of them — is still recognisable.
  */
-export function InventoryTree({ items, emptyLabel }: { items: CharacterItem[]; emptyLabel: string }) {
+export function InventoryTree({
+  items,
+  emptyLabel,
+  characterSerial,
+}: {
+  items: CharacterItem[]
+  emptyLabel: string
+  characterSerial: string
+}) {
   const { t } = useTranslation()
 
   if (items.length === 0) {
@@ -19,32 +28,34 @@ export function InventoryTree({ items, emptyLabel }: { items: CharacterItem[]; e
     <ul className="flex flex-col gap-1">
       {items.map((item) => (
         <li key={item.serial}>
-          <div className="flex items-center gap-3 rounded-lg px-2 py-1">
-            <CharacterImage
-              src={itemImageUrl(item.itemId, item.hue)}
-              alt={item.name === '' ? t('characters.inventory.unnamed') : item.name}
-              className="h-16 w-16 shrink-0 object-contain"
-              fallback={
-                <span className="flex h-16 w-16 shrink-0 items-center justify-center text-muted">
-                  {t('characters.inventory.noImage')}
-                </span>
-              }
-            />
+          <ItemTooltip characterSerial={characterSerial} itemSerial={item.serial}>
+            <div className="flex items-center gap-3 rounded-lg px-2 py-1">
+              <CharacterImage
+                src={itemImageUrl(item.itemId, item.hue)}
+                alt={item.name === '' ? t('characters.inventory.unnamed') : item.name}
+                className="h-16 w-16 shrink-0 object-contain"
+                fallback={
+                  <span className="flex h-16 w-16 shrink-0 items-center justify-center text-muted">
+                    {t('characters.inventory.noImage')}
+                  </span>
+                }
+              />
 
-            <span className="min-w-0">
-              <span className="block truncate text-ink">
-                {item.name === '' ? t('characters.inventory.unnamed') : item.name}
+              <span className="min-w-0">
+                <span className="block truncate text-ink">
+                  {item.name === '' ? t('characters.inventory.unnamed') : item.name}
+                </span>
+                <span className="flex gap-2 text-xs text-muted">
+                  {item.amount > 1 && <span>{t('characters.inventory.amount', { count: item.amount })}</span>}
+                  {item.layer !== null && <span>{item.layer}</span>}
+                </span>
               </span>
-              <span className="flex gap-2 text-xs text-muted">
-                {item.amount > 1 && <span>{t('characters.inventory.amount', { count: item.amount })}</span>}
-                {item.layer !== null && <span>{item.layer}</span>}
-              </span>
-            </span>
-          </div>
+            </div>
+          </ItemTooltip>
 
           {item.contents.length > 0 && (
             <div className="ml-8 border-l border-ink/10 pl-2">
-              <InventoryTree items={item.contents} emptyLabel={emptyLabel} />
+              <InventoryTree items={item.contents} emptyLabel={emptyLabel} characterSerial={characterSerial} />
             </div>
           )}
         </li>

--- a/ui/src/components/characters/InventoryTree.tsx
+++ b/ui/src/components/characters/InventoryTree.tsx
@@ -28,30 +28,36 @@ export function InventoryTree({
     <ul className="flex flex-col gap-1">
       {items.map((item) => (
         <li key={item.serial}>
-          <ItemTooltip characterSerial={characterSerial} itemSerial={item.serial}>
-            <div className="flex items-center gap-3 rounded-lg px-2 py-1">
-              <CharacterImage
-                src={itemImageUrl(item.itemId, item.hue)}
-                alt={item.name === '' ? t('characters.inventory.unnamed') : item.name}
-                className="h-16 w-16 shrink-0 object-contain"
-                fallback={
-                  <span className="flex h-16 w-16 shrink-0 items-center justify-center text-muted">
-                    {t('characters.inventory.noImage')}
-                  </span>
-                }
-              />
-
-              <span className="min-w-0">
-                <span className="block truncate text-ink">
-                  {item.name === '' ? t('characters.inventory.unnamed') : item.name}
-                </span>
-                <span className="flex gap-2 text-xs text-muted">
-                  {item.amount > 1 && <span>{t('characters.inventory.amount', { count: item.amount })}</span>}
-                  {item.layer !== null && <span>{item.layer}</span>}
-                </span>
+          <div className="flex items-center gap-3 rounded-lg px-2 py-1">
+            {/*
+              The trigger is the picture, not the row: anchoring to a full-width row would put the
+              tooltip somewhere in the middle of it rather than beside what you are pointing at.
+            */}
+            <ItemTooltip characterSerial={characterSerial} itemSerial={item.serial}>
+              <span tabIndex={0} className="shrink-0 rounded outline-none focus-visible:ring-2 focus-visible:ring-gold">
+                <CharacterImage
+                  src={itemImageUrl(item.itemId, item.hue)}
+                  alt={item.name === '' ? t('characters.inventory.unnamed') : item.name}
+                  className="h-16 w-16 object-contain"
+                  fallback={
+                    <span className="flex h-16 w-16 items-center justify-center text-muted">
+                      {t('characters.inventory.noImage')}
+                    </span>
+                  }
+                />
               </span>
-            </div>
-          </ItemTooltip>
+            </ItemTooltip>
+
+            <span className="min-w-0">
+              <span className="block truncate text-ink">
+                {item.name === '' ? t('characters.inventory.unnamed') : item.name}
+              </span>
+              <span className="flex gap-2 text-xs text-muted">
+                {item.amount > 1 && <span>{t('characters.inventory.amount', { count: item.amount })}</span>}
+                {item.layer !== null && <span>{item.layer}</span>}
+              </span>
+            </span>
+          </div>
 
           {item.contents.length > 0 && (
             <div className="ml-8 border-l border-ink/10 pl-2">

--- a/ui/src/components/characters/ItemTooltip.test.tsx
+++ b/ui/src/components/characters/ItemTooltip.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import '../../lib/i18n'
+import { TooltipProvider } from '../ui/tooltip'
+import { ItemTooltip } from './ItemTooltip'
+import type { ItemTooltip as Tooltip } from '../../lib/characters'
+
+const query = vi.hoisted(() => ({
+  data: undefined as Tooltip | undefined,
+  isPending: false,
+  enabledWhenCalled: [] as boolean[],
+}))
+
+vi.mock('../../lib/characters', async (original) => ({
+  ...(await original<typeof import('../../lib/characters')>()),
+  useItemTooltip: (_character: string, _item: string, enabled: boolean) => {
+    query.enabledWhenCalled.push(enabled)
+    return query
+  },
+}))
+
+function tooltip(over: Partial<Tooltip> = {}): Tooltip {
+  return {
+    serial: '0x4000000A',
+    lines: ['a dagger', 'Weight: 1 stone'],
+    templateId: 'dagger',
+    itemId: 0x13b9,
+    hue: 0,
+    amount: 1,
+    ...over,
+  } as Tooltip
+}
+
+function renderWith(data: Tooltip | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isPending: false }, state)
+  query.enabledWhenCalled = []
+
+  return render(
+    <TooltipProvider>
+      <ItemTooltip characterSerial="0x1" itemSerial="0x4000000A">
+        <button type="button">the item</button>
+      </ItemTooltip>
+    </TooltipProvider>,
+  )
+}
+
+describe('ItemTooltip', () => {
+  // The point of fetching on hover: a page with forty rows must make no tooltip requests until one
+  // is opened. An always-enabled hook passes every other test in this file and fails this one.
+  it('does not ask for anything until it opens', () => {
+    renderWith(tooltip())
+
+    expect(query.enabledWhenCalled).toEqual([false])
+  })
+
+  it('asks once it opens', async () => {
+    renderWith(tooltip())
+
+    await userEvent.tab()
+
+    expect(query.enabledWhenCalled).toContain(true)
+  })
+
+  it('shows the lines the game reports', async () => {
+    renderWith(tooltip())
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('a dagger')).toBeInTheDocument()
+    expect(screen.getByText('Weight: 1 stone')).toBeInTheDocument()
+  })
+
+  it('shows the technical fields', async () => {
+    renderWith(tooltip({ templateId: 'dagger', hue: 0x21, amount: 5 }))
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('dagger')).toBeInTheDocument()
+    expect(screen.getByText('0x4000000A')).toBeInTheDocument()
+  })
+
+  // A shard with no client files describes nothing, and an empty card is worse than a sentence.
+  it('says so when the game describes nothing', async () => {
+    renderWith(tooltip({ lines: [] }))
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('No description available')).toBeInTheDocument()
+  })
+
+  it('says it is loading while the request is in flight', async () => {
+    renderWith(undefined, { isPending: true })
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('Loading…')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/characters/ItemTooltip.tsx
+++ b/ui/src/components/characters/ItemTooltip.tsx
@@ -1,0 +1,72 @@
+import { useState, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { useItemTooltip } from '../../lib/characters'
+
+/**
+ * What the game says about an item, shown when you point at it.
+ *
+ * The request is made when the tooltip opens, never on render: a character's backpack is dozens of
+ * rows, and fetching on mount would turn one page view into one request each. `open` drives the
+ * hook's `enabled` for exactly that reason.
+ */
+export function ItemTooltip({
+  characterSerial,
+  itemSerial,
+  children,
+}: {
+  characterSerial: string
+  itemSerial: string
+  children: ReactNode
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const tooltip = useItemTooltip(characterSerial, itemSerial, open)
+
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+
+      <TooltipContent>
+        {tooltip.data === undefined ? (
+          <p className="text-muted">{t('characters.tooltip.loading')}</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {tooltip.data.lines.length === 0 ? (
+              <p className="text-muted">{t('characters.tooltip.unavailable')}</p>
+            ) : (
+              <div className="flex flex-col">
+                {tooltip.data.lines.map((line) => (
+                  <span key={line}>{line}</span>
+                ))}
+              </div>
+            )}
+
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 border-t border-ink/10 pt-2 text-xs text-muted">
+              <dt>{t('characters.tooltip.template')}</dt>
+              <dd className="text-right">{tooltip.data.templateId}</dd>
+
+              {tooltip.data.hue !== 0 && (
+                <>
+                  <dt>{t('characters.tooltip.hue')}</dt>
+                  <dd className="text-right">{`0x${tooltip.data.hue.toString(16)}`}</dd>
+                </>
+              )}
+
+              {tooltip.data.amount > 1 && (
+                <>
+                  <dt>{t('characters.tooltip.amount')}</dt>
+                  <dd className="text-right">{tooltip.data.amount}</dd>
+                </>
+              )}
+
+              <dt>{t('characters.tooltip.serial')}</dt>
+              <dd className="text-right">{tooltip.data.serial}</dd>
+            </dl>
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/ui/src/components/ui/tooltip.test.tsx
+++ b/ui/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
+
+function renderTooltip() {
+  return render(
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>hover me</TooltipTrigger>
+        <TooltipContent>the description</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>,
+  )
+}
+
+describe('Tooltip', () => {
+  it('says nothing until it is asked to', () => {
+    renderTooltip()
+
+    expect(screen.queryByText('the description')).not.toBeInTheDocument()
+  })
+
+  // Radix opens on hover and on focus. Focus is what jsdom drives reliably, and it is also the
+  // keyboard path a pointer test would never cover.
+  it('shows its content when the trigger takes focus', async () => {
+    renderTooltip()
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('the description')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+import { Tooltip as TooltipPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function TooltipProvider({ delayDuration = 200, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-max max-w-xs rounded-md border bg-card px-3 py-2 text-sm text-card-foreground shadow-md',
+          'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -17,15 +17,24 @@ function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimiti
 
 function TooltipContent({
   className,
-  sideOffset = 6,
+  side = 'right',
+  sideOffset = 8,
+  collisionPadding = 12,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
     <TooltipPrimitive.Portal>
+      {/*
+        Beside the trigger rather than above it: in a list, a tooltip on top covers the row you just
+        came from. Radix flips it on its own when there is no room, and the collision padding keeps
+        it off the viewport edge.
+      */}
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
+        side={side}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
           'z-50 w-max max-w-xs rounded-md border bg-card px-3 py-2 text-sm text-card-foreground shadow-md',
           'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -202,6 +202,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/characters/{serial}/items/{itemSerial}/tooltip": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * What the game says about one item the character is carrying or wearing.
+         * @description The lines are the object property list the game client renders, resolved to text — the item's
+         *     name, its weight, and whatever else the shard describes. A shard whose string table is not
+         *     loaded gets an **empty** list rather than an error: the technical fields are still worth having.
+         *
+         *     The route is nested under the character because an item knows its container, not whose it is.
+         *     Authorization is the character's — an account reads its own, staff read anyone's — and the item
+         *     must actually be in that character's equipment or backpack, so a serial cannot be probed here.
+         *
+         *     Answers 503 when the game loop does not respond: the property list is built on the loop, whose
+         *     cache is deliberately unsynchronized.
+         */
+        get: operations["GetItemTooltip"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/console/stream": {
         parameters: {
             query?: never;
@@ -1396,6 +1425,33 @@ export interface components {
              */
             totalPages: number;
         };
+        /** @description What the game itself says about one item, plus what the portal knows about it. */
+        ItemTooltipResponse: {
+            /** @description The item's serial, as `0x40000001`. */
+            serial: string;
+            /**
+             * @description The object property list as the game client renders it, resolved to text. Empty when the shard's
+             *     string table is not loaded — the technical fields are still worth showing, so that is not an error.
+             */
+            lines: string[];
+            /** @description The template it was built from. */
+            templateId: string;
+            /**
+             * Format: int32
+             * @description The art id.
+             */
+            itemId: number;
+            /**
+             * Format: int32
+             * @description 0 for the raw art.
+             */
+            hue: number;
+            /**
+             * Format: int32
+             * @description How many, for a stack.
+             */
+            amount: number;
+        };
         /**
          * Format: int32
          * @enum {integer}
@@ -1963,6 +2019,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CharacterDetailResponse"];
+                };
+            };
+        };
+    };
+    GetItemTooltip: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serial: string;
+                itemSerial: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ItemTooltipResponse"];
                 };
             };
         };

--- a/ui/src/lib/characters.ts
+++ b/ui/src/lib/characters.ts
@@ -86,3 +86,22 @@ export function itemImageUrl(itemId: number, hue = 0): string {
 
   return hue === 0 ? `/api/v1/images/items/${id}.png` : `/api/v1/images/items/${id}.png?hue=0x${hue.toString(16)}`
 }
+
+export type ItemTooltip = components['schemas']['ItemTooltipResponse']
+
+/**
+ * What the game says about one item the character carries.
+ *
+ * `enabled` is the whole design: the tooltip is fetched when it opens, not when the row renders. Left
+ * enabled on mount this would quietly become one request per row at page load, which is exactly what
+ * fetching on hover exists to avoid.
+ */
+export const useItemTooltip = (characterSerial: string, itemSerial: string, enabled: boolean) =>
+  useQuery({
+    queryKey: ['characters', characterSerial, 'items', itemSerial, 'tooltip'],
+    queryFn: () => apiFetch<ItemTooltip>(`/api/v1/characters/${characterSerial}/items/${itemSerial}/tooltip`),
+    enabled,
+    // An item's properties do not change while someone reads them, and re-hovering the same row
+    // should not go back to the server.
+    staleTime: 60_000,
+  })

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -321,6 +321,14 @@
       "lockUp": "Rising",
       "lockDown": "Falling",
       "lockLocked": "Locked"
+    },
+    "tooltip": {
+      "loading": "Loading…",
+      "unavailable": "No description available",
+      "template": "Template",
+      "hue": "Hue",
+      "amount": "Amount",
+      "serial": "Serial"
     }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -321,6 +321,14 @@
       "lockUp": "In crescita",
       "lockDown": "In calo",
       "lockLocked": "Bloccata"
+    },
+    "tooltip": {
+      "loading": "Caricamento…",
+      "unavailable": "Nessuna descrizione disponibile",
+      "template": "Template",
+      "hue": "Hue",
+      "amount": "Quantità",
+      "serial": "Serial"
     }
   }
 }

--- a/ui/src/routes/CharacterDetailScreen.test.tsx
+++ b/ui/src/routes/CharacterDetailScreen.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import '../lib/i18n'
 import { ApiError } from '../lib/api'
+import { TooltipProvider } from '../components/ui/tooltip'
 import { CharacterDetailScreen } from './CharacterDetailScreen'
 import type { CharacterDetail, CharacterItem } from '../lib/characters'
 
@@ -73,12 +75,17 @@ function detail(over: Partial<CharacterDetail> = {}): CharacterDetail {
 function renderAt(serial: string, data: CharacterDetail | undefined, state: Partial<typeof query> = {}) {
   Object.assign(query, { data, isPending: false, isError: false, error: null }, state)
 
+  // The inventory rows hold a tooltip with a query of its own, so the page needs both providers.
   return render(
-    <MemoryRouter initialEntries={[`/characters/${serial}`]}>
-      <Routes>
-        <Route path="/characters/:serial" element={<CharacterDetailScreen />} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={new QueryClient()}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={[`/characters/${serial}`]}>
+          <Routes>
+            <Route path="/characters/:serial" element={<CharacterDetailScreen />} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
   )
 }
 

--- a/ui/src/routes/CharacterDetailScreen.tsx
+++ b/ui/src/routes/CharacterDetailScreen.tsx
@@ -100,7 +100,11 @@ function Detail({ detail }: { detail: CharacterDetail }) {
         <div className="flex flex-col gap-6">
           <Card className="gap-3 p-4">
             <h2 className="font-bold text-ink">{t('characters.detail.equipment')}</h2>
-            <InventoryTree items={detail.equipment} emptyLabel={t('characters.detail.equipmentEmpty')} />
+            <InventoryTree
+              items={detail.equipment}
+              emptyLabel={t('characters.detail.equipmentEmpty')}
+              characterSerial={character.serial}
+            />
           </Card>
 
           <Card className="gap-3 p-4">
@@ -110,7 +114,11 @@ function Detail({ detail }: { detail: CharacterDetail }) {
 
           <Card className="gap-3 p-4">
             <h2 className="font-bold text-ink">{t('characters.detail.backpack')}</h2>
-            <InventoryTree items={detail.backpack} emptyLabel={t('characters.detail.backpackEmpty')} />
+            <InventoryTree
+              items={detail.backpack}
+              emptyLabel={t('characters.detail.backpackEmpty')}
+              characterSerial={character.serial}
+            />
           </Card>
         </div>
       </div>


### PR DESCRIPTION
Closes #174 (by hand once merged — this targets `develop`).

Pointing at an item in a character's equipment or backpack now shows what the game says about it.

## It existed at half, and the far half

`IOplService` already built the property list — but as `(cliloc, arguments)` pairs: numbers, not text. No route exposed it and the portal had no tooltip at all.

So the work was **rendering clilocs**: resolve the number, split TAB-separated arguments, substitute `~1_NUMBER~` placeholders, and follow an argument that is itself a `#cliloc`. That grammar is UO's, so it is resolved server-side — a browser should receive finished sentences. Verified against the running shard, where the stack path renders `500 Gold` with the amount substituted and the item name resolved from a nested cliloc.

## A correction I made mid-flight

The plan said this read could happen off the game loop, reasoning from the absence of an `AssertOnLoop` in `OplService`. That was wrong: `IOplService`'s own summary says it is loop-affine and **its cache is unsynchronized on purpose**. Building a snapshot from a request thread would race the loop that owns it.

The route now marshals through `IGameLoopContext.InvokeAsync` with a two-second timeout and a 503, following the account-delete route's precedent. Nobody hovering an item wants a spinner, and a loop that busy has a worse problem than a missing tooltip.

## The route nests under the character

A bare `/api/v1/items/{serial}/tooltip` would have to answer "may this caller see this item?", and no ownership chain from an item up to an account exists — an item knows its container, not whose it is.

`GET /api/v1/characters/{serial}/items/{itemSerial}/tooltip` reuses the character's authorization and requires the item to be in that character's tree, so a serial cannot be probed. There is a test for exactly that: a real item, not on this character, is a 404.

While wiring it, the ownership check moved into a shared `CharacterAccessService` used by both character routes — two copies of an authorization rule are two rules, and the second one drifts.

## Fetching on hover, and the test that keeps it honest

The request is made when a tooltip **opens**, never on render: a backpack is dozens of rows. A hook left enabled on mount passes every other test in the file, so one test asserts it is disabled until the tooltip opens.

## Checks

- .NET **2095 passed**; UI **286 passed**, build and Prettier clean; DocFX **0 warnings**; contract regenerated.
- Verified at real boot: tooltips for the shard's own items render as `Dagger` / `Weight: 1 stone` and `500 Gold`.

## Not included

Tooltips on template pictures, which have no serial and no property list, and would need a route of their own.