### PR TITLE
feat(ultima): bound the map block cache

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -11,9 +11,21 @@ launch generates it with defaults; edit and restart to apply changes.
 | `ShardName` | string | `Moongate` | The shard's name, shown in the client's server list. |
 | `StatsRefreshSeconds` | int | `30` | How often the public statistics snapshot is recomputed on the game loop. |
 | `UltimaDirectory` | string | — | Path to the UO client files. See the override note below. |
+| `MapBlockCacheSize` | int | `4096` | How many 8×8-tile map blocks each facet keeps in memory, land and statics counted separately. See the note below. |
 | `Network.Address` | string | `0.0.0.0` | Local bind address for the TCP listener. |
 | `Network.Port` | int | `2593` | TCP port for both login and game traffic (single process, single port). |
 | `Network.PublicAddress` | string | `127.0.0.1` | Address advertised to clients in the server list and game-server redirect. Must be reachable *from the client*. |
+
+### Map block cache
+
+Map blocks are read from the client files the first time something asks for them and kept in memory,
+least-recently-used dropped past `MapBlockCacheSize`. The default of 4096 holds a contiguous
+512×512-tile region per facet — far more than play needs, since a player sees roughly 18 tiles, and
+enough that panning the web map viewer around one area does not re-read constantly.
+
+Raise it on a shard whose players are spread thin across a facet; lower it on a memory-tight host.
+`0` disables the cache and re-reads every block, which is correct but slow. The bound matters most
+for the web map viewer: it streams tiles across a whole facet, and Felucca alone is 393,216 blocks.
 
 > [!NOTE]
 > **`UltimaDirectory` is currently always overridden at startup**: the

--- a/src/Moongate.Server.Abstractions/Data/Config/MoongateConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/MoongateConfig.cs
@@ -16,6 +16,15 @@ public sealed class MoongateConfig
     /// </summary>
     public string Language { get; set; } = "enu";
 
+    /// <summary>
+    /// How many 8x8-tile map blocks each facet keeps in memory, land and statics counted separately.
+    /// Blocks are read from the client files on demand and the least recently used are dropped past
+    /// this cap. The default holds a contiguous 512x512-tile region — far more than gameplay needs,
+    /// and enough that panning the web map viewer around one area does not re-read constantly. Lower
+    /// it on a memory-tight host; 0 disables caching entirely and re-reads every block.
+    /// </summary>
+    public int MapBlockCacheSize { get; set; } = 4096;
+
     public MoongateNetworkConfig Network { get; set; } = new();
 
     public NpcAiConfig NpcAi { get; set; } = new();

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -99,6 +99,10 @@ await ConsoleApp.RunAsync(
 
         NpcAiConfigValidator.Validate(moongateConfig.NpcAi);
 
+        // Set before any facet is touched: a TileMatrix reads this at construction, and the first
+        // block query is what constructs it.
+        Moongate.Ultima.Io.Files.CacheCapacityMapBlocks = Math.Max(moongateConfig.MapBlockCacheSize, 0);
+
         if (string.IsNullOrEmpty(moongateConfig.UltimaDirectory))
         {
             throw new UODirectoryNotValidException(

--- a/src/Moongate.Ultima/Caching/LruBlockCache.cs
+++ b/src/Moongate.Ultima/Caching/LruBlockCache.cs
@@ -1,0 +1,195 @@
+namespace Moongate.Ultima.Caching;
+
+/// <summary>
+/// Bounded LRU cache for map blocks, replacing the unbounded jagged arrays that previously kept every
+/// block a caller ever touched for the lifetime of the process. Keyed by the block's packed
+/// coordinates — see <see cref="Key" />.
+/// <para>
+/// Unlike <see cref="LruBitmapCache" /> there is no disposal to arrange: a block is a plain array, so
+/// a caller still holding one that has been evicted simply keeps it alive through the garbage
+/// collector. Eviction here can never pull the rug from under a reader, which is what forced that
+/// cache to leave <c>DisposeOnEvict</c> off by default.
+/// </para>
+/// <para>
+/// Thread safety: every public member is guarded by a single lock. The arrays this replaces were read
+/// with an unsynchronized read-modify-write (<c>_landTiles[x][y] ??= Read(x, y)</c>) from both the
+/// game loop and the HTTP threads that serve map tiles, so two readers could race on the same block.
+/// A miss costs a file read, which dwarfs the lock; a hit costs tens of nanoseconds.
+/// </para>
+/// </summary>
+public sealed class LruBlockCache<TValue> where TValue : class
+{
+    private readonly Lock _lock = new();
+
+    private readonly LinkedList<KeyValuePair<long, TValue>> _list = new();
+
+    private readonly Dictionary<long, LinkedListNode<KeyValuePair<long, TValue>>> _map;
+
+    private int _capacity;
+    private int _evictedCount;
+
+    public LruBlockCache(int capacity)
+    {
+        if (capacity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be non-negative.");
+        }
+
+        _capacity = capacity;
+        _map = new(Math.Min(capacity, 4096));
+    }
+
+    /// <summary>Maximum number of blocks held. Lowering it evicts down to the new cap immediately.</summary>
+    public int Capacity
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _capacity;
+            }
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _map.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Total blocks evicted since construction. Diagnostic, and what a test asserts to prove the
+    /// bounding actually happens rather than merely being configured.
+    /// </summary>
+    public int EvictedCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _evictedCount;
+            }
+        }
+    }
+
+    /// <summary>Packs block coordinates into one key. Block counts are well under 2^31 on every facet.</summary>
+    public static long Key(int x, int y)
+        => ((long)x << 32) | (uint)y;
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _list.Clear();
+            _map.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The cached block, or the one <paramref name="read" /> produces — stored and returned. The read
+    /// runs while the lock is held, so a block is never decoded twice concurrently; that is the whole
+    /// point of routing misses through here rather than filling the cache from outside.
+    /// </summary>
+    public TValue GetOrAdd(long key, Func<TValue> read)
+    {
+        lock (_lock)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                _list.Remove(node);
+                _list.AddFirst(node);
+
+                return node.Value.Value;
+            }
+
+            var value = read();
+
+            if (_capacity == 0)
+            {
+                return value;
+            }
+
+            _list.AddFirst(new LinkedListNode<KeyValuePair<long, TValue>>(new(key, value)));
+            _map[key] = _list.First!;
+            EvictWhileOverCapacityNoLock();
+
+            return value;
+        }
+    }
+
+    /// <summary>Inserts or replaces a block, as the patch and block-removal paths do.</summary>
+    public void Set(long key, TValue value)
+    {
+        lock (_lock)
+        {
+            if (_capacity == 0)
+            {
+                return;
+            }
+
+            if (_map.TryGetValue(key, out var existing))
+            {
+                _list.Remove(existing);
+            }
+
+            _list.AddFirst(new LinkedListNode<KeyValuePair<long, TValue>>(new(key, value)));
+            _map[key] = _list.First!;
+            EvictWhileOverCapacityNoLock();
+        }
+    }
+
+    public void SetCapacity(int newCapacity)
+    {
+        if (newCapacity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newCapacity));
+        }
+
+        lock (_lock)
+        {
+            _capacity = newCapacity;
+            EvictWhileOverCapacityNoLock();
+        }
+    }
+
+    public bool TryGet(long key, out TValue? value)
+    {
+        lock (_lock)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                _list.Remove(node);
+                _list.AddFirst(node);
+                value = node.Value.Value;
+
+                return true;
+            }
+
+            value = null;
+
+            return false;
+        }
+    }
+
+    private void EvictWhileOverCapacityNoLock()
+    {
+        while (_map.Count > _capacity)
+        {
+            var lru = _list.Last;
+
+            if (lru == null)
+            {
+                break;
+            }
+
+            _list.RemoveLast();
+            _map.Remove(lru.Value.Key);
+            _evictedCount++;
+        }
+    }
+}

--- a/src/Moongate.Ultima/Io/Files.cs
+++ b/src/Moongate.Ultima/Io/Files.cs
@@ -40,6 +40,17 @@ public sealed class Files
     public static int CacheCapacityAnimations { get; set; } = 1024;
 
     /// <summary>
+    /// Initial LRU capacity for each map's land and statics block caches, counted in 8x8-tile blocks
+    /// and applied to both caches of every facet. Default 4096 — a contiguous 512x512-tile region,
+    /// which is far more than gameplay ever needs (a player sees roughly 18 tiles, so 25 blocks) and
+    /// enough that panning the web map viewer around one area does not thrash. Bounding matters most
+    /// for that viewer: it streams tiles across a whole facet, and Felucca alone is 393216 blocks that
+    /// the previous unbounded arrays would all have kept. Set this before a map is first read, or call
+    /// <see cref="Moongate.Ultima.Maps.TileMatrix.SetCacheCapacity" /> at runtime.
+    /// </summary>
+    public static int CacheCapacityMapBlocks { get; set; } = 4096;
+
+    /// <summary>
     /// Contains the path infos
     /// </summary>
     public static Dictionary<string, string> MulPath { get; set; }

--- a/src/Moongate.Ultima/Maps/TileMatrix.cs
+++ b/src/Moongate.Ultima/Maps/TileMatrix.cs
@@ -1,14 +1,15 @@
 using System.Runtime.InteropServices;
 using Moongate.Ultima.Graphics;
 using Moongate.Ultima.Helpers;
+using Moongate.Ultima.Caching;
 using Moongate.Ultima.Io;
 
 namespace Moongate.Ultima.Maps;
 
 public sealed class TileMatrix : IDisposable
 {
-    private readonly HuedTile[][][][][] _staticTiles;
-    private readonly Tile[][][] _landTiles;
+    private readonly LruBlockCache<HuedTile[][][]> _staticTiles;
+    private readonly LruBlockCache<Tile[]> _landTiles;
     private bool[][] _removedStaticBlock;
     private List<StaticTile>[][] _staticTilesToAdd;
 
@@ -118,8 +119,8 @@ public sealed class TileMatrix : IDisposable
 
         InvalidLandBlock = new Tile[196];
 
-        _landTiles = new Tile[BlockWidth][][];
-        _staticTiles = new HuedTile[BlockWidth][][][][];
+        _landTiles = new(Files.CacheCapacityMapBlocks);
+        _staticTiles = new(Files.CacheCapacityMapBlocks);
 
         Patch = new(this, mapId, path);
     }
@@ -183,6 +184,20 @@ public sealed class TileMatrix : IDisposable
     public void Dispose()
         => CloseStreams();
 
+    /// <summary>Blocks currently held, land and statics counted separately. Diagnostic.</summary>
+    public (int Land, int Statics) CachedBlockCount
+        => (_landTiles.Count, _staticTiles.Count);
+
+    /// <summary>
+    /// Resizes both block caches after construction. Lowering the cap evicts down to it at once, so a
+    /// host can give memory back without restarting.
+    /// </summary>
+    public void SetCacheCapacity(int capacity)
+    {
+        _landTiles.SetCapacity(capacity);
+        _staticTiles.SetCapacity(capacity);
+    }
+
     public Tile[] GetLandBlock(int x, int y, bool patch = true)
     {
         if (x < 0 || y < 0 || x >= BlockWidth || y >= BlockHeight)
@@ -190,12 +205,7 @@ public sealed class TileMatrix : IDisposable
             return InvalidLandBlock;
         }
 
-        if (_landTiles[x] == null)
-        {
-            _landTiles[x] = new Tile[BlockHeight][];
-        }
-
-        var tiles = _landTiles[x][y] ?? (_landTiles[x][y] = ReadLandBlock(x, y));
+        var tiles = _landTiles.GetOrAdd(LruBlockCache<Tile[]>.Key(x, y), () => ReadLandBlock(x, y));
 
         if (Map.UseDiff && patch && Patch.LandBlocksCount > 0 && Patch.LandBlocks[x]?[y] != null)
         {
@@ -249,12 +259,7 @@ public sealed class TileMatrix : IDisposable
             return EmptyStaticBlock;
         }
 
-        if (_staticTiles[x] == null)
-        {
-            _staticTiles[x] = new HuedTile[BlockHeight][][][];
-        }
-
-        HuedTile[][][] tiles = _staticTiles[x][y] ?? (_staticTiles[x][y] = ReadStaticBlock(x, y));
+        var tiles = _staticTiles.GetOrAdd(LruBlockCache<HuedTile[][][]>.Key(x, y), () => ReadStaticBlock(x, y));
 
         if (Map.UseDiff && patch && Patch.StaticBlocksCount > 0 && Patch.StaticBlocks[x]?[y] != null)
         {
@@ -309,12 +314,7 @@ public sealed class TileMatrix : IDisposable
 
         _removedStaticBlock[blockX][blockY] = true;
 
-        if (_staticTiles[blockX] == null)
-        {
-            _staticTiles[blockX] = new HuedTile[BlockHeight][][][];
-        }
-
-        _staticTiles[blockX][blockY] = EmptyStaticBlock;
+        _staticTiles.Set(LruBlockCache<HuedTile[][][]>.Key(blockX, blockY), EmptyStaticBlock);
     }
 
     public void SetLandBlock(int x, int y, Tile[] value)
@@ -324,12 +324,7 @@ public sealed class TileMatrix : IDisposable
             return;
         }
 
-        if (_landTiles[x] == null)
-        {
-            _landTiles[x] = new Tile[BlockHeight][];
-        }
-
-        _landTiles[x][y] = value;
+        _landTiles.Set(LruBlockCache<Tile[]>.Key(x, y), value);
     }
 
     private long CalculateOffsetFromUOP(long offset)

--- a/tests/Moongate.Tests/Ultima/LruBlockCacheTests.cs
+++ b/tests/Moongate.Tests/Ultima/LruBlockCacheTests.cs
@@ -1,0 +1,148 @@
+using Moongate.Ultima.Caching;
+
+namespace Moongate.Tests.Ultima;
+
+/// <summary>
+/// The bound on map-block memory. What matters is that eviction happens and that a reader holding an
+/// evicted block is unharmed — the arrays this replaced grew for the life of the process.
+/// </summary>
+public class LruBlockCacheTests
+{
+    [Fact]
+    public void GetOrAdd_ReadsOnlyOnceForTheSameBlock()
+    {
+        var cache = new LruBlockCache<int[]>(8);
+        var reads = 0;
+
+        cache.GetOrAdd(LruBlockCache<int[]>.Key(1, 2), () => { reads++; return [1]; });
+        cache.GetOrAdd(LruBlockCache<int[]>.Key(1, 2), () => { reads++; return [1]; });
+
+        Assert.Equal(1, reads);
+    }
+
+    // The coordinates are packed into one long; two different blocks must not collide, and the pack
+    // has to survive a y that would sign-extend if it were not masked.
+    [Theory]
+    [InlineData(0, 0, 0, 1)]
+    [InlineData(1, 0, 0, 1)]
+    [InlineData(767, 511, 767, 512)]
+    public void Key_DistinctBlocksGetDistinctKeys(int x1, int y1, int x2, int y2)
+        => Assert.NotEqual(LruBlockCache<int[]>.Key(x1, y1), LruBlockCache<int[]>.Key(x2, y2));
+
+    [Fact]
+    public void Key_TheSameBlockAlwaysPacksTheSame()
+        => Assert.Equal(LruBlockCache<int[]>.Key(300, 400), LruBlockCache<int[]>.Key(300, 400));
+
+    [Fact]
+    public void GetOrAdd_PastCapacity_EvictsAndStaysAtTheCap()
+    {
+        var cache = new LruBlockCache<int[]>(4);
+
+        for (var block = 0; block < 20; block++)
+        {
+            cache.GetOrAdd(LruBlockCache<int[]>.Key(block, 0), () => [block]);
+        }
+
+        Assert.Equal(4, cache.Count);
+        Assert.Equal(16, cache.EvictedCount);
+    }
+
+    // Least-RECENTLY-used, not least-recently-added: touching a block has to save it.
+    [Fact]
+    public void GetOrAdd_TouchingABlock_SpareItFromEviction()
+    {
+        var cache = new LruBlockCache<int[]>(2);
+        var oldest = LruBlockCache<int[]>.Key(0, 0);
+
+        cache.GetOrAdd(oldest, () => [0]);
+        cache.GetOrAdd(LruBlockCache<int[]>.Key(1, 0), () => [1]);
+        cache.GetOrAdd(oldest, () => [99]);
+        cache.GetOrAdd(LruBlockCache<int[]>.Key(2, 0), () => [2]);
+
+        Assert.True(cache.TryGet(oldest, out _));
+        Assert.False(cache.TryGet(LruBlockCache<int[]>.Key(1, 0), out _));
+    }
+
+    /// <summary>
+    /// A block is a plain array, so a caller holding one that gets evicted keeps reading it. This is
+    /// what makes evicting map blocks safe where evicting bitmaps was not.
+    /// </summary>
+    [Fact]
+    public void AnEvictedBlock_IsStillUsableByWhoeverHeldIt()
+    {
+        var cache = new LruBlockCache<int[]>(1);
+        var held = cache.GetOrAdd(LruBlockCache<int[]>.Key(0, 0), () => [7, 8, 9]);
+
+        cache.GetOrAdd(LruBlockCache<int[]>.Key(1, 0), () => [0]);
+
+        Assert.False(cache.TryGet(LruBlockCache<int[]>.Key(0, 0), out _));
+        Assert.Equal([7, 8, 9], held);
+    }
+
+    [Fact]
+    public void SetCapacity_Lowered_GivesTheMemoryBackAtOnce()
+    {
+        var cache = new LruBlockCache<int[]>(10);
+
+        for (var block = 0; block < 10; block++)
+        {
+            cache.GetOrAdd(LruBlockCache<int[]>.Key(block, 0), () => [block]);
+        }
+
+        cache.SetCapacity(3);
+
+        Assert.Equal(3, cache.Count);
+    }
+
+    [Fact]
+    public void Set_ReplacesABlockWithoutGrowingTheCache()
+    {
+        var cache = new LruBlockCache<int[]>(4);
+        var key = LruBlockCache<int[]>.Key(5, 5);
+
+        cache.GetOrAdd(key, () => [1]);
+        cache.Set(key, [2]);
+
+        Assert.Equal(1, cache.Count);
+        Assert.True(cache.TryGet(key, out var value));
+        Assert.Equal([2], value);
+    }
+
+    // Capacity 0 means "do not cache", not "cache everything": the read still has to answer.
+    [Fact]
+    public void GetOrAdd_WithCapacityZero_StillReadsAndReturns()
+    {
+        var cache = new LruBlockCache<int[]>(0);
+
+        Assert.Equal([4], cache.GetOrAdd(LruBlockCache<int[]>.Key(0, 0), () => [4]));
+        Assert.Equal(0, cache.Count);
+    }
+
+    [Fact]
+    public void ANegativeCapacity_IsRefused()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new LruBlockCache<int[]>(-1));
+
+    /// <summary>
+    /// The arrays this replaced were filled with an unsynchronized read-modify-write, read from the
+    /// game loop and from the HTTP threads serving map tiles at the same time. Concurrent readers of
+    /// one block must see one read and one array.
+    /// </summary>
+    [Fact]
+    public void ConcurrentReadersOfOneBlock_ReadItOnceAndAllSeeTheSameArray()
+    {
+        var cache = new LruBlockCache<int[]>(64);
+        var reads = 0;
+        var key = LruBlockCache<int[]>.Key(3, 4);
+
+        var results = new int[64][];
+
+        Parallel.For(
+            0,
+            results.Length,
+            index => results[index] = cache.GetOrAdd(key, () => { Interlocked.Increment(ref reads); return [1]; })
+        );
+
+        Assert.Equal(1, reads);
+        Assert.All(results, array => Assert.Same(results[0], array));
+    }
+}

--- a/tests/Moongate.Tests/Ultima/TileMatrixCacheDataTests.cs
+++ b/tests/Moongate.Tests/Ultima/TileMatrixCacheDataTests.cs
@@ -1,0 +1,81 @@
+using Moongate.Tests.Support;
+using Moongate.Ultima.Io;
+using Moongate.Ultima.Maps;
+
+namespace Moongate.Tests.Ultima;
+
+/// <summary>
+/// The block cache against a real client. Unit tests prove the cache evicts; only the files can say
+/// that a facet still reads correctly once blocks start being dropped underneath it.
+/// </summary>
+public class TileMatrixCacheDataTests
+{
+    [ClientFilesFact]
+    public void ReadingFarMoreBlocksThanTheCap_StaysAtTheCap()
+    {
+        var tiles = Facet();
+
+        tiles.SetCacheCapacity(64);
+
+        // 400 distinct blocks, walking a diagonal so no two share coordinates.
+        for (var block = 0; block < 400; block++)
+        {
+            tiles.GetLandBlock(block, block);
+            tiles.GetStaticBlock(block, block);
+        }
+
+        var (land, statics) = tiles.CachedBlockCount;
+
+        Assert.Equal(64, land);
+        Assert.Equal(64, statics);
+    }
+
+    /// <summary>
+    /// The point of the whole change: before, every block a caller ever touched stayed for the life of
+    /// the process. Panning the web map viewer across Felucca would have kept all 393216.
+    /// </summary>
+    [ClientFilesFact]
+    public void ABlockEvictedAndReadAgain_ReadsBackTheSameTiles()
+    {
+        var tiles = Facet();
+
+        tiles.SetCacheCapacity(4);
+
+        var before = (Tile[])tiles.GetLandBlock(100, 100).Clone();
+
+        for (var block = 0; block < 50; block++)
+        {
+            tiles.GetLandBlock(200 + block, 200 + block);
+        }
+
+        var after = tiles.GetLandBlock(100, 100);
+
+        Assert.Equal(before.Length, after.Length);
+        Assert.All(
+            Enumerable.Range(0, before.Length),
+            index =>
+            {
+                Assert.Equal(before[index].Id, after[index].Id);
+                Assert.Equal(before[index].Z, after[index].Z);
+            }
+        );
+    }
+
+    [ClientFilesFact]
+    public void OutOfBoundsBlocks_AreStillRefusedWithoutTouchingTheCache()
+    {
+        var tiles = Facet();
+
+        tiles.SetCacheCapacity(16);
+
+        Assert.Same(TileMatrix.InvalidLandBlock, tiles.GetLandBlock(-1, 0));
+        Assert.Same(TileMatrix.InvalidLandBlock, tiles.GetLandBlock(tiles.BlockWidth, 0));
+    }
+
+    private static TileMatrix Facet()
+    {
+        Files.SetDirectory(ClientFiles.Directory);
+
+        return Map.Felucca.Tiles;
+    }
+}


### PR DESCRIPTION
Fixes #193.

Map blocks were read on demand and then kept for the life of the process — the jagged arrays behind `TileMatrix` filled with `_landTiles[x][y] ??= Read(x, y)` and nothing ever came out. Harmless for play, where players cluster on a handful of blocks. The **web map viewer** made it real: it streams tiles across a whole facet through the same `TileMatrix`, and Felucca alone is 393,216 blocks.

## The cache

`LruBlockCache` is the third of this shape in the assembly, after `LruBitmapCache` and `LruAnimationCache` — and the simplest of the three. A block is a plain array, so a caller still holding one that has been evicted keeps reading it through the garbage collector. That is exactly what forced `LruBitmapCache` to leave `DisposeOnEvict` off by default, and it does not apply here: evicting a map block can never pull the rug from under a reader.

No new dependency. `Moongate.Ultima` is one of the six published packages and today depends only on ImageSharp and `System.IO.Hashing`; a `PackageReference` for an LRU would become transitive for everyone consuming `Moongate.Server.Abstractions`.

## It also closes a race

Those arrays were filled with an **unsynchronized read-modify-write**, and they are read from the game loop *and* from the HTTP threads serving map tiles — there was not one `lock` in `TileMatrix`. Two readers could decode the same block at once. Misses now run inside the caches lock, which is dwarfed by the file read it guards, and a test asserts 64 concurrent readers of one block cause exactly one read and share one array.

## Capacity

**4096 blocks per facet**, land and statics counted separately — a contiguous 512×512-tile region, against the roughly 25 blocks a players view spans. Same figure as the existing `CacheCapacityArt`, and enough that panning the viewer around one area does not re-read constantly.

Set from `moongate.yaml` (`MapBlockCacheSize`) through `Files.CacheCapacityMapBlocks`, alongside the art, gump and animation knobs. `TileMatrix.SetCacheCapacity` resizes after construction, so a host can give memory back without restarting; `0` disables caching and re-reads every block.

## Tests

`LruBlockCacheTests` — eviction, recency beating insertion order, capacity 0 still answering, resizing down, an evicted block still usable by whoever held it, and the concurrency case above.

`TileMatrixCacheDataTests` runs against a real client directory: 400 blocks read with a cap of 64 leave exactly 64 held, a block evicted and read again comes back tile-for-tile identical, and out-of-bounds blocks are still refused. These skip visibly where there is no client, as CI does.

Full suite green (2220). DocFX at 0 warnings with the new setting documented. Verified on a real boot: the server starts clean and `/api/v1/images/maps/0/0/0/0.png` still answers 200 — the path that motivated the change.

No packet class touched, no API change, so the packet reference and the UI contract are untouched.