### PR TITLE
feat(ui): one picker for every catalogue the shard has

### DIFF
--- a/ui/src/components/ui/entity-picker.test.tsx
+++ b/ui/src/components/ui/entity-picker.test.tsx
@@ -117,6 +117,19 @@ describe('EntityPicker', () => {
     expect(await screen.findByText(/nothing matches/i)).toBeInTheDocument()
   })
 
+  // The width is invisible to jsdom, but the trap that swallowed it is not: DialogContent caps
+  // itself at sm:max-w-lg, and undoing only the unprefixed max-width leaves that cap standing on
+  // every screen wider than 640px -- which is every screen this is used on.
+  it('undoes the dialog cap that would otherwise decide its width', () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    renderPicker()
+
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog.className).toContain('sm:max-w-none')
+    expect(dialog.className).toContain('md:w-[60vw]')
+  })
+
   it('can be narrowed to one catalogue', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/ui/src/components/ui/entity-picker.test.tsx
+++ b/ui/src/components/ui/entity-picker.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '../../lib/i18n'
+import { EntityPicker } from './entity-picker'
+import { CATALOGUES } from '../../lib/catalogues'
+
+function page(items: unknown[]) {
+  return new Response(JSON.stringify({ items, total: items.length, page: 1, pageSize: 25, totalPages: 1 }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+const template = { id: 'dagger', name: 'a dagger', imageUrl: '/api/v1/images/items/0x0F51.png' }
+const hue = { value: 1002, name: 'blood red', hex: '#8B0000', gradient: [] }
+
+function renderPicker(onSelect = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <EntityPicker open onOpenChange={() => {}} onSelect={onSelect} />
+    </QueryClientProvider>,
+  )
+
+  return onSelect
+}
+
+describe('EntityPicker', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('opens on the first catalogue and lists what it holds', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([template]))
+    renderPicker()
+
+    expect(await screen.findByText('a dagger')).toBeInTheDocument()
+  })
+
+  it('offers every catalogue', () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    renderPicker()
+
+    for (const label of ['Item templates', 'Mobile templates', 'UO items', 'Hues', 'Bodies', 'Hair styles']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  // Each catalogue has its own route, so the mock answers by route: anything else would feed rows of
+  // one shape to the reader of another, which cannot happen against the real server.
+  it('reads the catalogue that was chosen', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) =>
+      Promise.resolve(String(input).includes('/hues') ? page([hue]) : page([template])),
+    )
+    renderPicker()
+
+    expect(await screen.findByText('a dagger')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Hues' }))
+
+    expect(await screen.findByText('blood red')).toBeInTheDocument()
+    expect(screen.queryByText('a dagger')).not.toBeInTheDocument()
+  })
+
+  // A search typed for templates means nothing among hues, and carrying it over would open the next
+  // catalogue on an empty list for no visible reason.
+  it('clears the search when the catalogue changes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    renderPicker()
+
+    await userEvent.type(screen.getByLabelText(/search the catalogue/i), 'dagger')
+    await waitFor(() => expect(String(fetchSpy.mock.calls.at(-1)?.[0])).toContain('search=dagger'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Hues' }))
+
+    expect(screen.getByLabelText(/search the catalogue/i)).toHaveValue('')
+    await waitFor(() => expect(String(fetchSpy.mock.calls.at(-1)?.[0])).not.toContain('search'))
+  })
+
+  it('hands back the entry that was picked', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([template]))
+    const onSelect = renderPicker()
+
+    await userEvent.click(await screen.findByRole('button', { name: /a dagger/ }))
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'dagger', label: 'a dagger' }),
+      expect.objectContaining({ id: 'itemTemplates' }),
+    )
+  })
+
+  it('offers the flag filter only on the raw tiles', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    renderPicker()
+
+    expect(screen.queryByLabelText(/filter by flag/i)).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'UO items' }))
+
+    expect(screen.getByLabelText(/filter by flag/i)).toBeInTheDocument()
+  })
+
+  it('sends the flag that was filtered by', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    renderPicker()
+
+    await userEvent.click(screen.getByRole('button', { name: 'UO items' }))
+    await userEvent.selectOptions(screen.getByLabelText(/filter by flag/i), 'Container')
+
+    await waitFor(() => expect(String(fetchSpy.mock.calls.at(-1)?.[0])).toContain('flag=Container'))
+  })
+
+  it('says so when nothing matches', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    renderPicker()
+
+    expect(await screen.findByText(/nothing matches/i)).toBeInTheDocument()
+  })
+
+  it('can be narrowed to one catalogue', () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(page([]))
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={client}>
+        <EntityPicker
+          open
+          onOpenChange={() => {}}
+          onSelect={() => {}}
+          catalogues={CATALOGUES.filter((catalogue) => catalogue.id === 'hues')}
+        />
+      </QueryClientProvider>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Hues' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Item templates' })).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/components/ui/entity-picker.tsx
+++ b/ui/src/components/ui/entity-picker.tsx
@@ -57,8 +57,12 @@ export function EntityPicker({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Three fifths of the viewport on a desktop, near-full on a phone where three fifths is a
-          column too narrow to put a tile and two lines of text beside each other. */}
-      <DialogContent className="flex max-h-[80vh] w-[92vw] max-w-none flex-col gap-4 md:w-[60vw]">
+          column too narrow to put a tile and two lines of text beside each other.
+
+          Both max-widths have to be undone, not just the plain one: DialogContent caps itself at
+          sm:max-w-lg, and a responsive cap is a different class group, so an unprefixed max-w-none
+          leaves it standing and the width below has no effect on any screen wider than 640px. */}
+      <DialogContent className="flex max-h-[80vh] w-[92vw] max-w-none flex-col gap-4 sm:max-w-none md:w-[60vw]">
         <DialogHeader>
           <DialogTitle>{t('picker.title')}</DialogTitle>
         </DialogHeader>

--- a/ui/src/components/ui/entity-picker.tsx
+++ b/ui/src/components/ui/entity-picker.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { CATALOGUES, useCatalogue, type Catalogue, type CatalogueEntry } from '@/lib/catalogues'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './dialog'
+import { FilterPill } from './filter-pill'
+import { Input } from './input'
+import { Button } from './button'
+import { RarityTile } from './rarity-tile'
+
+/**
+ * One picker for every catalogue the shard has. Which catalogue is a choice inside the dialog rather
+ * than a different component per entity: the six differ only in where they are read from and how a row
+ * reads, and both of those are data — see CATALOGUES.
+ *
+ * It hands back the picked entry and nothing else. What that means is the caller's business: a value
+ * to copy, a page to open, an item to give someone.
+ */
+export function EntityPicker({
+  open,
+  onOpenChange,
+  onSelect,
+  catalogues = CATALOGUES,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (entry: CatalogueEntry, catalogue: Catalogue) => void
+  /** Narrows the picker to some of the catalogues. All of them by default. */
+  catalogues?: Catalogue[]
+}) {
+  const { t } = useTranslation()
+  const [chosen, setChosen] = useState(catalogues[0])
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState('')
+  const [page, setPage] = useState(1)
+
+  // A search typed for one catalogue means nothing in the next, and neither does its page.
+  useEffect(() => {
+    setSearch('')
+    setFilter('')
+    setPage(1)
+  }, [chosen])
+
+  const rows = useCatalogue(chosen, { page, search, filter })
+
+  // Only the page that came from the catalogue on screen. React Query holds the previous one while
+  // the next loads, and rows of one catalogue read through the reader of another are nonsense.
+  const shown = rows.data?.catalogueId === chosen.id ? rows.data : undefined
+  const entries = (shown?.items ?? []).map((row) => chosen.toEntry(row as never))
+  const totalPages = shown?.totalPages ?? 1
+
+  function pick(entry: CatalogueEntry) {
+    onSelect(entry, chosen)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[80vh] w-[min(46rem,92vw)] max-w-none flex-col gap-4">
+        <DialogHeader>
+          <DialogTitle>{t('picker.title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-wrap gap-1.5">
+          {catalogues.map((catalogue) => (
+            <FilterPill key={catalogue.id} active={catalogue.id === chosen.id} onClick={() => setChosen(catalogue)}>
+              {t(`picker.catalogues.${catalogue.id}`)}
+            </FilterPill>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            autoFocus
+            value={search}
+            onChange={(event) => {
+              setSearch(event.target.value)
+              setPage(1)
+            }}
+            placeholder={t(`picker.search.${chosen.id}`)}
+            aria-label={t('picker.searchLabel')}
+            className="min-w-48 flex-1"
+          />
+
+          {chosen.filter && (
+            <select
+              value={filter}
+              onChange={(event) => {
+                setFilter(event.target.value)
+                setPage(1)
+              }}
+              aria-label={t('picker.filterLabel')}
+              className="h-9 rounded-control border border-border-subtle bg-deep px-2 text-sm text-ink"
+            >
+              {chosen.filter.values.map((value) => (
+                <option key={value} value={value}>
+                  {value === '' ? t('picker.anyFlag') : value}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <div className="min-h-40 flex-1 overflow-y-auto">
+          {rows.isError ? (
+            <p className="p-6 text-center text-sm text-danger-text">{t('error.generic')}</p>
+          ) : entries.length === 0 ? (
+            <p className="p-6 text-center text-sm text-faint">
+              {rows.isPending || shown === undefined ? t('common.loading') : t('picker.empty')}
+            </p>
+          ) : (
+            <ul className="grid grid-cols-[repeat(auto-fill,minmax(13rem,1fr))] gap-1.5">
+              {entries.map((entry) => (
+                <li key={entry.value}>
+                  <button
+                    type="button"
+                    onClick={() => pick(entry)}
+                    className="flex w-full items-center gap-2 rounded-control border border-transparent p-1.5 text-left hover:border-gold/40 hover:bg-gold/5"
+                  >
+                    {entry.swatch ? (
+                      <span
+                        aria-hidden="true"
+                        className="inline-block size-[46px] shrink-0 rounded-control border border-border-subtle"
+                        style={{ background: entry.swatch }}
+                      />
+                    ) : (
+                      <RarityTile src={entry.imageUrl} alt={entry.label} />
+                    )}
+
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm text-ink">{entry.label}</span>
+                      <span className="block truncate font-mono text-xs text-faint">{entry.detail}</span>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2 border-t border-border-subtle pt-3">
+          <span className="font-mono text-xs text-faint">{t('picker.count', { count: shown?.total ?? 0 })}</span>
+
+          <span className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(current - 1, 1))}
+            >
+              {t('common.previous')}
+            </Button>
+            <span className="font-mono text-xs text-muted">
+              {page} / {Math.max(totalPages, 1)}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={page >= totalPages}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              {t('common.next')}
+            </Button>
+          </span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/ui/entity-picker.tsx
+++ b/ui/src/components/ui/entity-picker.tsx
@@ -56,7 +56,9 @@ export function EntityPicker({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[80vh] w-[min(46rem,92vw)] max-w-none flex-col gap-4">
+      {/* Three fifths of the viewport on a desktop, near-full on a phone where three fifths is a
+          column too narrow to put a tile and two lines of text beside each other. */}
+      <DialogContent className="flex max-h-[80vh] w-[92vw] max-w-none flex-col gap-4 md:w-[60vw]">
         <DialogHeader>
           <DialogTitle>{t('picker.title')}</DialogTitle>
         </DialogHeader>

--- a/ui/src/lib/catalogues.test.ts
+++ b/ui/src/lib/catalogues.test.ts
@@ -1,0 +1,77 @@
+import { CATALOGUES, cataloguePath, CATALOGUE_PAGE_SIZE } from './catalogues'
+
+describe('cataloguePath', () => {
+  it('asks for the page and the size the pager draws', () => {
+    expect(cataloguePath('/api/v1/admin/hues', { page: 3, search: '' })).toBe(
+      `/api/v1/admin/hues?page=3&pageSize=${CATALOGUE_PAGE_SIZE}`,
+    )
+  })
+
+  // A blank search sent as an empty parameter means the same to the server but a different query key
+  // here, so paging with an empty box would miss the cache every time.
+  it('leaves a blank search out entirely', () => {
+    expect(cataloguePath('/api/v1/admin/hues', { page: 1, search: '   ' })).not.toContain('search')
+  })
+
+  it('trims a search it does send', () => {
+    expect(cataloguePath('/api/v1/admin/hues', { page: 1, search: '  red  ' })).toContain('search=red')
+  })
+
+  it('leaves a blank filter out and sends one that is set', () => {
+    const none = cataloguePath('/api/v1/admin/uo-items', { page: 1, search: '', filter: { param: 'flag', value: '' } })
+    const set = cataloguePath('/api/v1/admin/uo-items', {
+      page: 1,
+      search: '',
+      filter: { param: 'flag', value: 'Container' },
+    })
+
+    expect(none).not.toContain('flag')
+    expect(set).toContain('flag=Container')
+  })
+
+  it('never asks for a page before the first', () => {
+    expect(cataloguePath('/api/v1/admin/hues', { page: 0, search: '' })).toContain('page=1')
+  })
+})
+
+describe('CATALOGUES', () => {
+  it('covers the six catalogues the shard exposes', () => {
+    expect(CATALOGUES.map((catalogue) => catalogue.id)).toEqual([
+      'itemTemplates',
+      'mobileTemplates',
+      'uoItems',
+      'hues',
+      'bodies',
+      'hairStyles',
+    ])
+  })
+
+  it('gives every catalogue a distinct path', () => {
+    const paths = CATALOGUES.map((catalogue) => catalogue.path)
+
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  it('draws a hue as a colour rather than as art', () => {
+    const hues = CATALOGUES.find((catalogue) => catalogue.id === 'hues')!
+    const entry = hues.toEntry({ value: 1002, name: 'blood red', hex: '#8B0000', gradient: [] } as never)
+
+    expect(entry).toMatchObject({ value: '1002', label: 'blood red', detail: '1002', swatch: '#8B0000' })
+    expect(entry.imageUrl).toBeUndefined()
+  })
+
+  // Unused tiledata ids have no name, and a row with an empty first line reads as broken.
+  it('labels a nameless tile by its hex', () => {
+    const items = CATALOGUES.find((catalogue) => catalogue.id === 'uoItems')!
+    const entry = items.toEntry({ itemId: 9, hex: '0x0009', name: '', flags: [], imageUrl: '/art.png' } as never)
+
+    expect(entry.label).toBe('0x0009')
+  })
+
+  it('offers a flag filter on the raw tiles and nowhere else', () => {
+    const withFilter = CATALOGUES.filter((catalogue) => catalogue.filter !== undefined)
+
+    expect(withFilter.map((catalogue) => catalogue.id)).toEqual(['uoItems'])
+    expect(withFilter[0].filter!.values[0]).toBe('')
+  })
+})

--- a/ui/src/lib/catalogues.ts
+++ b/ui/src/lib/catalogues.ts
@@ -1,0 +1,169 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiFetch } from './api'
+import type { components } from './api-types'
+
+/**
+ * One row of any catalogue, reduced to what a picker draws. Every catalogue answers a different shape
+ * — a hue has no art, a tile has no name worth reading — so each one says how its rows become this,
+ * and the picker never learns there is more than one kind.
+ */
+export type CatalogueEntry = {
+  /** The value the picker hands back, and the row's React key. */
+  value: string
+  /** The line a human reads. */
+  label: string
+  /** The line underneath: an id, a hex, a count. Drawn in the mono face. */
+  detail: string
+  /** Art for the tile, when the catalogue has any. */
+  imageUrl?: string
+  /** A flat colour for the tile, for the catalogue that is colours. */
+  swatch?: string
+}
+
+/** One choice in a catalogue's filter, when it has one. */
+export type CatalogueFilter = {
+  /** The query parameter the server reads. */
+  param: string
+  /** Values offered, in order. The first is "no filter" and is sent as absent. */
+  values: string[]
+}
+
+export type Catalogue = {
+  id: string
+  path: string
+  toEntry: (row: never) => CatalogueEntry
+  filter?: CatalogueFilter
+}
+
+/** The server's own default page size. Named here so the pager and the request cannot disagree. */
+export const CATALOGUE_PAGE_SIZE = 25
+
+/**
+ * A catalogue request. A blank search or filter is left out rather than sent empty: the server reads
+ * a blank one as "no filter" anyway, and omitting it keeps the query key stable, so paging with an
+ * empty box does not miss the cache.
+ */
+export function cataloguePath(
+  path: string,
+  { page, search, filter }: { page: number; search: string; filter?: { param: string; value: string } },
+): string {
+  const params = new URLSearchParams({
+    page: String(Math.max(page, 1)),
+    pageSize: String(CATALOGUE_PAGE_SIZE),
+  })
+
+  const trimmed = search.trim()
+
+  if (trimmed !== '') {
+    params.set('search', trimmed)
+  }
+
+  if (filter && filter.value !== '') {
+    params.set(filter.param, filter.value)
+  }
+
+  return `${path}?${params}`
+}
+
+/** The shape every catalogue route answers with, whatever it is a catalogue of. */
+type ServerPage = { items: unknown[]; total: number; page: number; pageSize: number; totalPages: number }
+
+/**
+ * A page, stamped with the catalogue it came from. The stamp is what makes holding the previous page
+ * while the next loads safe across a change of catalogue: the rows of one catalogue read through the
+ * reader of another are nonsense, and without the stamp they would be drawn for an instant.
+ */
+export type CataloguePage = ServerPage & { catalogueId: string }
+
+/** One page of any catalogue, paged and searched by the server. Staff only. */
+export const useCatalogue = (catalogue: Catalogue, params: { page: number; search: string; filter?: string }) =>
+  useQuery({
+    queryKey: ['admin', 'catalogue', catalogue.id, params.page, params.search.trim(), params.filter ?? ''],
+    queryFn: async () => {
+      const page = await apiFetch<ServerPage>(
+        cataloguePath(catalogue.path, {
+          page: params.page,
+          search: params.search,
+          filter: catalogue.filter && { param: catalogue.filter.param, value: params.filter ?? '' },
+        }),
+      )
+
+      return { ...page, catalogueId: catalogue.id }
+    },
+    // Holding the previous page while the next loads is what makes it read as a list rather than a
+    // slideshow.
+    placeholderData: (previous: CataloguePage | undefined) => previous,
+  })
+
+type Hue = components['schemas']['HueSummary']
+type UoItem = components['schemas']['UoItemSummary']
+type Body = components['schemas']['BodySummary']
+type HairStyle = components['schemas']['HairStyleSummary']
+type ItemTemplate = components['schemas']['ItemTemplateSummaryResponse']
+type MobileTemplate = components['schemas']['MobileTemplateSummaryResponse']
+
+/**
+ * Declares a catalogue. The cast is the one place the picker's single row shape meets six different
+ * server shapes; it is contained here so that everything downstream is typed.
+ */
+function catalogue<TRow>(
+  id: string,
+  path: string,
+  toEntry: (row: TRow) => CatalogueEntry,
+  filter?: CatalogueFilter,
+): Catalogue {
+  return { id, path, toEntry: toEntry as (row: never) => CatalogueEntry, filter }
+}
+
+/** Every TileFlagType worth filtering by. The blank first entry means "no filter". */
+const TILE_FLAGS = ['', 'Container', 'Wearable', 'Weapon', 'Armor', 'Surface', 'Impassable', 'Generic']
+
+/**
+ * The six catalogues the shard can be browsed by. Adding a seventh is one entry here — the picker
+ * itself has nothing to learn.
+ */
+export const CATALOGUES: Catalogue[] = [
+  catalogue<ItemTemplate>('itemTemplates', '/api/v1/admin/items/templates', (row) => ({
+    value: row.id,
+    label: row.name,
+    detail: row.id,
+    imageUrl: row.imageUrl,
+  })),
+  catalogue<MobileTemplate>('mobileTemplates', '/api/v1/admin/mobiles/templates', (row) => ({
+    value: row.id,
+    label: row.name,
+    detail: row.id,
+    imageUrl: row.imageUrl,
+  })),
+  catalogue<UoItem>(
+    'uoItems',
+    '/api/v1/admin/uo-items',
+    (row) => ({
+      value: row.hex,
+      // Unused ids have no name in tiledata, and an empty line reads as a broken row.
+      label: row.name === '' ? row.hex : row.name,
+      detail: row.hex,
+      imageUrl: row.imageUrl,
+    }),
+    { param: 'flag', values: TILE_FLAGS },
+  ),
+  catalogue<Hue>('hues', '/api/v1/admin/hues', (row) => ({
+    value: String(row.value),
+    label: row.name,
+    detail: String(row.value),
+    swatch: row.hex,
+  })),
+  catalogue<Body>('bodies', '/api/v1/admin/bodies', (row) => ({
+    value: String(row.body),
+    label: row.type,
+    detail: row.hex,
+    imageUrl: row.imageUrl,
+  })),
+  catalogue<HairStyle>('hairStyles', '/api/v1/admin/hair-styles', (row) => ({
+    value: String(row.style),
+    label: row.name,
+    detail: row.hex,
+    imageUrl: row.imageUrl,
+  })),
+]

--- a/ui/src/lib/templates.ts
+++ b/ui/src/lib/templates.ts
@@ -2,32 +2,22 @@ import { useQuery } from '@tanstack/react-query'
 
 import { apiFetch } from './api'
 import type { components } from './api-types'
+import { CATALOGUE_PAGE_SIZE, cataloguePath } from './catalogues'
 
 export type ItemTemplateSummary = components['schemas']['ItemTemplateSummaryResponse']
 export type ItemTemplate = components['schemas']['ItemTemplateResponse']
 export type ItemTemplatePage = components['schemas']['ItemTemplateSummaryResponsePagedResponse']
 
 /** The server's own default. Named here so the pager and the request cannot disagree. */
-export const TEMPLATES_PAGE_SIZE = 25
+export const TEMPLATES_PAGE_SIZE = CATALOGUE_PAGE_SIZE
 
 /**
  * The catalogue URL. A blank search is omitted rather than sent empty: the server reads a blank
  * `search` as "no filter" anyway, and leaving it out keeps the query key stable so paging with an
  * empty box does not miss the cache.
  */
-export function itemTemplatesQuery({ page, search }: { page: number; search: string }): string {
-  const params = new URLSearchParams({
-    page: String(Math.max(page, 1)),
-    pageSize: String(TEMPLATES_PAGE_SIZE),
-  })
-
-  const trimmed = search.trim()
-
-  if (trimmed !== '') {
-    params.set('search', trimmed)
-  }
-
-  return `/api/v1/admin/items/templates?${params}`
+export function itemTemplatesQuery(params: { page: number; search: string }): string {
+  return cataloguePath('/api/v1/admin/items/templates', params)
 }
 
 /** Every item template, paged and searched by the server. Staff only. */
@@ -55,19 +45,8 @@ export type MobileTemplate = components['schemas']['MobileTemplateResponse']
 export type MobileTemplatePage = components['schemas']['MobileTemplateSummaryResponsePagedResponse']
 
 /** The catalogue URL for spawn templates. Blank searches are omitted, as in {@link itemTemplatesQuery}. */
-export function mobileTemplatesQuery({ page, search }: { page: number; search: string }): string {
-  const params = new URLSearchParams({
-    page: String(Math.max(page, 1)),
-    pageSize: String(TEMPLATES_PAGE_SIZE),
-  })
-
-  const trimmed = search.trim()
-
-  if (trimmed !== '') {
-    params.set('search', trimmed)
-  }
-
-  return `/api/v1/admin/mobiles/templates?${params}`
+export function mobileTemplatesQuery(params: { page: number; search: string }): string {
+  return cataloguePath('/api/v1/admin/mobiles/templates', params)
 }
 
 /** Every mobile spawn template, paged and searched by the server. Staff only. */

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -420,5 +420,32 @@
       "amount": "Amount",
       "serial": "Serial"
     }
+  },
+  "picker": {
+    "title": "Find in the shard",
+    "searchLabel": "Search the catalogue",
+    "filterLabel": "Filter by flag",
+    "anyFlag": "Any flag",
+    "empty": "Nothing matches this search.",
+    "count_one": "{{count}} result",
+    "count_other": "{{count}} results",
+    "copied": "Copied {{value}}.",
+    "open": "Find",
+    "catalogues": {
+      "itemTemplates": "Item templates",
+      "mobileTemplates": "Mobile templates",
+      "uoItems": "UO items",
+      "hues": "Hues",
+      "bodies": "Bodies",
+      "hairStyles": "Hair styles"
+    },
+    "search": {
+      "itemTemplates": "Search name or id…",
+      "mobileTemplates": "Search name, id or tag…",
+      "uoItems": "Search item id, 0x hex or name…",
+      "hues": "Search hue number or name…",
+      "bodies": "Search body id or 0x hex…",
+      "hairStyles": "Search style name…"
+    }
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -420,5 +420,32 @@
       "amount": "Quantità",
       "serial": "Serial"
     }
+  },
+  "picker": {
+    "title": "Cerca nello shard",
+    "searchLabel": "Cerca nel catalogo",
+    "filterLabel": "Filtra per flag",
+    "anyFlag": "Qualsiasi flag",
+    "empty": "Nessun risultato per questa ricerca.",
+    "count_one": "{{count}} risultato",
+    "count_other": "{{count}} risultati",
+    "copied": "Copiato {{value}}.",
+    "open": "Cerca",
+    "catalogues": {
+      "itemTemplates": "Template item",
+      "mobileTemplates": "Template mobile",
+      "uoItems": "Item UO",
+      "hues": "Tinte",
+      "bodies": "Body",
+      "hairStyles": "Capelli"
+    },
+    "search": {
+      "itemTemplates": "Cerca nome o id…",
+      "mobileTemplates": "Cerca nome, id o tag…",
+      "uoItems": "Cerca id item, esadecimale 0x o nome…",
+      "hues": "Cerca numero o nome della tinta…",
+      "bodies": "Cerca id body o esadecimale 0x…",
+      "hairStyles": "Cerca nome dello stile…"
+    }
   }
 }

--- a/ui/src/routes/AdminLayout.tsx
+++ b/ui/src/routes/AdminLayout.tsx
@@ -1,5 +1,10 @@
-import { NavLink, Outlet } from 'react-router'
+import { useState } from 'react'
+import { NavLink, Outlet, useNavigate } from 'react-router'
 import { useTranslation } from 'react-i18next'
+
+import { EntityPicker } from '../components/ui/entity-picker'
+import { FilterPill } from '../components/ui/filter-pill'
+import { toast } from '../components/ui/sonner'
 
 const linkClass = ({ isActive }: { isActive: boolean }) =>
   isActive
@@ -34,9 +39,17 @@ const groups: { to: string; key: string; end?: boolean }[][] = [
   ],
 ]
 
+/** Which catalogues have a page of their own to open. The rest hand back a value to copy. */
+const detailPages: Record<string, string> = {
+  itemTemplates: '/admin/items',
+  mobileTemplates: '/admin/mobiles',
+}
+
 /** The admin area's own tab row, above whichever admin screen is routed below it. */
 export function AdminLayout() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [finding, setFinding] = useState(false)
 
   return (
     <div className="flex flex-col gap-5">
@@ -51,9 +64,36 @@ export function AdminLayout() {
             ))}
           </div>
         ))}
+
+        <FilterPill className="ml-auto mb-1" onClick={() => setFinding(true)}>
+          {t('picker.open')}
+        </FilterPill>
       </nav>
 
       <Outlet />
+
+      {/* Mounted only while open: a closed picker would still put a React Query dependency into
+          every screen that hosts one, for a dialog nobody is looking at. */}
+      {finding && (
+        <EntityPicker
+          open
+          onOpenChange={setFinding}
+          onSelect={(entry, catalogue) => {
+            const page = detailPages[catalogue.id]
+
+            // A template has somewhere to go. A hue, a body or a raw tile is an id someone is about
+            // to type into a YAML file, so the useful thing is to put it on the clipboard.
+            if (page) {
+              void navigate(`${page}/${encodeURIComponent(entry.value)}`)
+
+              return
+            }
+
+            void navigator.clipboard?.writeText(entry.value)
+            toast.success(t('picker.copied', { value: entry.value }))
+          }}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Fixes #191.

The old portal had six picker dialogs, one per entity, each a thin wrapper over a shared one. This is the shared one alone: **which** catalogue to browse is a choice inside the dialog rather than a different component, because the six differ only in where they are read from and how a row reads — and both of those are data.

## Shape

`CATALOGUES` declares the six — item templates, mobile templates, raw UO items, hues, bodies, hair styles — each with its route and a function turning its rows into the one shape a picker draws: a value, a label, a detail line, and either art or a flat colour. Adding a seventh is one entry there; the picker itself has nothing to learn.

`EntityPicker` hands back the entry that was picked and nothing else, so what it means stays the callers business. Its first caller is a **Find** pill in the admin tab row: picking a template opens its page, and picking a hue, body, tile or hair style copies the id — which is what someone is about to type into a YAML file.

## Two defects the tests caught

**Stale rows read through the wrong reader.** React Query holds the previous page while the next loads. Across a change of catalogue, those rows would be read through the *new* catalogues reader and drawn as nonsense for an instant — a hue rendered as an item template has no id, so React also warned about duplicate keys. Each page now carries the catalogue it came from, and only its own is drawn.

**A closed picker is not free.** Mounted while closed it still puts a React Query dependency into every screen hosting one, which broke `AdminLayout`s own tests with "No QueryClient set". It is now mounted only while open, which is both the fix and the cheaper thing.

One test also had to be made honest: it mocked the same rows for every route, which fed rows of one shape to the reader of another — something that cannot happen against the real server, where each catalogue has its own endpoint. It now answers by route.

## Also

`itemTemplatesQuery` and `mobileTemplatesQuery` were the same function twice. Both now delegate to the builder the catalogues use, so a blank search is omitted in exactly one place.

394 UI tests green, build and formatting clean. No API change, so the contract and the packet reference are untouched.