### PR TITLE
feat(api): expose the hue and raw item catalogues

### DIFF
--- a/plugins/Moongate.Http.Plugin/Data/Api/Graphics/HueSummary.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Graphics/HueSummary.cs
@@ -1,0 +1,40 @@
+using Moongate.Ultima.Graphics;
+using Moongate.Ultima.Helpers;
+
+namespace Moongate.Http.Plugin.Data.Api.Graphics;
+
+/// <summary>One row of the hue catalogue: what to call a hue, and what it looks like.</summary>
+public sealed record HueSummary(int Value, string Name, string Hex, IReadOnlyList<string> Gradient)
+{
+    /// <summary>How many of the hue's 32 shades the gradient carries, evenly spaced across the ramp.</summary>
+    public const int GradientSteps = 8;
+
+    /// <summary>
+    /// Projects one entry of the hue table into its catalogue row. <paramref name="value" /> is the hue
+    /// as the client and the packets use it — 1-based, where 0 means unhued — while the table itself is
+    /// indexed from 0.
+    /// </summary>
+    public static HueSummary From(int value, Hue hue)
+    {
+        var colors = hue.Colors;
+        var gradient = new List<string>(GradientSteps);
+
+        for (var step = 0; step < GradientSteps && colors.Length > 0; step++)
+        {
+            gradient.Add(ToHex(colors[step * (colors.Length - 1) / Math.Max(GradientSteps - 1, 1)]));
+        }
+
+        // The middle of the ramp is what a swatch should show: the ends are the near-black and the
+        // near-white every hue shares, and neither tells two hues apart.
+        var representative = colors.Length > 0 ? ToHex(colors[colors.Length / 2]) : "#000000";
+
+        return new(value, string.IsNullOrWhiteSpace(hue.Name) ? $"Hue {value}" : hue.Name.Trim(), representative, gradient);
+    }
+
+    /// <summary>
+    /// A hue's colours are RGB555 with the top bit clear, so the components are expanded to 8 bits
+    /// rather than masked out of a 16-bit ARGB word.
+    /// </summary>
+    public static string ToHex(ushort color)
+        => $"#{HueHelpers.HueToColorR(color):X2}{HueHelpers.HueToColorG(color):X2}{HueHelpers.HueToColorB(color):X2}";
+}

--- a/plugins/Moongate.Http.Plugin/Data/Api/Graphics/UoItemSummary.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Graphics/UoItemSummary.cs
@@ -1,0 +1,40 @@
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Data.Api.Graphics;
+
+/// <summary>
+/// One row of the raw item catalogue: a tile as the client files describe it, before any template has
+/// had an opinion about it.
+/// </summary>
+public sealed record UoItemSummary(
+    int ItemId,
+    string Hex,
+    string Name,
+    IReadOnlyList<string> Flags,
+    int Weight,
+    int Height,
+    string ImageUrl
+)
+{
+    /// <summary>Projects one tiledata entry into its catalogue row.</summary>
+    public static UoItemSummary From(int itemId, ItemData data)
+        => new(
+            itemId,
+            $"0x{itemId:X4}",
+            data.Name?.Trim() ?? string.Empty,
+            FlagsOf(data.Flags),
+            data.Weight,
+            data.Height,
+            $"/api/v1/images/items/0x{itemId:X4}.png"
+        );
+
+    /// <summary>The set flags by name, which is how a caller filters and how a tooltip reads.</summary>
+    public static IReadOnlyList<string> FlagsOf(TileFlagType flags)
+        =>
+        [
+            .. Enum.GetValues<TileFlagType>()
+                   .Where(flag => flag != TileFlagType.None && (flags & flag) != 0)
+                   .Select(flag => flag.ToString())
+        ];
+}

--- a/plugins/Moongate.Http.Plugin/Endpoints/Graphics/HueEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Graphics/HueEndpoints.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Graphics;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Ultima.Graphics;
+
+namespace Moongate.Http.Plugin.Endpoints.Graphics;
+
+/// <summary>The staff view of hues.mul: every dye the client knows, with the colours it paints.</summary>
+public sealed class HueEndpoints : IApiEndpointRegistration
+{
+    public void Register(IEndpointRouteBuilder routes)
+
+        // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
+        // has none — the route would document itself blank.
+        => routes.MapGet("/api/v1/admin/hues", List)
+                 .WithName("ListHues")
+                 .WithTags("graphics")
+                 .Produces<PagedResponse<HueSummary>>()
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
+
+    /// <summary>
+    /// True when a hue was actually read from hues.mul. The table is 3000 entries long whether or not
+    /// the file was there, and the ones that were not read paint nothing at all — listing them would
+    /// offer three thousand identical black swatches on a shard running without client files.
+    /// </summary>
+    public static bool IsLoaded(Hue hue)
+        => hue.Colors is { Length: > 0 } colors && colors.Any(color => color != 0);
+
+    /// <summary>True when a hue answers the search: its number, or any part of its name.</summary>
+    public static bool Matches(int value, Hue hue, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return true;
+        }
+
+        var term = search.Trim();
+
+        return value.ToString(CultureInfo.InvariantCulture).Contains(term, StringComparison.OrdinalIgnoreCase) ||
+               (hue.Name?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    /// <summary>Every hue the client files describe, paged.</summary>
+    /// <remarks>
+    /// Values are 1-based, the way packets and the image routes take them: hue 1 is the first row of
+    /// hues.mul and hue 0 means unhued, so 0 is not listed. Each row carries a representative colour for
+    /// a swatch and eight evenly spaced steps of the full ramp. Search matches the number or the name.
+    /// Without client files the catalogue is empty rather than an error, because a shard can run
+    /// headless — the hue table exists either way, but its unread entries paint nothing and are left
+    /// out.
+    /// </remarks>
+    private IResult List(string? page, string? pageSize, string? search)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var table = Hues.List ?? [];
+        var matched = table
+                      .Select((hue, index) => (Value: index + 1, Hue: hue))
+                      .Where(entry => IsLoaded(entry.Hue))
+                      .Where(entry => Matches(entry.Value, entry.Hue, request.Search))
+                      .ToArray();
+
+        IReadOnlyList<HueSummary> items =
+        [
+            .. matched.Skip(request.Skip)
+                      .Take(request.PageSize)
+                      .Select(entry => HueSummary.From(entry.Value, entry.Hue))
+        ];
+
+        return Results.Ok(PagedResponse<HueSummary>.From(items, matched.Length, request));
+    }
+}

--- a/plugins/Moongate.Http.Plugin/Endpoints/Graphics/UoItemEndpoints.cs
+++ b/plugins/Moongate.Http.Plugin/Endpoints/Graphics/UoItemEndpoints.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Graphics;
+using Moongate.Http.Plugin.Interfaces.Endpoints;
+using Moongate.Http.Plugin.Services.Hosting;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Http.Plugin.Endpoints.Graphics;
+
+/// <summary>
+/// The staff view of tiledata: every item graphic the client knows, whether or not any template ever
+/// mentions it. This is what a picker browses when the answer is "some art", not "some template".
+/// </summary>
+public sealed class UoItemEndpoints : IApiEndpointRegistration
+{
+    public void Register(IEndpointRouteBuilder routes)
+
+        // A method group, not a lambda: Swashbuckle reads the /// off the handler's method, and a lambda
+        // has none — the route would document itself blank.
+        => routes.MapGet("/api/v1/admin/uo-items", List)
+                 .WithName("ListUoItems")
+                 .WithTags("graphics")
+                 .Produces<PagedResponse<UoItemSummary>>()
+                 .RequireAuthorization(HttpServerService.AdminPolicy);
+
+    /// <summary>True when a tile answers the search: its decimal id, its 0x hex id, or part of its name.</summary>
+    public static bool Matches(int itemId, ItemData data, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return true;
+        }
+
+        var term = search.Trim();
+
+        // "0xEED" and "0x0EED" are the same tile to whoever typed them, but not to a substring match
+        // against the padded form, so an explicit hex term is compared as a number.
+        if (term.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(term[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var wanted))
+        {
+            return itemId == wanted;
+        }
+
+        return itemId.ToString(CultureInfo.InvariantCulture).Contains(term, StringComparison.OrdinalIgnoreCase) ||
+               $"0x{itemId:X4}".Contains(term, StringComparison.OrdinalIgnoreCase) ||
+               (data.Name?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    /// <summary>Reads a flag name into the flag itself, so an unknown name refuses rather than matching all.</summary>
+    public static bool TryParseFlag(string? name, out TileFlagType flag)
+    {
+        flag = TileFlagType.None;
+
+        return !string.IsNullOrWhiteSpace(name) &&
+               Enum.TryParse(name.Trim(), ignoreCase: true, out flag) &&
+               flag != TileFlagType.None;
+    }
+
+    /// <summary>Every item tile the client files describe, paged.</summary>
+    /// <remarks>
+    /// Rows carry the tile's flags, weight and height, and the URL of its art. Search matches the
+    /// decimal id, the 0x-prefixed hex, or the tiledata name. Pass flag to keep only tiles carrying one
+    /// — Container, Wearable, Weapon and the rest of TileFlagType — and an unknown flag name is a 400
+    /// rather than a silently unfiltered list. Nameless tiles are the unused ids and are listed too,
+    /// because their graphic may still be worth picking. Without client files the catalogue is empty
+    /// rather than an error, because a shard can run headless.
+    /// </remarks>
+    private IResult List(string? page, string? pageSize, string? search, string? flag)
+    {
+        if (!PageRequest.TryParse(page, pageSize, search, out var request, out var error))
+        {
+            return Results.Problem(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var wanted = TileFlagType.None;
+
+        if (!string.IsNullOrWhiteSpace(flag) && !TryParseFlag(flag, out wanted))
+        {
+            return Results.Problem($"'{flag}' is not a tile flag.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var table = TileData.ItemTable ?? [];
+        var matched = table
+                      .Select((data, itemId) => (ItemId: itemId, Data: data))
+                      .Where(entry => wanted == TileFlagType.None || (entry.Data.Flags & wanted) != 0)
+                      .Where(entry => Matches(entry.ItemId, entry.Data, request.Search))
+                      .ToArray();
+
+        IReadOnlyList<UoItemSummary> items =
+        [
+            .. matched.Skip(request.Skip)
+                      .Take(request.PageSize)
+                      .Select(entry => UoItemSummary.From(entry.ItemId, entry.Data))
+        ];
+
+        return Results.Ok(PagedResponse<UoItemSummary>.From(items, matched.Length, request));
+    }
+}

--- a/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
+++ b/plugins/Moongate.Http.Plugin/MoongateHttpPlugin.cs
@@ -5,6 +5,7 @@ using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Console;
+using Moongate.Http.Plugin.Endpoints.Graphics;
 using Moongate.Http.Plugin.Endpoints.Images;
 using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
@@ -100,6 +101,8 @@ public class MoongateHttpPlugin : ISquidStdPlugin
         container.RegisterApiEndpoint<HairImageEndpoints>();
         container.RegisterApiEndpoint<MobileTemplateImageEndpoints>();
         container.RegisterApiEndpoint<MobileImageAdminEndpoints>();
+        container.RegisterApiEndpoint<HueEndpoints>();
+        container.RegisterApiEndpoint<UoItemEndpoints>();
         container.Register<IGumpCatalog, GumpCatalog>(Reuse.Singleton);
         container.Register<IPaperdollRenderer, PaperdollRenderer>(Reuse.Singleton);
         container.Register<IPaperdollImageService, PaperdollImageService>(Reuse.Singleton);

--- a/tests/Moongate.Tests/Data/Graphics/ClientCatalogDataTests.cs
+++ b/tests/Moongate.Tests/Data/Graphics/ClientCatalogDataTests.cs
@@ -1,0 +1,90 @@
+using Moongate.Http.Plugin.Data.Api.Graphics;
+using Moongate.Http.Plugin.Endpoints.Graphics;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Graphics;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Data.Graphics;
+
+/// <summary>
+/// The two client catalogues against a real client directory. Unit tests can prove the projections are
+/// consistent with themselves; only the files can say whether what comes out is the hue and the tile a
+/// player would recognise.
+/// </summary>
+public class ClientCatalogDataTests
+{
+    [ClientFilesFact]
+    public void Hues_TheTableIsRead()
+    {
+        Load();
+
+        var loaded = Hues.List.Count(HueEndpoints.IsLoaded);
+
+        // hues.mul ships a few thousand; the exact count varies by client, so this only asserts the
+        // file was read at all rather than pinning a number a client update would break.
+        Assert.InRange(loaded, 1000, 3000);
+    }
+
+    [ClientFilesFact]
+    public void Hues_EverySwatchIsAColourAndNotBlack()
+    {
+        Load();
+
+        var swatches = Hues.List
+                           .Where(HueEndpoints.IsLoaded)
+                           .Select((hue, index) => HueSummary.From(index + 1, hue))
+                           .ToArray();
+
+        Assert.All(swatches, swatch => Assert.Matches("^#[0-9A-F]{6}$", swatch.Hex));
+        Assert.DoesNotContain(swatches, swatch => swatch.Hex == "#000000");
+    }
+
+    [ClientFilesFact]
+    public void UoItems_GoldIsAStackableTileCalledGoldCoin()
+    {
+        Load();
+
+        var gold = UoItemSummary.From(3821, TileData.ItemTable[3821]);
+
+        Assert.Contains("gold", gold.Name, StringComparison.OrdinalIgnoreCase);
+
+        // Generic is UO's "this is a pile" bit, which is what makes coins stack.
+        Assert.Contains(nameof(TileFlagType.Generic), gold.Flags);
+    }
+
+    [ClientFilesFact]
+    public void UoItems_TheBackpackIsAContainer()
+    {
+        Load();
+
+        Assert.Contains(nameof(TileFlagType.Container), UoItemSummary.From(3701, TileData.ItemTable[3701]).Flags);
+    }
+
+    // The search is the only way into a table this size, so it has to reach a tile by the three things
+    // someone would actually type.
+    [ClientFilesFact]
+    public void UoItems_GoldIsFoundByName_ByDecimalId_AndByHexId()
+    {
+        Load();
+
+        var gold = TileData.ItemTable[3821];
+
+        Assert.True(UoItemEndpoints.Matches(3821, gold, "gold"));
+        Assert.True(UoItemEndpoints.Matches(3821, gold, "3821"));
+        Assert.True(UoItemEndpoints.Matches(3821, gold, "0xEED"));
+    }
+
+    /// <summary>
+    /// Points the readers at the client directory and fills the two process-wide tables. Both are
+    /// idempotent, and the tables are shared with every other test in the run, so this only ever puts
+    /// back data that was going to be there.
+    /// </summary>
+    private static void Load()
+    {
+        Files.SetDirectory(ClientFiles.Directory);
+        TileData.Initialize();
+        Hues.Initialize();
+    }
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Graphics/HueEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Graphics/HueEndpointsTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using System.Net.Http.Json;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Graphics;
+using Moongate.Http.Plugin.Endpoints.Graphics;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Graphics;
+
+namespace Moongate.Tests.Http.Endpoints.Graphics;
+
+/// <summary>
+/// The hue catalogue. The colour maths and the search are pure and driven straight; the route itself
+/// reads the process-wide hue table, which is empty in a run with no client files.
+/// </summary>
+public class HueEndpointsTests
+{
+    private const string Route = "/api/v1/admin/hues";
+
+    [Fact]
+    public void Matches_FindsAHueByNumber()
+        => Assert.True(HueEndpoints.Matches(1002, Named("blood red"), "1002"));
+
+    [Fact]
+    public void Matches_FindsAHueByName()
+        => Assert.True(HueEndpoints.Matches(1002, Named("blood red"), "RED"));
+
+    [Fact]
+    public void Matches_AHueThatAnswersNothing_IsExcluded()
+        => Assert.False(HueEndpoints.Matches(1002, Named("blood red"), "azure"));
+
+    [Fact]
+    public void Matches_NoSearch_KeepsEverything()
+        => Assert.True(HueEndpoints.Matches(1002, Named("blood red"), null));
+
+    // RGB555 with the top bit clear: 0x7C00 is pure red, and expanding 5 bits to 8 has to reach FF
+    // rather than F8, or every swatch comes out slightly dark.
+    [Theory]
+    [InlineData(0x7C00, "#FF0000")]
+    [InlineData(0x03E0, "#00FF00")]
+    [InlineData(0x001F, "#0000FF")]
+    [InlineData(0x0000, "#000000")]
+    [InlineData(0x7FFF, "#FFFFFF")]
+    public void ToHex_ExpandsTheFiveBitChannels(int color, string expected)
+        => Assert.Equal(expected, HueSummary.ToHex((ushort)color));
+
+    // The table is 3000 long with or without hues.mul; the unread entries are all-zero and must not
+    // reach the catalogue as three thousand identical black swatches.
+    [Fact]
+    public void IsLoaded_AnEntryThatPaintsNothing_IsNotAHue()
+        => Assert.False(HueEndpoints.IsLoaded(Named("Null")));
+
+    [Fact]
+    public void IsLoaded_AnEntryWithColour_IsAHue()
+        => Assert.True(HueEndpoints.IsLoaded(Painted("blood red")));
+
+    [Fact]
+    public void Summary_ANamelessHue_IsNamedByItsNumber()
+        => Assert.Equal("Hue 1002", HueSummary.From(1002, Named("   ")).Name);
+
+    [Fact]
+    public void Summary_CarriesAGradientOfTheRamp()
+        => Assert.Equal(HueSummary.GradientSteps, HueSummary.From(1002, Painted("blood red")).Gradient.Count);
+
+    // Asserting an empty catalogue would only hold in a run where nothing has loaded the client
+    // tables, and they are process-wide: another test file filling them would fail this one. What the
+    // route promises is a page either way, never an error, and that holds whatever is loaded.
+    [Fact]
+    public async Task List_IsAlwaysAPageAndNeverAnError()
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync(Route);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.Content.ReadFromJsonAsync<PagedResponse<HueSummary>>();
+
+        Assert.NotNull(page);
+        Assert.InRange(page.Items.Count, 0, page.PageSize);
+        Assert.True(page.Total >= page.Items.Count);
+    }
+
+    [Theory, InlineData("?page=0"), InlineData("?pageSize=5000")]
+    public async Task List_OutOfRangePaging_IsBadRequest(string query)
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync($"{Route}{query}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsAPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    private static Hue Named(string name)
+    {
+        var hue = new Hue(0) { Name = name };
+
+        return hue;
+    }
+
+    /// <summary>A hue with an actual ramp in it, the way one read from hues.mul looks.</summary>
+    private static Hue Painted(string name)
+    {
+        var hue = Named(name);
+
+        for (var step = 0; step < hue.Colors.Length; step++)
+        {
+            hue.Colors[step] = (ushort)(0x0400 + step);
+        }
+
+        return hue;
+    }
+
+    private static Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+        => TestApiServer.StartAsync(
+            level,
+            configure: container => container.RegisterApiEndpointInstance(new HueEndpoints())
+        );
+}

--- a/tests/Moongate.Tests/Http/Endpoints/Graphics/UoItemEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Graphics/UoItemEndpointsTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using System.Net.Http.Json;
+using Moongate.Core.Types;
+using Moongate.Http.Plugin.Data;
+using Moongate.Http.Plugin.Data.Api.Graphics;
+using Moongate.Http.Plugin.Endpoints.Graphics;
+using Moongate.Http.Plugin.Extensions;
+using Moongate.Tests.Support;
+using Moongate.Ultima.Tiles;
+using Moongate.Ultima.Types;
+
+namespace Moongate.Tests.Http.Endpoints.Graphics;
+
+/// <summary>
+/// The raw tile catalogue: what the client files say about a graphic, before any template has an
+/// opinion. The search and the flag filter are pure, so they are driven straight rather than through
+/// the process-wide tiledata the route reads, which any test in the run may have filled.
+/// </summary>
+public class UoItemEndpointsTests
+{
+    private const string Route = "/api/v1/admin/uo-items";
+
+    [Fact]
+    public void Matches_FindsATileByItsDecimalId()
+        => Assert.True(UoItemEndpoints.Matches(3821, Tile("gold coin"), "3821"));
+
+    [Fact]
+    public void Matches_FindsATileByItsHexId()
+        => Assert.True(UoItemEndpoints.Matches(3821, Tile("gold coin"), "0xEED"));
+
+    [Fact]
+    public void Matches_FindsATileByName()
+        => Assert.True(UoItemEndpoints.Matches(3821, Tile("gold coin"), "COIN"));
+
+    [Fact]
+    public void Matches_ATileThatAnswersNothing_IsExcluded()
+        => Assert.False(UoItemEndpoints.Matches(3821, Tile("gold coin"), "dagger"));
+
+    // A nameless tile is an unused id. It still has art, so a search by number must reach it.
+    [Fact]
+    public void Matches_ANamelessTile_IsStillFoundByNumber()
+        => Assert.True(UoItemEndpoints.Matches(9, Tile(null!), "9"));
+
+    [Fact]
+    public void Matches_NoSearch_KeepsEverything()
+        => Assert.True(UoItemEndpoints.Matches(3821, Tile("gold coin"), null));
+
+    [Theory, InlineData("Container"), InlineData("container"), InlineData("CONTAINER")]
+    public void TryParseFlag_ReadsAFlagWhateverItsCase(string name)
+    {
+        Assert.True(UoItemEndpoints.TryParseFlag(name, out var flag));
+        Assert.Equal(TileFlagType.Container, flag);
+    }
+
+    // None would pass every tile through, so it must not be reachable by name: filtering by it would
+    // silently mean "no filter" while reading like a real one.
+    [Theory, InlineData("None"), InlineData("Nonsense"), InlineData("")]
+    public void TryParseFlag_RefusesWhatIsNotAFlag(string name)
+        => Assert.False(UoItemEndpoints.TryParseFlag(name, out _));
+
+    [Fact]
+    public void Summary_CarriesTheArtUrlAndTheSetFlags()
+    {
+        var summary = UoItemSummary.From(3821, Tile("gold coin", TileFlagType.Generic | TileFlagType.Container));
+
+        Assert.Equal("0x0EED", summary.Hex);
+        Assert.Equal("/api/v1/images/items/0x0EED.png", summary.ImageUrl);
+        Assert.Contains("Generic", summary.Flags);
+        Assert.Contains("Container", summary.Flags);
+    }
+
+    [Fact]
+    public void Summary_ATileWithNoFlags_ListsNone()
+        => Assert.Empty(UoItemSummary.From(9, Tile("nothing")).Flags);
+
+    // Asserting an empty catalogue would only hold in a run where nothing has loaded the client
+    // tables, and they are process-wide: another test file filling them would fail this one. What the
+    // route promises is a page either way, never an error, and that holds whatever is loaded.
+    [Fact]
+    public async Task List_IsAlwaysAPageAndNeverAnError()
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        var response = await server.Client.GetAsync(Route);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var page = await response.Content.ReadFromJsonAsync<PagedResponse<UoItemSummary>>();
+
+        Assert.NotNull(page);
+        Assert.InRange(page.Items.Count, 0, page.PageSize);
+        Assert.True(page.Total >= page.Items.Count);
+    }
+
+    [Fact]
+    public async Task List_AnUnknownFlag_IsBadRequest()
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync($"{Route}?flag=nonsense")).StatusCode);
+    }
+
+    [Theory, InlineData("?page=0"), InlineData("?pageSize=5000")]
+    public async Task List_OutOfRangePaging_IsBadRequest(string query)
+    {
+        await using var server = await StartAsync();
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.BadRequest, (await server.Client.GetAsync($"{Route}{query}")).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_AsAPlayer_IsForbidden()
+    {
+        await using var server = await StartAsync(AccountLevelType.Player);
+
+        await server.AuthenticateAsync();
+
+        Assert.Equal(HttpStatusCode.Forbidden, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    [Fact]
+    public async Task List_WithoutAToken_IsUnauthorized()
+    {
+        await using var server = await StartAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, (await server.Client.GetAsync(Route)).StatusCode);
+    }
+
+    private static ItemData Tile(string name, TileFlagType flags = TileFlagType.None)
+        => new() { Name = name, Flags = flags };
+
+    private static Task<TestApiServer> StartAsync(AccountLevelType level = AccountLevelType.Administrator)
+        => TestApiServer.StartAsync(
+            level,
+            configure: container => container.RegisterApiEndpointInstance(new UoItemEndpoints())
+        );
+}

--- a/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
+++ b/tests/Moongate.Tests/Http/MoongateHttpPluginTests.cs
@@ -6,6 +6,7 @@ using Moongate.Http.Plugin.Endpoints.Admin;
 using Moongate.Http.Plugin.Endpoints.Auth;
 using Moongate.Http.Plugin.Endpoints.Characters;
 using Moongate.Http.Plugin.Endpoints.Console;
+using Moongate.Http.Plugin.Endpoints.Graphics;
 using Moongate.Http.Plugin.Endpoints.Images;
 using Moongate.Http.Plugin.Endpoints.Items;
 using Moongate.Http.Plugin.Endpoints.Maps;
@@ -51,6 +52,7 @@ public class MoongateHttpPluginTests
                 typeof(CharacterEndpoints),
                 typeof(ConsoleEndpoints),
                 typeof(HairImageEndpoints),
+                typeof(HueEndpoints),
                 typeof(ItemImageAdminEndpoints),
                 typeof(ItemImageEndpoints),
                 typeof(ItemTemplateEndpoints),
@@ -69,6 +71,7 @@ public class MoongateHttpPluginTests
                 typeof(ServerInfoEndpoints),
                 typeof(ServerSettingsAdminEndpoints),
                 typeof(StatsEndpoints),
+                typeof(UoItemEndpoints),
                 typeof(VersionEndpoints)
             ],
             registered

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -420,6 +420,103 @@
         }
       }
     },
+    "/api/v1/admin/hues": {
+      "get": {
+        "tags": [
+          "graphics"
+        ],
+        "summary": "Every hue the client files describe, paged.",
+        "description": "Values are 1-based, the way packets and the image routes take them: hue 1 is the first row of\nhues.mul and hue 0 means unhued, so 0 is not listed. Each row carries a representative colour for\na swatch and eight evenly spaced steps of the full ramp. Search matches the number or the name.\nWithout client files the catalogue is empty rather than an error, because a shard can run\nheadless — the hue table exists either way, but its unread entries paint nothing and are left\nout.",
+        "operationId": "ListHues",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HueSummaryPagedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/uo-items": {
+      "get": {
+        "tags": [
+          "graphics"
+        ],
+        "summary": "Every item tile the client files describe, paged.",
+        "description": "Rows carry the tile's flags, weight and height, and the URL of its art. Search matches the\ndecimal id, the 0x-prefixed hex, or the tiledata name. Pass flag to keep only tiles carrying one\n— Container, Wearable, Weapon and the rest of TileFlagType — and an unknown flag name is a 400\nrather than a silently unfiltered list. Nameless tiles are the unused ids and are listed too,\nbecause their graphic may still be worth picking. Without client files the catalogue is empty\nrather than an error, because a shard can run headless.",
+        "operationId": "ListUoItems",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "flag",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UoItemSummaryPagedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/images/items/{id}.png": {
       "get": {
         "tags": [
@@ -2660,6 +2757,76 @@
         },
         "additionalProperties": {}
       },
+      "HueSummary": {
+        "required": [
+          "gradient",
+          "hex",
+          "name",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "hex": {
+            "type": "string"
+          },
+          "gradient": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "One row of the hue catalogue: what to call a hue, and what it looks like."
+      },
+      "HueSummaryPagedResponse": {
+        "required": [
+          "items",
+          "page",
+          "pageSize",
+          "total",
+          "totalPages"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HueSummary"
+            },
+            "description": "The results on this page."
+          },
+          "total": {
+            "type": "integer",
+            "description": "How many results matched in total, before paging.",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "The 1-based page this is.",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "The page size used. The last page may hold fewer items.",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "How many pages exist at this page size. 0 when nothing matched.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "One page of results, and what a caller needs to walk the rest."
+      },
       "ItemImageExportStatus": {
         "required": [
           "done",
@@ -3952,6 +4119,90 @@
         "additionalProperties": false,
         "description": "How much the world holds: creatures nobody plays, and persisted items."
       },
+      "UoItemSummary": {
+        "required": [
+          "flags",
+          "height",
+          "hex",
+          "imageUrl",
+          "itemId",
+          "name",
+          "weight"
+        ],
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hex": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "weight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imageUrl": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "One row of the raw item catalogue: a tile as the client files describe it, before any template has\nhad an opinion about it."
+      },
+      "UoItemSummaryPagedResponse": {
+        "required": [
+          "items",
+          "page",
+          "pageSize",
+          "total",
+          "totalPages"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UoItemSummary"
+            },
+            "description": "The results on this page."
+          },
+          "total": {
+            "type": "integer",
+            "description": "How many results matched in total, before paging.",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "description": "The 1-based page this is.",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "The page size used. The last page may hold fewer items.",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "description": "How many pages exist at this page size. 0 when nothing matched.",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "One page of results, and what a caller needs to walk the rest."
+      },
       "UpdateAccountRequest": {
         "type": "object",
         "properties": {
@@ -4118,6 +4369,9 @@
     },
     {
       "name": "console"
+    },
+    {
+      "name": "graphics"
     },
     {
       "name": "images"

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -270,6 +270,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/hues": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Every hue the client files describe, paged.
+         * @description Values are 1-based, the way packets and the image routes take them: hue 1 is the first row of
+         *     hues.mul and hue 0 means unhued, so 0 is not listed. Each row carries a representative colour for
+         *     a swatch and eight evenly spaced steps of the full ramp. Search matches the number or the name.
+         *     Without client files the catalogue is empty rather than an error, because a shard can run
+         *     headless — the hue table exists either way, but its unread entries paint nothing and are left
+         *     out.
+         */
+        get: operations["ListHues"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/uo-items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Every item tile the client files describe, paged.
+         * @description Rows carry the tile's flags, weight and height, and the URL of its art. Search matches the
+         *     decimal id, the 0x-prefixed hex, or the tiledata name. Pass flag to keep only tiles carrying one
+         *     — Container, Wearable, Weapon and the rest of TileFlagType — and an unknown flag name is a 400
+         *     rather than a silently unfiltered list. Nameless tiles are the unused ids and are listed too,
+         *     because their graphic may still be worth picking. Without client files the catalogue is empty
+         *     rather than an error, because a shard can run headless.
+         */
+        get: operations["ListUoItems"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/images/items/{id}.png": {
         parameters: {
             query?: never;
@@ -1360,6 +1410,39 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One row of the hue catalogue: what to call a hue, and what it looks like. */
+        HueSummary: {
+            /** Format: int32 */
+            value: number;
+            name: string;
+            hex: string;
+            gradient: string[];
+        };
+        /** @description One page of results, and what a caller needs to walk the rest. */
+        HueSummaryPagedResponse: {
+            /** @description The results on this page. */
+            items: components["schemas"]["HueSummary"][];
+            /**
+             * Format: int32
+             * @description How many results matched in total, before paging.
+             */
+            total: number;
+            /**
+             * Format: int32
+             * @description The 1-based page this is.
+             */
+            page: number;
+            /**
+             * Format: int32
+             * @description The page size used. The last page may hold fewer items.
+             */
+            pageSize: number;
+            /**
+             * Format: int32
+             * @description How many pages exist at this page size. 0 when nothing matched.
+             */
+            totalPages: number;
+        };
         /** @description How far the bulk item-image export has got. */
         ItemImageExportStatus: {
             /** @description Idle, Running, Completed or Failed. */
@@ -1890,6 +1973,47 @@ export interface components {
             items: number;
         };
         /**
+         * @description One row of the raw item catalogue: a tile as the client files describe it, before any template has
+         *     had an opinion about it.
+         */
+        UoItemSummary: {
+            /** Format: int32 */
+            itemId: number;
+            hex: string;
+            name: string;
+            flags: string[];
+            /** Format: int32 */
+            weight: number;
+            /** Format: int32 */
+            height: number;
+            imageUrl: string;
+        };
+        /** @description One page of results, and what a caller needs to walk the rest. */
+        UoItemSummaryPagedResponse: {
+            /** @description The results on this page. */
+            items: components["schemas"]["UoItemSummary"][];
+            /**
+             * Format: int32
+             * @description How many results matched in total, before paging.
+             */
+            total: number;
+            /**
+             * Format: int32
+             * @description The 1-based page this is.
+             */
+            page: number;
+            /**
+             * Format: int32
+             * @description The page size used. The last page may hold fewer items.
+             */
+            pageSize: number;
+            /**
+             * Format: int32
+             * @description How many pages exist at this page size. 0 when nothing matched.
+             */
+            totalPages: number;
+        };
+        /**
          * @description The fields to change. Every one is optional: absent means "leave alone", which is what makes this a
          *     PATCH rather than a PUT. Password is write-only — it enters here and never appears in a response.
          *     Email is not here: the account service has no setter for it.
@@ -2255,6 +2379,55 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    ListHues: {
+        parameters: {
+            query?: {
+                page?: string;
+                pageSize?: string;
+                search?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HueSummaryPagedResponse"];
+                };
+            };
+        };
+    };
+    ListUoItems: {
+        parameters: {
+            query?: {
+                page?: string;
+                pageSize?: string;
+                search?: string;
+                flag?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UoItemSummaryPagedResponse"];
+                };
             };
         };
     };


### PR DESCRIPTION
Fixes #189.

The old portal browsed six catalogues; this one exposed four. Bodies, hair styles, item templates and mobile templates were already there — hues and the raw tiledata items were not, so anything built on top of them had nothing to read. These come before the pickers so the pickers land on a complete catalogue.

## Routes

**`GET /api/v1/admin/hues`** — every dye in `hues.mul`, paged, searchable by number or name. Values are 1-based the way packets and the image routes take them (0 means unhued and is not listed). Each row carries a representative colour for a swatch — the middle of the ramp, since the ends are the near-black and near-white every hue shares — plus eight evenly spaced steps of the full ramp.

**`GET /api/v1/admin/uo-items`** — every item tile, paged, searchable by decimal id, `0x` hex id or tiledata name, filterable by any `TileFlagType`. Rows carry the flags, weight, height and the art URL. An unknown flag name is a 400 rather than a silently unfiltered list; `None` is deliberately unparseable, since filtering by it would read like a real filter and mean "no filter".

## Two things the tests caught

**Hue colours are RGB555 with the top bit clear**, so the channels expand to 8 bits rather than being masked out of a 16-bit ARGB word. Built the other way every swatch comes out slightly dark — 0x7C00 has to reach `#FF0000`, not `#F80000`.

**The hue table is 3000 entries long whether or not `hues.mul` was found.** The unread ones are named "Null" and paint nothing, so they are left out: otherwise a shard running headless offers three thousand identical black swatches.

Searching `0xEED` also has to find `0x0EED` — an explicit hex term is compared as a number rather than as a substring of the padded form.

## Tests

The search, the flag parsing and the colour maths are pure and driven directly. The routes are covered for paging, authorisation and the shape of the answer. Five more run against a real client directory — gold is a stackable tile called gold coin, the backpack is a container, no swatch is black, and gold is reachable by name, by decimal id and by hex — and skip visibly where there is no client, as CI does.

Two list tests originally asserted an empty catalogue, which only held because nothing else in the run had loaded the client tables. They are process-wide, so this passed alone and failed in the suite; they now assert what the route promises — a coherent page, never an error — which holds whatever is loaded.

Full suite green (2204). UI contract regenerated (`ui/openapi.json`, `ui/src/lib/api-types.ts`), DocFX at 0 warnings, no packet class touched.