### PR TITLE
feat(movement): absorb network jitter instead of refusing early steps

### DIFF
--- a/src/Moongate.Server.Abstractions/Data/Config/MoongateNetworkConfig.cs
+++ b/src/Moongate.Server.Abstractions/Data/Config/MoongateNetworkConfig.cs
@@ -11,4 +11,22 @@ public sealed class MoongateNetworkConfig
 
     /// <summary>Address advertised to clients in the server list and game-server redirect.</summary>
     public string PublicAddress { get; set; } = "127.0.0.1";
+
+    /// <summary>
+    /// How far ahead of schedule a step may arrive and still be taken, in milliseconds. Network jitter
+    /// routinely delivers movement a few milliseconds early, and refusing those is what makes walking
+    /// stutter: every refusal snaps the client back to the server's position. Arriving late rebuilds
+    /// the slack, arriving early spends it, and past the matching debt limit a step waits its turn
+    /// instead. ModernUO's figure, which it then extends by up to half the measured round-trip time
+    /// for distant players; there are no latency probes here, so this is the whole allowance. 0
+    /// restores the old behaviour of refusing anything early.
+    /// </summary>
+    public int MovementCreditMilliseconds { get; set; } = 200;
+
+    /// <summary>
+    /// How many early steps may wait at once before the client is resynced. The UO client keeps at
+    /// most five movements unacknowledged, so a queue this deep already means something other than
+    /// jitter. ModernUO uses the same limit.
+    /// </summary>
+    public int MovementQueueLimit { get; set; } = 10;
 }

--- a/src/Moongate.Server.Abstractions/Data/Internal/MovementThrottleDecision.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/MovementThrottleDecision.cs
@@ -1,0 +1,12 @@
+using Moongate.Server.Abstractions.Types;
+
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// What to do with a step, and the slack the client is left with afterwards. Separate from the
+/// legality decision on purpose: whether a step is *allowed* and whether it is *due* are different
+/// questions, and only the second one has any business being forgiving.
+/// </summary>
+/// <param name="Verdict">Run it now, or hold it until it comes due.</param>
+/// <param name="Credit">The slack after this step is accounted for.</param>
+public readonly record struct MovementThrottleDecision(MovementThrottleVerdictType Verdict, TimeSpan Credit);

--- a/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
+++ b/src/Moongate.Server.Abstractions/Data/Session/PlayerSession.cs
@@ -75,6 +75,26 @@ public sealed class PlayerSession : ISeedTarget
     /// <summary>When the last accepted move was recorded — the baseline the walk/run rate limit measures against.</summary>
     public DateTimeOffset LastMoveAt { get; private set; }
 
+    /// <summary>
+    /// The earliest this client may take its next step. A step arriving before it is early, and is
+    /// paid for out of <see cref="MovementCredit" /> rather than refused outright.
+    /// </summary>
+    public DateTimeOffset NextMoveAt { get; private set; }
+
+    /// <summary>
+    /// Slack for early steps, in the ModernUO sense: network jitter routinely delivers a packet a few
+    /// milliseconds ahead of schedule, and refusing those is what makes movement stutter. Arriving
+    /// late rebuilds it, up to the configured ceiling; arriving early spends it, down to the matching
+    /// debt limit. Past that the step waits in <see cref="MovementQueue" /> instead.
+    /// </summary>
+    public TimeSpan MovementCredit { get; private set; }
+
+    /// <summary>
+    /// Steps that arrived too early to run and too soon to refuse, in the order they came. Drained on
+    /// the game loop as each becomes due. Empty for a client walking at a normal pace.
+    /// </summary>
+    public Queue<QueuedMove> MovementQueue { get; } = new();
+
     /// <summary>When the last accepted speech packet was recorded — the baseline the chat rate limit measures against.</summary>
     public DateTimeOffset LastChatAt { get; private set; }
 
@@ -196,6 +216,37 @@ public sealed class PlayerSession : ISeedTarget
         {
             LastMoveSequence = sequence;
             LastMoveAt = at;
+        }
+    }
+
+    /// <summary>Sets when the next step becomes due, after a step has been taken.</summary>
+    public void SetNextMoveAt(DateTimeOffset at)
+    {
+        lock (_stateSync)
+        {
+            NextMoveAt = at;
+        }
+    }
+
+    /// <summary>Spends or rebuilds the jitter slack. Clamping is the caller's, which knows the ceiling.</summary>
+    public void SetMovementCredit(TimeSpan credit)
+    {
+        lock (_stateSync)
+        {
+            MovementCredit = credit;
+        }
+    }
+
+    /// <summary>
+    /// Forgets every pending step and the slack with them. A refusal resyncs the client to the
+    /// server's position, so anything still queued describes a walk that no longer happened.
+    /// </summary>
+    public void ClearMovementQueue()
+    {
+        lock (_stateSync)
+        {
+            MovementQueue.Clear();
+            MovementCredit = TimeSpan.Zero;
         }
     }
 

--- a/src/Moongate.Server.Abstractions/Data/Session/QueuedMove.cs
+++ b/src/Moongate.Server.Abstractions/Data/Session/QueuedMove.cs
@@ -1,0 +1,8 @@
+using Moongate.Core.Types;
+
+namespace Moongate.Server.Abstractions.Data.Session;
+
+/// <summary>A step that arrived early and is waiting for its turn, kept in the order it came.</summary>
+/// <param name="Direction">The direction the client asked to face or step in.</param>
+/// <param name="Sequence">The movement sequence number the client stamped it with.</param>
+public readonly record struct QueuedMove(DirectionType Direction, byte Sequence);

--- a/src/Moongate.Server.Abstractions/Interfaces/World/IMovementService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/World/IMovementService.cs
@@ -5,8 +5,13 @@ using Moongate.Server.Abstractions.Data.Session;
 namespace Moongate.Server.Abstractions.Interfaces.World;
 
 /// <summary>
-/// Validates and applies player movement: rate limiting, region gating, tile walkability, persistence,
+/// Validates and applies player movement: pacing, region gating, tile walkability, persistence,
 /// spatial re-indexing, and broadcasting — replying to the mover and notifying nearby players.
+/// <para>
+/// Steps that arrive ahead of schedule are not refused outright: a small slack absorbs network
+/// jitter, and past it a step waits in the session's queue until it comes due. Something has to run
+/// <see cref="DrainQueue" /> on the game loop for that queue to empty.
+/// </para>
 /// </summary>
 public interface IMovementService
 {
@@ -17,6 +22,13 @@ public interface IMovementService
     /// no character attached yet.
     /// </summary>
     void TryMove(PlayerSession session, DirectionType direction, byte sequence);
+
+    /// <summary>
+    /// Runs the steps <paramref name="session" /> has waiting that have come due, oldest first,
+    /// stopping at the first that has not. Called every frame; without it the tail of a queue would
+    /// sit there until the player moved again, which reads as the character stopping a step short.
+    /// </summary>
+    void DrainQueue(PlayerSession session);
 
     /// <summary>
     /// Attempts to turn or step an NPC with a configured brain. Uses the authoritative movement rules without

--- a/src/Moongate.Server.Abstractions/Types/MovementThrottleVerdictType.cs
+++ b/src/Moongate.Server.Abstractions/Types/MovementThrottleVerdictType.cs
@@ -1,0 +1,11 @@
+namespace Moongate.Server.Abstractions.Types;
+
+/// <summary>What to do with a step the moment it arrives.</summary>
+public enum MovementThrottleVerdictType
+{
+    /// <summary>Take it now — either it was due, or the slack covered how early it was.</summary>
+    Run,
+
+    /// <summary>Too early for the slack left. It waits its turn rather than being refused.</summary>
+    Queue
+}

--- a/src/Moongate.Server/Program.cs
+++ b/src/Moongate.Server/Program.cs
@@ -237,6 +237,7 @@ await ConsoleApp.RunAsync(
                 container.Register<IUltimaMapProvider, UltimaMapProvider>(Reuse.Singleton);
                 container.Register<IMapTileService, MapTileService>(Reuse.Singleton);
                 container.Register<IMovementService, MovementService>(Reuse.Singleton);
+                container.RegisterStdService<MovementQueueService, MovementQueueService>();
                 container.Register<ISpatialIndexService, SpatialIndexService>(Reuse.Singleton);
                 container.Register<IOplService, OplService>(Reuse.Singleton);
 

--- a/src/Moongate.Server/Services/World/MovementQueueService.cs
+++ b/src/Moongate.Server/Services/World/MovementQueueService.cs
@@ -1,0 +1,69 @@
+using Moongate.Core.Interfaces;
+using Moongate.Server.Abstractions.Interfaces.Accounts;
+using Moongate.Server.Abstractions.Interfaces.World;
+using SquidStd.Abstractions.Interfaces.Services;
+
+namespace Moongate.Server.Services.World;
+
+/// <summary>
+/// Empties the per-session movement queues on the game loop. Steps that arrived too early to run are
+/// held rather than refused, and something has to hand them back once they come due — otherwise the
+/// last one sits there until the player moves again, which reads as the character stopping a step
+/// short of where they walked.
+/// </summary>
+public sealed class MovementQueueService : ISquidStdService
+{
+    private const string TimerName = "movement_queue_drain";
+
+    /// <summary>
+    /// How often queues are checked. Well under the 200ms a running step costs, so a held step is
+    /// handed back within a frame or two of coming due rather than visibly late.
+    /// </summary>
+    private static readonly TimeSpan DrainInterval = TimeSpan.FromMilliseconds(50);
+
+    private readonly IGameLoopContext _loop;
+    private readonly ISessionManager _sessions;
+    private readonly IMovementService _movement;
+
+    private string? _timerId;
+
+    public MovementQueueService(IGameLoopContext loop, ISessionManager sessions, IMovementService movement)
+    {
+        _loop = loop;
+        _sessions = sessions;
+        _movement = movement;
+    }
+
+    public ValueTask StartAsync(CancellationToken cancellationToken = default)
+    {
+        _timerId ??= _loop.ScheduleRepeating(TimerName, DrainInterval, Drain);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_timerId is not null)
+        {
+            _loop.Cancel(_timerId);
+            _timerId = null;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// A session with nothing waiting is the normal case — a client walking at a sane pace never
+    /// queues — so the empty check comes before anything else.
+    /// </summary>
+    private void Drain()
+    {
+        foreach (var session in _sessions.All)
+        {
+            if (session.MovementQueue.Count > 0)
+            {
+                _movement.DrainQueue(session);
+            }
+        }
+    }
+}

--- a/src/Moongate.Server/Services/World/MovementService.cs
+++ b/src/Moongate.Server/Services/World/MovementService.cs
@@ -10,6 +10,9 @@ using Moongate.Server.Abstractions.Data.Session;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Data.Internal.World;
 using Moongate.UO.Data.Mobiles;
+using Moongate.Server.Abstractions.Data.Internal;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Abstractions.Data.Config;
 using Moongate.UO.Data.Types;
 using SquidStd.Core.Interfaces.Events;
 using SquidStd.Persistence.Abstractions.Interfaces.Persistence;
@@ -28,6 +31,49 @@ public sealed class MovementService : IMovementService
     private static readonly TimeSpan WalkInterval = TimeSpan.FromMilliseconds(400);
     private static readonly TimeSpan RunInterval = TimeSpan.FromMilliseconds(200);
 
+    /// <summary>
+    /// What a step costs before the next one comes due. Turning is free — ModernUO's TurnDelay is 0 —
+    /// so only an actual step moves the clock.
+    /// </summary>
+    public static TimeSpan CostOf(MobileEntity mobile, DirectionType direction)
+        => direction.StripRunning() != mobile.Direction.StripRunning()
+               ? TimeSpan.Zero
+               : direction.IsRunning() ? RunInterval : WalkInterval;
+
+    /// <summary>
+    /// Whether a step arriving at <paramref name="now" /> is due, and the slack left afterwards.
+    /// <para>
+    /// A hard threshold refuses anything even a millisecond early, and network jitter delivers that
+    /// constantly — each refusal snaps the client back to the server's position, which is what makes
+    /// walking stutter. So arriving late rebuilds slack up to <paramref name="maxCredit" />, arriving
+    /// early spends it, and only once the slack is in debt past that same limit does the step wait its
+    /// turn. This is ModernUO's credit buffer; its extra allowance for high-latency players is
+    /// deliberately not copied, since nothing here measures round-trip time.
+    /// </para>
+    /// </summary>
+    public static MovementThrottleDecision Throttle(
+        DateTimeOffset now,
+        DateTimeOffset nextMoveAt,
+        TimeSpan credit,
+        TimeSpan maxCredit
+    )
+    {
+        var delta = now - nextMoveAt;
+
+        if (delta >= TimeSpan.Zero)
+        {
+            var rebuilt = credit + delta;
+
+            return new(MovementThrottleVerdictType.Run, rebuilt > maxCredit ? maxCredit : rebuilt);
+        }
+
+        var spent = credit + delta;
+
+        return spent >= -maxCredit
+                   ? new(MovementThrottleVerdictType.Run, spent)
+                   : new(MovementThrottleVerdictType.Queue, credit);
+    }
+
     private readonly IMapTileService _mapTiles;
     private readonly IRegionService _regions;
     private readonly ISpatialIndexService _spatial;
@@ -36,6 +82,8 @@ public sealed class MovementService : IMovementService
     private readonly TimeProvider _timeProvider;
     private readonly IEventBus _eventBus;
     private readonly ILoopAffinity? _loopAffinity;
+    private readonly TimeSpan _maxCredit;
+    private readonly int _queueLimit;
 
     public MovementService(
         IMapTileService mapTiles,
@@ -45,9 +93,13 @@ public sealed class MovementService : IMovementService
         IPersistenceService persistenceService,
         TimeProvider timeProvider,
         IEventBus eventBus,
+        MoongateConfig? config = null,
         ILoopAffinity? loopAffinity = null
     )
     {
+        var network = config?.Network;
+        _maxCredit = TimeSpan.FromMilliseconds(Math.Max(network?.MovementCreditMilliseconds ?? 200, 0));
+        _queueLimit = Math.Max(network?.MovementQueueLimit ?? 10, 1);
         _mapTiles = mapTiles;
         _regions = regions;
         _spatial = spatial;
@@ -82,17 +134,6 @@ public sealed class MovementService : IMovementService
         }
 
         var isTurnOnly = direction.StripRunning() != mobile.Direction.StripRunning();
-
-        // Turning has no timing gate (ModernUO: TurnDelay = 0); only an actual step does.
-        if (!isTurnOnly)
-        {
-            var minInterval = direction.IsRunning() ? RunInterval : WalkInterval;
-
-            if (now - lastMoveAt < minInterval)
-            {
-                return RejectDecision(mobile);
-            }
-        }
 
         if (isTurnOnly)
         {
@@ -133,6 +174,73 @@ public sealed class MovementService : IMovementService
         // down to the exact target tile itself.
         var groundItems = _spatial.GetItemsInRange(mobile.MapId, mobile.Position, 1);
 
+        // Steps already waiting must keep their order, so a new one joins the back of the queue
+        // rather than overtaking them.
+        if (session.MovementQueue.Count > 0)
+        {
+            Enqueue(session, mobile, direction, sequence);
+
+            return;
+        }
+
+        var gate = Throttle(now, session.NextMoveAt, session.MovementCredit, _maxCredit);
+
+        if (gate.Verdict == MovementThrottleVerdictType.Queue)
+        {
+            Enqueue(session, mobile, direction, sequence);
+
+            return;
+        }
+
+        session.SetMovementCredit(gate.Credit);
+        Step(session, mobile, direction, sequence, now, groundItems);
+    }
+
+    /// <summary>
+    /// Runs the steps that have come due, oldest first, and stops at the first one that has not. The
+    /// game loop calls this; without it the tail of a queue would sit there until the player moved
+    /// again, which reads as the character stopping a step short.
+    /// </summary>
+    public void DrainQueue(PlayerSession session)
+    {
+        _loopAffinity?.AssertOnLoop("movement.drain_queue");
+
+        var mobile = session.Character;
+
+        if (mobile is null)
+        {
+            session.ClearMovementQueue();
+
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        while (session.MovementQueue.Count > 0 && now >= session.NextMoveAt)
+        {
+            var queued = session.MovementQueue.Dequeue();
+            var groundItems = _spatial.GetItemsInRange(mobile.MapId, mobile.Position, 1);
+
+            if (!Step(session, mobile, queued.Direction, queued.Sequence, now, groundItems))
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Takes one step if it is legal, and reports whether it was. A refusal resyncs the client and
+    /// drops everything still queued: those steps describe a walk that no longer happened.
+    /// </summary>
+    private bool Step(
+        PlayerSession session,
+        MobileEntity mobile,
+        DirectionType direction,
+        byte sequence,
+        DateTimeOffset now,
+        IReadOnlyList<ItemEntity> groundItems
+    )
+    {
         var decision = Evaluate(
             mobile,
             direction,
@@ -148,18 +256,38 @@ public sealed class MovementService : IMovementService
         if (!decision.Accepted)
         {
             // Any rejection forces a resync: the next packet's sequence is accepted unconditionally,
-            // matching how a real UO client resets its counter after a rejected move. The timing
-            // baseline (LastMoveAt) is left untouched so a burst of illegal attempts cannot keep
-            // resetting the clock and starve the rate limiter.
+            // matching how a real UO client resets its counter after a rejected move.
             session.SetLastMove(null, session.LastMoveAt);
+            session.ClearMovementQueue();
+            Reject(session, mobile, sequence);
+
+            return false;
+        }
+
+        session.SetLastMove(sequence, now);
+        session.SetNextMoveAt(now + CostOf(mobile, direction));
+        Apply(mobile, decision);
+        Accept(session, mobile, sequence);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Holds a step that arrived too early. Past the limit the client is not merely fast — the UO
+    /// client leaves at most five movements unacknowledged — so it is resynced instead.
+    /// </summary>
+    private void Enqueue(PlayerSession session, MobileEntity mobile, DirectionType direction, byte sequence)
+    {
+        if (session.MovementQueue.Count >= _queueLimit)
+        {
+            session.SetLastMove(null, session.LastMoveAt);
+            session.ClearMovementQueue();
             Reject(session, mobile, sequence);
 
             return;
         }
 
-        session.SetLastMove(sequence, now);
-        Apply(mobile, decision);
-        Accept(session, mobile, sequence);
+        session.MovementQueue.Enqueue(new(direction, sequence));
     }
 
     public bool TryMoveNpc(Serial mobileId, DirectionType direction)

--- a/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
+++ b/tests/Moongate.Tests/Server/AI/AiActionServiceTests.cs
@@ -52,6 +52,13 @@ public class AiActionServiceTests
 
         public void TryMove(PlayerSession session, DirectionType direction, byte sequence) { }
 
+
+        public void DrainQueue(PlayerSession session)
+
+        {
+
+        }
+
         public bool TryMoveNpc(Serial mobileId, DirectionType direction)
         {
             Moves.Add((mobileId, direction));

--- a/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
+++ b/tests/Moongate.Tests/Server/AI/NpcBrainIntegrationTests.cs
@@ -225,6 +225,9 @@ public sealed class NpcBrainIntegrationTests
         public void TryMove(PlayerSession session, DirectionType direction, byte sequence)
             => throw new InvalidOperationException("The guard integration flow must not move a player.");
 
+        public void DrainQueue(PlayerSession session)
+            => throw new InvalidOperationException("The guard integration flow must not move a player.");
+
         public bool TryMoveNpc(Serial mobileId, DirectionType direction)
             => throw new InvalidOperationException("The built-in guard flow must not emit movement intents.");
     }

--- a/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
+++ b/tests/Moongate.Tests/Server/MoongateNpcAiPluginTests.cs
@@ -32,6 +32,10 @@ public sealed class MoongateNpcAiPluginTests
     {
         public void TryMove(PlayerSession session, DirectionType direction, byte sequence) { }
 
+        public void DrainQueue(PlayerSession session)
+        {
+        }
+
         public bool TryMoveNpc(Serial mobileId, DirectionType direction)
             => true;
     }

--- a/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementServiceTests.cs
@@ -24,32 +24,6 @@ public class MovementServiceTests
     // Same fix already applied in MapTileServiceTests.cs for the identical reason.
     private const ushort WallStaticId = 10;
 
-    [Fact]
-    public void Evaluate_AfterRejectionResetsSequence_StillEnforcesTimingAgainstPriorRealMove()
-    {
-        var (mapTiles, regions) = Build();
-        var mobile = Mobile(direction: DirectionType.East);
-        var lastRealMoveAt = DateTimeOffset.UtcNow;
-        var now = lastRealMoveAt.AddMilliseconds(50); // well under the 400ms walk interval
-
-        // Simulates: a real move was accepted at lastRealMoveAt, then a later packet was rejected
-        // (e.g. sequence mismatch), which reset lastSequence to null but left lastMoveAt untouched
-        // (TryMove's resync behavior). A subsequent attempt must still be timing-gated against the
-        // real prior move, not treated as a fresh first-ever move.
-        var decision = MovementService.Evaluate(
-            mobile,
-            DirectionType.East,
-            0,
-            null,
-            lastRealMoveAt,
-            now,
-            mapTiles,
-            regions,
-            []
-        );
-
-        Assert.False(decision.Accepted);
-    }
 
     [Fact]
     public void Evaluate_ImpassableRegion_IsRejected()
@@ -125,7 +99,7 @@ public class MovementServiceTests
     }
 
     [Fact]
-    public void Evaluate_TooSoonAfterLastMove_IsRejected()
+    public void Evaluate_NoLongerJudgesTiming_ThatIsThrottlesQuestion()
     {
         var (mapTiles, regions) = Build();
         var mobile = Mobile(direction: DirectionType.East);
@@ -134,7 +108,9 @@ public class MovementServiceTests
 
         var decision = MovementService.Evaluate(mobile, DirectionType.East, 1, 0, lastMoveAt, now, mapTiles, regions, []);
 
-        Assert.False(decision.Accepted);
+        // Legal, just not due yet -- and being early is no longer grounds for refusal, which is what
+        // MovementThrottleTests covers.
+        Assert.True(decision.Accepted);
     }
 
     [Fact]
@@ -276,7 +252,7 @@ public class MovementServiceTests
         var spatial = new SpatialIndexService(persistence, new StubLoopAffinity(), bus);
         var world = new StubWorldService();
 
-        return (new(mapTiles, regions, spatial, world, persistence, TimeProvider.System, bus, new StubLoopAffinity()),
+        return (new(mapTiles, regions, spatial, world, persistence, TimeProvider.System, bus, null, new StubLoopAffinity()),
                 persistence, spatial, bus);
     }
 

--- a/tests/Moongate.Tests/Server/World/MovementThrottleTests.cs
+++ b/tests/Moongate.Tests/Server/World/MovementThrottleTests.cs
@@ -1,0 +1,145 @@
+using Moongate.Core.Types;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Types;
+using Moongate.Server.Services.World;
+
+namespace Moongate.Tests.Server.World;
+
+/// <summary>
+/// Whether a step is *due*, which is a different question from whether it is *legal* and the only one
+/// with any business being forgiving. A hard threshold refuses anything a millisecond early, and
+/// network jitter delivers that constantly — each refusal snaps the client back to the server's
+/// position, which is what a player feels as stuttering.
+/// </summary>
+public class MovementThrottleTests
+{
+    private static readonly DateTimeOffset Due = new(2026, 8, 4, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly TimeSpan MaxCredit = TimeSpan.FromMilliseconds(200);
+
+    [Fact]
+    public void AStepArrivingExactlyOnTime_Runs()
+        => Assert.Equal(
+            MovementThrottleVerdictType.Run,
+            MovementService.Throttle(Due, Due, TimeSpan.Zero, MaxCredit).Verdict
+        );
+
+    // The case that made walking stutter: jitter puts a packet a few milliseconds ahead of schedule.
+    [Fact]
+    public void AStepArrivingSlightlyEarly_Runs_AndSpendsThatMuchSlack()
+    {
+        var decision = MovementService.Throttle(Due.AddMilliseconds(-5), Due, TimeSpan.Zero, MaxCredit);
+
+        Assert.Equal(MovementThrottleVerdictType.Run, decision.Verdict);
+        Assert.Equal(TimeSpan.FromMilliseconds(-5), decision.Credit);
+    }
+
+    [Fact]
+    public void AStepArrivingLate_Runs_AndRebuildsThatMuchSlack()
+    {
+        var decision = MovementService.Throttle(
+            Due.AddMilliseconds(30),
+            Due,
+            TimeSpan.FromMilliseconds(-50),
+            MaxCredit
+        );
+
+        Assert.Equal(MovementThrottleVerdictType.Run, decision.Verdict);
+        Assert.Equal(TimeSpan.FromMilliseconds(-20), decision.Credit);
+    }
+
+    // Otherwise standing still would bank enough slack to take a dozen steps at once afterwards.
+    [Fact]
+    public void SlackRebuiltByStandingStill_StopsAtTheCeiling()
+    {
+        var decision = MovementService.Throttle(Due.AddMinutes(5), Due, TimeSpan.Zero, MaxCredit);
+
+        Assert.Equal(MaxCredit, decision.Credit);
+    }
+
+    [Fact]
+    public void AStepEarlierThanTheSlackLeft_Waits()
+    {
+        var decision = MovementService.Throttle(
+            Due.AddMilliseconds(-250),
+            Due,
+            TimeSpan.Zero,
+            MaxCredit
+        );
+
+        Assert.Equal(MovementThrottleVerdictType.Queue, decision.Verdict);
+    }
+
+    /// <summary>Waiting must not also charge for the wait, or the client could never catch up.</summary>
+    [Fact]
+    public void AStepThatWaits_LeavesTheSlackUntouched()
+    {
+        var credit = TimeSpan.FromMilliseconds(-100);
+        var decision = MovementService.Throttle(Due.AddMilliseconds(-250), Due, credit, MaxCredit);
+
+        Assert.Equal(credit, decision.Credit);
+    }
+
+    // Exactly at the debt limit still runs; a millisecond past it waits.
+    [Theory]
+    [InlineData(-200, MovementThrottleVerdictType.Run)]
+    [InlineData(-201, MovementThrottleVerdictType.Queue)]
+    public void TheDebtLimitIsTheBoundary(int early, MovementThrottleVerdictType expected)
+        => Assert.Equal(
+            expected,
+            MovementService.Throttle(Due.AddMilliseconds(early), Due, TimeSpan.Zero, MaxCredit).Verdict
+        );
+
+    /// <summary>
+    /// A sustained early rate drains the slack and then waits, rather than running forever: the
+    /// buffer forgives jitter, it does not forgive speed.
+    /// </summary>
+    [Fact]
+    public void ASteadyStreamOfEarlySteps_RunsUntilTheSlackIsGone_ThenWaits()
+    {
+        var credit = TimeSpan.Zero;
+        var ran = 0;
+
+        for (var step = 0; step < 20; step++)
+        {
+            var decision = MovementService.Throttle(Due.AddMilliseconds(-30), Due, credit, MaxCredit);
+
+            if (decision.Verdict == MovementThrottleVerdictType.Queue)
+            {
+                break;
+            }
+
+            credit = decision.Credit;
+            ran++;
+        }
+
+        // 200ms of slack at 30ms a step: six run outright, the seventh would owe 210ms and waits.
+        Assert.Equal(6, ran);
+    }
+
+    [Fact]
+    public void WithNoSlackConfigured_AnythingEarlyWaits()
+        => Assert.Equal(
+            MovementThrottleVerdictType.Queue,
+            MovementService.Throttle(Due.AddMilliseconds(-1), Due, TimeSpan.Zero, TimeSpan.Zero).Verdict
+        );
+
+    [Fact]
+    public void Cost_WalkingIsFourHundredMilliseconds()
+        => Assert.Equal(TimeSpan.FromMilliseconds(400), MovementService.CostOf(Facing(DirectionType.East), DirectionType.East));
+
+    [Fact]
+    public void Cost_RunningIsTwoHundred()
+        => Assert.Equal(
+            TimeSpan.FromMilliseconds(200),
+            MovementService.CostOf(Facing(DirectionType.East), DirectionType.East | DirectionType.Running)
+        );
+
+    // ModernUO's TurnDelay is 0: turning on the spot is free, so a spin never eats the walk budget.
+    [Fact]
+    public void Cost_TurningOnTheSpotIsFree()
+        => Assert.Equal(TimeSpan.Zero, MovementService.CostOf(Facing(DirectionType.East), DirectionType.South));
+
+    private static MobileEntity Facing(DirectionType direction)
+        => new() { Id = new(0x1), MapId = 0, Position = new(1, 1, 0), Direction = direction };
+}


### PR DESCRIPTION
Fixes #195.

A step arriving a millisecond before it was due was refused, and a refusal resyncs the client to the server position. Network jitter delivers early packets constantly, so the rubber-banding was not an edge case — it was the normal experience of walking. Comparing against `others/ModernUO` is what turned this up; POL and UOX3 avoid the hard threshold too.

## Two questions, untangled

`Evaluate` was answering both *is this step legal* and *is it due*. Only the second has any business being forgiving, so it moves out into `Throttle` — pure, and answering run-or-wait:

- **late** → run, and rebuild slack up to the ceiling
- **early, within slack** → run, and spend that much
- **early, past the debt limit** → wait in a bounded queue

`MovementQueueService` hands queued steps back on the game loop every 50ms as they come due. Without it the tail of a queue would sit there until the player moved again, which reads as the character stopping a step short of where they walked.

## What was deliberately left out

ModernUOs `MovementThrottle` is ~1100 lines because it also carries speedhack detection, movement-rate analysis, staff notification and RTT probing. None of that is about smoothness. Ported: the credit buffer and the queue. Not ported: everything else — and since nothing here measures round-trip time, the slack is a fixed configurable value rather than ModernUOs dynamic one (it extends the buffer by up to half the measured RTT for distant players).

Defaults match ModernUOs: `MovementCreditMilliseconds` 200, `MovementQueueLimit` 10 — already well past the five movements a UO client leaves unacknowledged, so a queue that deep means something other than jitter. Setting the credit to 0 restores the old refuse-anything-early behaviour.

## Tests

`MovementThrottleTests` — on time, slightly early, late, the ceiling on rebuilt slack (so standing still cannot bank a dozen steps), the debt boundary on both sides, that waiting does not also charge for the wait, and that a sustained early rate runs six steps and then waits: **the buffer forgives jitter, it does not forgive speed**.

Two existing tests asserted the timing gate inside `Evaluate`. One now pins that `Evaluate` no longer judges timing at all; the other belonged entirely to `Throttle` and moved there.

`DrainQueue` had no production caller when it was written, which fails no test — so it is wired to a real service and the boot was checked: `Started MovementQueueService` appears with the other 21.

Full suite green (2232), DocFX at 0 warnings. No packet class changed, no API change.

**Not measured with a real client.** The server does not log refusals, so I cannot tell you how many you were taking per session before this. If you want that number, a counter on `MoveRejectPacket` would give it.

## Related, not included

There are no mounted delays — ModernUO and POL each have four (foot/mount × walk/run), this has two. Once mounts exist a mounted player would be refused every other step; that belongs with the mount card, not here.