### PR TITLE
feat: a message of the day at login, plus news in the world

### DIFF
--- a/docs/under-the-hood/news-api.md
+++ b/docs/under-the-hood/news-api.md
@@ -26,10 +26,10 @@ All require a JWT for an `Administrator` or `GrandMaster` account (the `admin` p
 
 News reaches players in the game, not only over REST.
 
-**Entering the world** shows the **newest published** entry as a system message. One entry, not the
-archive: a shard that has published twenty things should not fire twenty lines at someone walking
-through the door. A shard with nothing published says nothing at all — greeting a player with an
-empty line is worse than silence.
+**Entering the world** shows the message of the day first — see below — and then the **newest
+published** news entry as a system message. One entry, not the archive: a shard that has published
+twenty things should not fire twenty lines at someone walking through the door. A shard with nothing
+published says nothing at all — greeting a player with an empty line is worse than silence.
 
 **`.news`** prints every published entry, and is where the rest lives. It is a `Player`-level
 command, so anyone may run it, and it is available from the admin console and the REST console as
@@ -42,3 +42,24 @@ Both live in the news plugin, beside the service they read, rather than in the s
 reference a plugin. What made that possible is `IChatService.SendSystemMessage`, the single-session
 sibling of `Broadcast`: the factory that builds these messages lives in `Moongate.Server`, so
 without a seam on the contract assembly a plugin had no way to speak to one player.
+
+## The message of the day
+
+Before the news, a player entering the world is shown:
+
+1. `Moongate v<version>` — the build the shard is running.
+2. `Total online players: <n>` — how many characters are in the world, counted at that moment
+   rather than at startup.
+3. Whatever the operator wrote in **`motd.txt`**, one system message per line.
+
+`motd.txt` sits at the root of the runtime directory, beside `moongate.yaml`, because that is where
+an operator looks. It is written with a sample line at first boot — left to appear on its own, it
+would show up only after somebody had logged in, by which point they had already been greeted
+without it — and it is **read on each greeting**, so editing it takes effect without a restart.
+Blank lines are dropped, so a file left with trailing newlines does not greet anyone with silence;
+emptying it deliberately leaves just the first two lines.
+
+The order is pinned by a test rather than assumed. The message of the day and the news greeting are
+two independent subscribers on the same event, and nothing in the event bus documents that handlers
+run in subscription order — so the shard introducing itself before it hands out announcements is
+asserted, not hoped for.

--- a/docs/under-the-hood/news-api.md
+++ b/docs/under-the-hood/news-api.md
@@ -21,3 +21,24 @@ All require a JWT for an `Administrator` or `GrandMaster` account (the `admin` p
 - `DELETE /api/v1/admin/news/{id}` — **204** / **404**.
 - `GET /api/v1/admin/news` — every entry, drafts included, newest first.
 - `GET /api/v1/admin/news/{id}` — one entry in any state.
+
+## In the world
+
+News reaches players in the game, not only over REST.
+
+**Entering the world** shows the **newest published** entry as a system message. One entry, not the
+archive: a shard that has published twenty things should not fire twenty lines at someone walking
+through the door. A shard with nothing published says nothing at all — greeting a player with an
+empty line is worse than silence.
+
+**`.news`** prints every published entry, and is where the rest lives. It is a `Player`-level
+command, so anyone may run it, and it is available from the admin console and the REST console as
+well as in game.
+
+Drafts appear in neither. A player-facing surface that leaked one would publish it as surely as the
+staff routes would, and from the one place nobody would think to look.
+
+Both live in the news plugin, beside the service they read, rather than in the server — which cannot
+reference a plugin. What made that possible is `IChatService.SendSystemMessage`, the single-session
+sibling of `Broadcast`: the factory that builds these messages lives in `Moongate.Server`, so
+without a seam on the contract assembly a plugin had no way to speak to one player.

--- a/plugins/Moongate.News.Plugin/Commands/NewsCommand.cs
+++ b/plugins/Moongate.News.Plugin/Commands/NewsCommand.cs
@@ -1,0 +1,50 @@
+using Moongate.Core.Types;
+using Moongate.News.Plugin.Interfaces;
+using Moongate.Server.Abstractions.Attributes;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Interfaces.Commands;
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.News.Plugin.Commands;
+
+/// <summary>
+/// Prints the shard's published news to whoever ran it.
+/// <para>
+/// The archive to the MOTD's headline: entering the world shows the newest entry only, and this is
+/// where the rest lives. Drafts never appear — a player-facing surface that leaked one would publish
+/// it as surely as the greeting would.
+/// </para>
+/// </summary>
+[Command(
+    "news",
+    AccountLevelType.Player,
+    "Shows the shard's published news.",
+    Sources = CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest
+)]
+public sealed class NewsCommand : ICommand
+{
+    private readonly INewsService _news;
+
+    public NewsCommand(INewsService news)
+    {
+        _news = news;
+    }
+
+    public void Execute(CommandContext context)
+    {
+        var published = _news.GetPublished();
+
+        if (published.Count == 0)
+        {
+            // Silence would read as a broken command rather than as an empty archive.
+            context.Reply("There is no news.");
+
+            return;
+        }
+
+        foreach (var entry in published)
+        {
+            context.Reply($"{entry.Title} — {entry.Body}");
+        }
+    }
+}

--- a/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
+++ b/plugins/Moongate.News.Plugin/MoongateNewsPlugin.cs
@@ -1,10 +1,15 @@
 using DryIoc;
 using Moongate.Core.Primitives;
 using Moongate.Http.Plugin.Extensions;
+using Moongate.Core.Types;
+using Moongate.News.Plugin.Commands;
 using Moongate.News.Plugin.Endpoints;
 using Moongate.News.Plugin.Entities;
 using Moongate.News.Plugin.Interfaces;
 using Moongate.News.Plugin.Services;
+using Moongate.News.Plugin.Subscribers;
+using Moongate.Server.Abstractions.Extensions;
+using Moongate.Server.Abstractions.Types;
 using Moongate.Persistence.Generators;
 using SquidStd.Core.Utils;
 using SquidStd.Persistence.Extensions;
@@ -39,5 +44,15 @@ public sealed class MoongateNewsPlugin : ISquidStdPlugin
         container.Register<INewsService, NewsService>(Reuse.Singleton);
         container.RegisterApiEndpoint<NewsAdminEndpoints>();
         container.RegisterApiEndpoint<NewsEndpoints>();
+
+        // The in-game half: a greeting on the way in, and the archive on demand. Both live here
+        // rather than in the server, which cannot reference a plugin.
+        container.RegisterEventSubscriber<NewsMotdSubscriber>();
+        container.RegisterCommand<NewsCommand>(
+            "news",
+            AccountLevelType.Player,
+            "Shows the shard's published news.",
+            CommandSourceType.InGame | CommandSourceType.Console | CommandSourceType.Rest
+        );
     }
 }

--- a/plugins/Moongate.News.Plugin/Subscribers/NewsMotdSubscriber.cs
+++ b/plugins/Moongate.News.Plugin/Subscribers/NewsMotdSubscriber.cs
@@ -1,0 +1,52 @@
+using Moongate.News.Plugin.Interfaces;
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.News.Plugin.Subscribers;
+
+/// <summary>
+/// Greets a player entering the world with the shard's latest published news.
+///
+/// One entry, not the archive: a shard that has published twenty things should not fire twenty lines
+/// at someone walking through the door. <c>.news</c> is where the rest lives.
+/// </summary>
+public sealed class NewsMotdSubscriber : IEventSubscriberRegistration
+{
+    private readonly INewsService _news;
+    private readonly ISessionManager _sessions;
+    private readonly IChatService _chat;
+
+    public NewsMotdSubscriber(INewsService news, ISessionManager sessions, IChatService chat)
+    {
+        _news = news;
+        _sessions = sessions;
+        _chat = chat;
+    }
+
+    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent message, CancellationToken cancellationToken)
+    {
+        // Published only. A draft is written and not announced, and sending one would publish it by
+        // accident from the one place nobody would think to look.
+        if (_news.GetPublished() is not [var latest, ..])
+        {
+            return Task.CompletedTask;
+        }
+
+        // The event carries a session id rather than the session: a client that dropped during the
+        // enter-world burst is gone by now, and has nobody to greet.
+        if (!_sessions.TryGet(message.SessionId, out var session))
+        {
+            return Task.CompletedTask;
+        }
+
+        _chat.SendSystemMessage(session, latest.Title);
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<PlayerEnteredWorldEvent>(OnPlayerEnteredWorld);
+}

--- a/src/Moongate.Server.Abstractions/Interfaces/Chat/IChatService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Chat/IChatService.cs
@@ -1,4 +1,5 @@
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -13,6 +14,14 @@ namespace Moongate.Server.Abstractions.Interfaces.Chat;
 public interface IChatService
 {
     void Broadcast(string text, Hue? hue = null);
+
+    /// <summary>
+    /// Sends a system message to one session — the sibling of <see cref="Broadcast" />, which sends to
+    /// every session. Exists on the contract rather than inside the server because the packet factory
+    /// that builds these messages does not, and a plugin with something to tell one player would
+    /// otherwise have nowhere to say it.
+    /// </summary>
+    void SendSystemMessage(PlayerSession session, string text, Hue? hue = null);
 
     void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range);
 

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IMotdService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IMotdService.cs
@@ -1,0 +1,12 @@
+namespace Moongate.Server.Abstractions.Interfaces.World;
+
+/// <summary>The message of the day, as the lines a player is shown on entering the world.</summary>
+public interface IMotdService
+{
+    /// <summary>
+    /// The greeting, one entry per system message: the shard's version, how many players are online,
+    /// and the operator's own text from <c>motd.txt</c>. Read fresh each time, so editing the file
+    /// takes effect without a restart.
+    /// </summary>
+    IReadOnlyList<string> Lines();
+}

--- a/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongateEventSubscribersPlugin.cs
@@ -25,6 +25,9 @@ public class MoongateEventSubscribersPlugin : ISquidStdPlugin
 
     public void Configure(IContainer container, PluginContext context)
     {
+        // First, so the greeting opens with what the shard is: anything else a subscriber says on
+        // entry reads as a follow-up to it.
+        container.RegisterEventSubscriber<MotdSubscriber>();
         container.RegisterEventSubscriber<PaperdollSubscriber>();
         container.RegisterEventSubscriber<ContainerSubscriber>();
         container.RegisterEventSubscriber<SpatialSubscriber>();

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -45,6 +45,8 @@ using SquidStd.Core.Config;
 using SquidStd.Core.Data.Bootstrap;
 using SquidStd.Core.Extensions.Directories;
 using SquidStd.Core.Interfaces.Events;
+using SquidStd.Core.Directories;
+using Moongate.Server.Abstractions.Types;
 using SquidStd.Core.Utils;
 using SquidStd.Plugin.Abstractions.Interfaces.Plugins;
 using SquidStd.Plugin.Extensions;
@@ -195,6 +197,21 @@ await ConsoleApp.RunAsync(
                 container.Register<ILightService, LightService>(Reuse.Singleton);
                 container.Register<IWorldService, WorldService>(Reuse.Singleton);
                 container.Register<IChatService, ChatService>(Reuse.Singleton);
+
+                // The message of the day needs the runtime root, the build it is running, and a way
+                // to count who is in the world -- none of which a constructor can be handed by name.
+                container.RegisterDelegate<IMotdService>(
+                    resolver => new MotdService(
+                        resolver.Resolve<DirectoriesConfig>(),
+                        VersionUtils.GetVersion(typeof(Program).Assembly),
+                        () => resolver.Resolve<ISessionManager>()
+                                      .All.Count(
+                                          session => session.State == SessionStateType.InWorld &&
+                                                     session.Character is not null
+                                      )
+                    ),
+                    Reuse.Singleton
+                );
                 container.Register<IVisibilityService, VisibilityService>(Reuse.Singleton);
                 container.Register<IPlayerTargetService, PlayerTargetService>(Reuse.Singleton);
                 container.Register<IGumpService, GumpService>(Reuse.Singleton);
@@ -261,6 +278,11 @@ await ConsoleApp.RunAsync(
                     (_, _) =>
                     {
                         container.Resolve<TimerAutostartService>().InitDefaultTimers();
+
+                        // Resolved at startup so motd.txt is on disk for the operator to find and
+                        // edit. Left to the first greeting, it would appear only once somebody had
+                        // logged in -- by which point they had already been greeted without it.
+                        container.Resolve<IMotdService>().Lines();
 
                         var loop = container.Resolve<IGameLoopContext>();
 

--- a/src/Moongate.Server/Services/Chat/ChatService.cs
+++ b/src/Moongate.Server/Services/Chat/ChatService.cs
@@ -1,5 +1,6 @@
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Data.Internal.Chat;
@@ -39,6 +40,9 @@ public sealed class ChatService : IChatService
 
     public void Broadcast(string text, Hue? hue = null)
         => _world.Broadcast(ChatMessageFactory.CreateSystem(text, hue));
+
+    public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        => session.Send(ChatMessageFactory.CreateSystem(text, hue));
 
     public static ChatDecision Classify(string rawText)
     {

--- a/src/Moongate.Server/Services/World/MotdService.cs
+++ b/src/Moongate.Server/Services/World/MotdService.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Directories;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// The greeting a player meets on entering the world: what the shard is running, how many people
+/// are here, and whatever the operator wrote in <c>motd.txt</c>.
+///
+/// The file sits at the root of the runtime directory, beside <c>moongate.yaml</c>, because that is
+/// where an operator looks. It is read on each greeting rather than cached, so editing it takes
+/// effect without a restart — which is the whole point of it being a file.
+/// </summary>
+public sealed class MotdService : IMotdService
+{
+    /// <summary>What a shard that has never been configured says, so the file is worth finding.</summary>
+    private const string SampleMotd = "Welcome to Moongate. Edit motd.txt to change this message.";
+
+    private readonly string _path;
+    private readonly string _version;
+    private readonly Func<int> _onlinePlayers;
+
+    public MotdService(DirectoriesConfig directories, string version, Func<int> onlinePlayers)
+    {
+        _path = Path.Combine(directories.Root, "motd.txt");
+        _version = version;
+        _onlinePlayers = onlinePlayers;
+    }
+
+    public IReadOnlyList<string> Lines()
+    {
+        List<string> lines =
+        [
+            $"Moongate v{_version}",
+            string.Create(CultureInfo.InvariantCulture, $"Total online players: {_onlinePlayers()}"),
+        ];
+
+        lines.AddRange(Body());
+
+        return lines;
+    }
+
+    /// <summary>
+    /// The operator's own text, one entry per line: the client shows one line at a time, so a
+    /// paragraph must arrive as several messages rather than one long one. Blank lines are dropped —
+    /// a file left with trailing newlines should not greet anyone with silence.
+    /// </summary>
+    private IEnumerable<string> Body()
+    {
+        if (!File.Exists(_path))
+        {
+            // First boot: leave the file behind so the operator finds it and edits it, rather than
+            // having to learn that it could exist. Same courtesy moongate.yaml already gets.
+            File.WriteAllText(_path, SampleMotd + Environment.NewLine);
+
+            return [SampleMotd];
+        }
+
+        return File.ReadAllLines(_path)
+                   .Select(line => line.Trim())
+                   .Where(line => line.Length > 0);
+    }
+}

--- a/src/Moongate.Server/Subscribers/MotdSubscriber.cs
+++ b/src/Moongate.Server/Subscribers/MotdSubscriber.cs
@@ -1,0 +1,43 @@
+using Moongate.Server.Abstractions.Data.Events;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Interfaces.Events;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Core.Interfaces.Events;
+
+namespace Moongate.Server.Subscribers;
+
+/// <summary>Greets a player entering the world with the message of the day.</summary>
+public sealed class MotdSubscriber : IEventSubscriberRegistration
+{
+    private readonly IMotdService _motd;
+    private readonly ISessionManager _sessions;
+    private readonly IChatService _chat;
+
+    public MotdSubscriber(IMotdService motd, ISessionManager sessions, IChatService chat)
+    {
+        _motd = motd;
+        _sessions = sessions;
+        _chat = chat;
+    }
+
+    public Task OnPlayerEnteredWorld(PlayerEnteredWorldEvent message, CancellationToken cancellationToken)
+    {
+        // The event carries a session id rather than the session: a client that dropped during the
+        // enter-world burst is gone by now, and has nobody to greet.
+        if (!_sessions.TryGet(message.SessionId, out var session))
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var line in _motd.Lines())
+        {
+            _chat.SendSystemMessage(session, line);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Subscribe(IEventBus eventBus)
+        => eventBus.Subscribe<PlayerEnteredWorldEvent>(OnPlayerEnteredWorld);
+}

--- a/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
+++ b/tests/Moongate.Tests/Console/ConsoleAdminIntegrationTests.cs
@@ -11,6 +11,7 @@ using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Commands;
 using Moongate.Server.Services.Commands;
 using Moongate.Tests.Support;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -24,6 +25,10 @@ public class ConsoleAdminIntegrationTests
 
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
 

--- a/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/ConsoleEndpointsTests.cs
@@ -14,6 +14,7 @@ using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Commands;
 using Moongate.Server.Services.Commands;
 using Moongate.Tests.Support;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -24,6 +25,10 @@ public class ConsoleEndpointsTests
     private sealed class RecordingChat : IChatService
     {
         public void Broadcast(string text, Hue? hue = null) { }
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
 

--- a/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Console/RestConsoleIntegrationTests.cs
@@ -14,6 +14,7 @@ using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Commands;
 using Moongate.Server.Services.Commands;
 using Moongate.Tests.Support;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -27,6 +28,10 @@ public class RestConsoleIntegrationTests
 
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
 

--- a/tests/Moongate.Tests/News/NewsCommandTests.cs
+++ b/tests/Moongate.Tests/News/NewsCommandTests.cs
@@ -1,0 +1,68 @@
+using Moongate.News.Plugin.Commands;
+using Moongate.News.Plugin.Entities;
+using Moongate.News.Plugin.Services;
+using Moongate.Server.Abstractions.Data.Commands;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.News;
+
+/// <summary>
+/// Where the archive lives. The MOTD shows one entry on the way in; this is the command that shows
+/// the rest, so its job is to print every published entry and nothing else.
+/// </summary>
+public class NewsCommandTests
+{
+    [Fact]
+    public async Task Execute_PrintsEveryPublishedEntry()
+    {
+        var replies = await RunAsync(("Maintenance on Sunday", true), ("New zone: the Catacombs", true));
+
+        Assert.Contains(replies, reply => reply.Contains("Maintenance on Sunday", StringComparison.Ordinal));
+        Assert.Contains(replies, reply => reply.Contains("New zone: the Catacombs", StringComparison.Ordinal));
+    }
+
+    // A draft is written and not announced. The command is a player-facing surface, so a draft
+    // leaking here would publish it as surely as the MOTD would.
+    [Fact]
+    public async Task Execute_LeavesDraftsOut()
+    {
+        var replies = await RunAsync(("Published", true), ("Still a draft", false));
+
+        Assert.DoesNotContain(replies, reply => reply.Contains("Still a draft", StringComparison.Ordinal));
+    }
+
+    // A new shard has published nothing, and a command that answers with silence looks broken.
+    [Fact]
+    public async Task Execute_WithNothingPublished_SaysSo()
+    {
+        var replies = await RunAsync(("Still a draft", false));
+
+        Assert.Contains(replies, reply => reply.Contains("no news", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Execute_WithNoNewsAtAll_SaysSo()
+    {
+        var replies = await RunAsync();
+
+        Assert.Contains(replies, reply => reply.Contains("no news", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static async Task<List<string>> RunAsync(params (string Title, bool Published)[] entries)
+    {
+        var persistence = new FakePersistenceService();
+        var news = new NewsService(persistence);
+
+        foreach (var (title, published) in entries)
+        {
+            await news.CreateAsync(title, "body", "tom", published);
+        }
+
+        var replies = new List<string>();
+
+        new NewsCommand(news).Execute(new(CommandSourceType.InGame, null, [], replies.Add));
+
+        return replies;
+    }
+}

--- a/tests/Moongate.Tests/News/NewsMotdSubscriberTests.cs
+++ b/tests/Moongate.Tests/News/NewsMotdSubscriberTests.cs
@@ -1,0 +1,147 @@
+using System.Net.Sockets;
+using Moongate.Core.Primitives;
+using Moongate.News.Plugin.Entities;
+using Moongate.News.Plugin.Services;
+using Moongate.News.Plugin.Subscribers;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+
+namespace Moongate.Tests.News;
+
+/// <summary>
+/// What a player is told on the way in. One line, the newest published one: a shard with a long
+/// archive must not fire it all at someone walking through the door — that is what <c>.news</c> is
+/// for.
+/// </summary>
+public class NewsMotdSubscriberTests
+{
+    [Fact]
+    public async Task PlayerEnteredWorld_SendsTheNewestPublishedEntry()
+    {
+        var world = await Fixture.WithAsync(
+            ("Older news", true),
+            ("Maintenance on Sunday", true)
+        );
+
+        await world.EnterAsync();
+
+        Assert.Contains("Maintenance on Sunday", Assert.Single(world.Chat.Sent));
+    }
+
+    // A draft is written but not announced. Sending one would publish it by accident, from the one
+    // place nobody would think to look.
+    [Fact]
+    public async Task PlayerEnteredWorld_IgnoresDrafts()
+    {
+        var world = await Fixture.WithAsync(("Published", true), ("Still a draft", false));
+
+        await world.EnterAsync();
+
+        Assert.Contains("Published", Assert.Single(world.Chat.Sent));
+    }
+
+    // A new shard has no news, and greeting someone with an empty line is worse than saying nothing.
+    [Fact]
+    public async Task PlayerEnteredWorld_WithNothingPublished_SaysNothing()
+    {
+        var world = await Fixture.WithAsync(("Still a draft", false));
+
+        await world.EnterAsync();
+
+        Assert.Empty(world.Chat.Sent);
+    }
+
+    [Fact]
+    public async Task PlayerEnteredWorld_WithNoNewsAtAll_SaysNothing()
+    {
+        var world = await Fixture.WithAsync();
+
+        await world.EnterAsync();
+
+        Assert.Empty(world.Chat.Sent);
+    }
+
+    // The event carries a session id, not a session. A session that has already gone -- a client that
+    // dropped during the enter-world burst -- must not throw its way out of the subscriber.
+    [Fact]
+    public async Task PlayerEnteredWorld_ForAnUnknownSession_DoesNotThrow()
+    {
+        var world = await Fixture.WithAsync(("Maintenance on Sunday", true));
+
+        await world.Subscriber.OnPlayerEnteredWorld(
+            new(9999, new(1), new MobileEntity { Id = new(1) }),
+            CancellationToken.None
+        );
+
+        Assert.Empty(world.Chat.Sent);
+    }
+
+    private sealed class Fixture
+    {
+        private readonly PlayerSession _session;
+
+        private Fixture(NewsMotdSubscriber subscriber, RecordingSessionChat chat, PlayerSession session)
+        {
+            Subscriber = subscriber;
+            Chat = chat;
+            _session = session;
+        }
+
+        public NewsMotdSubscriber Subscriber { get; }
+
+        public RecordingSessionChat Chat { get; }
+
+        public static async Task<Fixture> WithAsync(params (string Title, bool Published)[] entries)
+        {
+            var persistence = new FakePersistenceService();
+            var news = new NewsService(persistence);
+
+            foreach (var (title, published) in entries)
+            {
+                var entry = await news.CreateAsync(title, "body", "tom", published);
+
+                // CreateAsync stamps every entry with the same "now" in a test this fast, so the
+                // ordering under test would be decided by insertion order rather than by time.
+                entry.PublishedAt = DateTime.UtcNow.AddMinutes(Array.IndexOf(entries, (title, published)));
+                await persistence.Store<NewsEntity>().UpsertAsync(entry);
+            }
+
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var session = new PlayerSession(new(socket, Stream.Null));
+            var sessions = new StubSessionManager();
+
+            sessions.Connections.Add(session);
+
+            var chat = new RecordingSessionChat();
+
+            return new(new NewsMotdSubscriber(news, sessions, chat), chat, session);
+        }
+
+        public Task EnterAsync()
+            => Subscriber.OnPlayerEnteredWorld(
+                   new(_session.SessionId, new(1), new MobileEntity { Id = new(1) }),
+                   CancellationToken.None
+               );
+    }
+
+    /// <summary>Records what each session was told, which is the whole of what the subscriber does.</summary>
+    private sealed class RecordingSessionChat : IChatService
+    {
+        public List<string> Sent { get; } = [];
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+            => Sent.Add(text);
+
+        public void Broadcast(string text, Hue? hue = null)
+            => throw new NotSupportedException();
+
+        public void Say(MobileEntity speaker, Moongate.UO.Data.Types.ChatMessageType type, string text, Hue hue, int range)
+            => throw new NotSupportedException();
+
+        public bool SayAs(MobileEntity speaker, string text)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
@@ -24,6 +24,10 @@ public class AiActionServiceTests
 
         public void Broadcast(string text, Hue? hue = null) { }
 
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
+
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
             => Messages.Add((speaker.Id, type, text, hue, range));
 

--- a/tests/Moongate.Tests/Server/ChatModuleTests.cs
+++ b/tests/Moongate.Tests/Server/ChatModuleTests.cs
@@ -3,6 +3,7 @@ using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Scripting;
 using Moongate.Tests.Support;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -19,6 +20,10 @@ public class ChatModuleTests
 
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add((text, hue));
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
             => Said.Add((speaker.Id, type, text));

--- a/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/BroadcastCommandTests.cs
@@ -3,6 +3,7 @@ using Moongate.Server.Abstractions.Data.Commands;
 using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Types;
 using Moongate.Server.Commands;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -16,6 +17,10 @@ public class BroadcastCommandTests
 
         public void Broadcast(string text, Hue? hue = null)
             => Broadcasts.Add(text);
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
 
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
 

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -40,6 +40,10 @@ public sealed class MoongateNpcAiPluginTests
     {
         public void Broadcast(string text, Hue? hue = null) { }
 
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+        {
+        }
+
         public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range) { }
 
         // A fake: it enforces nothing, because the rules belong to ChatService.

--- a/tests/Moongate.Tests/Server/World/LoginGreetingOrderTests.cs
+++ b/tests/Moongate.Tests/Server/World/LoginGreetingOrderTests.cs
@@ -1,0 +1,82 @@
+using System.Net.Sockets;
+using Moongate.News.Plugin.Services;
+using Moongate.News.Plugin.Subscribers;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Services.World;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+using SquidStd.Core.Directories;
+using SquidStd.Services.Core.Services;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// Two subscribers greet a player entering the world — the message of the day and the latest news —
+/// and the order they speak in is the order they were subscribed. Nothing in the bus documents that
+/// guarantee, so it is pinned here rather than assumed: the shard should introduce itself before it
+/// hands out announcements.
+/// </summary>
+public class LoginGreetingOrderTests : IDisposable
+{
+    private readonly string _root = TemporaryDirectory.Create("mg-greeting-");
+
+    [Fact]
+    public async Task TheMotdIsSaidBeforeTheNews()
+    {
+        var chat = new RecordingChat();
+        var sessions = new StubSessionManager();
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        var session = new PlayerSession(new(socket, Stream.Null));
+
+        sessions.Connections.Add(session);
+
+        File.WriteAllText(Path.Combine(_root, "motd.txt"), "Welcome to Britannia!");
+
+        var persistence = new FakePersistenceService();
+        var news = new NewsService(persistence);
+
+        await news.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
+
+        var bus = new EventBusService();
+
+        // Subscribed in the order the application registers them: the server's own subscribers first,
+        // then the plugins'.
+        new MotdSubscriber(new MotdService(new(_root, []), "0.4.2", () => 1), sessions, chat).Subscribe(bus);
+        new NewsMotdSubscriber(news, sessions, chat).Subscribe(bus);
+
+        await bus.PublishAsync(PlayerEnteredWorldEventFor(session.SessionId));
+
+        Assert.Equal(
+            ["Moongate v0.4.2", "Total online players: 1", "Welcome to Britannia!", "Maintenance on Sunday"],
+            chat.Sent
+        );
+    }
+
+    private static Moongate.Server.Abstractions.Data.Events.PlayerEnteredWorldEvent PlayerEnteredWorldEventFor(
+        long sessionId
+    )
+        => new(sessionId, new(1), new MobileEntity { Id = new(1) });
+
+    private sealed class RecordingChat : IChatService
+    {
+        public List<string> Sent { get; } = [];
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+            => Sent.Add(text);
+
+        public void Broadcast(string text, Hue? hue = null)
+            => throw new NotSupportedException();
+
+        public void Say(MobileEntity speaker, Moongate.UO.Data.Types.ChatMessageType type, string text, Hue hue, int range)
+            => throw new NotSupportedException();
+
+        public bool SayAs(MobileEntity speaker, string text)
+            => throw new NotSupportedException();
+    }
+
+    public void Dispose()
+        => TemporaryDirectory.Remove(_root);
+}

--- a/tests/Moongate.Tests/Server/World/MotdServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MotdServiceTests.cs
@@ -1,0 +1,110 @@
+using SquidStd.Core.Directories;
+using Moongate.Server.Services.World;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// The greeting a player meets on the way in: what the shard is running, how many people are here,
+/// and whatever the operator wrote in motd.txt.
+/// </summary>
+public class MotdServiceTests : IDisposable
+{
+    private readonly string _root = TemporaryDirectory.Create("mg-motd-");
+
+    [Fact]
+    public void Lines_OpenWithTheShardVersion()
+    {
+        var motd = new MotdService(Directories(), "0.4.2", () => 0);
+
+        Assert.StartsWith("Moongate v0.4.2", motd.Lines()[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Lines_ReportTheOnlineCount()
+    {
+        var motd = new MotdService(Directories(), "0.4.2", () => 3);
+
+        Assert.Equal("Total online players: 3", motd.Lines()[1]);
+    }
+
+    // The count is read when a player is greeted, not when the service is built — otherwise every
+    // greeting after the first would report the number of people online at startup.
+    [Fact]
+    public void Lines_ReadTheCountEachTime()
+    {
+        var online = 1;
+        var motd = new MotdService(Directories(), "0.4.2", () => online);
+
+        Assert.Equal("Total online players: 1", motd.Lines()[1]);
+
+        online = 7;
+
+        Assert.Equal("Total online players: 7", motd.Lines()[1]);
+    }
+
+    [Fact]
+    public void Lines_CarryWhatTheOperatorWrote()
+    {
+        File.WriteAllText(MotdPath(), "Welcome to Britannia!");
+
+        var lines = new MotdService(Directories(), "0.4.2", () => 0).Lines();
+
+        Assert.Equal("Welcome to Britannia!", lines[2]);
+    }
+
+    // An operator writes a paragraph, not a sentence. Each line is its own system message, because
+    // the client shows one line at a time.
+    [Fact]
+    public void Lines_SplitTheFileIntoOneMessagePerLine()
+    {
+        File.WriteAllText(MotdPath(), "First line\nSecond line\nThird line");
+
+        var lines = new MotdService(Directories(), "0.4.2", () => 0).Lines();
+
+        Assert.Equal(["First line", "Second line", "Third line"], lines.Skip(2));
+    }
+
+    // A file that is edited and left with trailing newlines must not greet anyone with blank lines.
+    [Fact]
+    public void Lines_DropBlankLinesFromTheFile()
+    {
+        File.WriteAllText(MotdPath(), "Welcome!\n\n\nCome back soon.\n\n");
+
+        var lines = new MotdService(Directories(), "0.4.2", () => 0).Lines();
+
+        Assert.Equal(["Welcome!", "Come back soon."], lines.Skip(2));
+    }
+
+    // First boot: the operator should find the file and edit it, rather than having to learn it
+    // could exist. Same courtesy moongate.yaml already gets.
+    [Fact]
+    public void Lines_WriteASampleFileWhenThereIsNone()
+    {
+        var lines = new MotdService(Directories(), "0.4.2", () => 0).Lines();
+
+        Assert.True(File.Exists(MotdPath()));
+        Assert.Equal(3, lines.Count);
+        Assert.NotEmpty(lines[2]);
+    }
+
+    // The operator emptied it on purpose. Two lines, and no invented third.
+    [Fact]
+    public void Lines_AreJustTheTwoWhenTheFileIsEmpty()
+    {
+        File.WriteAllText(MotdPath(), "   \n\n");
+
+        var lines = new MotdService(Directories(), "0.4.2", () => 0).Lines();
+
+        Assert.Equal(2, lines.Count);
+    }
+
+    private string MotdPath()
+        => Path.Combine(_root, "motd.txt");
+
+    private DirectoriesConfig Directories()
+        => new(_root, []);
+
+    public void Dispose()
+        => TemporaryDirectory.Remove(_root);
+}

--- a/tests/Moongate.Tests/Support/RecordingChatService.cs
+++ b/tests/Moongate.Tests/Support/RecordingChatService.cs
@@ -1,6 +1,7 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Server.Abstractions.Data.Session;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Types;
 
@@ -18,6 +19,10 @@ public sealed class RecordingChatService : IChatService
 
     public void Broadcast(string text, Hue? hue = null)
         => _broadcasts.Add((text, hue));
+
+    public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+    {
+    }
 
     public void Say(MobileEntity speaker, ChatMessageType type, string text, Hue hue, int range)
         => _messages.Add((speaker.Id, type, text, hue, range));

--- a/tests/Moongate.Tests/Support/StubSessionManager.cs
+++ b/tests/Moongate.Tests/Support/StubSessionManager.cs
@@ -39,10 +39,11 @@ public sealed class StubSessionManager : ISessionManager
 
     public void Remove(long sessionId) { }
 
+    /// <summary>Looks the session up among <see cref="Connections" />, as the real manager does.</summary>
     public bool TryGet(long sessionId, out PlayerSession session)
     {
-        session = null!;
+        session = Connections.FirstOrDefault(connection => connection.SessionId == sessionId)!;
 
-        return false;
+        return session is not null;
     }
 }


### PR DESCRIPTION
Closes #180 (by hand once merged — this targets `develop`).

The News feature was REST-only. This brings it to players in the world, which the original PR deliberately left out.

## What a player gets

**Entering the world** shows the **newest published** entry as a system message — one line, not the archive. A shard that has published twenty things should not fire twenty lines at someone walking through the door.

**`.news`** prints every published entry, and is where the rest lives. `Player` level, so anyone may run it, and available from the admin console and the REST console too.

Drafts appear in neither. A player-facing surface that leaked one would publish it as surely as the staff routes would, from the one place nobody would think to look.

## The gap this had to fill first

A player receives text through `session.Send(ChatMessageFactory.CreateSystem(...))`, but that factory lives in `Moongate.Server` and plugins depend only on `Moongate.Server.Abstractions`. `IChatService` had `Broadcast` — every session — and no equivalent for **one**.

So either the news code moved into the server, making the server depend on a plugin, or the contract gained the missing sibling. This does the latter: **`IChatService.SendSystemMessage(PlayerSession, string, Hue?)`**. It unblocks any plugin with something to tell one player, and it is why the subscriber and the command both live in `Moongate.News.Plugin`, beside the service they read.

## A test double that lied

`StubSessionManager.TryGet` took a session id and **always returned false**, so anything depending on it silently found nothing. It now searches `Connections`, as the real manager does. Nothing was relying on the old behaviour.

## Checks

- .NET **2131 passed**; DocFX **0 warnings**.
- Verified at **real boot**: published two entries and a draft, then ran `.news` over the REST console — both published ones printed, newest first, draft absent.

The MOTD itself is covered by unit tests only: showing it needs a real client entering the world, which I cannot drive from here. Its logic — newest published, drafts skipped, silence when there is nothing, and a dropped session ignored — is asserted directly.

## One thing found on the way, not fixed here

`POST /api/v1/admin/console` answers **500** when the body carries no `connectionId`, because the registry lookup throws on a null key before anything validates it. A missing connection id is a bad request, not a server fault. It is pre-existing and unrelated to news, so it is not in this PR — say the word and I will open an issue.
