### PR TITLE
fix(api): name items the way UO names them

### DIFF
--- a/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterItemResponse.cs
+++ b/plugins/Moongate.Http.Plugin/Data/Api/Characters/CharacterItemResponse.cs
@@ -5,7 +5,10 @@ namespace Moongate.Http.Plugin.Data.Api.Characters;
 /// carries script and loot ids: a field added to the entity later would publish itself.
 /// </summary>
 /// <param name="Serial">The item's serial, as <c>0x40000001</c>.</param>
-/// <param name="Name">The item's name. Blank when the item is named by cliloc rather than stored text.</param>
+/// <param name="Name">
+/// What to call the item: whatever it was renamed to, else its template's name, else the client's own
+/// word for that graphic. Almost nothing in UO stores a name, so the third case is the common one.
+/// </param>
 /// <param name="TemplateId">The template it was built from.</param>
 /// <param name="ItemId">The art id, which addresses <c>/api/v1/images/items/{id}.png</c>.</param>
 /// <param name="Hue">0 for the raw art.</param>

--- a/plugins/Moongate.Http.Plugin/Services/Characters/CharacterInventoryReader.cs
+++ b/plugins/Moongate.Http.Plugin/Services/Characters/CharacterInventoryReader.cs
@@ -1,7 +1,9 @@
 using Moongate.Core.Primitives;
 using Moongate.Http.Plugin.Data.Api.Characters;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Extensions;
 using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Localization;
 
 namespace Moongate.Http.Plugin.Services.Characters;
 
@@ -18,10 +20,14 @@ public sealed class CharacterInventoryReader
     public const int MaxDepth = 10;
 
     private readonly IItemService _items;
+    private readonly IItemTemplateService _templates;
+    private readonly IClilocService _clilocs;
 
-    public CharacterInventoryReader(IItemService items)
+    public CharacterInventoryReader(IItemService items, IItemTemplateService templates, IClilocService clilocs)
     {
         _items = items;
+        _templates = templates;
+        _clilocs = clilocs;
     }
 
     /// <summary>The backpack's contents as a tree. Empty when the character has no backpack.</summary>
@@ -60,7 +66,7 @@ public sealed class CharacterInventoryReader
 
         return new(
             item.Id.ToString(),
-            item.Name,
+            _clilocs.DisplayName(item, _templates.GetById(item.TemplateId)),
             item.TemplateId,
             item.ItemId,
             item.Hue.Value,

--- a/src/Moongate.Server.Abstractions/Extensions/ItemNamingExtensions.cs
+++ b/src/Moongate.Server.Abstractions/Extensions/ItemNamingExtensions.cs
@@ -1,0 +1,38 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Interfaces.Localization;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Server.Abstractions.Extensions;
+
+/// <summary>
+/// The one place that answers "what is this item called" for server-side surfaces — an admin list, a
+/// Lua field, a log line. Not for the game client, which is sent the cliloc number and renders the
+/// word itself, in the player's language and with its own plural.
+/// </summary>
+public static class ItemNamingExtensions
+{
+    /// <summary>
+    /// The name to show for <paramref name="item" />: whatever it was renamed to, else what its
+    /// template calls it, else the client's own word for that graphic, else the template id.
+    /// <para>
+    /// The cliloc step is the one that matters and the one easy to leave out: UO names almost
+    /// everything by graphic, not by stored text, so an item nobody renamed has an empty
+    /// <see cref="ItemEntity.Name" /> and is not nameless at all. Skipping it is how a pair of pants
+    /// ends up reported as unnamed.
+    /// </para>
+    /// </summary>
+    public static string DisplayName(this IClilocService clilocs, ItemEntity item, ItemTemplate? template)
+    {
+        if (item.Name.Length > 0)
+        {
+            return item.Name;
+        }
+
+        if (template?.Name is { Length: > 0 } templateName)
+        {
+            return templateName;
+        }
+
+        return clilocs.Text(ItemClilocs.ForItemId(item.ItemId)) ?? item.TemplateId;
+    }
+}

--- a/src/Moongate.Server/Scripting/ItemModule.cs
+++ b/src/Moongate.Server/Scripting/ItemModule.cs
@@ -1,5 +1,6 @@
 using Moongate.Core.Primitives;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Extensions;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Localization;
 using Moongate.Server.Scripting.Views;
@@ -26,18 +27,21 @@ public sealed class ItemModule
     private readonly IItemService _items;
     private readonly IEntityStore<MobileEntity, Serial> _mobiles;
     private readonly IClilocService _clilocs;
+    private readonly IItemTemplateService _templates;
 
     public ItemModule(
         IItemFactoryService factory,
         IItemService items,
         IPersistenceService persistence,
-        IClilocService clilocs
+        IClilocService clilocs,
+        IItemTemplateService templates
     )
     {
         _factory = factory;
         _items = items;
         _mobiles = persistence.GetStore<MobileEntity, Serial>();
         _clilocs = clilocs;
+        _templates = templates;
     }
 
     [ScriptFunction("add_to_container", "Places an item into a container at (x, y); false on unknown serials.")]
@@ -194,9 +198,7 @@ public sealed class ItemModule
     /// template id. The same chain the tooltip uses in OplService.
     /// </summary>
     private string DisplayName(ItemEntity item)
-        => item.Name.Length > 0
-               ? item.Name
-               : _clilocs.Text(ItemClilocs.ForItemId(item.ItemId)) ?? item.TemplateId;
+        => _clilocs.DisplayName(item, _templates.GetById(item.TemplateId));
 
     private uint? Persist(IReadOnlyList<ItemEntity> created)
     {

--- a/tests/Moongate.Tests/Http/Characters/CharacterInventoryReaderTests.cs
+++ b/tests/Moongate.Tests/Http/Characters/CharacterInventoryReaderTests.cs
@@ -1,6 +1,7 @@
 using Moongate.Http.Plugin.Data.Api.Characters;
 using Moongate.Http.Plugin.Services.Characters;
 using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
 using Moongate.Tests.Support;
 using Moongate.Ultima.Types;
 
@@ -22,7 +23,7 @@ public class CharacterInventoryReaderTests
 
         Put(items, backpack, Item(items, 0x40000001, "sword"));
 
-        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+        var contents = new CharacterInventoryReader(items, new ItemTemplateService(), new StubClilocService()).ReadBackpack(MobileWith(backpack));
 
         Assert.Equal("0x40000001", Assert.Single(contents).Serial);
     }
@@ -37,7 +38,7 @@ public class CharacterInventoryReaderTests
         Put(items, backpack, bag);
         Put(items, bag, Item(items, 1, "potion"));
 
-        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+        var contents = new CharacterInventoryReader(items, new ItemTemplateService(), new StubClilocService()).ReadBackpack(MobileWith(backpack));
 
         var found = Assert.Single(contents);
 
@@ -48,7 +49,7 @@ public class CharacterInventoryReaderTests
     [Fact]
     public void ReadBackpack_IsEmptyWhenTheCharacterHasNoBackpack()
     {
-        var reader = new CharacterInventoryReader(new StubItemService([]));
+        var reader = new CharacterInventoryReader(new StubItemService([]), new ItemTemplateService(), new StubClilocService());
 
         Assert.Empty(reader.ReadBackpack(new() { Id = new(1) }));
     }
@@ -62,7 +63,7 @@ public class CharacterInventoryReaderTests
         Put(items, backpack, Item(items, 1, "sword"));
         Put(items, backpack, Item(items, 2, "gold"));
 
-        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+        var contents = new CharacterInventoryReader(items, new ItemTemplateService(), new StubClilocService()).ReadBackpack(MobileWith(backpack));
 
         Assert.Equal(["sword", "gold"], contents.Select(item => item.Name));
     }
@@ -82,7 +83,7 @@ public class CharacterInventoryReaderTests
             current = bag;
         }
 
-        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+        var contents = new CharacterInventoryReader(items, new ItemTemplateService(), new StubClilocService()).ReadBackpack(MobileWith(backpack));
 
         Assert.Equal(CharacterInventoryReader.MaxDepth, Depth(contents));
     }
@@ -99,7 +100,7 @@ public class CharacterInventoryReaderTests
         Put(items, backpack, bag);
         Put(items, bag, backpack); // the cycle
 
-        var contents = new CharacterInventoryReader(items).ReadBackpack(MobileWith(backpack));
+        var contents = new CharacterInventoryReader(items, new ItemTemplateService(), new StubClilocService()).ReadBackpack(MobileWith(backpack));
 
         // It returns rather than hanging, and stops where it would repeat itself.
         var bagNode = Assert.Single(contents);
@@ -115,7 +116,7 @@ public class CharacterInventoryReaderTests
 
         robe.EquippedLayer = LayerType.OuterTorso;
 
-        var worn = new CharacterInventoryReader(new StubItemService([robe])).ReadEquipment(new() { Id = new(1) });
+        var worn = new CharacterInventoryReader(new StubItemService([robe]), new ItemTemplateService(), new StubClilocService()).ReadEquipment(new() { Id = new(1) });
 
         var found = Assert.Single(worn);
 

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/CharacterDetailEndpointsTests.cs
@@ -11,6 +11,8 @@ using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Mobiles;
 using Moongate.Server.Services.Accounts;
 using Moongate.Server.Services.Mobiles;
+using Moongate.Server.Services.Items;
+using Moongate.Server.Abstractions.Interfaces.Localization;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Types;
 
@@ -195,6 +197,8 @@ public class CharacterDetailEndpointsTests
                               container.RegisterInstance<IItemService>(new StubItemService([]));
                               container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
                               container.Register<CharacterAccessService>(Reuse.Singleton);
+                              container.RegisterInstance<IItemTemplateService>(new ItemTemplateService());
+                              container.RegisterInstance<IClilocService>(new StubClilocService());
                               container.Register<CharacterInventoryReader>(Reuse.Singleton);
                               container.RegisterInstance(SkillRegistry());
                               container.Register<CharacterSkillReader>(Reuse.Singleton);

--- a/tests/Moongate.Tests/Http/Endpoints/Characters/ItemTooltipEndpointsTests.cs
+++ b/tests/Moongate.Tests/Http/Endpoints/Characters/ItemTooltipEndpointsTests.cs
@@ -14,6 +14,7 @@ using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.Localization;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.Server.Services.Accounts;
+using Moongate.Server.Services.Items;
 using Moongate.Tests.Support;
 using Moongate.Ultima.Types;
 using Moongate.UO.Data.Types;
@@ -241,12 +242,13 @@ public class ItemTooltipEndpointsTests
                configure: container =>
                           {
                               container.RegisterInstance<IItemService>(world);
-                              container.RegisterInstance(
+                              container.RegisterInstance<IClilocService>(
                                   clilocs ?? StubClilocService.Entries((WeightCliloc, "Weight: ~1_WEIGHT~ stone"))
                               );
                               container.RegisterInstance<IOplService>(new StubOplService(WeightCliloc));
                               container.Register<ICharacterQueryService, CharacterQueryService>(Reuse.Singleton);
                               container.Register<CharacterAccessService>(Reuse.Singleton);
+                              container.RegisterInstance<IItemTemplateService>(new ItemTemplateService());
                               container.Register<CharacterInventoryReader>(Reuse.Singleton);
                               container.Register<OplTextRenderer>(Reuse.Singleton);
                               container.RegisterApiEndpointInstance(

--- a/tests/Moongate.Tests/Server/ItemModuleTests.cs
+++ b/tests/Moongate.Tests/Server/ItemModuleTests.cs
@@ -176,6 +176,6 @@ public class ItemModuleTests
         var factory = new ItemFactoryService(templates, new(1));
         var itemService = new ItemService(persistence);
 
-        return (new(factory, itemService, persistence, new StubClilocService("gold coin")), persistence);
+        return (new(factory, itemService, persistence, new StubClilocService("gold coin"), templates), persistence);
     }
 }

--- a/tests/Moongate.Tests/Server/Items/ItemNamingTests.cs
+++ b/tests/Moongate.Tests/Server/Items/ItemNamingTests.cs
@@ -1,0 +1,62 @@
+using Moongate.Persistence.Entities;
+using Moongate.Server.Abstractions.Extensions;
+using Moongate.Tests.Support;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// What an item is called on a server-side surface. Almost nothing in UO stores a name — the client
+/// is told a graphic and looks the word up itself — so an item with an empty Name is the normal case,
+/// not a nameless one.
+/// </summary>
+public class ItemNamingTests
+{
+    private const int LongPants = 5433;
+
+    [Fact]
+    public void AnItemSomebodyRenamed_KeepsThatName()
+        => Assert.Equal(
+            "Excalibur",
+            Clilocs().DisplayName(Item(LongPants, name: "Excalibur"), Template("long pants"))
+        );
+
+    [Fact]
+    public void AnUnnamedItem_TakesItsTemplatesName()
+        => Assert.Equal("long pants", Clilocs().DisplayName(Item(LongPants), Template("long pants")));
+
+    /// <summary>
+    /// The case that reported items as unnamed: no stored name, no template name, but the client
+    /// files know the word perfectly well.
+    /// </summary>
+    [Fact]
+    public void AnItemNamedOnlyByItsGraphic_TakesTheClientsWordForIt()
+        => Assert.Equal("long pants", Clilocs("long pants").DisplayName(Item(LongPants), Template(null)));
+
+    [Fact]
+    public void WithNoClientFiles_TheTemplateIdIsBetterThanNothing()
+        => Assert.Equal("long_pants", Clilocs().DisplayName(Item(LongPants), Template(null)));
+
+    [Fact]
+    public void WithNoTemplateAtAll_TheChainStillAnswers()
+        => Assert.Equal("long pants", Clilocs("long pants").DisplayName(Item(LongPants), null));
+
+    // A renamed item beats its template, and the template beats the client's word: most specific wins.
+    [Fact]
+    public void TheMostSpecificNameWins()
+    {
+        var clilocs = Clilocs("long pants");
+
+        Assert.Equal("Excalibur", clilocs.DisplayName(Item(LongPants, name: "Excalibur"), Template("trousers")));
+        Assert.Equal("trousers", clilocs.DisplayName(Item(LongPants), Template("trousers")));
+    }
+
+    private static StubClilocService Clilocs(string? text = null)
+        => new(text);
+
+    private static ItemEntity Item(int itemId, string name = "")
+        => new() { Id = new(0x40000002), TemplateId = "long_pants", ItemId = itemId, Name = name };
+
+    private static ItemTemplate? Template(string? name)
+        => new() { Id = "long_pants", Name = name ?? string.Empty, ItemId = LongPants };
+}

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2260,7 +2260,7 @@
           },
           "name": {
             "type": "string",
-            "description": "The item's name. Blank when the item is named by cliloc rather than stored text."
+            "description": "What to call the item: whatever it was renamed to, else its template's name, else the client's own\nword for that graphic. Almost nothing in UO stores a name, so the third case is the common one."
           },
           "templateId": {
             "type": "string",

--- a/ui/src/lib/api-types.ts
+++ b/ui/src/lib/api-types.ts
@@ -1185,7 +1185,10 @@ export interface components {
         CharacterItemResponse: {
             /** @description The item's serial, as `0x40000001`. */
             serial: string;
-            /** @description The item's name. Blank when the item is named by cliloc rather than stored text. */
+            /**
+             * @description What to call the item: whatever it was renamed to, else its template's name, else the client's own
+             *     word for that graphic. Almost nothing in UO stores a name, so the third case is the common one.
+             */
             name: string;
             /** @description The template it was built from. */
             templateId: string;


### PR DESCRIPTION
Fixes #197.

The character endpoint reported most items as having no name, and the portal drew them as **"Unnamed item"** — a pair of pants, a shirt, a dagger. It copied `ItemEntity.Name` straight out, and that field is empty for anything nobody renamed: UO names almost everything by *graphic*, through the cliloc at `1020000 + itemId`, which the client resolves in the player's own language. An item with an empty `Name` is the normal case, not a nameless one.

## The chain existed three times and this path used none of them

`ItemModule.DisplayName`, `OplService` and `ItemTemplateEndpoints` each carried a version of it. `CharacterItemResponse` meanwhile *documented* the gap rather than closing it:

> Blank when the item is named by cliloc rather than stored text.

So there is one resolver now, in `Server.Abstractions` where both the server and the plugins can see it: renamed → the template's name → the client's word for that graphic → the template id.

**A disagreement nobody had noticed.** `ItemModule`'s copy skipped the template name; `OplService`'s consulted it. The same item could be called two different things in Lua and over the API. Moving `ItemModule` onto the shared chain settles it.

`OplService` keeps its own path deliberately: it sends the cliloc *number* to the game client, which renders the word itself and builds the plural for a stack. Text is only for the surfaces that cannot do that — an admin list, a Lua field, a log line.

## Tests

`ItemNamingTests` covers the four links, that the most specific name wins, and the reported case exactly — no stored name, no template name, and a client that knows the word perfectly well.

Adding the two dependencies to `CharacterInventoryReader` surfaced that the test containers registered neither; both now do, and one of them was registering the cliloc stub by concrete type rather than by interface, which is why it resolved for the endpoint but not for the reader.

Verified against a running server, which is how the bug was seen in the first place:

```
long_pants     itemId 5433  ->  'long pants'
shirt          itemId 5399  ->  'shirt'
dagger         itemId 3922  ->  'dagger'
wooden_shield  itemId 7034  ->  'wooden shield'
```

Full suite green (2226), DocFX at 0 warnings. The UI contract is regenerated — the `<param>` doc on `CharacterItemResponse` changed, which drifts it.
