### PR TITLE
docs(api): restore the paragraph breaks in two endpoint remarks

### DIFF
--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/CharacterDetailEndpoints.cs
@@ -39,11 +39,12 @@ public sealed class CharacterDetailEndpoints : IApiEndpointRegistration
     /// The serial takes the form the rest of the API reports, <c>0x40000001</c>, or plain decimal. An
     /// account may read its own characters; staff may read anyone's, and everyone else gets 403. A
     /// serial naming no character is 404, and so is one that is not a number.
-    /// The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the
-    /// worn items by layer, the backpack and the bank box among them, without expanding them. Skills
-    /// are the ones the character has, by name, in points rather than the tenths the entity stores.
-    /// Read off the game loop, so an item the loop moves mid-read may appear in neither place or in
-    /// both. The next request settles it: this is a view, not a ledger.
+    /// - The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists
+    /// the worn items by layer, the backpack and the bank box among them, without expanding them.
+    /// - Skills are the ones the character has, by name, in points rather than the tenths the entity
+    /// stores.
+    /// - Read off the game loop, so an item the loop moves mid-read may appear in neither place or
+    /// in both. The next request settles it: this is a view, not a ledger.
     /// </remarks>
     private IResult GetOne(string serial, ClaimsPrincipal user)
     {

--- a/plugins/Moongate.Http.Plugin/Endpoints/Characters/ItemTooltipEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Characters/ItemTooltipEndpoints.cs
@@ -75,11 +75,11 @@ public sealed class ItemTooltipEndpoints : IApiEndpointRegistration
     /// The lines are the object property list the game client renders, resolved to text — the item's
     /// name, its weight, and whatever else the shard describes. A shard whose string table is not
     /// loaded gets an **empty** list rather than an error: the technical fields are still worth having.
-    /// The route is nested under the character because an item knows its container, not whose it is.
-    /// Authorization is the character's — an account reads its own, staff read anyone's — and the item
-    /// must actually be in that character's equipment or backpack, so a serial cannot be probed here.
-    /// Answers 503 when the game loop does not respond: the property list is built on the loop, whose
-    /// cache is deliberately unsynchronized.
+    /// - The route is nested under the character because an item knows its container, not whose it
+    /// is. Authorization is the character's — an account reads its own, staff read anyone's — and the
+    /// item must actually be in that character's equipment or backpack, so a serial cannot be probed.
+    /// - Answers 503 when the game loop does not respond: the property list is built on the loop,
+    /// whose cache is deliberately unsynchronized.
     /// </remarks>
     private async Task<IResult> GetTooltip(string serial, string itemSerial, ClaimsPrincipal user)
     {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -307,7 +307,7 @@
           "characters"
         ],
         "summary": "One character in full: stats, appearance, what they wear and what they carry.",
-        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An\naccount may read its own characters; staff may read anyone's, and everyone else gets 403. A\nserial naming no character is 404, and so is one that is not a number.\nThe backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the\nworn items by layer, the backpack and the bank box among them, without expanding them. Skills\nare the ones the character has, by name, in points rather than the tenths the entity stores.\nRead off the game loop, so an item the loop moves mid-read may appear in neither place or in\nboth. The next request settles it: this is a view, not a ledger.",
+        "description": "The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An\naccount may read its own characters; staff may read anyone's, and everyone else gets 403. A\nserial naming no character is 404, and so is one that is not a number.\n- The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists\nthe worn items by layer, the backpack and the bank box among them, without expanding them.\n- Skills are the ones the character has, by name, in points rather than the tenths the entity\nstores.\n- Read off the game loop, so an item the loop moves mid-read may appear in neither place or\nin both. The next request settles it: this is a view, not a ledger.",
         "operationId": "GetCharacter",
         "parameters": [
           {
@@ -339,7 +339,7 @@
           "characters"
         ],
         "summary": "What the game says about one item the character is carrying or wearing.",
-        "description": "The lines are the object property list the game client renders, resolved to text — the item's\nname, its weight, and whatever else the shard describes. A shard whose string table is not\nloaded gets an **empty** list rather than an error: the technical fields are still worth having.\nThe route is nested under the character because an item knows its container, not whose it is.\nAuthorization is the character's — an account reads its own, staff read anyone's — and the item\nmust actually be in that character's equipment or backpack, so a serial cannot be probed here.\nAnswers 503 when the game loop does not respond: the property list is built on the loop, whose\ncache is deliberately unsynchronized.",
+        "description": "The lines are the object property list the game client renders, resolved to text — the item's\nname, its weight, and whatever else the shard describes. A shard whose string table is not\nloaded gets an **empty** list rather than an error: the technical fields are still worth having.\n- The route is nested under the character because an item knows its container, not whose it\nis. Authorization is the character's — an account reads its own, staff read anyone's — and the\nitem must actually be in that character's equipment or backpack, so a serial cannot be probed.\n- Answers 503 when the game loop does not respond: the property list is built on the loop,\nwhose cache is deliberately unsynchronized.",
         "operationId": "GetItemTooltip",
         "parameters": [
           {

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -185,11 +185,12 @@ export interface paths {
          * @description The serial takes the form the rest of the API reports, `0x40000001`, or plain decimal. An
          *     account may read its own characters; staff may read anyone's, and everyone else gets 403. A
          *     serial naming no character is 404, and so is one that is not a number.
-         *     The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists the
-         *     worn items by layer, the backpack and the bank box among them, without expanding them. Skills
-         *     are the ones the character has, by name, in points rather than the tenths the entity stores.
-         *     Read off the game loop, so an item the loop moves mid-read may appear in neither place or in
-         *     both. The next request settles it: this is a view, not a ledger.
+         *     - The backpack is a tree: nested containers are expanded, to a depth of 10. Equipment lists
+         *     the worn items by layer, the backpack and the bank box among them, without expanding them.
+         *     - Skills are the ones the character has, by name, in points rather than the tenths the entity
+         *     stores.
+         *     - Read off the game loop, so an item the loop moves mid-read may appear in neither place or
+         *     in both. The next request settles it: this is a view, not a ledger.
          */
         get: operations["GetCharacter"];
         put?: never;
@@ -212,11 +213,11 @@ export interface paths {
          * @description The lines are the object property list the game client renders, resolved to text — the item's
          *     name, its weight, and whatever else the shard describes. A shard whose string table is not
          *     loaded gets an **empty** list rather than an error: the technical fields are still worth having.
-         *     The route is nested under the character because an item knows its container, not whose it is.
-         *     Authorization is the character's — an account reads its own, staff read anyone's — and the item
-         *     must actually be in that character's equipment or backpack, so a serial cannot be probed here.
-         *     Answers 503 when the game loop does not respond: the property list is built on the loop, whose
-         *     cache is deliberately unsynchronized.
+         *     - The route is nested under the character because an item knows its container, not whose it
+         *     is. Authorization is the character's — an account reads its own, staff read anyone's — and the
+         *     item must actually be in that character's equipment or backpack, so a serial cannot be probed.
+         *     - Answers 503 when the game loop does not respond: the property list is built on the loop,
+         *     whose cache is deliberately unsynchronized.
          */
         get: operations["GetItemTooltip"];
         put?: never;


### PR DESCRIPTION
The 2026-08-02 reformat deleted the blank `///` lines inside two `<remarks>`, so three distinct facts in each of `GetCharacter` and `GetItemTooltip` ran together into a single block on the published reference. Both are routes written this week, and their remarks are the only multi-paragraph ones on the API.

## Two obvious repairs do not work

I tried both rather than assuming:

| attempt | result |
|---|---|
| `<para>` tags | Swashbuckle emits **no `description` key at all** — strictly worse than a run-on paragraph |
| blank `///` lines | exactly what the formatter deleted; and two of them collapse to one newline anyway |

## What does work

A **bullet list**. The marker is a real character no formatter strips, and in CommonMark a bullet list interrupts a paragraph — so the blocks separate whether or not a blank line precedes them.

Verified the formatter-proofness directly: deleted the blank lines by hand, regenerated, and confirmed the markers and the separation survive.

## Checks

Build clean, DocFX **0 warnings**, contract regenerated.
