### PR TITLE
fix(items): keep a split pile where the player put it

### DIFF
--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IContainerRule.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IContainerRule.cs
@@ -1,0 +1,16 @@
+using Moongate.Persistence.Entities;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Server.Abstractions.Interfaces.Items;
+
+/// <summary>
+/// Decides whether an item can hold other items. The drop path needs this to tell the two gestures the
+/// 0x08 packet cannot: releasing something into a bag, and releasing it onto whatever is drawn there.
+/// </summary>
+public interface IContainerRule
+{
+    /// <summary>True when <paramref name="item" /> is something a player can put things inside.</summary>
+    /// <param name="item">The item being dropped onto.</param>
+    /// <param name="template">Its template, consulted only when the client tables cannot answer.</param>
+    bool IsContainer(ItemEntity item, ItemTemplate? template);
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -190,6 +190,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IItemFactoryService, ItemFactoryService>(Reuse.Singleton);
                 container.Register<IItemService, ItemService>(Reuse.Singleton);
                 container.Register<IStackableRule, TileDataStackableRule>(Reuse.Singleton);
+                container.Register<IContainerRule, TileDataContainerRule>(Reuse.Singleton);
                 container.Register<IDragDropService, DragDropService>(Reuse.Singleton);
                 container.Register<IContainerOpenerRegistry, ContainerOpenerRegistry>(Reuse.Singleton);
                 container.Register<ILootService, LootService>(Reuse.Singleton);

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -273,6 +273,16 @@ public sealed class DragDropService : IDragDropService
         return true;
     }
 
+    /// <summary>
+    /// What the client sends for X and Y when the item was released on the container itself rather than
+    /// at a spot inside its open gump. ModernUO reads the same value as -1 and splits on it.
+    /// </summary>
+    private const int NoGumpPosition = 0xFFFF;
+
+    /// <summary>True when the drop named a container but no place inside it.</summary>
+    private static bool IsUnpositioned(Point2D position)
+        => position.X == NoGumpPosition || position.Y == NoGumpPosition || position.X < 0 || position.Y < 0;
+
     private static AddItemToContainerPacket ContainerPacket(ItemEntity item, Serial containerId, Point2D position)
         => new(item.Id, (ushort)item.ItemId, (ushort)item.Amount, position, containerId, item.Hue);
 
@@ -301,7 +311,11 @@ public sealed class DragDropService : IDragDropService
             return new(false, LiftRejectReasonType.OutOfRange);
         }
 
-        var stack = FindStack(container, item);
+        // Released on a spot inside the gump, the player is putting the item exactly there: counting
+        // coins out into two piles is the whole reason UO lets you split one. Merging is the other two
+        // gestures -- released on the container itself, which carries no position, and released onto
+        // the pile, which names the pile and arrives at DropOnItem.
+        var stack = IsUnpositioned(position) ? FindStack(container, item) : null;
 
         if (stack is not null)
         {

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -35,6 +35,7 @@ public sealed class DragDropService : IDragDropService
     private readonly IItemTemplateService _templates;
     private readonly IWorldService _world;
     private readonly IStackableRule _stackable;
+    private readonly IContainerRule _containers;
     private readonly ILoopAffinity? _loopAffinity;
     private readonly IEventBus? _eventBus;
 
@@ -44,6 +45,7 @@ public sealed class DragDropService : IDragDropService
         IItemTemplateService templates,
         IWorldService world,
         IStackableRule stackable,
+        IContainerRule containers,
         ILoopAffinity? loopAffinity = null,
         IEventBus? eventBus = null
     )
@@ -53,6 +55,7 @@ public sealed class DragDropService : IDragDropService
         _templates = templates;
         _world = world;
         _stackable = stackable;
+        _containers = containers;
         _loopAffinity = loopAffinity;
         _eventBus = eventBus;
     }
@@ -119,9 +122,21 @@ public sealed class DragDropService : IDragDropService
             return new(false, LiftRejectReasonType.Inspecific);
         }
 
-        return containerId == Serial.Zero
-                   ? DropOnGround(actor, item, groundPosition)
-                   : DropInContainer(actor, item, containerId, containerPosition);
+        if (containerId == Serial.Zero)
+        {
+            return DropOnGround(actor, item, groundPosition);
+        }
+
+        // One serial, two gestures. Released over a bag the client sends the bag; released over
+        // whatever is drawn in a slot it sends that item. Only the first is a container drop, and
+        // taking the second for one nests the item inside something that never opens.
+        if (_items.GetById(containerId) is { } target &&
+            !_containers.IsContainer(target, _templates.GetById(target.TemplateId)))
+        {
+            return DropOnItem(actor, item, target, containerPosition);
+        }
+
+        return DropInContainer(actor, item, containerId, containerPosition);
     }
 
     /// <summary>
@@ -290,15 +305,7 @@ public sealed class DragDropService : IDragDropService
 
         if (stack is not null)
         {
-            stack.Amount += item.Amount;
-            _items.Save(stack);
-            _items.Delete(item.Id);
-
-            _world.SendToPlayer(actor.Id, ContainerPacket(stack, container.Id, stack.ContainerPosition));
-
-            _eventBus?.Publish(new ItemDroppedEvent(stack.Id, actor.Id, container.Id));
-
-            return new(true, LiftRejectReasonType.Inspecific);
+            return MergeInto(actor, stack, item);
         }
 
         _items.AddToContainer(container, item, position);
@@ -306,6 +313,64 @@ public sealed class DragDropService : IDragDropService
         _world.SendToPlayer(actor.Id, ContainerPacket(item, container.Id, position));
 
         _eventBus?.Publish(new ItemDroppedEvent(item.Id, actor.Id, container.Id));
+
+        return new(true, LiftRejectReasonType.Inspecific);
+    }
+
+    /// <summary>
+    /// A release onto an item rather than into one. Piles merge -- coins onto coins is the gesture
+    /// players make constantly -- and anything that cannot merge lands beside the target, in whatever
+    /// holds it, because the target itself has nowhere to put it.
+    /// </summary>
+    private LiftDecision DropOnItem(MobileEntity actor, ItemEntity item, ItemEntity target, Point2D position)
+    {
+        if (target.Id == item.Id || IsDescendantOf(target, item.Id) || !Reachable(target, actor))
+        {
+            return new(false, LiftRejectReasonType.CannotLift);
+        }
+
+        var (mapId, worldPosition) = WorldLocation(target, actor);
+
+        if (actor.MapId != mapId || !actor.Position.InRange(worldPosition, LiftRange))
+        {
+            return new(false, LiftRejectReasonType.OutOfRange);
+        }
+
+        var targetStackable = _stackable.IsStackable(target, _templates.GetById(target.TemplateId));
+        var droppedStackable = _stackable.IsStackable(item, _templates.GetById(item.TemplateId));
+
+        if (CanStack(target, item, targetStackable, droppedStackable))
+        {
+            return MergeInto(actor, target, item);
+        }
+
+        // Loose on the ground with nothing to merge into: refusing bounces it back where it came
+        // from, which beats inventing a spot for it.
+        return target.ParentContainerId != Serial.Zero
+                   ? DropInContainer(actor, item, target.ParentContainerId, position)
+                   : new LiftDecision(false, LiftRejectReasonType.CannotLift);
+    }
+
+    /// <summary>
+    /// Pours one pile into another. The target keeps its serial and grows; the dropped entity stops
+    /// existing. Sending the target's new amount is what redraws it -- the client has been showing the
+    /// old one since before the drag started.
+    /// </summary>
+    private LiftDecision MergeInto(MobileEntity actor, ItemEntity stack, ItemEntity item)
+    {
+        stack.Amount += item.Amount;
+        _items.Save(stack);
+        _items.Delete(item.Id);
+
+        if (stack.ParentContainerId != Serial.Zero)
+        {
+            _world.SendToPlayer(
+                actor.Id,
+                ContainerPacket(stack, stack.ParentContainerId, stack.ContainerPosition)
+            );
+        }
+
+        _eventBus?.Publish(new ItemDroppedEvent(stack.Id, actor.Id, stack.ParentContainerId));
 
         return new(true, LiftRejectReasonType.Inspecific);
     }

--- a/src/Moongate.Server/Services/Items/TileDataContainerRule.cs
+++ b/src/Moongate.Server/Services/Items/TileDataContainerRule.cs
@@ -1,0 +1,29 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Server.Services.Items;
+
+/// <summary>
+/// Reads containerhood off the client's own tiledata, the way <see cref="TileDataStackableRule" />
+/// reads stackability: <see cref="TileFlagType.Container" /> is the bit the client itself uses to
+/// decide whether double-clicking a thing opens a gump.
+/// <para>
+/// The client files win. The template's <c>Category</c> is the fallback for an id the tables do not
+/// describe, and for tests, which run without a client directory.
+/// </para>
+/// </summary>
+public sealed class TileDataContainerRule : IContainerRule
+{
+    public bool IsContainer(ItemEntity item, ItemTemplate? template)
+    {
+        if (TileData.ItemTable is { Length: > 0 } tiles && item.ItemId >= 0 && item.ItemId < tiles.Length)
+        {
+            return (tiles[item.ItemId].Flags & TileFlagType.Container) != 0;
+        }
+
+        return string.Equals(template?.Category, "Container", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/DragDropServiceDropTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropServiceDropTests.cs
@@ -101,11 +101,15 @@ public class DragDropServiceDropTests
     [Fact]
     public void Drop_OntoACompatibleStack_MergesAndDeletesTheDroppedEntity()
     {
-        // 100 gold in the backpack; lift 40, then drop the 40 back onto the 60.
+        // 100 gold in the backpack; lift 40, then drop the 40 back onto the 60 -- which the client
+        // reports by naming the 60, not the backpack. Named with a spot inside the backpack instead,
+        // the two halves would stay apart, and SplitStackPlacementTests covers that.
         var fixture = DragDropFixture.WithGoldInBackpack(100);
         fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 40, Serial.Zero, out var heldId, out _);
 
-        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(60, 80));
+        var remainder = fixture.BackpackContents().Single(item => item.Id != heldId);
+
+        fixture.Service.Drop(fixture.Actor, heldId, remainder.Id, Point3D.Zero, new(60, 80));
 
         var stack = Assert.Single(fixture.BackpackContents());
         Assert.Equal(100, stack.Amount);

--- a/tests/Moongate.Tests/Server/Items/DragDropStackMergeTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropStackMergeTests.cs
@@ -1,0 +1,68 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// Two stacks that were never one, merged by hand — a player dragging one pile of gold onto another.
+/// The existing merge test splits a stack and rejoins it, which exercises a different path: there the
+/// dropped entity was born a moment earlier from the very stack it returns to.
+/// </summary>
+public class DragDropStackMergeTests
+{
+    [Fact]
+    public void DroppingAStackOntoAnother_KeepsEveryCoin()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(500);
+        var second = SecondGoldStack(fixture, 500);
+
+        fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(50, 70));
+
+        var total = fixture.BackpackContents().Sum(item => item.Amount);
+
+        Assert.Equal(1000, total);
+    }
+
+    [Fact]
+    public void DroppingAStackOntoAnother_LeavesOneStack()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(500);
+        var second = SecondGoldStack(fixture, 500);
+
+        fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(50, 70));
+
+        var stack = Assert.Single(fixture.BackpackContents());
+
+        Assert.Equal(1000, stack.Amount);
+    }
+
+    // The container keeps a list of what it holds. A merge that deletes the absorbed entity without
+    // unlisting it leaves the backpack pointing at something that no longer exists.
+    [Fact]
+    public void DroppingAStackOntoAnother_LeavesNoDanglingIdInTheContainer()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(500);
+        var second = SecondGoldStack(fixture, 500);
+
+        fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(50, 70));
+
+        var listed = fixture.Items.GetById(fixture.Backpack.Id)!.ContainedItemIds;
+
+        Assert.All(listed, id => Assert.NotNull(fixture.Items.GetById(id)));
+    }
+
+    private static ItemEntity SecondGoldStack(DragDropFixture fixture, int amount)
+    {
+        var gold = new ItemEntity { TemplateId = "gold", ItemId = 3821, Amount = amount, Hue = new(0) };
+
+        fixture.Items.Create(gold);
+        fixture.Items.AddToContainer(fixture.Backpack, gold, new(60, 70));
+
+        return gold;
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/DragDropStackMergeTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DragDropStackMergeTests.cs
@@ -9,6 +9,10 @@ namespace Moongate.Tests.Server.Items;
 /// Two stacks that were never one, merged by hand — a player dragging one pile of gold onto another.
 /// The existing merge test splits a stack and rejoins it, which exercises a different path: there the
 /// dropped entity was born a moment earlier from the very stack it returns to.
+/// <para>
+/// The drop names the pile it lands on, which is what the client sends for this gesture. Naming the
+/// backpack and a spot inside it is the other gesture, and it deliberately does not merge.
+/// </para>
 /// </summary>
 public class DragDropStackMergeTests
 {
@@ -19,7 +23,7 @@ public class DragDropStackMergeTests
         var second = SecondGoldStack(fixture, 500);
 
         fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
-        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(50, 70));
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Gold.Id, Point3D.Zero, new(50, 70));
 
         var total = fixture.BackpackContents().Sum(item => item.Amount);
 
@@ -33,7 +37,7 @@ public class DragDropStackMergeTests
         var second = SecondGoldStack(fixture, 500);
 
         fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
-        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(50, 70));
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Gold.Id, Point3D.Zero, new(50, 70));
 
         var stack = Assert.Single(fixture.BackpackContents());
 
@@ -49,7 +53,7 @@ public class DragDropStackMergeTests
         var second = SecondGoldStack(fixture, 500);
 
         fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
-        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, new(50, 70));
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Gold.Id, Point3D.Zero, new(50, 70));
 
         var listed = fixture.Items.GetById(fixture.Backpack.Id)!.ContainedItemIds;
 

--- a/tests/Moongate.Tests/Server/Items/DropOnItemTests.cs
+++ b/tests/Moongate.Tests/Server/Items/DropOnItemTests.cs
@@ -1,0 +1,71 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// Dropping onto an item rather than into a container. The 0x08 packet carries one serial for both
+/// gestures: release over a bag and the client sends the bag, release over a pile of gold and it sends
+/// the pile. The other merge tests all pass the backpack, which is the gesture the player did not make.
+/// </summary>
+public class DropOnItemTests
+{
+    [Fact]
+    public void DroppingGoldOntoGold_MergesIntoTheTargetStack()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(500);
+        var second = fixture.AddGoldToBackpack(500, new(60, 70));
+
+        fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Gold.Id, Point3D.Zero, new(50, 70));
+
+        var stack = Assert.Single(fixture.BackpackContents());
+
+        Assert.Equal(1000, stack.Amount);
+    }
+
+    // Gold is not a bag. Nesting the coins inside the target hides them from a client that has no way
+    // to open it, and leaves the target drawn at its old amount -- the pile reads as eaten.
+    [Fact]
+    public void DroppingGoldOntoGold_PutsNothingInsideTheTargetStack()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(500);
+        var second = fixture.AddGoldToBackpack(500, new(60, 70));
+
+        fixture.Service.Lift(fixture.Actor, second.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Gold.Id, Point3D.Zero, new(50, 70));
+
+        Assert.Empty(fixture.Items.GetContents(fixture.Gold.Id));
+    }
+
+    /// <summary>
+    /// The same gesture with something that cannot merge: it belongs beside the target, in whatever
+    /// holds the target, not inside it.
+    /// </summary>
+    [Fact]
+    public void DroppingAnItemOntoAPlainItem_LandsBesideItInTheSameContainer()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(500);
+        var sword = fixture.AddSwordToBackpack(new(60, 70));
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, sword.Id, Point3D.Zero, new(50, 70));
+
+        Assert.Empty(fixture.Items.GetContents(sword.Id));
+        Assert.Contains(fixture.BackpackContents(), item => item.Id == heldId);
+    }
+
+    /// <summary>A bag is a container, so the gesture keeps meaning what it always meant.</summary>
+    [Fact]
+    public void DroppingAnItemOntoABag_StillGoesInside()
+    {
+        var fixture = DragDropFixture.WithBagInBackpack();
+        var gold = fixture.AddGoldToBackpack(500, new(60, 70));
+
+        fixture.Service.Lift(fixture.Actor, gold.Id, 500, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Bag.Id, Point3D.Zero, new(10, 10));
+
+        Assert.Contains(fixture.Items.GetContents(fixture.Bag.Id), item => item.Id == heldId);
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/SplitStackPlacementTests.cs
+++ b/tests/Moongate.Tests/Server/Items/SplitStackPlacementTests.cs
@@ -1,0 +1,80 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// Splitting a pile and putting the piece down somewhere else. The gesture only exists because the two
+/// halves stay apart: a player counting coins out drops them on an empty spot, and a drop that hunts
+/// the container for anything it could merge with undoes the split before the client can draw it.
+/// </summary>
+public class SplitStackPlacementTests
+{
+    private static readonly Point2D EmptySpot = new(46, 102);
+
+    private static readonly Point2D WhereTheStackIs = new(127, 100);
+
+    /// <summary>The client sends 0xFFFF for both coordinates when the item was released on the bag itself.</summary>
+    private static readonly Point2D OnTheContainerItself = new(0xFFFF, 0xFFFF);
+
+    [Fact]
+    public void DroppingASplitPieceOnAnEmptySpot_LeavesTwoStacks()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(1000);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 100, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, EmptySpot);
+
+        var stacks = fixture.BackpackContents().Select(item => item.Amount).OrderBy(amount => amount).ToList();
+
+        Assert.Equal([100, 900], stacks);
+    }
+
+    [Fact]
+    public void DroppingASplitPieceOnAnEmptySpot_LeavesItWhereItWasPut()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(1000);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 100, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, EmptySpot);
+
+        var piece = fixture.BackpackContents().Single(item => item.Amount == 100);
+
+        Assert.Equal(EmptySpot, piece.ContainerPosition);
+    }
+
+    /// <summary>Released on the bag rather than inside it, there is no spot to honour, so piles join.</summary>
+    [Fact]
+    public void DroppingOnTheContainerItself_MergesWithWhatIsAlreadyThere()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(1000);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 100, Serial.Zero, out var heldId, out _);
+        fixture.Service.Drop(fixture.Actor, heldId, fixture.Backpack.Id, Point3D.Zero, OnTheContainerItself);
+
+        var stack = Assert.Single(fixture.BackpackContents());
+
+        Assert.Equal(1000, stack.Amount);
+    }
+
+    /// <summary>
+    /// The other way to put the halves back together: drop the piece onto the pile, which the client
+    /// reports by naming the pile.
+    /// </summary>
+    [Fact]
+    public void DroppingASplitPieceBackOntoTheStack_MergesThemAgain()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(1000);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 100, Serial.Zero, out var heldId, out _);
+
+        var remainder = fixture.BackpackContents().Single(item => item.Id != heldId);
+
+        fixture.Service.Drop(fixture.Actor, heldId, remainder.Id, Point3D.Zero, WhereTheStackIs);
+
+        var stack = Assert.Single(fixture.BackpackContents());
+
+        Assert.Equal(1000, stack.Amount);
+    }
+}

--- a/tests/Moongate.Tests/Server/Items/SplitStackRefreshTests.cs
+++ b/tests/Moongate.Tests/Server/Items/SplitStackRefreshTests.cs
@@ -1,0 +1,85 @@
+using Moongate.Core.Geometry;
+using Moongate.Core.Primitives;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Data.Session;
+using Moongate.Server.Abstractions.Interfaces.World;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Subscribers;
+using Moongate.Tests.Support;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// Lifting part of a stack leaves a remainder the client has never been sent. SplitStack saves it so
+/// the refresh subscriber turns that into an add — its own comment says the alternative "reads as the
+/// client eating it", which is exactly what a player reported. This checks the wire, not the store.
+/// </summary>
+public class SplitStackRefreshTests
+{
+    [Fact]
+    public void LiftingPartOfAStack_TellsTheClientAboutTheRemainder()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(100);
+        var world = new RecordingWorldService();
+
+        new ItemRefreshSubscriber(fixture.Items, fixture.Persistence, new ContainerOpenerRegistry(), world)
+            .Subscribe(fixture.EventBus);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 40, Serial.Zero, out var heldId, out _);
+
+        var remainder = fixture.BackpackContents().Single(item => item.Id != heldId);
+
+        Assert.Contains(world.Added, sent => sent.Packet.Serial == remainder.Id);
+    }
+
+    // Recording the packet is not enough: a send addressed to nobody looks identical to a delivered
+    // one from inside the world service. The player who lifted it has to be the recipient.
+    [Fact]
+    public void LiftingPartOfAStack_TellsTheRightPlayer()
+    {
+        var fixture = DragDropFixture.WithGoldInBackpack(100);
+        var world = new RecordingWorldService();
+
+        new ItemRefreshSubscriber(fixture.Items, fixture.Persistence, new ContainerOpenerRegistry(), world)
+            .Subscribe(fixture.EventBus);
+
+        fixture.Service.Lift(fixture.Actor, fixture.Gold.Id, 40, Serial.Zero, out var heldId, out _);
+
+        var remainder = fixture.BackpackContents().Single(item => item.Id != heldId);
+        var sent = world.Added.Where(entry => entry.Packet.Serial == remainder.Id).ToList();
+
+        Assert.NotEmpty(sent);
+        Assert.All(sent, entry => Assert.Equal(fixture.Actor.Id, entry.Recipient));
+    }
+
+    /// <summary>Records the container adds, which is the whole of what this test is about.</summary>
+    private sealed class RecordingWorldService : IWorldService
+    {
+        public List<(Serial Recipient, AddItemToContainerPacket Packet)> Added { get; } = [];
+
+        public int SendToPlayer<TPacket>(Serial mobileId, TPacket packet) where TPacket : IOutgoingPacket
+        {
+            if (packet is AddItemToContainerPacket add)
+            {
+                Added.Add((mobileId, add));
+            }
+
+            return 1;
+        }
+
+        public int Broadcast<TPacket>(TPacket packet) where TPacket : IOutgoingPacket => 0;
+
+        public void SendEnterWorld(PlayerSession session, MobileEntity mobile) { }
+
+        public int SendToPlayersInRange<TPacket>(
+            int mapId,
+            Point3D center,
+            int range,
+            TPacket packet,
+            Serial? except = null
+        )
+            where TPacket : IOutgoingPacket => 0;
+    }
+}

--- a/tests/Moongate.Tests/Support/DragDropFixture.cs
+++ b/tests/Moongate.Tests/Support/DragDropFixture.cs
@@ -1,4 +1,5 @@
 using Moongate.Core.Extensions;
+using Moongate.Core.Geometry;
 using Moongate.Persistence.Entities;
 using Moongate.Server.Services.Items;
 using Moongate.Ultima.Types;
@@ -50,6 +51,7 @@ public sealed class DragDropFixture
             }
         );
         templates.Register(new() { Id = "bag", Name = "Bag", Category = "Container", ItemId = 3702, IsMovable = true });
+        templates.Register(new() { Id = "sword", Name = "Sword", Category = "Weapon", ItemId = 5046, IsMovable = true });
 
         Service = new(
             Items,
@@ -57,6 +59,7 @@ public sealed class DragDropFixture
             templates,
             new StubWorldService(),
             new StubStackableRule(),
+            new StubContainerRule(),
             eventBus: EventBus
         );
 
@@ -83,6 +86,26 @@ public sealed class DragDropFixture
         Items.AddToContainer(Bag, gold, new(20, 30));
 
         return gold;
+    }
+
+    /// <summary>A second stack of gold in the backpack, for the merge cases.</summary>
+    public ItemEntity AddGoldToBackpack(int amount, Point2D position)
+    {
+        var gold = new ItemEntity { TemplateId = "gold", ItemId = 3821, Amount = amount, Hue = new(0) };
+        Items.Create(gold);
+        Items.AddToContainer(Backpack, gold, position);
+
+        return gold;
+    }
+
+    /// <summary>Something that neither stacks nor holds anything, to drop other things onto.</summary>
+    public ItemEntity AddSwordToBackpack(Point2D position)
+    {
+        var sword = new ItemEntity { TemplateId = "sword", ItemId = 5046, Amount = 1 };
+        Items.Create(sword);
+        Items.AddToContainer(Backpack, sword, position);
+
+        return sword;
     }
 
     /// <summary>Takes the backpack off the actor, to exercise the bounce falling all the way to the feet.</summary>

--- a/tests/Moongate.Tests/Support/StubContainerRule.cs
+++ b/tests/Moongate.Tests/Support/StubContainerRule.cs
@@ -1,0 +1,15 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Tests.Support;
+
+/// <summary>
+/// Containerhood from the template alone. Tests run without a client directory, so the tiledata the
+/// real rule reads is empty and its own fallback is exactly this.
+/// </summary>
+public sealed class StubContainerRule : IContainerRule
+{
+    public bool IsContainer(ItemEntity item, ItemTemplate? template)
+        => string.Equals(template?.Category, "Container", StringComparison.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
Fixes #187.

Splitting a stack did nothing: the piece was reabsorbed by the pile it came from before the client could draw it, so the backpack went straight back to one stack of the original size. Reported in game as "I split it and nothing happens".

## The bug

`DropInContainer` hunted the whole container for anything the item could stack with and poured it in, wherever the player had let go. A reproduction with temporary logging — released at (46,102), the pile sits at (127,100), merged anyway:

```
LIFT  0x4000000F amount 100
DROP  held 0x4000000F (gold x100) onto container 0x40000000 at 46,102
DROP  merge: 0x4000000F x100 into 0x40000010 x900 -> x1000
```

UO has three drop gestures and only two of them merge. Released on a spot inside the gump the item goes exactly there — counting coins out into separate piles is the whole reason splitting exists. Released on the container itself the client sends no position, and released on the pile it names the pile; both merge. The position tells them apart, so a stack is only looked for when the drop carries none.

## Second defect, found on the way

A drop naming an item that is not a container nested the dropped item **inside** it: nothing in the domain distinguished a container from any other item, so `AddToContainer` happily took a pile of gold as a parent. The item then had no gump to open, and read as eaten.

`IContainerRule` fills that gap, mirroring `TileDataStackableRule` exactly: `TileFlagType.Container` off the client tiledata, with the template category as the fallback for ids the tables do not describe and for tests, which run without a client directory. A drop onto a non-container now merges when the piles can stack, and otherwise lands beside the target in whatever holds it.

## Tests

- `SplitStackPlacementTests` — the four gestures: two piles left apart, the piece left where it was put, merging on the container itself, merging onto the pile.
- `DropOnItemTests` — gold onto gold merges, nothing is nested inside the target, a plain item lands beside its target, a bag still opens.
- `DragDropStackMergeTests` and `SplitStackRefreshTests` — added while hunting this: two independently created stacks merging, and the remainder reaching the right client after a split.

Two existing tests encoded the old behaviour and passed because of it; they now make the gesture they describe.

Full suite green (2161). Verified in game against a real client: splitting leaves two piles, and both merge gestures still work.

No packet class changed, so the packet reference is untouched. No API change, so the UI contract is untouched.