### PR TITLE
chore(deps): bump Scalar.AspNetCore and Scriban

### DIFF
--- a/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
+++ b/plugins/Moongate.Http.Plugin/Moongate.Http.Plugin.csproj
@@ -40,7 +40,7 @@
             what lets the web app run on the game's own container. Scalar reads the document either way.
         -->
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.16.16"/>
+        <PackageReference Include="Scalar.AspNetCore" Version="2.16.17" />
         <PackageReference Include="SquidStd.Abstractions" Version="0.41.0"/>
         <PackageReference Include="SquidStd.Plugin.Abstractions" Version="0.41.0"/>
         <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">

--- a/src/Moongate.Server/Moongate.Server.csproj
+++ b/src/Moongate.Server/Moongate.Server.csproj
@@ -31,7 +31,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Scriban" Version="7.2.5"/>
+        <PackageReference Include="Scriban" Version="7.2.6" />
         <PackageReference Include="SquidStd.Abstractions" Version="0.41.0"/>
         <PackageReference Include="SquidStd.Core" Version="0.41.0"/>
         <PackageReference Include="SquidStd.Plugin" Version="0.41.0"/>


### PR DESCRIPTION
Two patch bumps that appeared in the working tree this morning — not from the feature work merged today. Carried onto a branch rather than committed to `develop` directly.

| | from | to |
|---|---|---|
| `Scalar.AspNetCore` | 2.16.16 | 2.16.17 |
| `Scriban` | 7.2.5 | 7.2.6 |

## Checks

- **2095 tests passed** after restoring the new versions.
- Verified by **booting the server**, which matters more than usual here: neither package is exercised much by the suite. Scalar serves the API reference and Scriban renders notification templates, so a break would show at runtime rather than in a test.
  - `/scalar/v1` → 200
  - `/swagger/v1/swagger.json` → 200
  - `/health` → 200
  - boot log clean, no errors or exceptions.