### PR TITLE
feat(ui): item template catalogue and detail screen

### DIFF
--- a/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileAppearanceResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileAppearanceResponse.cs
@@ -1,0 +1,32 @@
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>How a template says a mobile looks, shared by the template and each of its variants.</summary>
+/// <param name="Body">The animation body id.</param>
+/// <param name="SkinHue">
+/// A hue <em>spec</em>, not a number: a single value or a range like <c>0x455-0x45a</c> resolved once
+/// per spawn. Reported as written, because picking one end of a range would lie about the other.
+/// </param>
+/// <param name="HairHue">A hue spec, like <paramref name="SkinHue" />.</param>
+/// <param name="FacialHairHue">A hue spec, like <paramref name="SkinHue" />.</param>
+public sealed record MobileAppearanceResponse(
+    int Body,
+    string? SkinHue,
+    int HairStyle,
+    string? HairHue,
+    int FacialHairStyle,
+    string? FacialHairHue
+)
+{
+    /// <summary>Projects a template's appearance.</summary>
+    public static MobileAppearanceResponse From(MobileAppearance appearance)
+        => new(
+            appearance.Body,
+            appearance.SkinHue,
+            appearance.HairStyle,
+            appearance.HairHue,
+            appearance.FacialHairStyle,
+            appearance.FacialHairHue
+        );
+}

--- a/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileEquipmentResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileEquipmentResponse.cs
@@ -1,0 +1,14 @@
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>One item a template spawns its mobile wearing.</summary>
+/// <param name="Item">The item template id to spawn.</param>
+/// <param name="Layer">The layer it goes on.</param>
+/// <param name="Hue">A hue spec, or null to leave the item its own colour.</param>
+public sealed record MobileEquipmentResponse(string Item, string Layer, string? Hue)
+{
+    /// <summary>Projects one equipment entry.</summary>
+    public static MobileEquipmentResponse From(MobileEquipmentEntry entry)
+        => new(entry.Item, entry.Layer, entry.Hue);
+}

--- a/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileTemplateResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileTemplateResponse.cs
@@ -1,0 +1,58 @@
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>One mobile spawn template in full.</summary>
+/// <param name="NamePool">The pool a spawn draws its name from when the template has no fixed one.</param>
+/// <param name="Gender">The gender name, or null when the template lets a spawn pick.</param>
+/// <param name="BaseMobile">The template this one merges over, or null when it stands alone.</param>
+/// <param name="Skills">Skill values by name, as the template sets them.</param>
+/// <param name="Variants">Weighted alternatives, each with its own appearance and equipment.</param>
+public sealed record MobileTemplateResponse(
+    string Id,
+    string Name,
+    string NamePool,
+    string? Gender,
+    string Title,
+    string Category,
+    string Description,
+    IReadOnlyList<string> Tags,
+    string? BaseMobile,
+    int Strength,
+    int Dexterity,
+    int Intelligence,
+    IReadOnlyDictionary<string, int> Skills,
+    MobileAppearanceResponse Appearance,
+    IReadOnlyList<MobileEquipmentResponse> Equipment,
+    IReadOnlyList<MobileVariantResponse> Variants,
+    string? LootTableId,
+    string? BrainScript,
+    string ImageUrl,
+    string PaperdollUrl
+)
+{
+    /// <summary>Projects a template in full, both picture urls included.</summary>
+    public static MobileTemplateResponse From(MobileTemplate template)
+        => new(
+            template.Id,
+            template.Name,
+            template.NamePool,
+            template.Gender?.ToString(),
+            template.Title,
+            template.Category,
+            template.Description,
+            template.Tags,
+            template.BaseMobile,
+            template.Strength,
+            template.Dexterity,
+            template.Intelligence,
+            template.Skills,
+            MobileAppearanceResponse.From(template.Appearance),
+            [.. template.Equipment.Select(MobileEquipmentResponse.From)],
+            [.. template.Variants.Select(MobileVariantResponse.From)],
+            template.LootTableId,
+            template.BrainScript,
+            MobileTemplateUrls.Figure(template.Id),
+            MobileTemplateUrls.Paperdoll(template.Id)
+        );
+}

--- a/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileTemplateSummaryResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileTemplateSummaryResponse.cs
@@ -1,0 +1,37 @@
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>One row of the staff mobile template listing.</summary>
+/// <param name="Body">The animation body id, which is what the picture is drawn from.</param>
+/// <param name="VariantCount">How many weighted alternatives the template carries.</param>
+public sealed record MobileTemplateSummaryResponse(
+    string Id,
+    string Name,
+    string Title,
+    string Category,
+    IReadOnlyList<string> Tags,
+    int Body,
+    int Strength,
+    int Dexterity,
+    int Intelligence,
+    int VariantCount,
+    string ImageUrl
+)
+{
+    /// <summary>Projects a template into its listing row, figure url included.</summary>
+    public static MobileTemplateSummaryResponse From(MobileTemplate template)
+        => new(
+            template.Id,
+            template.Name,
+            template.Title,
+            template.Category,
+            template.Tags,
+            template.Appearance.Body,
+            template.Strength,
+            template.Dexterity,
+            template.Intelligence,
+            template.Variants.Count,
+            MobileTemplateUrls.Figure(template.Id)
+        );
+}

--- a/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileTemplateUrls.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileTemplateUrls.cs
@@ -1,0 +1,14 @@
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>
+/// Where a template's pictures live. In one place so the row and the detail cannot disagree, and
+/// escaped because template ids come from YAML and are not guaranteed to be URL-safe.
+/// </summary>
+internal static class MobileTemplateUrls
+{
+    public static string Figure(string id)
+        => $"/api/v1/images/mobiles/templates/{Uri.EscapeDataString(id)}.png";
+
+    public static string Paperdoll(string id)
+        => $"/api/v1/images/mobiles/templates/{Uri.EscapeDataString(id)}/paperdoll.png";
+}

--- a/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileVariantResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Mobiles/MobileVariantResponse.cs
@@ -1,0 +1,29 @@
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Data.Api.Mobiles;
+
+/// <summary>One variant of a template: a weighted alternative look, name pool and loot.</summary>
+/// <param name="Weight">Its share of the draw, relative to the other variants.</param>
+/// <param name="Gender">The gender name, or null when the variant does not fix one.</param>
+public sealed record MobileVariantResponse(
+    string Name,
+    int Weight,
+    string? Gender,
+    string? NamePool,
+    string? LootTableId,
+    MobileAppearanceResponse Appearance,
+    IReadOnlyList<MobileEquipmentResponse> Equipment
+)
+{
+    /// <summary>Projects one variant, its own appearance and equipment included.</summary>
+    public static MobileVariantResponse From(MobileVariant variant)
+        => new(
+            variant.Name,
+            variant.Weight,
+            variant.Gender?.ToString(),
+            variant.NamePool,
+            variant.LootTableId,
+            MobileAppearanceResponse.From(variant.Appearance),
+            [.. variant.Equipment.Select(MobileEquipmentResponse.From)]
+        );
+}

--- a/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Mobiles/MobileTemplateEndpoints.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Mobiles;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Http.Plugin.Endpoints.Mobiles;
+
+/// <summary>Staff-only, read-only views over the mobile spawn template registry.</summary>
+public sealed class MobileTemplateEndpoints : IApiEndpointRegistration
+{
+    private readonly IMobileTemplateService _templates;
+
+    public MobileTemplateEndpoints(IMobileTemplateService templates)
+    {
+        _templates = templates;
+    }
+
+    public void Register(IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/v1/admin/mobiles/templates", List)
+              .WithName("ListMobileTemplates")
+              .WithTags("mobiles")
+              .Produces<PagedResponse<MobileTemplateSummaryResponse>>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+
+        routes.MapGet("/api/v1/admin/mobiles/templates/{id}", Get)
+              .WithName("GetMobileTemplate")
+              .WithTags("mobiles")
+              .Produces<MobileTemplateResponse>()
+              .RequireAuthorization(HttpServerService.AdminPolicy);
+    }
+
+    /// <summary>Fetches one mobile template by id, variants and equipment included.</summary>
+    /// <remarks>Ids are case-insensitive. Answers 404 when no template carries the id.</remarks>
+    private IResult Get(string id)
+    {
+        var template = _templates.GetById(id);
+
+        return template is null
+                   ? Results.Problem($"No mobile template with id '{id}'.", statusCode: StatusCodes.Status404NotFound)
+                   : Results.Ok(MobileTemplateResponse.From(template));
+    }
+
+    /// <summary>Every mobile template, paged.</summary>
+    /// <remarks>
+    /// Ordered by template id. Pass search to filter: free text, case-insensitive, matching the
+    /// template's id, name, title, category or any tag. Page is 1-based and defaults to 1; pageSize
+    /// defaults to 25 and cannot exceed 100. A search matching nothing is an empty page, not an error.
+    ///
+    /// A template's hues are reported as the specs they are — a value or a range resolved per spawn —
+    /// rather than as numbers.
+    /// </remarks>
+    private IResult List(string? page, string? pageSize, string? search)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var matched = Filter(_templates.All, request.Search);
+
+        IReadOnlyList<MobileTemplateSummaryResponse> items =
+        [
+            .. matched.Skip(request.Skip).Take(request.PageSize).Select(MobileTemplateSummaryResponse.From)
+        ];
+
+        return Results.Ok(PagedResponse<MobileTemplateSummaryResponse>.From(items, matched.Count, request));
+    }
+
+    /// <summary>
+    /// The registry already hands templates back ordered by id, so this only narrows them — paging a
+    /// re-sorted list would be a second ordering to keep in step with the first.
+    /// </summary>
+    private static List<MobileTemplate> Filter(IReadOnlyList<MobileTemplate> all, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return [.. all];
+        }
+
+        return
+        [
+            .. all.Where(
+                template =>
+                    Matches(template.Id, search) ||
+                    Matches(template.Name, search) ||
+                    Matches(template.Title, search) ||
+                    Matches(template.Category, search) ||
+                    template.Tags.Any(tag => Matches(tag, search))
+            )
+        ];
+    }
+
+    private static bool Matches(string value, string search)
+        => value.Contains(search, StringComparison.OrdinalIgnoreCase);
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -130,6 +130,7 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.Register<OplTextRenderer>(Reuse.Singleton);
         container.RegisterApiEndpoint<ItemTooltipEndpoints>();
         container.RegisterApiEndpoint<ItemTemplateEndpoints>();
+        container.RegisterApiEndpoint<MobileTemplateEndpoints>();
 
         // A REST web-terminal onto the admin command set: the registry holds the open SSE feeds,
         // the endpoints POST commands and stream their output.

--- a/src/Moongate.Server.Abstractions/Interfaces/Mobiles/IMobileTemplateService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Mobiles/IMobileTemplateService.cs
@@ -5,7 +5,7 @@ namespace Moongate.Server.Abstractions.Interfaces.Mobiles;
 /// <summary>In-memory registry of mobile spawn templates, queryable by id, tag or category.</summary>
 public interface IMobileTemplateService
 {
-    /// <summary>All registered mobile templates.</summary>
+    /// <summary>All registered mobile templates, ordered by id.</summary>
     IReadOnlyList<MobileTemplate> All { get; }
 
     /// <summary>Number of registered mobile templates.</summary>

--- a/src/Moongate.Server/Services/Mobiles/MobileTemplateService.cs
+++ b/src/Moongate.Server/Services/Mobiles/MobileTemplateService.cs
@@ -8,7 +8,11 @@ public sealed class MobileTemplateService : IMobileTemplateService
 {
     private readonly Dictionary<string, MobileTemplate> _byId = new(StringComparer.OrdinalIgnoreCase);
 
-    public IReadOnlyList<MobileTemplate> All => _byId.Values.ToList();
+    // Ordered, because the admin catalogue pages over this: a page taken from an unordered
+    // dictionary can repeat a row or drop one with nothing in the response admitting it. The item
+    // registry orders by id for the same reason.
+    public IReadOnlyList<MobileTemplate> All =>
+        [.. _byId.Values.OrderBy(template => template.Id, StringComparer.OrdinalIgnoreCase)];
 
     public int Count => _byId.Count;
 

--- a/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileTemplateEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Mobiles/MobileTemplateEndpointsTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http.Json;
+using DryIoc;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Mobiles;
+using Moongate.Http.Plugin.Endpoints.Mobiles;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
+using Moongate.Server.Services.Mobiles;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Mobiles.Templates;
+
+namespace Moongate.Tests.Http.Endpoints.Mobiles;
+
+/// <summary>
+/// The staff view of the spawn template registry: paged, searchable across the fields someone would
+/// actually type, and closed to anyone who is not staff.
+/// </summary>
+public class MobileTemplateEndpointsTests
+{
+    private const string Route = "/api/v1/admin/mobiles/templates";
+
+    [Fact]
+    public async Task List_ReturnsEveryTemplateWithItsFigure()
+    {
+        await using var server = await StartAsync(Orc("orc"), Orc("brigand"));
+
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<MobileTemplateSummaryResponse>>(Route);
+
+        Assert.Equal(2, page!.Total);
+        Assert.All(page.Items, template => Assert.StartsWith("/api/v1/images/mobiles/templates/", template.ImageUrl));
+    }
+
+    [Fact]
+    public async Task List_IsOrderedById()
+    {
+        await using var server = await StartAsync(Orc("orc"), Orc("brigand"));
+
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<MobileTemplateSummaryResponse>>(Route);
+
+        Assert.Equal(["brigand", "orc"], page!.Items.Select(template => template.Id));
+    }
+
+    // Searching a tag is the case a caller cannot get any other way: tags are not a column, so no
+    // client-side filter over the visible rows could find one.
+    [Fact]
+    public async Task List_SearchMatchesATag()
+    {
+        var tagged = Orc("brigand");
+
+        tagged.Tags = ["humanoid", "bandit"];
+
+        await using var server = await StartAsync(Orc("orc"), tagged);
+
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<MobileTemplateSummaryResponse>>(
+                       $"{Route}?search=bandit"
+                   );
+
+        Assert.Equal("brigand", Assert.Single(page!.Items).Id);
+    }
+
+    [Fact]
+    public async Task List_SearchMatchesTheTitle()
+    {
+        var titled = Orc("brigand");
+
+        titled.Title = "the highwayman";
+
+        await using var server = await StartAsync(Orc("orc"), titled);
+
+        await server.AuthenticateAsync();
+
+        var page = await server.Client.GetFromJsonAsync<PagedResponse<MobileTemplateSummaryResponse>>(
+                       $"{Route}?search=highwayman"
+                   );
+
+        Assert.Equal("brigand", Assert.Single(page!.Items).Id);
+    }
+
+    [Fact]
+    public async Task List_NoMatches_IsAnEmptyPageNotANotFound()
+    {
+        await using var server = await StartAsync(Orc("orc"));
+
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync($"{Route}?search=nobody");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.Content.ReadFromJsonAsync<PagedResponse<MobileTemplateSummaryResponse>>();
+
+        Assert.Equal(0, page!.Total);
+        Assert.Empty(page.Items);
+    }
+
+    [Theory, InlineData("?page=0"), InlineData("?pageSize=5000")]
+    public async Task List_OutOfRangePaging_IsBadRequest(string query)
+    {
+        await using var server = await StartAsync(Orc("orc"));
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync($"{Route}{query}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsOneTemplateWithItsVariants()
+    {
+        await using var server = await StartAsync(Orc("orc"));
+
+        await server.AuthenticateAsync();
+
+        var template = await server.Client.GetFromJsonAsync<MobileTemplateResponse>($"{Route}/orc");
+
+        Assert.Equal("an orc", template!.Name);
+        Assert.Equal("orc scout", Assert.Single(template.Variants).Name);
+    }
+
+    [Fact]
+    public async Task Get_IdsAreCaseInsensitive()
+    {
+        await using var server = await StartAsync(Orc("orc"));
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.OK, (await server.Client.GetAsync($"{Route}/ORC")).StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AnUnknownId_IsNotFound()
+    {
+        await using var server = await StartAsync(Orc("orc"));
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.NotFound, (await server.Client.GetAsync($"{Route}/nope")).StatusCode);
+    }
+
+    // A valid token that is simply not staff, which is a 403 rather than a 401.
+    [Fact]
+    public async Task List_AsAPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player, Orc("orc"));
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync(Orc("orc"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    private static MobileTemplate Orc(string id)
+    {
+        var template = new MobileTemplate
+        {
+            Id = id,
+            Name = "an orc",
+            Category = "monster",
+            Tags = ["monster"],
+            Appearance = new() { Body = 17 },
+        };
+
+        template.Variants.Add(new() { Name = "orc scout", Weight = 1 });
+
+        return template;
+    }
+
+    private static Task<TestApiServer> StartAsync(params MobileTemplate[] templates)
+        => StartAsync(AccountLevelType.Administrator, templates);
+
+    private static async Task<TestApiServer> StartAsync(AccountLevelType level, params MobileTemplate[] templates)
+        => await TestApiServer.StartAsync(
+               level,
+               configure: container =>
+                          {
+                              var registry = new MobileTemplateService();
+
+                              foreach (var template in templates)
+                              {
+                                  registry.Register(template);
+                              }
+
+                              container.RegisterInstance<IMobileTemplateService>(registry);
+                              container.RegisterApiEndpointInstance(
+                                  new MobileTemplateEndpoints(container.Resolve<IMobileTemplateService>())
+                              );
+                          }
+           );
+}

--- a/tests/Moongate.Tests/Http/Mobiles/MobileTemplateResponseTests.cs
+++ b/tests/Moongate.Tests/Http/Mobiles/MobileTemplateResponseTests.cs
@@ -1,0 +1,170 @@
+using Moongate.Http.Plugin.Data.Api.Mobiles;
+using Moongate.UO.Data.Mobiles.Templates;
+using Moongate.UO.Data.Types;
+
+namespace Moongate.Tests.Http.Mobiles;
+
+/// <summary>
+/// What the DTOs owe the caller: every field the template carries, the hue specs left as the strings
+/// they are, and an art url built the same way the item summary builds its own.
+/// </summary>
+public class MobileTemplateResponseTests
+{
+    [Fact]
+    public void Summary_CarriesTheFieldsARowNeeds()
+    {
+        var summary = MobileTemplateSummaryResponse.From(Orc());
+
+        Assert.Equal("orc", summary.Id);
+        Assert.Equal("an orc", summary.Name);
+        Assert.Equal("the brute", summary.Title);
+        Assert.Equal("monster", summary.Category);
+        Assert.Equal(["monster", "green"], summary.Tags);
+        Assert.Equal(17, summary.Body);
+        Assert.Equal(96, summary.Strength);
+    }
+
+    [Fact]
+    public void Summary_CountsTheVariants()
+        => Assert.Equal(2, MobileTemplateSummaryResponse.From(Orc()).VariantCount);
+
+    [Fact]
+    public void Summary_AddressesTheTemplateArt()
+        => Assert.Equal("/api/v1/images/mobiles/templates/orc.png", MobileTemplateSummaryResponse.From(Orc()).ImageUrl);
+
+    // Ids come from YAML and are not guaranteed to be URL-safe.
+    [Fact]
+    public void Summary_EscapesAnIdThatNeedsIt()
+    {
+        var summary = MobileTemplateSummaryResponse.From(new() { Id = "orc chief" });
+
+        Assert.Equal("/api/v1/images/mobiles/templates/orc%20chief.png", summary.ImageUrl);
+    }
+
+    [Fact]
+    public void Detail_CarriesEveryFlatField()
+    {
+        var detail = MobileTemplateResponse.From(Orc());
+
+        Assert.Equal("orc", detail.Id);
+        Assert.Equal("orcs", detail.NamePool);
+        Assert.Equal("A green brute.", detail.Description);
+        Assert.Equal("base_monster", detail.BaseMobile);
+        Assert.Equal(96, detail.Strength);
+        Assert.Equal(70, detail.Dexterity);
+        Assert.Equal(30, detail.Intelligence);
+        Assert.Equal("orc_loot", detail.LootTableId);
+        Assert.Equal("orc_brain", detail.BrainScript);
+    }
+
+    [Fact]
+    public void Detail_NamesTheGender()
+        => Assert.Equal("Male", MobileTemplateResponse.From(Orc()).Gender);
+
+    // Gender is optional on a template — a spawn picks one. Null says "either", which is not the
+    // same thing as male.
+    [Fact]
+    public void Detail_LeavesTheGenderNullWhenTheTemplateDoesNotFixOne()
+        => Assert.Null(MobileTemplateResponse.From(new() { Id = "orc" }).Gender);
+
+    [Fact]
+    public void Detail_CarriesTheSkills()
+    {
+        var detail = MobileTemplateResponse.From(Orc());
+
+        Assert.Equal(80, detail.Skills["Swordsmanship"]);
+    }
+
+    // Hues on a template are SPECS: a value or a range resolved per spawn. Reporting them as numbers
+    // would mean picking one end of a range and lying about the other.
+    [Fact]
+    public void Detail_ReportsHueSpecsAsTheStringsTheyAre()
+    {
+        var detail = MobileTemplateResponse.From(Orc());
+
+        Assert.Equal("0x455-0x45a", detail.Appearance.SkinHue);
+        Assert.Equal("1102", detail.Appearance.HairHue);
+        Assert.Equal(17, detail.Appearance.Body);
+    }
+
+    [Fact]
+    public void Detail_CarriesTheEquipment()
+    {
+        var worn = Assert.Single(MobileTemplateResponse.From(Orc()).Equipment);
+
+        Assert.Equal("orc_club", worn.Item);
+        Assert.Equal("OneHanded", worn.Layer);
+        Assert.Equal("0x0", worn.Hue);
+    }
+
+    [Fact]
+    public void Detail_CarriesEachVariantWithItsOwnAppearanceAndEquipment()
+    {
+        var variants = MobileTemplateResponse.From(Orc()).Variants;
+
+        Assert.Equal(["orc scout", "orc chief"], variants.Select(variant => variant.Name));
+
+        var chief = variants[1];
+
+        Assert.Equal(3, chief.Weight);
+        Assert.Equal("Female", chief.Gender);
+        Assert.Equal("chief_loot", chief.LootTableId);
+        Assert.Equal(18, chief.Appearance.Body);
+        Assert.Equal("orc_axe", Assert.Single(chief.Equipment).Item);
+    }
+
+    [Fact]
+    public void Detail_AddressesBothPictures()
+    {
+        var detail = MobileTemplateResponse.From(Orc());
+
+        Assert.Equal("/api/v1/images/mobiles/templates/orc.png", detail.ImageUrl);
+        Assert.Equal("/api/v1/images/mobiles/templates/orc/paperdoll.png", detail.PaperdollUrl);
+    }
+
+    private static MobileTemplate Orc()
+    {
+        var template = new MobileTemplate
+        {
+            Id = "orc",
+            Name = "an orc",
+            NamePool = "orcs",
+            Gender = MobileTemplateGenderType.Male,
+            Title = "the brute",
+            Category = "monster",
+            Description = "A green brute.",
+            Tags = ["monster", "green"],
+            BaseMobile = "base_monster",
+            Strength = 96,
+            Dexterity = 70,
+            Intelligence = 30,
+            LootTableId = "orc_loot",
+            BrainScript = "orc_brain",
+            Appearance = new()
+            {
+                Body = 17,
+                SkinHue = "0x455-0x45a",
+                HairStyle = 8252,
+                HairHue = "1102",
+            },
+            Equipment = [new() { Item = "orc_club", Layer = "OneHanded", Hue = "0x0" }],
+        };
+
+        template.Skills["Swordsmanship"] = 80;
+
+        template.Variants.Add(new() { Name = "orc scout", Weight = 1 });
+        template.Variants.Add(
+            new()
+            {
+                Name = "orc chief",
+                Weight = 3,
+                Gender = MobileTemplateGenderType.Female,
+                LootTableId = "chief_loot",
+                Appearance = new() { Body = 18 },
+                Equipment = [new() { Item = "orc_axe", Layer = "OneHanded" }],
+            }
+        );
+
+        return template;
+    }
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -59,6 +59,7 @@ public class MoongateHttpPluginTests
                 typeof(MapImageEndpoints),
                 typeof(MobileCharacterImageEndpoints),
                 typeof(MobileImageAdminEndpoints),
+                typeof(MobileTemplateEndpoints),
                 typeof(MobileTemplateImageEndpoints),
                 typeof(OnlinePlayerAdminEndpoints),
                 typeof(PaperdollEndpoints),

--- a/tests/Moongate.Tests/Server/Mobiles/MobileTemplateServiceTests.cs
+++ b/tests/Moongate.Tests/Server/Mobiles/MobileTemplateServiceTests.cs
@@ -1,3 +1,4 @@
+using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Services.Mobiles;
 
 namespace Moongate.Tests.Server.Mobiles;
@@ -38,5 +39,36 @@ public class MobileTemplateServiceTests
 
         Assert.Equal(1, service.Count);
         Assert.Equal("Second", service.GetById("orc")!.Name);
+    }
+
+    // The admin catalogue pages over this, and a page taken from an unordered dictionary can repeat
+    // a row or drop one with nothing in the response admitting it. The item registry orders by id
+    // for the same reason.
+    [Fact]
+    public void All_IsOrderedById()
+    {
+        IMobileTemplateService service = new MobileTemplateService();
+
+        service.Register(new() { Id = "orc" });
+        service.Register(new() { Id = "brigand" });
+        service.Register(new() { Id = "Zombie" });
+
+        Assert.Equal(["brigand", "orc", "Zombie"], service.All.Select(template => template.Id));
+    }
+
+    [Fact]
+    public void All_IsEmptyBeforeAnythingIsRegistered()
+        => Assert.Empty(((IMobileTemplateService)new MobileTemplateService()).All);
+
+    // Registering the same id twice is a reload, not a duplicate: the loader re-registers on startup.
+    [Fact]
+    public void All_ReportsOneEntryPerId()
+    {
+        IMobileTemplateService service = new MobileTemplateService();
+
+        service.Register(new() { Id = "orc", Name = "an orc" });
+        service.Register(new() { Id = "orc", Name = "an orc chief" });
+
+        Assert.Equal("an orc chief", Assert.Single(service.All).Name);
     }
 }

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -1093,6 +1093,83 @@
         }
       }
     },
+    "/api/v1/admin/mobiles/templates": {
+      "get": {
+        "tags": [
+          "mobiles"
+        ],
+        "summary": "Every mobile template, paged.",
+        "description": "Ordered by template id. Pass search to filter: free text, case-insensitive, matching the\ntemplate's id, name, title, category or any tag. Page is 1-based and defaults to 1; pageSize\ndefaults to 25 and cannot exceed 100. A search matching nothing is an empty page, not an error.\n            \nA template's hues are reported as the specs they are — a value or a range resolved per spawn —\nrather than as numbers.",
+        "operationId": "ListMobileTemplates",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MobileTemplateSummaryResponsePagedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/mobiles/templates/{id}": {
+      "get": {
+        "tags": [
+          "mobiles"
+        ],
+        "summary": "Fetches one mobile template by id, variants and equipment included.",
+        "description": "Ids are case-insensitive. Answers 404 when no template carries the id.",
+        "operationId": "GetMobileTemplate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MobileTemplateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/admin/images/bodies": {
       "post": {
         "tags": [
@@ -3037,6 +3114,327 @@
         },
         "additionalProperties": false,
         "description": "How far the map image pre-warm has got."
+      },
+      "MobileAppearanceResponse": {
+        "required": [
+          "body",
+          "facialHairStyle",
+          "hairStyle"
+        ],
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "integer",
+            "description": "The animation body id.",
+            "format": "int32"
+          },
+          "skinHue": {
+            "type": "string",
+            "description": "A hue <em>spec</em>, not a number: a single value or a range like `0x455-0x45a` resolved once\nper spawn. Reported as written, because picking one end of a range would lie about the other.",
+            "nullable": true
+          },
+          "hairStyle": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hairHue": {
+            "type": "string",
+            "description": "A hue spec, like SkinHue.",
+            "nullable": true
+          },
+          "facialHairStyle": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "facialHairHue": {
+            "type": "string",
+            "description": "A hue spec, like SkinHue.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "How a template says a mobile looks, shared by the template and each of its variants."
+      },
+      "MobileEquipmentResponse": {
+        "required": [
+          "item",
+          "layer"
+        ],
+        "type": "object",
+        "properties": {
+          "item": {
+            "type": "string",
+            "description": "The item template id to spawn."
+          },
+          "layer": {
+            "type": "string",
+            "description": "The layer it goes on."
+          },
+          "hue": {
+            "type": "string",
+            "description": "A hue spec, or null to leave the item its own colour.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "One item a template spawns its mobile wearing."
+      },
+      "MobileTemplateResponse": {
+        "required": [
+          "appearance",
+          "category",
+          "description",
+          "dexterity",
+          "equipment",
+          "id",
+          "imageUrl",
+          "intelligence",
+          "name",
+          "namePool",
+          "paperdollUrl",
+          "skills",
+          "strength",
+          "tags",
+          "title",
+          "variants"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namePool": {
+            "type": "string",
+            "description": "The pool a spawn draws its name from when the template has no fixed one."
+          },
+          "gender": {
+            "type": "string",
+            "description": "The gender name, or null when the template lets a spawn pick.",
+            "nullable": true
+          },
+          "title": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "baseMobile": {
+            "type": "string",
+            "description": "The template this one merges over, or null when it stands alone.",
+            "nullable": true
+          },
+          "strength": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dexterity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "intelligence": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "skills": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "description": "Skill values by name, as the template sets them."
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/MobileAppearanceResponse"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MobileEquipmentResponse"
+            }
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MobileVariantResponse"
+            },
+            "description": "Weighted alternatives, each with its own appearance and equipment."
+          },
+          "lootTableId": {
+            "type": "string",
+            "nullable": true
+          },
+          "brainScript": {
+            "type": "string",
+            "nullable": true
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "paperdollUrl": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "One mobile spawn template in full."
+      },
+      "MobileTemplateSummaryResponse": {
+        "required": [
+          "body",
+          "category",
+          "dexterity",
+          "id",
+          "imageUrl",
+          "intelligence",
+          "name",
+          "strength",
+          "tags",
+          "title",
+          "variantCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "body": {
+            "type": "integer",
+            "description": "The animation body id, which is what the picture is drawn from.",
+            "format": "int32"
+          },
+          "strength": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dexterity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "intelligence": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "variantCount": {
+            "type": "integer",
+            "description": "How many weighted alternatives the template carries.",
+            "format": "int32"
+          },
+          "imageUrl": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "One row of the staff mobile template listing."
+      },
+      "MobileTemplateSummaryResponsePagedResponse": {
+        "required": [
+          "items",
+          "page",
+          "pageSize",
+          "total",
+          "totalPages"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MobileTemplateSummaryResponse"
+            },
+            "description": "The results on this page."
+          },
+          "total": {
+            "type": "integer",
+            "description": "How many results matched in total, before paging.",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "The 1-based page this is.",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "The page size used. The last page may hold fewer items.",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "How many pages exist at this page size. 0 when nothing matched.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "One page of results, and what a caller needs to walk the rest."
+      },
+      "MobileVariantResponse": {
+        "required": [
+          "appearance",
+          "equipment",
+          "name",
+          "weight"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "integer",
+            "description": "Its share of the draw, relative to the other variants.",
+            "format": "int32"
+          },
+          "gender": {
+            "type": "string",
+            "description": "The gender name, or null when the variant does not fix one.",
+            "nullable": true
+          },
+          "namePool": {
+            "type": "string",
+            "nullable": true
+          },
+          "lootTableId": {
+            "type": "string",
+            "nullable": true
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/MobileAppearanceResponse"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MobileEquipmentResponse"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "One variant of a template: a weighted alternative look, name pool and loot."
       },
       "NewsResponse": {
         "required": [

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,6 +16,8 @@ import { CharacterDetailScreen } from './routes/CharacterDetailScreen'
 import { AdminLayout } from './routes/AdminLayout'
 import { AccountsScreen } from './routes/AccountsScreen'
 import { CharactersAdminScreen } from './routes/admin/CharactersAdminScreen'
+import { ItemTemplatesScreen } from './routes/admin/ItemTemplatesScreen'
+import { ItemTemplateDetailScreen } from './routes/admin/ItemTemplateDetailScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
 import { SettingsScreen } from './routes/SettingsScreen'
 import { ConsoleScreen } from './routes/ConsoleScreen'
@@ -91,6 +93,8 @@ export function App() {
                 <Route index element={<AdminScreen />} />
                 <Route path="accounts" element={<AccountsScreen />} />
                 <Route path="characters" element={<CharactersAdminScreen />} />
+                <Route path="items" element={<ItemTemplatesScreen />} />
+                <Route path="items/:id" element={<ItemTemplateDetailScreen />} />
                 <Route path="plugins" element={<PluginsScreen />} />
                 <Route path="settings" element={<SettingsScreen />} />
                 <Route path="console" element={<ConsoleScreen />} />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,6 +18,8 @@ import { AccountsScreen } from './routes/AccountsScreen'
 import { CharactersAdminScreen } from './routes/admin/CharactersAdminScreen'
 import { ItemTemplatesScreen } from './routes/admin/ItemTemplatesScreen'
 import { ItemTemplateDetailScreen } from './routes/admin/ItemTemplateDetailScreen'
+import { MobileTemplatesScreen } from './routes/admin/MobileTemplatesScreen'
+import { MobileTemplateDetailScreen } from './routes/admin/MobileTemplateDetailScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
 import { SettingsScreen } from './routes/SettingsScreen'
 import { ConsoleScreen } from './routes/ConsoleScreen'
@@ -95,6 +97,8 @@ export function App() {
                 <Route path="characters" element={<CharactersAdminScreen />} />
                 <Route path="items" element={<ItemTemplatesScreen />} />
                 <Route path="items/:id" element={<ItemTemplateDetailScreen />} />
+                <Route path="mobiles" element={<MobileTemplatesScreen />} />
+                <Route path="mobiles/:id" element={<MobileTemplateDetailScreen />} />
                 <Route path="plugins" element={<PluginsScreen />} />
                 <Route path="settings" element={<SettingsScreen />} />
                 <Route path="console" element={<ConsoleScreen />} />

--- a/ui/src/components/templates/ItemTemplateTooltip.test.tsx
+++ b/ui/src/components/templates/ItemTemplateTooltip.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import '../../lib/i18n'
+import { TooltipProvider } from '../ui/tooltip'
+import { ItemTemplateTooltip } from './ItemTemplateTooltip'
+import type { ItemTemplateSummary } from '../../lib/templates'
+
+function template(over: Partial<ItemTemplateSummary> = {}): ItemTemplateSummary {
+  return {
+    id: 'plate_mail',
+    name: 'Plate Mail',
+    category: 'armor',
+    itemId: 0x1415,
+    hue: 0,
+    rarity: 'Rare',
+    goldValue: 250,
+    weight: 40,
+    tags: ['armor', 'metal'],
+    imageUrl: '/api/v1/images/items/0x1415.png',
+    ...over,
+  } as ItemTemplateSummary
+}
+
+function renderCard(summary: ItemTemplateSummary) {
+  return render(
+    <TooltipProvider>
+      <ItemTemplateTooltip template={summary}>
+        <button type="button">the row</button>
+      </ItemTemplateTooltip>
+    </TooltipProvider>,
+  )
+}
+
+describe('ItemTemplateTooltip', () => {
+  it('shows the name, the rarity and the numbers', async () => {
+    renderCard(template())
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('Plate Mail')).toBeInTheDocument()
+    expect(screen.getByText('Rare')).toBeInTheDocument()
+    expect(screen.getByText('40')).toBeInTheDocument()
+    expect(screen.getByText('250')).toBeInTheDocument()
+  })
+
+  it('shows the sprite the row already carries', async () => {
+    renderCard(template())
+
+    await userEvent.tab()
+
+    expect(await screen.findByAltText('Plate Mail')).toHaveAttribute('src', '/api/v1/images/items/0x1415.png')
+  })
+
+  it('shows the tags', async () => {
+    renderCard(template({ tags: ['armor', 'metal'] }))
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('armor, metal')).toBeInTheDocument()
+  })
+
+  it('omits the tag row when there are none', async () => {
+    renderCard(template({ tags: [] }))
+
+    await userEvent.tab()
+
+    await screen.findByText('Plate Mail')
+    expect(screen.queryByText('Tags')).not.toBeInTheDocument()
+  })
+
+  // The card renders from the row it was handed. If this ever needs a QueryClientProvider, someone
+  // has added a fetch to it — and that is one request per hover for data already on screen.
+  it('needs no query client, because it fetches nothing', async () => {
+    renderCard(template())
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('Plate Mail')).toBeInTheDocument()
+  })
+
+  it('falls back to the id when the template has no name', async () => {
+    renderCard(template({ name: '' }))
+
+    await userEvent.tab()
+
+    expect(await screen.findByText('plate_mail')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/templates/ItemTemplateTooltip.tsx
+++ b/ui/src/components/templates/ItemTemplateTooltip.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { RarityBadge, rarityColor } from './RarityBadge'
+import type { ItemTemplateSummary } from '../../lib/templates'
+
+/**
+ * A hover card for an item template, in the shape players know from Wowhead: the sprite beside a
+ * rarity-coloured name, then the numbers.
+ *
+ * It renders from the row it was handed and **fetches nothing** — unlike the item tooltip, whose
+ * property list lives on the game loop and is not in the row. Everything here is already on screen,
+ * so a request per hover would buy nothing.
+ */
+export function ItemTemplateTooltip({ template, children }: { template: ItemTemplateSummary; children: ReactNode }) {
+  const { t } = useTranslation()
+  const name = template.name === '' ? template.id : template.name
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+
+      <TooltipContent>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-start gap-2">
+            <img src={template.imageUrl} alt={name} className="h-10 w-10 shrink-0 object-contain" />
+
+            <span className="min-w-0">
+              <span className="block truncate font-bold" style={{ color: rarityColor(template.rarity) }}>
+                {name}
+              </span>
+              <RarityBadge rarity={template.rarity} />
+            </span>
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 border-t border-ink/10 pt-2 text-xs">
+            <Row label={t('admin.templates.weight')} value={template.weight} />
+            <Row label={t('admin.templates.value')} value={template.goldValue} />
+            <Row label={t('admin.templates.category')} value={template.category} />
+            {template.tags.length > 0 && <Row label={t('admin.templates.tags')} value={template.tags.join(', ')} />}
+          </dl>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string | number }) {
+  return (
+    <>
+      <dt className="text-muted">{label}</dt>
+      <dd className="text-right text-ink">{value}</dd>
+    </>
+  )
+}

--- a/ui/src/components/templates/MobileTemplateTooltip.tsx
+++ b/ui/src/components/templates/MobileTemplateTooltip.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import type { MobileTemplateSummary } from '../../lib/templates'
+
+/** A template's own name, or its id — many draw their name from a pool and carry none. */
+export const mobileTemplateLabel = (template: MobileTemplateSummary) =>
+  template.name === '' ? template.id : template.name
+
+/**
+ * A hover card for a spawn template, in the same shape as the item one. It renders from the row it
+ * was handed and **fetches nothing**: everything here is already on screen.
+ */
+export function MobileTemplateTooltip({
+  template,
+  children,
+}: {
+  template: MobileTemplateSummary
+  children: ReactNode
+}) {
+  const { t } = useTranslation()
+  const name = mobileTemplateLabel(template)
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+
+      <TooltipContent>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-start gap-2">
+            <img src={template.imageUrl} alt={name} className="h-12 w-10 shrink-0 object-contain" />
+
+            <span className="min-w-0">
+              <span className="block truncate font-bold text-ink">{name}</span>
+              {template.title !== '' && <span className="block truncate text-xs text-muted">{template.title}</span>}
+            </span>
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 border-t border-ink/10 pt-2 text-xs">
+            <Row
+              label={t('admin.templates.stats')}
+              value={`${template.strength} / ${template.dexterity} / ${template.intelligence}`}
+            />
+            <Row label={t('admin.templates.body')} value={template.body} />
+            <Row label={t('admin.templates.category')} value={template.category} />
+            {template.variantCount > 0 && <Row label={t('admin.templates.variants')} value={template.variantCount} />}
+            {template.tags.length > 0 && <Row label={t('admin.templates.tags')} value={template.tags.join(', ')} />}
+          </dl>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string | number }) {
+  return (
+    <>
+      <dt className="text-muted">{label}</dt>
+      <dd className="text-right text-ink">{value}</dd>
+    </>
+  )
+}

--- a/ui/src/components/templates/RarityBadge.test.tsx
+++ b/ui/src/components/templates/RarityBadge.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+
+import { RarityBadge } from './RarityBadge'
+
+describe('RarityBadge', () => {
+  it('names the rarity', () => {
+    render(<RarityBadge rarity="Legendary" />)
+
+    expect(screen.getByText('Legendary')).toBeInTheDocument()
+  })
+
+  it('colours each rarity differently', () => {
+    const { rerender } = render(<RarityBadge rarity="Rare" />)
+    const rare = screen.getByText('Rare').style.color
+
+    rerender(<RarityBadge rarity="Epic" />)
+
+    expect(screen.getByText('Epic').style.color).not.toBe(rare)
+  })
+
+  // Artifact is in the enum and was missing from the old portal's colour map — the exact case the
+  // fallback exists for, and a reason not to port that map as it was.
+  it('colours Artifact', () => {
+    render(<RarityBadge rarity="Artifact" />)
+
+    expect(screen.getByText('Artifact').style.color).not.toBe('')
+  })
+
+  // Rarity is optional on a template, and an empty badge is worse than no badge.
+  it('renders nothing when there is no rarity', () => {
+    const { container } = render(<RarityBadge rarity={null} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a blank rarity', () => {
+    const { container } = render(<RarityBadge rarity="" />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // The enum can gain a member. Naming it beats disappearing.
+  it('still names a rarity it has no colour for', () => {
+    render(<RarityBadge rarity="Mythical" />)
+
+    expect(screen.getByText('Mythical')).toBeInTheDocument()
+  })
+})

--- a/ui/src/components/templates/RarityBadge.tsx
+++ b/ui/src/components/templates/RarityBadge.tsx
@@ -1,0 +1,34 @@
+/**
+ * Wowhead's rarity palette, which players already read without being told. `Common` is the
+ * exception: Wowhead paints it white, which vanishes on this portal's light theme, so it takes the
+ * ink token and follows the theme instead.
+ *
+ * `Artifact` is in the server's enum and was missing from the old portal's map — which is why the
+ * lookup falls back rather than assuming the set is closed.
+ */
+const rarityColors: Record<string, string> = {
+  Common: 'var(--color-ink)',
+  Uncommon: '#1eff00',
+  Rare: '#0070dd',
+  Epic: '#a335ee',
+  Legendary: '#ff8000',
+  Artifact: '#e6cc80',
+}
+
+/** The colour for a rarity, or the muted token for one this portal has no word for. */
+export function rarityColor(rarity: string | null | undefined): string {
+  return (rarity && rarityColors[rarity]) || 'var(--color-muted)'
+}
+
+/** The rarity in its own colour, or nothing at all when the template has none. */
+export function RarityBadge({ rarity }: { rarity: string | null | undefined }) {
+  if (rarity === null || rarity === undefined || rarity === '') {
+    return null
+  }
+
+  return (
+    <span className="text-xs font-bold" style={{ color: rarityColor(rarity) }}>
+      {rarity}
+    </span>
+  )
+}

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -635,6 +635,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/mobiles/templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Every mobile template, paged.
+         * @description Ordered by template id. Pass search to filter: free text, case-insensitive, matching the
+         *     template's id, name, title, category or any tag. Page is 1-based and defaults to 1; pageSize
+         *     defaults to 25 and cannot exceed 100. A search matching nothing is an empty page, not an error.
+         *
+         *     A template's hues are reported as the specs they are — a value or a range resolved per spawn —
+         *     rather than as numbers.
+         */
+        get: operations["ListMobileTemplates"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/mobiles/templates/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetches one mobile template by id, variants and equipment included.
+         * @description Ids are case-insensitive. Answers 404 when no template carries the id.
+         */
+        get: operations["GetMobileTemplate"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/images/bodies": {
         parameters: {
             query?: never;
@@ -1517,6 +1562,134 @@ export interface components {
              * @description When the current or last pre-warm started; null if none ever has.
              */
             startedAt?: string | null;
+        };
+        /** @description How a template says a mobile looks, shared by the template and each of its variants. */
+        MobileAppearanceResponse: {
+            /**
+             * Format: int32
+             * @description The animation body id.
+             */
+            body: number;
+            /**
+             * @description A hue <em>spec</em>, not a number: a single value or a range like `0x455-0x45a` resolved once
+             *     per spawn. Reported as written, because picking one end of a range would lie about the other.
+             */
+            skinHue?: string | null;
+            /** Format: int32 */
+            hairStyle: number;
+            /** @description A hue spec, like SkinHue. */
+            hairHue?: string | null;
+            /** Format: int32 */
+            facialHairStyle: number;
+            /** @description A hue spec, like SkinHue. */
+            facialHairHue?: string | null;
+        };
+        /** @description One item a template spawns its mobile wearing. */
+        MobileEquipmentResponse: {
+            /** @description The item template id to spawn. */
+            item: string;
+            /** @description The layer it goes on. */
+            layer: string;
+            /** @description A hue spec, or null to leave the item its own colour. */
+            hue?: string | null;
+        };
+        /** @description One mobile spawn template in full. */
+        MobileTemplateResponse: {
+            id: string;
+            name: string;
+            /** @description The pool a spawn draws its name from when the template has no fixed one. */
+            namePool: string;
+            /** @description The gender name, or null when the template lets a spawn pick. */
+            gender?: string | null;
+            title: string;
+            category: string;
+            description: string;
+            tags: string[];
+            /** @description The template this one merges over, or null when it stands alone. */
+            baseMobile?: string | null;
+            /** Format: int32 */
+            strength: number;
+            /** Format: int32 */
+            dexterity: number;
+            /** Format: int32 */
+            intelligence: number;
+            /** @description Skill values by name, as the template sets them. */
+            skills: {
+                [key: string]: number;
+            };
+            appearance: components["schemas"]["MobileAppearanceResponse"];
+            equipment: components["schemas"]["MobileEquipmentResponse"][];
+            /** @description Weighted alternatives, each with its own appearance and equipment. */
+            variants: components["schemas"]["MobileVariantResponse"][];
+            lootTableId?: string | null;
+            brainScript?: string | null;
+            imageUrl: string;
+            paperdollUrl: string;
+        };
+        /** @description One row of the staff mobile template listing. */
+        MobileTemplateSummaryResponse: {
+            id: string;
+            name: string;
+            title: string;
+            category: string;
+            tags: string[];
+            /**
+             * Format: int32
+             * @description The animation body id, which is what the picture is drawn from.
+             */
+            body: number;
+            /** Format: int32 */
+            strength: number;
+            /** Format: int32 */
+            dexterity: number;
+            /** Format: int32 */
+            intelligence: number;
+            /**
+             * Format: int32
+             * @description How many weighted alternatives the template carries.
+             */
+            variantCount: number;
+            imageUrl: string;
+        };
+        /** @description One page of results, and what a caller needs to walk the rest. */
+        MobileTemplateSummaryResponsePagedResponse: {
+            /** @description The results on this page. */
+            items: components["schemas"]["MobileTemplateSummaryResponse"][];
+            /**
+             * Format: int32
+             * @description How many results matched in total, before paging.
+             */
+            total: number;
+            /**
+             * Format: int32
+             * @description The 1-based page this is.
+             */
+            page: number;
+            /**
+             * Format: int32
+             * @description The page size used. The last page may hold fewer items.
+             */
+            pageSize: number;
+            /**
+             * Format: int32
+             * @description How many pages exist at this page size. 0 when nothing matched.
+             */
+            totalPages: number;
+        };
+        /** @description One variant of a template: a weighted alternative look, name pool and loot. */
+        MobileVariantResponse: {
+            name: string;
+            /**
+             * Format: int32
+             * @description Its share of the draw, relative to the other variants.
+             */
+            weight: number;
+            /** @description The gender name, or null when the variant does not fix one. */
+            gender?: string | null;
+            namePool?: string | null;
+            lootTableId?: string | null;
+            appearance: components["schemas"]["MobileAppearanceResponse"];
+            equipment: components["schemas"]["MobileEquipmentResponse"][];
         };
         /** @description A news entry as returned by the API. */
         NewsResponse: {
@@ -2492,6 +2665,52 @@ export interface operations {
                 };
                 content: {
                     "image/png": string;
+                };
+            };
+        };
+    };
+    ListMobileTemplates: {
+        parameters: {
+            query?: {
+                page?: string;
+                pageSize?: string;
+                search?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MobileTemplateSummaryResponsePagedResponse"];
+                };
+            };
+        };
+    };
+    GetMobileTemplate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MobileTemplateResponse"];
                 };
             };
         };

--- a/ui/src/lib/templates.test.ts
+++ b/ui/src/lib/templates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { itemTemplatesQuery } from './templates'
+import { itemTemplatesQuery, mobileTemplatesQuery } from './templates'
 
 describe('item template query', () => {
   it('asks for the page it was given', () => {
@@ -22,5 +22,25 @@ describe('item template query', () => {
   // a failed request.
   it('never asks for a page below 1', () => {
     expect(itemTemplatesQuery({ page: 0, search: '' })).toBe('/api/v1/admin/items/templates?page=1&pageSize=25')
+  })
+})
+
+describe('mobile template query', () => {
+  it('asks for the page it was given', () => {
+    expect(mobileTemplatesQuery({ page: 2, search: '' })).toBe('/api/v1/admin/mobiles/templates?page=2&pageSize=25')
+  })
+
+  it('omits an empty search', () => {
+    expect(mobileTemplatesQuery({ page: 1, search: ' ' })).toBe('/api/v1/admin/mobiles/templates?page=1&pageSize=25')
+  })
+
+  it('encodes the search', () => {
+    expect(mobileTemplatesQuery({ page: 1, search: 'town guard' })).toBe(
+      '/api/v1/admin/mobiles/templates?page=1&pageSize=25&search=town+guard',
+    )
+  })
+
+  it('never asks for a page below 1', () => {
+    expect(mobileTemplatesQuery({ page: 0, search: '' })).toBe('/api/v1/admin/mobiles/templates?page=1&pageSize=25')
   })
 })

--- a/ui/src/lib/templates.test.ts
+++ b/ui/src/lib/templates.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { itemTemplatesQuery } from './templates'
+
+describe('item template query', () => {
+  it('asks for the page it was given', () => {
+    expect(itemTemplatesQuery({ page: 3, search: '' })).toBe('/api/v1/admin/items/templates?page=3&pageSize=25')
+  })
+
+  // Blank means no filter; sending `search=` would filter on the empty string.
+  it('omits an empty search', () => {
+    expect(itemTemplatesQuery({ page: 1, search: '  ' })).toBe('/api/v1/admin/items/templates?page=1&pageSize=25')
+  })
+
+  it('encodes the search', () => {
+    expect(itemTemplatesQuery({ page: 1, search: 'plate mail' })).toBe(
+      '/api/v1/admin/items/templates?page=1&pageSize=25&search=plate+mail',
+    )
+  })
+
+  // page 0 is a 400 from the server, so a bug that reaches it should be visible here rather than as
+  // a failed request.
+  it('never asks for a page below 1', () => {
+    expect(itemTemplatesQuery({ page: 0, search: '' })).toBe('/api/v1/admin/items/templates?page=1&pageSize=25')
+  })
+})

--- a/ui/src/lib/templates.ts
+++ b/ui/src/lib/templates.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiFetch } from './api'
+import type { components } from './api-types'
+
+export type ItemTemplateSummary = components['schemas']['ItemTemplateSummaryResponse']
+export type ItemTemplate = components['schemas']['ItemTemplateResponse']
+export type ItemTemplatePage = components['schemas']['ItemTemplateSummaryResponsePagedResponse']
+
+/** The server's own default. Named here so the pager and the request cannot disagree. */
+export const TEMPLATES_PAGE_SIZE = 25
+
+/**
+ * The catalogue URL. A blank search is omitted rather than sent empty: the server reads a blank
+ * `search` as "no filter" anyway, and leaving it out keeps the query key stable so paging with an
+ * empty box does not miss the cache.
+ */
+export function itemTemplatesQuery({ page, search }: { page: number; search: string }): string {
+  const params = new URLSearchParams({
+    page: String(Math.max(page, 1)),
+    pageSize: String(TEMPLATES_PAGE_SIZE),
+  })
+
+  const trimmed = search.trim()
+
+  if (trimmed !== '') {
+    params.set('search', trimmed)
+  }
+
+  return `/api/v1/admin/items/templates?${params}`
+}
+
+/** Every item template, paged and searched by the server. Staff only. */
+export const useItemTemplates = (params: { page: number; search: string }) =>
+  useQuery({
+    queryKey: ['admin', 'itemTemplates', params.page, params.search.trim()],
+    queryFn: () => apiFetch<ItemTemplatePage>(itemTemplatesQuery(params)),
+    // Holding the previous page while the next loads is what makes it read as a table rather than a
+    // slideshow.
+    placeholderData: (previous: ItemTemplatePage | undefined) => previous,
+  })
+
+/**
+ * One item template in full, specs included. The id is escaped because template ids come from YAML
+ * and are not guaranteed to be URL-safe.
+ */
+export const useItemTemplate = (id: string) =>
+  useQuery({
+    queryKey: ['admin', 'itemTemplates', id],
+    queryFn: () => apiFetch<ItemTemplate>(`/api/v1/admin/items/templates/${encodeURIComponent(id)}`),
+  })

--- a/ui/src/lib/templates.ts
+++ b/ui/src/lib/templates.ts
@@ -49,3 +49,38 @@ export const useItemTemplate = (id: string) =>
     queryKey: ['admin', 'itemTemplates', id],
     queryFn: () => apiFetch<ItemTemplate>(`/api/v1/admin/items/templates/${encodeURIComponent(id)}`),
   })
+
+export type MobileTemplateSummary = components['schemas']['MobileTemplateSummaryResponse']
+export type MobileTemplate = components['schemas']['MobileTemplateResponse']
+export type MobileTemplatePage = components['schemas']['MobileTemplateSummaryResponsePagedResponse']
+
+/** The catalogue URL for spawn templates. Blank searches are omitted, as in {@link itemTemplatesQuery}. */
+export function mobileTemplatesQuery({ page, search }: { page: number; search: string }): string {
+  const params = new URLSearchParams({
+    page: String(Math.max(page, 1)),
+    pageSize: String(TEMPLATES_PAGE_SIZE),
+  })
+
+  const trimmed = search.trim()
+
+  if (trimmed !== '') {
+    params.set('search', trimmed)
+  }
+
+  return `/api/v1/admin/mobiles/templates?${params}`
+}
+
+/** Every mobile spawn template, paged and searched by the server. Staff only. */
+export const useMobileTemplates = (params: { page: number; search: string }) =>
+  useQuery({
+    queryKey: ['admin', 'mobileTemplates', params.page, params.search.trim()],
+    queryFn: () => apiFetch<MobileTemplatePage>(mobileTemplatesQuery(params)),
+    placeholderData: (previous: MobileTemplatePage | undefined) => previous,
+  })
+
+/** One mobile template in full, variants and equipment included. */
+export const useMobileTemplate = (id: string) =>
+  useQuery({
+    queryKey: ['admin', 'mobileTemplates', id],
+    queryFn: () => apiFetch<MobileTemplate>(`/api/v1/admin/mobiles/templates/${encodeURIComponent(id)}`),
+  })

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -160,7 +160,8 @@
       "settings": "Settings",
       "console": "Console",
       "characters": "Characters",
-      "items": "Items"
+      "items": "Items",
+      "mobiles": "Mobiles"
     },
     "accounts": {
       "title": "Accounts",
@@ -300,7 +301,24 @@
       "book": "Book",
       "yes": "Yes",
       "no": "No",
-      "noImage": "—"
+      "noImage": "—",
+      "mobilesTitle": "Mobile Templates",
+      "mobilesSearch": "Search by id, name, title, category or tag…",
+      "title": "Title",
+      "body": "Body",
+      "stats": "Str / Dex / Int",
+      "variants": "Variants",
+      "skills": "Skills",
+      "equipment": "Equipment",
+      "appearance": "Appearance",
+      "gender": "Gender",
+      "namePool": "Name pool",
+      "base": "Base",
+      "brain": "Brain",
+      "lootTable": "Loot table",
+      "layer": "Layer",
+      "item": "Item",
+      "anyGender": "Any"
     }
   },
   "characters": {

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -159,7 +159,8 @@
       "plugins": "Plugins",
       "settings": "Settings",
       "console": "Console",
-      "characters": "Characters"
+      "characters": "Characters",
+      "items": "Items"
     },
     "accounts": {
       "title": "Accounts",
@@ -272,7 +273,34 @@
       "category": "Category",
       "tags": "Tags",
       "graphic": "Graphic",
-      "hue": "Hue"
+      "hue": "Hue",
+      "itemsTitle": "Item Templates",
+      "search": "Search by id, name, category or tag…",
+      "preview": "Preview",
+      "name": "Name",
+      "id": "Id",
+      "empty": "No template matches that search.",
+      "loadFailed": "The templates could not be loaded.",
+      "total": "{{count}} templates",
+      "notFound": "No template with that id.",
+      "back": "Back to templates",
+      "description": "Description",
+      "script": "Script",
+      "movable": "Movable",
+      "stackable": "Stackable",
+      "dyeable": "Dyeable",
+      "visibility": "Visibility",
+      "lootType": "Loot type",
+      "flippable": "Flippable",
+      "lootTables": "Loot tables",
+      "params": "Params",
+      "equip": "Equip",
+      "weapon": "Weapon",
+      "container": "Container",
+      "book": "Book",
+      "yes": "Yes",
+      "no": "No",
+      "noImage": "—"
     }
   },
   "characters": {

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -265,6 +265,14 @@
       "loadFailed": "The characters could not be loaded.",
       "noImage": "—",
       "unknownAccount": "Unknown"
+    },
+    "templates": {
+      "weight": "Weight",
+      "value": "Value",
+      "category": "Category",
+      "tags": "Tags",
+      "graphic": "Graphic",
+      "hue": "Hue"
     }
   },
   "characters": {

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -160,7 +160,8 @@
       "settings": "Impostazioni",
       "console": "Console",
       "characters": "Personaggi",
-      "items": "Oggetti"
+      "items": "Oggetti",
+      "mobiles": "Mobili"
     },
     "accounts": {
       "title": "Account",
@@ -300,7 +301,24 @@
       "book": "Libro",
       "yes": "Sì",
       "no": "No",
-      "noImage": "—"
+      "noImage": "—",
+      "mobilesTitle": "Template mobili",
+      "mobilesSearch": "Cerca per id, nome, titolo, categoria o tag…",
+      "title": "Titolo",
+      "body": "Body",
+      "stats": "For / Des / Int",
+      "variants": "Varianti",
+      "skills": "Abilità",
+      "equipment": "Equipaggiamento",
+      "appearance": "Aspetto",
+      "gender": "Genere",
+      "namePool": "Pool nomi",
+      "base": "Base",
+      "brain": "Brain",
+      "lootTable": "Loot table",
+      "layer": "Layer",
+      "item": "Oggetto",
+      "anyGender": "Qualsiasi"
     }
   },
   "characters": {

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -159,7 +159,8 @@
       "plugins": "Plugin",
       "settings": "Impostazioni",
       "console": "Console",
-      "characters": "Personaggi"
+      "characters": "Personaggi",
+      "items": "Oggetti"
     },
     "accounts": {
       "title": "Account",
@@ -272,7 +273,34 @@
       "category": "Categoria",
       "tags": "Tag",
       "graphic": "Grafica",
-      "hue": "Hue"
+      "hue": "Hue",
+      "itemsTitle": "Template oggetti",
+      "search": "Cerca per id, nome, categoria o tag…",
+      "preview": "Anteprima",
+      "name": "Nome",
+      "id": "Id",
+      "empty": "Nessun template corrisponde alla ricerca.",
+      "loadFailed": "Non è stato possibile caricare i template.",
+      "total": "{{count}} template",
+      "notFound": "Nessun template con questo id.",
+      "back": "Torna ai template",
+      "description": "Descrizione",
+      "script": "Script",
+      "movable": "Spostabile",
+      "stackable": "Impilabile",
+      "dyeable": "Tingibile",
+      "visibility": "Visibilità",
+      "lootType": "Tipo loot",
+      "flippable": "Ribaltabile",
+      "lootTables": "Loot table",
+      "params": "Params",
+      "equip": "Equipaggiamento",
+      "weapon": "Arma",
+      "container": "Contenitore",
+      "book": "Libro",
+      "yes": "Sì",
+      "no": "No",
+      "noImage": "—"
     }
   },
   "characters": {

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -265,6 +265,14 @@
       "loadFailed": "Non è stato possibile caricare i personaggi.",
       "noImage": "—",
       "unknownAccount": "Sconosciuto"
+    },
+    "templates": {
+      "weight": "Peso",
+      "value": "Valore",
+      "category": "Categoria",
+      "tags": "Tag",
+      "graphic": "Grafica",
+      "hue": "Hue"
     }
   },
   "characters": {

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -23,6 +23,7 @@ describe('AdminLayout', () => {
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /characters/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /items/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /mobiles/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /console/i })).toBeInTheDocument()

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -22,6 +22,7 @@ describe('AdminLayout', () => {
     expect(screen.getByRole('link', { name: /overview/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /accounts/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /characters/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /items/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /console/i })).toBeInTheDocument()

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -22,6 +22,9 @@ export function AdminLayout() {
         <NavLink to="/admin/characters" className={linkClass}>
           {t('admin.nav.characters')}
         </NavLink>
+        <NavLink to="/admin/items" className={linkClass}>
+          {t('admin.nav.items')}
+        </NavLink>
         <NavLink to="/admin/plugins" className={linkClass}>
           {t('admin.nav.plugins')}
         </NavLink>

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -25,6 +25,9 @@ export function AdminLayout() {
         <NavLink to="/admin/items" className={linkClass}>
           {t('admin.nav.items')}
         </NavLink>
+        <NavLink to="/admin/mobiles" className={linkClass}>
+          {t('admin.nav.mobiles')}
+        </NavLink>
         <NavLink to="/admin/plugins" className={linkClass}>
           {t('admin.nav.plugins')}
         </NavLink>

--- a/ui/src/routes/admin/ItemTemplateDetailScreen.test.tsx
+++ b/ui/src/routes/admin/ItemTemplateDetailScreen.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+
+import '../../lib/i18n'
+import { ApiError } from '../../lib/api'
+import { ItemTemplateDetailScreen } from './ItemTemplateDetailScreen'
+import type { ItemTemplate } from '../../lib/templates'
+
+const query = vi.hoisted(() => ({
+  data: undefined as ItemTemplate | undefined,
+  isError: false,
+  error: null as unknown,
+  lastId: '' as string,
+}))
+
+vi.mock('../../lib/templates', async (original) => ({
+  ...(await original<typeof import('../../lib/templates')>()),
+  useItemTemplate: (id: string) => {
+    query.lastId = id
+    return query
+  },
+}))
+
+function template(over: Partial<ItemTemplate> = {}): ItemTemplate {
+  return {
+    id: 'plate_mail',
+    name: 'Plate Mail',
+    category: 'armor',
+    description: 'Heavy plate armour.',
+    itemId: 0x1415,
+    hue: 0,
+    rarity: 'Rare',
+    goldValue: 250,
+    weight: 40,
+    scriptId: undefined,
+    isMovable: true,
+    stackable: false,
+    dyeable: true,
+    visibility: 'Visible',
+    lootType: 'Regular',
+    tags: ['armor'],
+    flippableItemIds: [],
+    lootTables: [],
+    params: {},
+    equip: undefined,
+    weapon: undefined,
+    container: undefined,
+    book: undefined,
+    imageUrl: '/api/v1/images/items/0x1415.png',
+    ...over,
+  } as ItemTemplate
+}
+
+function renderAt(id: string, data: ItemTemplate | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isError: false, error: null }, state)
+
+  return render(
+    <MemoryRouter initialEntries={[`/admin/items/${id}`]}>
+      <Routes>
+        <Route path="/admin/items/:id" element={<ItemTemplateDetailScreen />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('ItemTemplateDetailScreen', () => {
+  it('asks for the template named in the route', () => {
+    renderAt('plate_mail', template())
+
+    expect(query.lastId).toBe('plate_mail')
+  })
+
+  it('shows the name, the description and the sprite', () => {
+    renderAt('plate_mail', template())
+
+    expect(screen.getByText('Plate Mail')).toBeInTheDocument()
+    expect(screen.getByText('Heavy plate armour.')).toBeInTheDocument()
+    expect(screen.getByAltText('Plate Mail')).toHaveAttribute('src', '/api/v1/images/items/0x1415.png')
+  })
+
+  it('shows the flags in words', () => {
+    renderAt('plate_mail', template({ isMovable: true, stackable: false }))
+
+    expect(screen.getByText('Movable').nextSibling).toHaveTextContent('Yes')
+    expect(screen.getByText('Stackable').nextSibling).toHaveTextContent('No')
+  })
+
+  // Specs are nullable, and an empty card for a template that has none is noise.
+  it('omits a spec the template does not have', () => {
+    renderAt('plate_mail', template({ weapon: undefined }))
+
+    expect(screen.queryByText('Weapon')).not.toBeInTheDocument()
+  })
+
+  it('shows a spec the template does have', () => {
+    // `layer` is a numeric enum on the equip spec, unlike the string layer a worn item reports.
+    renderAt('plate_mail', template({ equip: { layer: 13 } }))
+
+    expect(screen.getByText('Equip')).toBeInTheDocument()
+  })
+
+  // "No such template" and "the request broke" are different answers, and an id typed by hand makes
+  // the first one common.
+  it('says so when there is no template with that id', () => {
+    renderAt('nope', undefined, { isError: true, error: new ApiError(404, 'not found') })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('No template with that id.')
+  })
+
+  it('falls back to a generic failure for anything else', () => {
+    renderAt('plate_mail', undefined, { isError: true, error: new Error('network') })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The templates could not be loaded.')
+  })
+
+  it('offers the way back to the catalogue', () => {
+    renderAt('plate_mail', template())
+
+    expect(screen.getByRole('link', { name: /back to templates/i })).toHaveAttribute('href', '/admin/items')
+  })
+})

--- a/ui/src/routes/admin/ItemTemplateDetailScreen.tsx
+++ b/ui/src/routes/admin/ItemTemplateDetailScreen.tsx
@@ -1,0 +1,142 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router'
+
+import { Card } from '../../components/ui/card'
+import { RarityBadge, rarityColor } from '../../components/templates/RarityBadge'
+import { ApiError } from '../../lib/api'
+import { useItemTemplate, type ItemTemplate } from '../../lib/templates'
+
+export function ItemTemplateDetailScreen() {
+  const { t } = useTranslation()
+  const { id = '' } = useParams()
+  const template = useItemTemplate(id)
+
+  if (template.isError) {
+    // "No such template" and "the request broke" are different answers, and an id typed by hand
+    // makes the first one common.
+    const key =
+      template.error instanceof ApiError && template.error.status === 404
+        ? 'admin.templates.notFound'
+        : 'admin.templates.loadFailed'
+
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t(key)}
+      </p>
+    )
+  }
+
+  if (template.data === undefined) {
+    return <p className="text-sm text-muted">{t('common.loading')}</p>
+  }
+
+  return <Detail template={template.data} />
+}
+
+function Detail({ template }: { template: ItemTemplate }) {
+  const { t } = useTranslation()
+  const name = template.name === '' ? template.id : template.name
+
+  return (
+    <section className="space-y-4">
+      <Link to="/admin/items" className="text-sm text-muted hover:text-ink">
+        {t('admin.templates.back')}
+      </Link>
+
+      <Card className="gap-4 p-6">
+        <div className="flex items-start gap-4">
+          <img src={template.imageUrl} alt={name} className="h-20 w-20 shrink-0 object-contain" />
+
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold" style={{ color: rarityColor(template.rarity) }}>
+              {name}
+            </h1>
+            <RarityBadge rarity={template.rarity} />
+            {template.description !== '' && <p className="mt-2 text-sm text-muted">{template.description}</p>}
+          </div>
+        </div>
+
+        <dl className="grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+          <Field label={t('admin.templates.id')} value={template.id} />
+          <Field label={t('admin.templates.category')} value={template.category} />
+          <Field label={t('admin.templates.graphic')} value={`0x${template.itemId.toString(16)}`} />
+          <Field label={t('admin.templates.hue')} value={template.hue} />
+          <Field label={t('admin.templates.weight')} value={template.weight} />
+          <Field label={t('admin.templates.value')} value={template.goldValue} />
+          <Field label={t('admin.templates.visibility')} value={template.visibility} />
+          <Field label={t('admin.templates.lootType')} value={template.lootType} />
+          <Field label={t('admin.templates.movable')} value={yesNo(t, template.isMovable)} />
+          <Field label={t('admin.templates.stackable')} value={yesNo(t, template.stackable)} />
+          <Field label={t('admin.templates.dyeable')} value={yesNo(t, template.dyeable)} />
+          {template.scriptId !== null && template.scriptId !== undefined && (
+            <Field label={t('admin.templates.script')} value={template.scriptId} />
+          )}
+          {template.tags.length > 0 && <Field label={t('admin.templates.tags')} value={template.tags.join(', ')} />}
+          {(template.flippableItemIds?.length ?? 0) > 0 && (
+            <Field
+              label={t('admin.templates.flippable')}
+              value={template.flippableItemIds!.map((graphic) => `0x${graphic.toString(16)}`).join(', ')}
+            />
+          )}
+          {(template.lootTables?.length ?? 0) > 0 && (
+            <Field label={t('admin.templates.lootTables')} value={template.lootTables!.join(', ')} />
+          )}
+        </dl>
+      </Card>
+
+      {/* Specs are nullable. A card for one the template does not have is noise. */}
+      <Spec label={t('admin.templates.equip')} spec={template.equip} />
+      <Spec label={t('admin.templates.weapon')} spec={template.weapon} />
+      <Spec label={t('admin.templates.container')} spec={template.container} />
+      <Spec label={t('admin.templates.book')} spec={template.book} />
+      {Object.keys(template.params ?? {}).length > 0 && (
+        <Spec label={t('admin.templates.params')} spec={template.params} />
+      )}
+    </section>
+  )
+}
+
+/**
+ * One spec block, rendered generically from whatever fields it carries. The shapes differ per spec
+ * and grow with the game; naming each field here would mean editing this screen every time one
+ * gains a property.
+ */
+function Spec({ label, spec }: { label: string; spec: unknown }) {
+  if (spec === null || spec === undefined) {
+    return null
+  }
+
+  const entries = Object.entries(spec as Record<string, unknown>).filter(
+    ([, value]) => value !== null && value !== undefined,
+  )
+
+  if (entries.length === 0) {
+    return null
+  }
+
+  return (
+    <Card className="gap-3 p-4">
+      <h2 className="font-bold text-ink">{label}</h2>
+      <dl className="grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+        {entries.map(([key, value]) => (
+          <Field key={key} label={key} value={String(value)} />
+        ))}
+      </dl>
+    </Card>
+  )
+}
+
+function Field({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex justify-between gap-4 border-b border-ink/5 pb-1">
+      <dt className="text-muted">{label}</dt>
+      <dd className="text-right text-ink">{value}</dd>
+    </div>
+  )
+}
+
+/** Several template flags are nullable in the contract; an absent one reads as "no". */
+function yesNo(t: (key: string) => string, value: boolean | null | undefined): string {
+  return value === true ? t('admin.templates.yes') : t('admin.templates.no')
+}

--- a/ui/src/routes/admin/ItemTemplatesScreen.test.tsx
+++ b/ui/src/routes/admin/ItemTemplatesScreen.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+
+import '../../lib/i18n'
+import { TooltipProvider } from '../../components/ui/tooltip'
+import { ItemTemplatesScreen } from './ItemTemplatesScreen'
+import type { ItemTemplatePage, ItemTemplateSummary } from '../../lib/templates'
+
+const query = vi.hoisted(() => ({
+  data: undefined as ItemTemplatePage | undefined,
+  isPending: false,
+  isError: false,
+  lastParams: null as { page: number; search: string } | null,
+}))
+
+vi.mock('../../lib/templates', async (original) => ({
+  ...(await original<typeof import('../../lib/templates')>()),
+  useItemTemplates: (params: { page: number; search: string }) => {
+    query.lastParams = params
+    return query
+  },
+}))
+
+function template(id: string, name: string, over: Partial<ItemTemplateSummary> = {}): ItemTemplateSummary {
+  return {
+    id,
+    name,
+    category: 'armor',
+    itemId: 0x1415,
+    hue: 0,
+    rarity: 'Rare',
+    goldValue: 250,
+    weight: 40,
+    tags: ['armor'],
+    imageUrl: `/api/v1/images/items/0x1415.png`,
+    ...over,
+  } as ItemTemplateSummary
+}
+
+function page(items: ItemTemplateSummary[], over: Partial<ItemTemplatePage> = {}): ItemTemplatePage {
+  return { items, total: items.length, page: 1, pageSize: 25, totalPages: 1, ...over } as ItemTemplatePage
+}
+
+function renderWith(data: ItemTemplatePage | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isPending: false, isError: false }, state)
+
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <ItemTemplatesScreen />
+      </TooltipProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('ItemTemplatesScreen', () => {
+  it('lists the templates', () => {
+    renderWith(page([template('plate_mail', 'Plate Mail'), template('dagger', 'Dagger')]))
+
+    expect(screen.getByText('Plate Mail')).toBeInTheDocument()
+    expect(screen.getByText('Dagger')).toBeInTheDocument()
+  })
+
+  it('shows the sprite the row carries', () => {
+    renderWith(page([template('plate_mail', 'Plate Mail')]))
+
+    expect(screen.getByAltText('Plate Mail')).toHaveAttribute('src', '/api/v1/images/items/0x1415.png')
+  })
+
+  it('links each template to its detail page', () => {
+    renderWith(page([template('plate_mail', 'Plate Mail')]))
+
+    expect(screen.getByRole('link', { name: 'Plate Mail' })).toHaveAttribute('href', '/admin/items/plate_mail')
+  })
+
+  // The search is the server's. If this ever asserts filtered rows instead of the passed-through
+  // term, the screen has started filtering locally and searches a single page.
+  it('hands the typed search to the query', async () => {
+    renderWith(page([template('plate_mail', 'Plate Mail')]))
+
+    await userEvent.type(screen.getByPlaceholderText(/Search by id/), 'dag')
+
+    expect(query.lastParams?.search).toBe('dag')
+  })
+
+  it('asks for the next page', async () => {
+    renderWith(page([template('plate_mail', 'Plate Mail')], { totalPages: 3 }))
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    expect(query.lastParams?.page).toBe(2)
+  })
+
+  // Searching from page 3 would otherwise land on page 3 of a one-page result: an empty table that
+  // reads as "no matches" for a search that in fact matched.
+  it('returns to the first page when the search changes', async () => {
+    renderWith(page([template('plate_mail', 'Plate Mail')], { totalPages: 3 }))
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(query.lastParams?.page).toBe(2)
+
+    await userEvent.type(screen.getByPlaceholderText(/Search by id/), 'd')
+
+    expect(query.lastParams?.page).toBe(1)
+  })
+
+  it('reports the total, which counts every match and not just this page', () => {
+    renderWith(page([template('plate_mail', 'Plate Mail')], { total: 87, totalPages: 4 }))
+
+    expect(screen.getByText('87 templates')).toBeInTheDocument()
+  })
+
+  it('says so when a search matches nothing', () => {
+    renderWith(page([], { total: 0 }))
+
+    expect(screen.getByText('No template matches that search.')).toBeInTheDocument()
+  })
+
+  it('says so when the request failed', () => {
+    renderWith(undefined, { isError: true })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The templates could not be loaded.')
+  })
+
+  // Templates are named by cliloc when they carry no name of their own, and the server already
+  // resolves that — but an empty one must still be reachable.
+  it('falls back to the id for a template with no name', () => {
+    renderWith(page([template('mystery', '')]))
+
+    expect(screen.getByRole('link', { name: 'mystery' })).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/admin/ItemTemplatesScreen.tsx
+++ b/ui/src/routes/admin/ItemTemplatesScreen.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { DataTable } from '../../components/ui/data-table'
+import { ItemTemplateTooltip } from '../../components/templates/ItemTemplateTooltip'
+import { rarityColor } from '../../components/templates/RarityBadge'
+import { useItemTemplates, type ItemTemplateSummary } from '../../lib/templates'
+
+/** What to call a template the server could not name: its id beats an empty cell. */
+const label = (template: ItemTemplateSummary) => (template.name === '' ? template.id : template.name)
+
+export function ItemTemplatesScreen() {
+  const { t } = useTranslation()
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const templates = useItemTemplates({ page, search })
+
+  const columns = useMemo<ColumnDef<ItemTemplateSummary>[]>(
+    () => [
+      {
+        id: 'preview',
+        header: t('admin.templates.preview'),
+        cell: ({ row }) => (
+          <ItemTemplateTooltip template={row.original}>
+            <span
+              tabIndex={0}
+              className="inline-block rounded outline-none focus-visible:ring-2 focus-visible:ring-gold"
+            >
+              <img src={row.original.imageUrl} alt={label(row.original)} className="h-16 w-16 object-contain" />
+            </span>
+          </ItemTemplateTooltip>
+        ),
+      },
+      {
+        accessorKey: 'name',
+        header: t('admin.templates.name'),
+        cell: ({ row }) => (
+          <Link
+            to={`/admin/items/${row.original.id}`}
+            className="font-bold hover:underline"
+            style={{ color: rarityColor(row.original.rarity) }}
+          >
+            {label(row.original)}
+          </Link>
+        ),
+      },
+      { accessorKey: 'id', header: t('admin.templates.id') },
+      { accessorKey: 'category', header: t('admin.templates.category') },
+      { accessorKey: 'weight', header: t('admin.templates.weight') },
+      { accessorKey: 'goldValue', header: t('admin.templates.value') },
+      {
+        id: 'tags',
+        header: t('admin.templates.tags'),
+        cell: ({ row }) => row.original.tags.join(', '),
+      },
+    ],
+    [t],
+  )
+
+  // A new search restarts the paging. Without this, searching from page 3 asks the server for page 3
+  // of a result that may have one page, and the empty table reads as "no matches" for a search that
+  // in fact matched.
+  function changeSearch(value: string) {
+    setSearch(value)
+    setPage(1)
+  }
+
+  if (templates.isError) {
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t('admin.templates.loadFailed')}
+      </p>
+    )
+  }
+
+  const result = templates.data
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-xl text-ink">{t('admin.templates.itemsTitle')}</h1>
+        {result && <span className="text-sm text-muted">{t('admin.templates.total', { count: result.total })}</span>}
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={result?.items ?? []}
+        searchPlaceholder={t('admin.templates.search')}
+        search={{ value: search, onChange: changeSearch }}
+        pagination={{ page, totalPages: result?.totalPages ?? 1, onPageChange: setPage }}
+      />
+
+      {result && result.items.length === 0 && <p className="text-sm text-muted">{t('admin.templates.empty')}</p>}
+    </div>
+  )
+}

--- a/ui/src/routes/admin/MobileTemplateDetailScreen.test.tsx
+++ b/ui/src/routes/admin/MobileTemplateDetailScreen.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+
+import '../../lib/i18n'
+import { ApiError } from '../../lib/api'
+import { MobileTemplateDetailScreen } from './MobileTemplateDetailScreen'
+import type { MobileTemplate } from '../../lib/templates'
+
+const query = vi.hoisted(() => ({
+  data: undefined as MobileTemplate | undefined,
+  isError: false,
+  error: null as unknown,
+  lastId: '' as string,
+}))
+
+vi.mock('../../lib/templates', async (original) => ({
+  ...(await original<typeof import('../../lib/templates')>()),
+  useMobileTemplate: (id: string) => {
+    query.lastId = id
+    return query
+  },
+}))
+
+function template(over: Partial<MobileTemplate> = {}): MobileTemplate {
+  return {
+    id: 'warrior_guard_npc',
+    name: 'a guard',
+    namePool: 'guards',
+    gender: 'Male',
+    title: 'the guard',
+    category: 'npc',
+    description: 'A town guard.',
+    tags: ['npc', 'guard'],
+    baseMobile: 'base_human_npc',
+    strength: 96,
+    dexterity: 70,
+    intelligence: 30,
+    skills: { Swordsmanship: 80 },
+    appearance: {
+      body: 400,
+      skinHue: 'hue(1002:1058)',
+      hairStyle: 8251,
+      hairHue: 'hue(1102:1149)',
+      facialHairStyle: 0,
+      facialHairHue: undefined,
+    },
+    equipment: [{ item: 'plate_chest', layer: 'InnerTorso', hue: undefined }],
+    variants: [
+      {
+        name: 'female',
+        weight: 1,
+        gender: 'Female',
+        namePool: undefined,
+        lootTableId: undefined,
+        appearance: {
+          body: 401,
+          skinHue: undefined,
+          hairStyle: 0,
+          hairHue: undefined,
+          facialHairStyle: 0,
+          facialHairHue: undefined,
+        },
+        equipment: [],
+      },
+    ],
+    lootTableId: 'guard_loot',
+    brainScript: undefined,
+    imageUrl: '/api/v1/images/mobiles/templates/warrior_guard_npc.png',
+    paperdollUrl: '/api/v1/images/mobiles/templates/warrior_guard_npc/paperdoll.png',
+    ...over,
+  } as MobileTemplate
+}
+
+function renderAt(id: string, data: MobileTemplate | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isError: false, error: null }, state)
+
+  return render(
+    <MemoryRouter initialEntries={[`/admin/mobiles/${id}`]}>
+      <Routes>
+        <Route path="/admin/mobiles/:id" element={<MobileTemplateDetailScreen />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('MobileTemplateDetailScreen', () => {
+  it('asks for the template named in the route', () => {
+    renderAt('warrior_guard_npc', template())
+
+    expect(query.lastId).toBe('warrior_guard_npc')
+  })
+
+  it('shows both pictures', () => {
+    renderAt('warrior_guard_npc', template())
+
+    const pictures = screen.getAllByAltText('a guard')
+
+    expect(pictures.map((picture) => picture.getAttribute('src'))).toEqual([
+      '/api/v1/images/mobiles/templates/warrior_guard_npc.png',
+      '/api/v1/images/mobiles/templates/warrior_guard_npc/paperdoll.png',
+    ])
+  })
+
+  it('shows the skills and the equipment', () => {
+    renderAt('warrior_guard_npc', template())
+
+    expect(screen.getByText('Swordsmanship')).toBeInTheDocument()
+    expect(screen.getByText('plate_chest')).toBeInTheDocument()
+  })
+
+  it('shows each variant with its own body', () => {
+    renderAt('warrior_guard_npc', template())
+
+    expect(screen.getByText('female')).toBeInTheDocument()
+    expect(screen.getByText('401')).toBeInTheDocument()
+  })
+
+  // Hues are specs — a range resolved per spawn — and must survive to the screen intact.
+  it('shows a hue spec verbatim', () => {
+    renderAt('warrior_guard_npc', template())
+
+    expect(screen.getByText('hue(1002:1058)')).toBeInTheDocument()
+  })
+
+  // Null gender means the template lets a spawn pick, which is not the same as male.
+  it('says a template fixes no gender', () => {
+    renderAt('base_human_npc', template({ gender: undefined }))
+
+    expect(screen.getAllByText('Any').length).toBeGreaterThan(0)
+  })
+
+  // Many spawn templates carry no name of their own: a spawn draws one from a pool.
+  it('falls back to the id when the template has no name', () => {
+    renderAt('base_human_npc', template({ id: 'base_human_npc', name: '' }))
+
+    expect(screen.getByRole('heading', { name: 'base_human_npc' })).toBeInTheDocument()
+  })
+
+  it('says so when there is no template with that id', () => {
+    renderAt('nope', undefined, { isError: true, error: new ApiError(404, 'not found') })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('No template with that id.')
+  })
+
+  it('offers the way back to the catalogue', () => {
+    renderAt('warrior_guard_npc', template())
+
+    expect(screen.getByRole('link', { name: /back to templates/i })).toHaveAttribute('href', '/admin/mobiles')
+  })
+})

--- a/ui/src/routes/admin/MobileTemplateDetailScreen.tsx
+++ b/ui/src/routes/admin/MobileTemplateDetailScreen.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link, useParams } from 'react-router'
+
+import { Card } from '../../components/ui/card'
+import { ApiError } from '../../lib/api'
+import { useMobileTemplate, type MobileTemplate } from '../../lib/templates'
+
+type Appearance = MobileTemplate['appearance']
+type Equipment = MobileTemplate['equipment']
+type Variant = MobileTemplate['variants'][number]
+
+export function MobileTemplateDetailScreen() {
+  const { t } = useTranslation()
+  const { id = '' } = useParams()
+  const template = useMobileTemplate(id)
+
+  if (template.isError) {
+    const key =
+      template.error instanceof ApiError && template.error.status === 404
+        ? 'admin.templates.notFound'
+        : 'admin.templates.loadFailed'
+
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t(key)}
+      </p>
+    )
+  }
+
+  if (template.data === undefined) {
+    return <p className="text-sm text-muted">{t('common.loading')}</p>
+  }
+
+  return <Detail template={template.data} />
+}
+
+function Detail({ template }: { template: MobileTemplate }) {
+  const { t } = useTranslation()
+  const name = template.name === '' ? template.id : template.name
+
+  return (
+    <section className="space-y-4">
+      <Link to="/admin/mobiles" className="text-sm text-muted hover:text-ink">
+        {t('admin.templates.back')}
+      </Link>
+
+      <Card className="gap-4 p-6">
+        <div className="flex items-start gap-4">
+          <img src={template.imageUrl} alt={name} className="h-24 w-20 shrink-0 object-contain" />
+          <img src={template.paperdollUrl} alt={name} className="h-40 w-32 shrink-0 object-contain" />
+
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold text-ink">{name}</h1>
+            {template.title !== '' && <p className="text-sm text-muted">{template.title}</p>}
+            {template.description !== '' && <p className="mt-2 text-sm text-muted">{template.description}</p>}
+          </div>
+        </div>
+
+        <dl className="grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+          <Field label={t('admin.templates.id')} value={template.id} />
+          <Field label={t('admin.templates.category')} value={template.category} />
+          {/* Null means the template lets a spawn pick, which is not the same as male. */}
+          <Field label={t('admin.templates.gender')} value={template.gender ?? t('admin.templates.anyGender')} />
+          {template.namePool !== '' && <Field label={t('admin.templates.namePool')} value={template.namePool} />}
+          {template.baseMobile && <Field label={t('admin.templates.base')} value={template.baseMobile} />}
+          <Field
+            label={t('admin.templates.stats')}
+            value={`${template.strength} / ${template.dexterity} / ${template.intelligence}`}
+          />
+          {template.lootTableId && <Field label={t('admin.templates.lootTable')} value={template.lootTableId} />}
+          {template.brainScript && <Field label={t('admin.templates.brain')} value={template.brainScript} />}
+          {template.tags.length > 0 && <Field label={t('admin.templates.tags')} value={template.tags.join(', ')} />}
+        </dl>
+      </Card>
+
+      <Card className="gap-3 p-4">
+        <h2 className="font-bold text-ink">{t('admin.templates.appearance')}</h2>
+        <AppearanceFields appearance={template.appearance} />
+      </Card>
+
+      {Object.keys(template.skills).length > 0 && (
+        <Card className="gap-3 p-4">
+          <h2 className="font-bold text-ink">{t('admin.templates.skills')}</h2>
+          <dl className="grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+            {Object.entries(template.skills).map(([skill, value]) => (
+              <Field key={skill} label={skill} value={value} />
+            ))}
+          </dl>
+        </Card>
+      )}
+
+      {template.equipment.length > 0 && (
+        <Card className="gap-3 p-4">
+          <h2 className="font-bold text-ink">{t('admin.templates.equipment')}</h2>
+          <EquipmentList equipment={template.equipment} />
+        </Card>
+      )}
+
+      {template.variants.map((variant) => (
+        <VariantCard key={variant.name} variant={variant} />
+      ))}
+    </section>
+  )
+}
+
+function VariantCard({ variant }: { variant: Variant }) {
+  const { t } = useTranslation()
+
+  return (
+    <Card className="gap-3 p-4">
+      <h2 className="font-bold text-ink">
+        {variant.name}
+        <span className="ml-2 text-xs font-normal text-muted">
+          {t('admin.templates.weight')} {variant.weight}
+        </span>
+      </h2>
+
+      <dl className="grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+        <Field label={t('admin.templates.gender')} value={variant.gender ?? t('admin.templates.anyGender')} />
+        {variant.namePool && <Field label={t('admin.templates.namePool')} value={variant.namePool} />}
+        {variant.lootTableId && <Field label={t('admin.templates.lootTable')} value={variant.lootTableId} />}
+      </dl>
+
+      <AppearanceFields appearance={variant.appearance} />
+      {variant.equipment.length > 0 && <EquipmentList equipment={variant.equipment} />}
+    </Card>
+  )
+}
+
+/**
+ * The hues are specs, not numbers — `hue(1002:1058)` is a range resolved once per spawn — so they
+ * are shown verbatim rather than parsed into something that would lose the range.
+ */
+function AppearanceFields({ appearance }: { appearance: Appearance }) {
+  const { t } = useTranslation()
+
+  return (
+    <dl className="grid gap-x-8 gap-y-2 text-sm sm:grid-cols-2">
+      <Field label={t('admin.templates.body')} value={appearance.body} />
+      {appearance.skinHue && <Field label="Skin hue" value={appearance.skinHue} />}
+      {appearance.hairStyle > 0 && <Field label="Hair style" value={appearance.hairStyle} />}
+      {appearance.hairHue && <Field label="Hair hue" value={appearance.hairHue} />}
+      {appearance.facialHairStyle > 0 && <Field label="Facial hair" value={appearance.facialHairStyle} />}
+      {appearance.facialHairHue && <Field label="Facial hair hue" value={appearance.facialHairHue} />}
+    </dl>
+  )
+}
+
+function EquipmentList({ equipment }: { equipment: Equipment }) {
+  return (
+    <ul className="flex flex-col text-sm">
+      {equipment.map((worn) => (
+        <li key={`${worn.layer}-${worn.item}`} className="flex justify-between gap-4 border-b border-ink/5 py-1">
+          <span className="text-muted">{worn.layer}</span>
+          <span className="text-ink">
+            {worn.item}
+            {worn.hue && <span className="ml-2 text-xs text-muted">{worn.hue}</span>}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function Field({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex justify-between gap-4 border-b border-ink/5 pb-1">
+      <dt className="text-muted">{label}</dt>
+      <dd className="text-right text-ink">{value}</dd>
+    </div>
+  )
+}

--- a/ui/src/routes/admin/MobileTemplatesScreen.test.tsx
+++ b/ui/src/routes/admin/MobileTemplatesScreen.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+
+import '../../lib/i18n'
+import { TooltipProvider } from '../../components/ui/tooltip'
+import { MobileTemplatesScreen } from './MobileTemplatesScreen'
+import type { MobileTemplatePage, MobileTemplateSummary } from '../../lib/templates'
+
+const query = vi.hoisted(() => ({
+  data: undefined as MobileTemplatePage | undefined,
+  isPending: false,
+  isError: false,
+  lastParams: null as { page: number; search: string } | null,
+}))
+
+vi.mock('../../lib/templates', async (original) => ({
+  ...(await original<typeof import('../../lib/templates')>()),
+  useMobileTemplates: (params: { page: number; search: string }) => {
+    query.lastParams = params
+    return query
+  },
+}))
+
+function template(id: string, name: string, over: Partial<MobileTemplateSummary> = {}): MobileTemplateSummary {
+  return {
+    id,
+    name,
+    title: 'the guard',
+    category: 'npc',
+    tags: ['npc'],
+    body: 400,
+    strength: 96,
+    dexterity: 70,
+    intelligence: 30,
+    variantCount: 2,
+    imageUrl: `/api/v1/images/mobiles/templates/${id}.png`,
+    ...over,
+  } as MobileTemplateSummary
+}
+
+function page(items: MobileTemplateSummary[], over: Partial<MobileTemplatePage> = {}): MobileTemplatePage {
+  return { items, total: items.length, page: 1, pageSize: 25, totalPages: 1, ...over } as MobileTemplatePage
+}
+
+function renderWith(data: MobileTemplatePage | undefined, state: Partial<typeof query> = {}) {
+  Object.assign(query, { data, isPending: false, isError: false }, state)
+
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <MobileTemplatesScreen />
+      </TooltipProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('MobileTemplatesScreen', () => {
+  it('lists the templates', () => {
+    renderWith(page([template('warrior_guard', 'a guard'), template('brigand', 'a brigand')]))
+
+    expect(screen.getByText('a guard')).toBeInTheDocument()
+    expect(screen.getByText('a brigand')).toBeInTheDocument()
+  })
+
+  it('shows the sprite the row carries', () => {
+    renderWith(page([template('warrior_guard', 'a guard')]))
+
+    expect(screen.getByAltText('a guard')).toHaveAttribute('src', '/api/v1/images/mobiles/templates/warrior_guard.png')
+  })
+
+  it('links each template to its detail page', () => {
+    renderWith(page([template('warrior_guard', 'a guard')]))
+
+    expect(screen.getByRole('link', { name: 'a guard' })).toHaveAttribute('href', '/admin/mobiles/warrior_guard')
+  })
+
+  // The search is the server's. If this ever asserts filtered rows instead of the passed-through
+  // term, the screen has started filtering locally and searches a single page.
+  it('hands the typed search to the query', async () => {
+    renderWith(page([template('warrior_guard', 'a guard')]))
+
+    await userEvent.type(screen.getByPlaceholderText(/Search by id, name, title/), 'bri')
+
+    expect(query.lastParams?.search).toBe('bri')
+  })
+
+  it('asks for the next page', async () => {
+    renderWith(page([template('warrior_guard', 'a guard')], { totalPages: 3 }))
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    expect(query.lastParams?.page).toBe(2)
+  })
+
+  // Searching from page 3 would otherwise land on page 3 of a one-page result: an empty table that
+  // reads as "no matches" for a search that in fact matched.
+  it('returns to the first page when the search changes', async () => {
+    renderWith(page([template('warrior_guard', 'a guard')], { totalPages: 3 }))
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(query.lastParams?.page).toBe(2)
+
+    await userEvent.type(screen.getByPlaceholderText(/Search by id, name, title/), 'd')
+
+    expect(query.lastParams?.page).toBe(1)
+  })
+
+  it('reports the total, which counts every match and not just this page', () => {
+    renderWith(page([template('warrior_guard', 'a guard')], { total: 87, totalPages: 4 }))
+
+    expect(screen.getByText('87 templates')).toBeInTheDocument()
+  })
+
+  it('says so when a search matches nothing', () => {
+    renderWith(page([], { total: 0 }))
+
+    expect(screen.getByText('No template matches that search.')).toBeInTheDocument()
+  })
+
+  it('says so when the request failed', () => {
+    renderWith(undefined, { isError: true })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The templates could not be loaded.')
+  })
+
+  // Many spawn templates carry no name of their own — a spawn draws one from a pool — so the id is
+  // the only label there is. Real data has several.
+  it('falls back to the id for a template with no name', () => {
+    renderWith(page([template('base_human_npc', '')]))
+
+    expect(screen.getByRole('link', { name: 'base_human_npc' })).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/admin/MobileTemplatesScreen.tsx
+++ b/ui/src/routes/admin/MobileTemplatesScreen.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { DataTable } from '../../components/ui/data-table'
+import { MobileTemplateTooltip, mobileTemplateLabel } from '../../components/templates/MobileTemplateTooltip'
+import { useMobileTemplates, type MobileTemplateSummary } from '../../lib/templates'
+
+export function MobileTemplatesScreen() {
+  const { t } = useTranslation()
+  const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const templates = useMobileTemplates({ page, search })
+
+  const columns = useMemo<ColumnDef<MobileTemplateSummary>[]>(
+    () => [
+      {
+        id: 'preview',
+        header: t('admin.templates.preview'),
+        cell: ({ row }) => (
+          <MobileTemplateTooltip template={row.original}>
+            <span
+              tabIndex={0}
+              className="inline-block rounded outline-none focus-visible:ring-2 focus-visible:ring-gold"
+            >
+              <img
+                src={row.original.imageUrl}
+                alt={mobileTemplateLabel(row.original)}
+                className="h-16 w-12 object-contain"
+              />
+            </span>
+          </MobileTemplateTooltip>
+        ),
+      },
+      {
+        accessorKey: 'name',
+        header: t('admin.templates.name'),
+        cell: ({ row }) => (
+          <Link to={`/admin/mobiles/${row.original.id}`} className="font-bold text-gold hover:underline">
+            {mobileTemplateLabel(row.original)}
+          </Link>
+        ),
+      },
+      { accessorKey: 'title', header: t('admin.templates.title') },
+      { accessorKey: 'category', header: t('admin.templates.category') },
+      { accessorKey: 'body', header: t('admin.templates.body') },
+      {
+        id: 'stats',
+        header: t('admin.templates.stats'),
+        cell: ({ row }) => `${row.original.strength} / ${row.original.dexterity} / ${row.original.intelligence}`,
+      },
+      { accessorKey: 'variantCount', header: t('admin.templates.variants') },
+    ],
+    [t],
+  )
+
+  // A new search restarts the paging, so searching from page 3 cannot land on page 3 of a one-page
+  // result and read as "no matches" for a search that matched.
+  function changeSearch(value: string) {
+    setSearch(value)
+    setPage(1)
+  }
+
+  if (templates.isError) {
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t('admin.templates.loadFailed')}
+      </p>
+    )
+  }
+
+  const result = templates.data
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-xl text-ink">{t('admin.templates.mobilesTitle')}</h1>
+        {result && <span className="text-sm text-muted">{t('admin.templates.total', { count: result.total })}</span>}
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={result?.items ?? []}
+        searchPlaceholder={t('admin.templates.mobilesSearch')}
+        search={{ value: search, onChange: changeSearch }}
+        pagination={{ page, totalPages: result?.totalPages ?? 1, onPageChange: setPage }}
+      />
+
+      {result && result.items.length === 0 && <p className="text-sm text-muted">{t('admin.templates.empty')}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
First of two PRs for #177. **Frontend only** — no C#, no contract regeneration, no packet docs.

`/api/v1/admin/items/templates` has been paged and searchable since it was written and nothing looked at it. The shard carries **1665** item templates.

## The screens

`/admin/items` lists them with the sprite, a rarity-coloured name, id, category, weight, value and tags, driven by the `DataTable` that learned server-side search and paging in #169. `/admin/items/:id` shows one in full.

A new search **resets the page to 1** — otherwise searching from page 3 asks for page 3 of a one-page result, and the empty table reads as "no matches" for a search that matched.

## The hover card does not fetch

Copying the item tooltip from #175 would have been wrong. That one fetches because an item's property list lives on the game loop and is not in the row. A template summary already carries everything the card shows, so it renders from the row in hand. **A test renders it with no `QueryClientProvider`**, so adding a fetch there breaks loudly.

## What of the old portal did not come across

`moongate-next_old` had 26 components here, including **forms**. Templates are read-only over this API on purpose — only `get` is mapped — because they are born from YAML and reloaded at startup, so a REST write would diverge until the next restart. No forms, and no picker dialogs either, since they existed to fill form fields.

Its rarity map was ported as an idea rather than as code: it lacked **Artifact**, which is in the server's enum and appears in the real data. The lookup falls back rather than assuming a closed set, and `Common` takes the ink token because Wowhead paints it white, which vanishes on the light theme.

## Detail screen specs

Each of equip / weapon / container / book renders **generically** from whatever fields it carries, and is omitted when the template has none. Naming the fields would mean editing this screen every time a spec grows a property.

## Checks

- UI **321 passed**, build and Prettier clean.
- Verified against a running shard: the endpoint reports 1665 templates with their sprites and rarities.

Several contract fields turned out nullable where my fixtures assumed otherwise — `lootTables`, `flippableItemIds`, the boolean flags, and `equip.layer` is a numeric enum rather than a string. The typecheck caught every one; the tests could not.

## Next

Phase B — the mobile template endpoints, which do not exist, and its screen.