### PR TITLE
feat(news): manage news from the portal, announce one when it goes public

### DIFF
--- a/docs/under-the-hood/news-api.md
+++ b/docs/under-the-hood/news-api.md
@@ -22,6 +22,22 @@ All require a JWT for an `Administrator` or `GrandMaster` account (the `admin` p
 - `GET /api/v1/admin/news` — every entry, drafts included, newest first.
 - `GET /api/v1/admin/news/{id}` — one entry in any state.
 
+## Announced when it goes public
+
+Publishing an entry **broadcasts its title to everyone in the world**. The trigger is the
+transition, not the save: created already published, or a draft flipped to published. Editing
+something already published announces nothing — a typo corrected three times would otherwise be
+three interruptions — and neither does unpublishing. Publishing again after a retraction does
+announce, because the shard is saying it is back on.
+
+The broadcast is **posted to the game loop** rather than sent from the request thread, which is what
+the REST console already does: it reaches every live session, and the calls that touch sessions
+belong on the loop.
+
+The portal manages news at `/admin/news` — every entry including drafts, with create, edit, delete
+and a draft/published switch. The dialog warns before an entry is published for the first time,
+since that is the moment everyone gets interrupted.
+
 ## In the world
 
 News reaches players in the game, not only over REST.

--- a/plugins/Moongate.News.Plugin/Services/NewsService.cs
+++ b/plugins/Moongate.News.Plugin/Services/NewsService.cs
@@ -1,6 +1,8 @@
+using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
 using Moongate.News.Plugin.Entities;
 using Moongate.News.Plugin.Interfaces;
+using Moongate.Server.Abstractions.Interfaces.Chat;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
 
 namespace Moongate.News.Plugin.Services;
@@ -10,9 +12,14 @@ public sealed class NewsService : INewsService
 {
     private readonly IEntityStore<NewsEntity, Serial> _store;
 
-    public NewsService(IPersistenceService persistence)
+    private readonly IChatService _chat;
+    private readonly IGameLoopContext _loop;
+
+    public NewsService(IPersistenceService persistence, IChatService chat, IGameLoopContext loop)
     {
         _store = persistence.GetStore<NewsEntity, Serial>();
+        _chat = chat;
+        _loop = loop;
     }
 
     public async ValueTask<NewsEntity> CreateAsync(
@@ -34,6 +41,8 @@ public sealed class NewsService : INewsService
             UpdatedAt = now
         };
         await _store.UpsertAsync(news, ct);
+
+        Announce(news, wasPublished: false);
 
         return news;
     }
@@ -63,12 +72,35 @@ public sealed class NewsService : INewsService
             return null;
         }
 
+        // Read before the mutation: whether this save PUBLISHES the entry is the difference between
+        // the old state and the new one, and after the assignment the old one is gone.
+        var wasPublished = news.IsPublished;
+
         news.Title = title;
         news.Body = body;
         news.IsPublished = isPublished;
         news.UpdatedAt = DateTime.UtcNow;
         await _store.UpsertAsync(news, ct);
 
+        Announce(news, wasPublished);
+
         return news;
+    }
+
+    /// <summary>
+    /// Tells everyone in the world, but only when the entry has just become public. Editing something
+    /// already published is not news: a typo corrected three times would be three announcements.
+    ///
+    /// Posted to the game loop rather than broadcast from here — this reaches every live session, and
+    /// the calls that touch sessions belong on the loop. It is what the REST console already does.
+    /// </summary>
+    private void Announce(NewsEntity news, bool wasPublished)
+    {
+        if (!news.IsPublished || wasPublished)
+        {
+            return;
+        }
+
+        _loop.Post(() => _chat.Broadcast(news.Title));
     }
 }

--- a/tests/Moongate.Tests/News/NewsAnnouncementTests.cs
+++ b/tests/Moongate.Tests/News/NewsAnnouncementTests.cs
@@ -1,0 +1,153 @@
+using Moongate.News.Plugin.Services;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.Chat;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Hues;
+
+namespace Moongate.Tests.News;
+
+/// <summary>
+/// When the shard interrupts everyone. Publishing is the event worth announcing; editing something
+/// already published is not, or a typo corrected three times becomes three announcements.
+/// </summary>
+public class NewsAnnouncementTests
+{
+    [Fact]
+    public async Task CreatingAPublishedEntry_Announces()
+    {
+        var world = Fixture.Build();
+
+        await world.News.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
+
+        Assert.Contains("Maintenance on Sunday", Assert.Single(world.Chat.Broadcasts));
+    }
+
+    [Fact]
+    public async Task CreatingADraft_SaysNothing()
+    {
+        var world = Fixture.Build();
+
+        await world.News.CreateAsync("Still cooking", "soon", "tom", false);
+
+        Assert.Empty(world.Chat.Broadcasts);
+    }
+
+    [Fact]
+    public async Task PublishingADraft_Announces()
+    {
+        var world = Fixture.Build();
+        var draft = await world.News.CreateAsync("Still cooking", "soon", "tom", false);
+
+        await world.News.UpdateAsync(draft.Id, "Now ready", "here it is", true);
+
+        Assert.Contains("Now ready", Assert.Single(world.Chat.Broadcasts));
+    }
+
+    // The whole reason the trigger is the transition rather than the save: fixing a typo must not
+    // interrupt everyone again.
+    [Fact]
+    public async Task EditingAnAlreadyPublishedEntry_SaysNothingAgain()
+    {
+        var world = Fixture.Build();
+        var entry = await world.News.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
+
+        world.Chat.Broadcasts.Clear();
+
+        await world.News.UpdateAsync(entry.Id, "Maintenance on Sunday", "at 22:30", true);
+
+        Assert.Empty(world.Chat.Broadcasts);
+    }
+
+    [Fact]
+    public async Task UnpublishingAnEntry_SaysNothing()
+    {
+        var world = Fixture.Build();
+        var entry = await world.News.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
+
+        world.Chat.Broadcasts.Clear();
+
+        await world.News.UpdateAsync(entry.Id, "Maintenance on Sunday", "at 22:00", false);
+
+        Assert.Empty(world.Chat.Broadcasts);
+    }
+
+    // Publishing again after a retraction is a fresh announcement: the shard said it was off, and is
+    // now saying it is back on.
+    [Fact]
+    public async Task RepublishingAfterARetraction_AnnouncesAgain()
+    {
+        var world = Fixture.Build();
+        var entry = await world.News.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
+
+        await world.News.UpdateAsync(entry.Id, "Maintenance on Sunday", "at 22:00", false);
+
+        world.Chat.Broadcasts.Clear();
+
+        await world.News.UpdateAsync(entry.Id, "Maintenance on Sunday", "at 22:00", true);
+
+        Assert.Single(world.Chat.Broadcasts);
+    }
+
+    [Fact]
+    public async Task UpdatingSomethingThatDoesNotExist_SaysNothing()
+    {
+        var world = Fixture.Build();
+
+        Assert.Null(await world.News.UpdateAsync(new(0xDEAD), "Ghost", "boo", true));
+        Assert.Empty(world.Chat.Broadcasts);
+    }
+
+    // The announcement touches every live session, so it runs where world writes run. Posting it is
+    // what the REST console already does rather than writing from the request thread.
+    [Fact]
+    public async Task TheAnnouncement_RunsOnTheGameLoop()
+    {
+        var world = Fixture.Build();
+
+        await world.News.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
+
+        Assert.Equal(1, world.Loop.PostCount);
+    }
+
+    private sealed class Fixture
+    {
+        private Fixture(NewsService news, RecordingBroadcastChat chat, StubGameLoopContext loop)
+        {
+            News = news;
+            Chat = chat;
+            Loop = loop;
+        }
+
+        public NewsService News { get; }
+
+        public RecordingBroadcastChat Chat { get; }
+
+        public StubGameLoopContext Loop { get; }
+
+        public static Fixture Build()
+        {
+            var chat = new RecordingBroadcastChat();
+            var loop = new StubGameLoopContext();
+
+            return new(new NewsService(new FakePersistenceService(), chat, loop), chat, loop);
+        }
+    }
+
+    private sealed class RecordingBroadcastChat : IChatService
+    {
+        public List<string> Broadcasts { get; } = [];
+
+        public void Broadcast(string text, Hue? hue = null)
+            => Broadcasts.Add(text);
+
+        public void SendSystemMessage(PlayerSession session, string text, Hue? hue = null)
+            => throw new NotSupportedException();
+
+        public void Say(MobileEntity speaker, Moongate.UO.Data.Types.ChatMessageType type, string text, Hue hue, int range)
+            => throw new NotSupportedException();
+
+        public bool SayAs(MobileEntity speaker, string text)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Moongate.Tests/News/NewsCommandTests.cs
+++ b/tests/Moongate.Tests/News/NewsCommandTests.cs
@@ -52,7 +52,7 @@ public class NewsCommandTests
     private static async Task<List<string>> RunAsync(params (string Title, bool Published)[] entries)
     {
         var persistence = new FakePersistenceService();
-        var news = new NewsService(persistence);
+        var news = new NewsService(persistence, new RecordingChatService(), new StubGameLoopContext());
 
         foreach (var (title, published) in entries)
         {

--- a/tests/Moongate.Tests/News/NewsMotdSubscriberTests.cs
+++ b/tests/Moongate.Tests/News/NewsMotdSubscriberTests.cs
@@ -97,7 +97,7 @@ public class NewsMotdSubscriberTests
         public static async Task<Fixture> WithAsync(params (string Title, bool Published)[] entries)
         {
             var persistence = new FakePersistenceService();
-            var news = new NewsService(persistence);
+            var news = new NewsService(persistence, new RecordingChatService(), new StubGameLoopContext());
 
             foreach (var (title, published) in entries)
             {

--- a/tests/Moongate.Tests/News/NewsServiceTests.cs
+++ b/tests/Moongate.Tests/News/NewsServiceTests.cs
@@ -56,5 +56,5 @@ public class NewsServiceTests
     }
 
     private static NewsService Build()
-        => new(new FakePersistenceService());
+        => new(new FakePersistenceService(), new RecordingChatService(), new StubGameLoopContext());
 }

--- a/tests/Moongate.Tests/Server/World/LoginGreetingOrderTests.cs
+++ b/tests/Moongate.Tests/Server/World/LoginGreetingOrderTests.cs
@@ -36,7 +36,7 @@ public class LoginGreetingOrderTests : IDisposable
         File.WriteAllText(Path.Combine(_root, "motd.txt"), "Welcome to Britannia!");
 
         var persistence = new FakePersistenceService();
-        var news = new NewsService(persistence);
+        var news = new NewsService(persistence, new RecordingChatService(), new StubGameLoopContext());
 
         await news.CreateAsync("Maintenance on Sunday", "at 22:00", "tom", true);
 

--- a/tests/Moongate.Tests/Support/TestApiServer.cs
+++ b/tests/Moongate.Tests/Support/TestApiServer.cs
@@ -25,6 +25,7 @@ using Moongate.Http.Plugin.Services.Plugins;
 using Moongate.Http.Plugin.Services.Registration;
 using Moongate.Server.Abstractions.Data.Config;
 using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.Chat;
 using Moongate.Server.Abstractions.Interfaces.Notifications;
 using Moongate.Server.Abstractions.Interfaces.Plugins;
 using Moongate.Server.Abstractions.Interfaces.Server;
@@ -183,6 +184,10 @@ public sealed class TestApiServer : IAsyncDisposable
         // the work inline satisfies it with nothing to flake on.
         var gameLoop = loop ?? new StubGameLoopContext();
         container.RegisterInstance(gameLoop);
+
+        // Anything that speaks to players needs this: the news service announces a publication
+        // through it, and an endpoint test should not have to know that.
+        container.RegisterInstance<IChatService>(new RecordingChatService());
 
         container.RegisterApiEndpointInstance(
             new AccountEndpoints(accounts, gameLoop)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,7 @@ import { ItemTemplatesScreen } from './routes/admin/ItemTemplatesScreen'
 import { ItemTemplateDetailScreen } from './routes/admin/ItemTemplateDetailScreen'
 import { MobileTemplatesScreen } from './routes/admin/MobileTemplatesScreen'
 import { MobileTemplateDetailScreen } from './routes/admin/MobileTemplateDetailScreen'
+import { NewsScreen } from './routes/admin/NewsScreen'
 import { PluginsScreen } from './routes/PluginsScreen'
 import { SettingsScreen } from './routes/SettingsScreen'
 import { ConsoleScreen } from './routes/ConsoleScreen'
@@ -99,6 +100,7 @@ export function App() {
                 <Route path="items/:id" element={<ItemTemplateDetailScreen />} />
                 <Route path="mobiles" element={<MobileTemplatesScreen />} />
                 <Route path="mobiles/:id" element={<MobileTemplateDetailScreen />} />
+                <Route path="news" element={<NewsScreen />} />
                 <Route path="plugins" element={<PluginsScreen />} />
                 <Route path="settings" element={<SettingsScreen />} />
                 <Route path="console" element={<ConsoleScreen />} />

--- a/ui/src/lib/news.ts
+++ b/ui/src/lib/news.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { apiFetch } from './api'
+import type { components } from './api-types'
+
+export type News = components['schemas']['NewsResponse']
+export type CreateNews = components['schemas']['CreateNewsRequest']
+export type UpdateNews = components['schemas']['UpdateNewsRequest']
+
+const LIST_KEY = ['admin', 'news']
+
+/** Every entry, drafts included, newest first. Staff only. */
+export const useNews = () => useQuery({ queryKey: LIST_KEY, queryFn: () => apiFetch<News[]>('/api/v1/admin/news') })
+
+export function useCreateNews() {
+  const client = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: CreateNews) =>
+      apiFetch<News>('/api/v1/admin/news', { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: () => client.invalidateQueries({ queryKey: LIST_KEY }),
+  })
+}
+
+export function useUpdateNews() {
+  const client = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: number; patch: UpdateNews }) =>
+      apiFetch<News>(`/api/v1/admin/news/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(patch),
+      }),
+    onSuccess: () => client.invalidateQueries({ queryKey: LIST_KEY }),
+  })
+}
+
+export function useDeleteNews() {
+  const client = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => apiFetch<void>(`/api/v1/admin/news/${id}`, { method: 'DELETE' }),
+    onSuccess: () => client.invalidateQueries({ queryKey: LIST_KEY }),
+  })
+}

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -161,7 +161,8 @@
       "console": "Console",
       "characters": "Characters",
       "items": "Items",
-      "mobiles": "Mobiles"
+      "mobiles": "Mobiles",
+      "news": "News"
     },
     "accounts": {
       "title": "Accounts",
@@ -319,6 +320,27 @@
       "layer": "Layer",
       "item": "Item",
       "anyGender": "Any"
+    },
+    "news": {
+      "title": "News",
+      "search": "Search news…",
+      "newsTitle": "Title",
+      "author": "Author",
+      "status": "Status",
+      "published": "Published",
+      "draft": "Draft",
+      "updated": "Updated",
+      "new": "New entry",
+      "edit": "Edit",
+      "delete": "Delete",
+      "body": "Body",
+      "publish": "Published",
+      "save": "Save",
+      "cancel": "Cancel",
+      "empty": "No news yet",
+      "loadFailed": "The news could not be loaded.",
+      "deleteConfirm": "Delete “{{title}}”? This cannot be undone.",
+      "announceHint": "Publishing announces the title to everyone in the world."
     }
   },
   "characters": {

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -161,7 +161,8 @@
       "console": "Console",
       "characters": "Personaggi",
       "items": "Oggetti",
-      "mobiles": "Mobili"
+      "mobiles": "Mobili",
+      "news": "News"
     },
     "accounts": {
       "title": "Account",
@@ -319,6 +320,27 @@
       "layer": "Layer",
       "item": "Oggetto",
       "anyGender": "Qualsiasi"
+    },
+    "news": {
+      "title": "News",
+      "search": "Cerca news…",
+      "newsTitle": "Titolo",
+      "author": "Autore",
+      "status": "Stato",
+      "published": "Pubblicata",
+      "draft": "Bozza",
+      "updated": "Aggiornata",
+      "new": "Nuova",
+      "edit": "Modifica",
+      "delete": "Elimina",
+      "body": "Testo",
+      "publish": "Pubblicata",
+      "save": "Salva",
+      "cancel": "Annulla",
+      "empty": "Nessuna news",
+      "loadFailed": "Non è stato possibile caricare le news.",
+      "deleteConfirm": "Eliminare «{{title}}»? L’operazione non è reversibile.",
+      "announceHint": "Pubblicandola, il titolo viene annunciato a tutti nel mondo."
     }
   },
   "characters": {

--- a/ui/src/routes/AdminLayout.test.tsx
+++ b/ui/src/routes/AdminLayout.test.tsx
@@ -24,6 +24,7 @@ describe('AdminLayout', () => {
     expect(screen.getByRole('link', { name: /characters/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /items/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /mobiles/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /news/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /plugins/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /console/i })).toBeInTheDocument()

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -28,6 +28,9 @@ export function AdminLayout() {
         <NavLink to="/admin/mobiles" className={linkClass}>
           {t('admin.nav.mobiles')}
         </NavLink>
+        <NavLink to="/admin/news" className={linkClass}>
+          {t('admin.nav.news')}
+        </NavLink>
         <NavLink to="/admin/plugins" className={linkClass}>
           {t('admin.nav.plugins')}
         </NavLink>

--- a/ui/src/routes/admin/NewsScreen.test.tsx
+++ b/ui/src/routes/admin/NewsScreen.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import '../../lib/i18n'
+import { NewsScreen } from './NewsScreen'
+import type { News } from '../../lib/news'
+
+const state = vi.hoisted(() => ({
+  data: [] as News[] | undefined,
+  isError: false,
+  created: [] as unknown[],
+  updated: [] as unknown[],
+  deleted: [] as number[],
+}))
+
+vi.mock('../../lib/news', async (original) => ({
+  ...(await original<typeof import('../../lib/news')>()),
+  useNews: () => ({ data: state.data, isError: state.isError, isPending: false }),
+  useCreateNews: () => ({ mutateAsync: async (body: unknown) => void state.created.push(body) }),
+  useUpdateNews: () => ({ mutateAsync: async (body: unknown) => void state.updated.push(body) }),
+  useDeleteNews: () => ({ mutateAsync: async (id: number) => void state.deleted.push(id) }),
+}))
+
+function entry(id: number, title: string, isPublished: boolean): News {
+  return {
+    id,
+    title,
+    body: 'the body',
+    author: 'tom',
+    publishedAt: '2026-08-03T10:00:00Z',
+    updatedAt: '2026-08-03T10:00:00Z',
+    isPublished,
+  } as News
+}
+
+function renderWith(data: News[] | undefined, over: Partial<typeof state> = {}) {
+  Object.assign(state, { data, isError: false, created: [], updated: [], deleted: [] }, over)
+
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <NewsScreen />
+    </QueryClientProvider>,
+  )
+}
+
+describe('NewsScreen', () => {
+  it('lists every entry, drafts included', () => {
+    renderWith([entry(1, 'Maintenance', true), entry(2, 'Still cooking', false)])
+
+    expect(screen.getByText('Maintenance')).toBeInTheDocument()
+    expect(screen.getByText('Still cooking')).toBeInTheDocument()
+  })
+
+  it('tells a draft from a published entry', () => {
+    renderWith([entry(1, 'Maintenance', true), entry(2, 'Still cooking', false)])
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+  })
+
+  it('opens an empty dialog for a new entry', async () => {
+    renderWith([entry(1, 'Maintenance', true)])
+
+    await userEvent.click(screen.getByRole('button', { name: 'New entry' }))
+
+    expect(screen.getByLabelText('Title')).toHaveValue('')
+  })
+
+  it('opens the dialog filled in for an existing entry', async () => {
+    renderWith([entry(1, 'Maintenance', true)])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.getByLabelText('Title')).toHaveValue('Maintenance')
+  })
+
+  // Publishing interrupts everyone in the world, so the dialog says so before it happens — and only
+  // when it is actually about to happen.
+  it('warns before an entry is published for the first time', async () => {
+    renderWith([entry(2, 'Still cooking', false)])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.queryByText(/announces the title/)).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('switch'))
+
+    expect(screen.getByText(/announces the title/)).toBeInTheDocument()
+  })
+
+  it('does not warn when the entry is already published', async () => {
+    renderWith([entry(1, 'Maintenance', true)])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(screen.queryByText(/announces the title/)).not.toBeInTheDocument()
+  })
+
+  // Deleting is not reversible, so it asks first.
+  it('asks before deleting', async () => {
+    const confirm = vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
+
+    renderWith([entry(1, 'Maintenance', true)])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(confirm).toHaveBeenCalled()
+    expect(state.deleted).toEqual([])
+
+    confirm.mockRestore()
+  })
+
+  it('deletes once confirmed', async () => {
+    const confirm = vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+
+    renderWith([entry(1, 'Maintenance', true)])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(state.deleted).toEqual([1])
+
+    confirm.mockRestore()
+  })
+
+  it('says so when the request failed', () => {
+    renderWith(undefined, { isError: true })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('The news could not be loaded.')
+  })
+
+  it('says so when there is nothing yet', () => {
+    renderWith([])
+
+    expect(screen.getByText('No news yet')).toBeInTheDocument()
+  })
+})

--- a/ui/src/routes/admin/NewsScreen.tsx
+++ b/ui/src/routes/admin/NewsScreen.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { DataTable } from '../../components/ui/data-table'
+import { Badge } from '../../components/ui/badge'
+import { Button } from '../../components/ui/button'
+import { toast } from '../../components/ui/sonner'
+import { NewsDialog } from '../news/NewsDialog'
+import { useDeleteNews, useNews, type News } from '../../lib/news'
+
+export function NewsScreen() {
+  const { t } = useTranslation()
+  const news = useNews()
+  const remove = useDeleteNews()
+  const [editing, setEditing] = useState<News | null>(null)
+  const [open, setOpen] = useState(false)
+
+  async function confirmDelete(entry: News) {
+    if (!globalThis.confirm(t('admin.news.deleteConfirm', { title: entry.title }))) {
+      return
+    }
+
+    try {
+      await remove.mutateAsync(entry.id)
+    } catch {
+      toast.error(t('error.generic'))
+    }
+  }
+
+  const columns = useMemo<ColumnDef<News>[]>(
+    () => [
+      { accessorKey: 'title', header: t('admin.news.newsTitle') },
+      { accessorKey: 'author', header: t('admin.news.author') },
+      {
+        accessorKey: 'isPublished',
+        header: t('admin.news.status'),
+        cell: ({ getValue }) =>
+          (getValue() as boolean) ? (
+            <Badge variant="success">{t('admin.news.published')}</Badge>
+          ) : (
+            <Badge variant="info">{t('admin.news.draft')}</Badge>
+          ),
+      },
+      {
+        accessorKey: 'updatedAt',
+        header: t('admin.news.updated'),
+        cell: ({ getValue }) => new Date(getValue() as string).toLocaleString(),
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <span className="flex gap-2">
+            <Button
+              variant="default"
+              className="px-3 py-1 text-xs"
+              onClick={() => {
+                setEditing(row.original)
+                setOpen(true)
+              }}
+            >
+              {t('admin.news.edit')}
+            </Button>
+            <Button variant="outline" className="px-3 py-1 text-xs" onClick={() => confirmDelete(row.original)}>
+              {t('admin.news.delete')}
+            </Button>
+          </span>
+        ),
+      },
+    ],
+    // confirmDelete closes over `remove` and `t`, both stable enough for a row action.
+    [t],
+  )
+
+  if (news.isError) {
+    return (
+      <p role="alert" className="text-sm text-danger-text">
+        {t('admin.news.loadFailed')}
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-display text-xl text-ink">{t('admin.news.title')}</h1>
+        <Button
+          onClick={() => {
+            setEditing(null)
+            setOpen(true)
+          }}
+        >
+          {t('admin.news.new')}
+        </Button>
+      </div>
+
+      <DataTable columns={columns} data={news.data ?? []} searchPlaceholder={t('admin.news.search')} />
+
+      {news.data?.length === 0 && <p className="text-sm text-muted">{t('admin.news.empty')}</p>}
+
+      <NewsDialog entry={editing} open={open} onOpenChange={setOpen} />
+    </div>
+  )
+}

--- a/ui/src/routes/news/NewsDialog.tsx
+++ b/ui/src/routes/news/NewsDialog.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/dialog'
+import { Input } from '../../components/ui/input'
+import { Label } from '../../components/ui/label'
+import { Button } from '../../components/ui/button'
+import { Switch } from '../../components/ui/switch'
+import { toast } from '../../components/ui/sonner'
+import { useCreateNews, useUpdateNews, type News } from '../../lib/news'
+
+/**
+ * Writes a news entry, new or existing. One dialog for both: the fields are identical, and two would
+ * be two places to keep the publish warning in step.
+ */
+export function NewsDialog({
+  entry,
+  open,
+  onOpenChange,
+}: {
+  entry: News | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const create = useCreateNews()
+  const update = useUpdateNews()
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [isPublished, setIsPublished] = useState(false)
+
+  // The dialog outlives the entry it edits, so its fields are refilled whenever the subject changes.
+  useEffect(() => {
+    setTitle(entry?.title ?? '')
+    setBody(entry?.body ?? '')
+    setIsPublished(entry?.isPublished ?? false)
+  }, [entry, open])
+
+  async function submit(event: FormEvent) {
+    event.preventDefault()
+
+    try {
+      if (entry === null) {
+        await create.mutateAsync({ title, body, isPublished })
+      } else {
+        await update.mutateAsync({ id: entry.id, patch: { title, body, isPublished } })
+      }
+
+      onOpenChange(false)
+    } catch {
+      toast.error(t('error.generic'))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>{entry === null ? t('admin.news.new') : t('admin.news.edit')}</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="news-title">{t('admin.news.newsTitle')}</Label>
+            <Input id="news-title" value={title} onChange={(e) => setTitle(e.target.value)} required />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="news-body">{t('admin.news.body')}</Label>
+            <textarea
+              id="news-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={6}
+              className="rounded-md border bg-transparent px-3 py-2 text-sm text-ink outline-none focus-visible:ring-2 focus-visible:ring-gold"
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Switch id="news-published" checked={isPublished} onCheckedChange={setIsPublished} />
+            <Label htmlFor="news-published">{t('admin.news.publish')}</Label>
+          </div>
+
+          {/* Publishing interrupts everyone in the world, so it should not be a surprise. */}
+          {isPublished && !(entry?.isPublished ?? false) && (
+            <p className="text-xs text-muted">{t('admin.news.announceHint')}</p>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              {t('admin.news.cancel')}
+            </Button>
+            <Button type="submit">{t('admin.news.save')}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
Closes #183 (by hand once merged — this targets `develop`).

## Announced when it goes public

Publishing broadcasts the entry's title to everyone in the world. **The trigger is the transition, not the save:**

| | |
|---|---|
| created already published | announces |
| created as a draft | silent |
| draft → published | announces |
| editing something already published | **silent** — a typo corrected three times would be three interruptions |
| published → draft | silent |
| republished after a retraction | announces — the shard is saying it is back on |

The transition is the service's knowledge, so the announcement lives there rather than duplicated across the create and update routes. `UpdateAsync` reads `IsPublished` **before** mutating the entity: after the assignment the old state is gone, and with it the only thing that distinguishes a publication from a save.

**It is posted to the game loop**, not broadcast from the request thread. It reaches every live session, and the REST console already broadcasts that way — this follows the precedent rather than inventing a second rule. There is a test asserting the work went through the loop, not just that the text was right.

## Managed from the portal

`/admin/news` has the shape `/admin/accounts` has: a table of every entry including drafts, create and edit through one dialog, delete behind a confirmation, and a draft/published switch.

The dialog **warns before an entry is published for the first time** — that is the moment everyone in the world gets interrupted, and it should not be a surprise. It does not warn when the entry is already published, since saving it again announces nothing. Both cases are asserted.

## Checks

- .NET **2148 passed**; UI **354 passed**; build and Prettier clean; DocFX **0 warnings**.
- Contract untouched — no C# `///` changed, so nothing to regenerate.
- Exercised against a running shard: created a draft, published it, then edited it while published. All accepted, boot log clean.

**The broadcast itself was not observed**, and I want to be exact about that: `Broadcast` writes to in-world sessions and there was no player connected. What the shard confirmed is that the three transitions are accepted and nothing throws; that a connected player actually sees the line needs a client, like the MOTD in #181.

## One thing worth noting

`NewsResponse.id` is a **number**, where every other serial on this API is the `0x40000001` string. Not changed here — it is the existing contract and out of scope — but the typecheck caught my fixtures assuming otherwise, and the next person will trip on it too.
