### PR TITLE
feat(network): handle drop-wear (0x13)

### DIFF
--- a/docs/packets/families/items-containers.md
+++ b/docs/packets/families/items-containers.md
@@ -6,6 +6,7 @@ World items, worn items, container gumps, contents and lift rejects.
 |---|---|---|---|---|
 | [`0x07`](../incoming/0x07-pick-up-item.md) | Pick Up Item | C → S | 7 bytes (fixed) | The client asks to lift an item onto its cursor. |
 | [`0x08`](../incoming/0x08-drop-item.md) | Drop Item | C → S | 15 bytes (fixed) | Where the client wants to put the item it is holding. |
+| [`0x13`](../incoming/0x13-drop-wear-item.md) | Drop Wear Item | C → S | 10 bytes (fixed) | The client dropped what it was holding onto a paperdoll. |
 | [`0x24`](../outgoing/0x24-draw-container.md) | Draw Container | S → C | 7 bytes (fixed) | Opens the container's gump on the client. |
 | [`0x25`](../outgoing/0x25-add-item-to-container.md) | Add Item To Container | S → C | 21 bytes (fixed) | Drops one item into an already-open container gump. |
 | [`0x27`](../outgoing/0x27-lift-reject.md) | Lift Reject | S → C | 2 bytes (fixed) | The lift the client asked for is refused, and why. |

--- a/docs/packets/includes/family-cards.md
+++ b/docs/packets/includes/family-cards.md
@@ -21,7 +21,7 @@
   </a>
   <a class="mg-card" href="families/items-containers.md">
     <h3>Items &amp; containers</h3>
-    <div class="mg-card-ops">0x07 · 0x08 · 0x24 · 0x25 · 0x27 · 0x29 · 0x2E · 0x3C · 0xF3</div>
+    <div class="mg-card-ops">0x07 · 0x08 · 0x13 · 0x24 · 0x25 · 0x27 · 0x29 · 0x2E · 0x3C · 0xF3</div>
     <p>World items, worn items, container gumps, contents and lift rejects.</p>
   </a>
   <a class="mg-card" href="families/movement.md">

--- a/docs/packets/includes/packet-table.md
+++ b/docs/packets/includes/packet-table.md
@@ -1,6 +1,6 @@
 <div class="mg-stats">
-  <div class="mg-stat"><div class="mg-stat-num">61</div><div class="mg-stat-label">implemented packets</div></div>
-  <div class="mg-stat"><div class="mg-stat-num mg-grass">21</div><div class="mg-stat-label">incoming (client → server)</div></div>
+  <div class="mg-stat"><div class="mg-stat-num">62</div><div class="mg-stat-label">implemented packets</div></div>
+  <div class="mg-stat"><div class="mg-stat-num mg-grass">22</div><div class="mg-stat-label">incoming (client → server)</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-violet">40</div><div class="mg-stat-label">outgoing (server → client)</div></div>
   <div class="mg-stat"><div class="mg-stat-num mg-stone">7.x</div><div class="mg-stat-label">client target</div></div>
 </div>
@@ -13,6 +13,7 @@
 | [`0x08`](../incoming/0x08-drop-item.md) | Drop Item | C → S | 15 bytes (fixed) | Where the client wants to put the item it is holding. |
 | [`0x09`](../incoming/0x09-single-click.md) | Single Click | C → S | 5 bytes (fixed) | The client clicked an entity, identified by its serial. |
 | [`0x11`](../outgoing/0x11-status-bar-info.md) | Status Bar Info | S → C | Variable | The player's own status window. |
+| [`0x13`](../incoming/0x13-drop-wear-item.md) | Drop Wear Item | C → S | 10 bytes (fixed) | The client dropped what it was holding onto a paperdoll. |
 | [`0x1B`](../outgoing/0x1b-login-confirm.md) | Login Confirm | S → C | 37 bytes (fixed) | The first packet of the enter-world burst. |
 | [`0x1D`](../outgoing/0x1d-delete-object.md) | Delete Object | S → C | 5 bytes (fixed) | The entity is gone — stop drawing it. |
 | [`0x20`](../outgoing/0x20-draw-game-player.md) | Draw Game Player | S → C | 19 bytes (fixed) | Positions and renders the player's own mobile. |

--- a/docs/packets/incoming/0x13-drop-wear-item.md
+++ b/docs/packets/incoming/0x13-drop-wear-item.md
@@ -1,0 +1,16 @@
+# 0x13 — Drop Wear Item
+
+<span class="mg-dir mg-dir-in">Client → Server</span>
+
+Drop-wear item (0x13): the client dropped what it was holding onto a paperdoll. `Mobile` is who to put it on — normally the player themselves. 10 bytes fixed. <para> `Layer` is where the client believes the item goes, and the server does not take its word for it: which layer an item occupies is a property of the item. POL validates this byte and then assigns the item's own tile layer over it (eqpitem.cpp), for the same reason — honouring the request would let a client wear a dagger as a pair of boots. </para>
+
+- **Class:** [`DropWearItemPacket`](https://github.com/moongate-community/moongate/blob/main/src/Moongate.Network/Packets/Incoming/DropWearItemPacket.cs)
+- **Size:** 10 bytes (fixed)
+
+## Fields
+
+| Field | Type |
+|---|---|
+| `Serial` | `Serial` |
+| `Layer` | `byte` |
+| `Mobile` | `Serial` |

--- a/docs/packets/toc.yml
+++ b/docs/packets/toc.yml
@@ -38,6 +38,8 @@
       href: incoming/0x08-drop-item.md
     - name: "0x09 — Single Click"
       href: incoming/0x09-single-click.md
+    - name: "0x13 — Drop Wear Item"
+      href: incoming/0x13-drop-wear-item.md
     - name: "0x3A — Skill Lock Change"
       href: incoming/0x3a-skill-lock-change.md
     - name: "0x5D — Character Select"

--- a/src/Moongate.Network/Packets/Incoming/DropWearItemPacket.cs
+++ b/src/Moongate.Network/Packets/Incoming/DropWearItemPacket.cs
@@ -1,0 +1,31 @@
+using Moongate.Core.Primitives;
+using Moongate.Network.Attributes;
+using Moongate.Network.Interfaces;
+using Moongate.Network.Types;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Network.Packets.Incoming;
+
+/// <summary>
+/// Drop-wear item (0x13): the client dropped what it was holding onto a paperdoll. <c>Mobile</c> is who
+/// to put it on — normally the player themselves. 10 bytes fixed.
+/// <para>
+/// <c>Layer</c> is where the client believes the item goes, and the server does not take its word for
+/// it: which layer an item occupies is a property of the item. POL validates this byte and then assigns
+/// the item's own tile layer over it (eqpitem.cpp), for the same reason — honouring the request would
+/// let a client wear a dagger as a pair of boots.
+/// </para>
+/// </summary>
+[PacketDocumentation(PacketFamilyType.ItemsContainers, Length = 10)]
+public readonly record struct DropWearItemPacket(Serial Serial, byte Layer, Serial Mobile)
+    : IIncomingPacket<DropWearItemPacket>
+{
+    public static byte PacketId => 0x13;
+
+    public static DropWearItemPacket Read(ref SpanReader reader)
+    {
+        reader.ReadByte(); // packet id
+
+        return new(new(reader.ReadUInt32()), reader.ReadByte(), new(reader.ReadUInt32()));
+    }
+}

--- a/src/Moongate.Server.Abstractions/Data/Internal/WearDecision.cs
+++ b/src/Moongate.Server.Abstractions/Data/Internal/WearDecision.cs
@@ -1,0 +1,11 @@
+using Moongate.Ultima.Types;
+
+namespace Moongate.Server.Abstractions.Data.Internal;
+
+/// <summary>
+/// Whether a held item may be worn, and where it goes. The layer travels with the answer because it is
+/// derived from the item rather than taken from the request, so the caller has no other way to know it.
+/// </summary>
+/// <param name="Accepted">True when the item may be worn.</param>
+/// <param name="Layer">The layer the item occupies, or <see cref="LayerType.None" /> when it wears nowhere.</param>
+public readonly record struct WearDecision(bool Accepted, LayerType Layer);

--- a/src/Moongate.Server.Abstractions/Interfaces/Items/IDragDropService.cs
+++ b/src/Moongate.Server.Abstractions/Interfaces/Items/IDragDropService.cs
@@ -18,6 +18,18 @@ public interface IDragDropService
     void Bounce(MobileEntity actor, Serial itemId, HeldItemOrigin? origin);
 
     /// <summary>
+    /// Puts the held item on <paramref name="targetMobileId" />, at the layer the item itself occupies.
+    /// The layer is never taken from the client: which layer an item uses is a property of the item, and
+    /// trusting the request would let a client wear a dagger as a pair of boots.
+    /// <para>
+    /// Refuses when nothing is held, when the held item is not the one named, when the item is not
+    /// wearable, when the layer is already occupied, or when the target is anyone but the actor —
+    /// dressing another player needs a permission concept the shard does not have yet.
+    /// </para>
+    /// </summary>
+    LiftDecision Wear(MobileEntity actor, Serial heldItemId, Serial targetMobileId);
+
+    /// <summary>
     /// Drops the held item into <paramref name="containerId" /> (or on the ground when it is
     /// <see cref="Serial.Zero" />) and reports whether it went through.
     /// </summary>

--- a/src/Moongate.Server/Handlers/DropWearItemHandler.cs
+++ b/src/Moongate.Server/Handlers/DropWearItemHandler.cs
@@ -1,0 +1,55 @@
+using Moongate.Network.Packets.Incoming;
+using Moongate.Network.Packets.Outgoing;
+using Moongate.Network.Types;
+using Moongate.Server.Abstractions.Data;
+using Moongate.Server.Abstractions.Interfaces.Items;
+using Moongate.Server.Abstractions.Interfaces.Network;
+
+namespace Moongate.Server.Handlers;
+
+/// <summary>
+/// Handles drop-wear (0x13): the held item was dropped onto a paperdoll. A refusal sends 0x27 and
+/// bounces the item back to where it was lifted from, otherwise it would stay attached to nothing —
+/// the same shape as a refused drop.
+/// </summary>
+public sealed class DropWearItemHandler : IPacketHandler<DropWearItemPacket>, IPacketHandlerRegistration
+{
+    private readonly IDragDropService _dragDrop;
+
+    public DropWearItemHandler(IDragDropService dragDrop)
+    {
+        _dragDrop = dragDrop;
+    }
+
+    public void Handle(DropWearItemPacket packet, in PacketContext context)
+    {
+        var session = context.Session;
+
+        if (session.Character is not { } character)
+        {
+            session.Send(new LiftRejectPacket(LiftRejectReasonType.Inspecific));
+
+            return;
+        }
+
+        // packet.Layer is deliberately not passed on: the service takes the layer from the item, so a
+        // client claiming a dagger goes on the boots layer is simply not asked.
+        var decision = _dragDrop.Wear(character, session.HeldItemId, packet.Mobile);
+
+        if (!decision.Accepted)
+        {
+            _dragDrop.Bounce(character, session.HeldItemId, session.HeldItemOrigin);
+            session.ClearHold();
+            session.Send(new LiftRejectPacket(decision.Reason));
+
+            return;
+        }
+
+        // No approval packet: the WornItemPacket the service broadcasts is what tells the client the
+        // item landed, and it reaches the wearer along with everyone else.
+        session.ClearHold();
+    }
+
+    public void Register(INetworkService network)
+        => network.RegisterHandler(this);
+}

--- a/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
+++ b/src/Moongate.Server/Plugins/MoongatePacketHandlersPlugin.cs
@@ -41,6 +41,7 @@ public class MoongatePacketHandlersPlugin : ISquidStdPlugin
         container.RegisterPacketHandler<ClientViewRangeHandler>();
         container.RegisterPacketHandler<PickUpItemHandler>();
         container.RegisterPacketHandler<DropItemHandler>();
+        container.RegisterPacketHandler<DropWearItemHandler>();
         container.RegisterPacketHandler<GumpMenuSelectionHandler>();
         container.RegisterPacketHandler<TargetCursorResponseHandler>();
     }

--- a/src/Moongate.Server/Services/Items/DragDropService.cs
+++ b/src/Moongate.Server/Services/Items/DragDropService.cs
@@ -1,6 +1,7 @@
 using Moongate.Core.Geometry;
 using Moongate.Core.Interfaces;
 using Moongate.Core.Primitives;
+using Moongate.Ultima.Types;
 using Moongate.Network.Packets.Outgoing;
 using Moongate.Network.Types;
 using Moongate.Persistence.Entities;
@@ -283,6 +284,44 @@ public sealed class DragDropService : IDragDropService
     private static bool IsUnpositioned(Point2D position)
         => position.X == NoGumpPosition || position.Y == NoGumpPosition || position.X < 0 || position.Y < 0;
 
+    /// <summary>
+    /// Whether the held item may be worn, and nothing else — no I/O, no session, no persistence.
+    /// <para>
+    /// The layer comes from <paramref name="template" />, which the tiledata resolver filled from the
+    /// item's own graphic at load. The client's layer byte is not consulted: POL validates it and then
+    /// assigns the item's own tile layer over the top (eqpitem.cpp), because taking the request's word
+    /// for it would let a client wear a dagger as a pair of boots.
+    /// </para>
+    /// </summary>
+    public static WearDecision EvaluateWear(
+        MobileEntity actor,
+        ItemEntity? held,
+        Serial heldItemId,
+        Serial targetMobileId,
+        ItemTemplate? template
+    )
+    {
+        // The held serial is the authority, exactly as it is on a drop: a packet naming anything else
+        // is a desynced or hostile client.
+        if (held is null || held.Id != heldItemId)
+        {
+            return new(false, LayerType.None);
+        }
+
+        // Dressing someone else is POL's can_clothe, which has no equivalent here yet.
+        if (targetMobileId != actor.Id)
+        {
+            return new(false, LayerType.None);
+        }
+
+        if (template?.Equip is not { Layer: var layer } || layer == LayerType.None)
+        {
+            return new(false, LayerType.None);
+        }
+
+        return actor.EquippedItemIds.ContainsKey(layer) ? new(false, layer) : new(true, layer);
+    }
+
     private static AddItemToContainerPacket ContainerPacket(ItemEntity item, Serial containerId, Point2D position)
         => new(item.Id, (ushort)item.ItemId, (ushort)item.Amount, position, containerId, item.Hue);
 
@@ -385,6 +424,33 @@ public sealed class DragDropService : IDragDropService
         }
 
         _eventBus?.Publish(new ItemDroppedEvent(stack.Id, actor.Id, stack.ParentContainerId));
+
+        return new(true, LiftRejectReasonType.Inspecific);
+    }
+
+    public LiftDecision Wear(MobileEntity actor, Serial heldItemId, Serial targetMobileId)
+    {
+        _loopAffinity?.AssertOnLoop("drag_drop.wear");
+
+        var held = heldItemId == Serial.Zero ? null : _items.GetById(heldItemId);
+        var template = held is null ? null : _templates.GetById(held.TemplateId);
+        var decision = EvaluateWear(actor, held, heldItemId, targetMobileId, template);
+
+        if (!decision.Accepted || held is null)
+        {
+            return new(false, LiftRejectReasonType.Inspecific);
+        }
+
+        // Equip raises ItemEquippedEvent itself, so nothing is published here. What it does not do is
+        // tell anyone looking: no subscriber turns that event into a WornItemPacket, so without this
+        // the item would be worn and invisible, to the wearer as much as to everyone else.
+        _items.Equip(actor, held, decision.Layer);
+        _world.SendToPlayersInRange(
+            actor.MapId,
+            actor.Position,
+            PlayerSession.MaxViewRange,
+            new WornItemPacket(held.Id, (ushort)held.ItemId, decision.Layer, actor.Id, held.Hue)
+        );
 
         return new(true, LiftRejectReasonType.Inspecific);
     }

--- a/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
+++ b/tests/Moongate.Tests/Network/PacketDocumentationTests.cs
@@ -24,7 +24,7 @@ public class PacketDocumentationTests
 
     [Fact]
     public void AllPacketTypes_AreDiscovered()
-        => Assert.Equal(61, PacketTypes.Count);
+        => Assert.Equal(62, PacketTypes.Count);
 
     [Theory, MemberData(nameof(Packets))]
     public void DeclaredSize_MatchesThePacketLengthsTable(Type packetType)

--- a/tests/Moongate.Tests/Network/Packets/DropWearItemPacketTests.cs
+++ b/tests/Moongate.Tests/Network/Packets/DropWearItemPacketTests.cs
@@ -1,0 +1,34 @@
+using Moongate.Network.Packets.Incoming;
+using SquidStd.Network.Spans;
+
+namespace Moongate.Tests.Network.Packets;
+
+/// <summary>
+/// Drop-wear (0x13): what the client sends when an item on the cursor is dropped onto a paperdoll.
+/// Ten bytes fixed — opcode, item, layer, and who to put it on.
+/// </summary>
+public class DropWearItemPacketTests
+{
+    [Fact]
+    public void Read_TakesTheItemTheLayerAndTheWearer()
+    {
+        byte[] wire =
+        [
+            0x13,
+            0x40, 0x00, 0x00, 0x0A,
+            0x05,
+            0x00, 0x00, 0x00, 0x01
+        ];
+
+        var reader = new SpanReader(wire);
+        var packet = DropWearItemPacket.Read(ref reader);
+
+        Assert.Equal(0x4000000Au, packet.Serial.Value);
+        Assert.Equal(5, packet.Layer);
+        Assert.Equal(0x00000001u, packet.Mobile.Value);
+    }
+
+    [Fact]
+    public void PacketId_Is0x13()
+        => Assert.Equal(0x13, DropWearItemPacket.PacketId);
+}

--- a/tests/Moongate.Tests/Server/Items/WearItemTests.cs
+++ b/tests/Moongate.Tests/Server/Items/WearItemTests.cs
@@ -1,0 +1,99 @@
+using Moongate.Core.Primitives;
+using Moongate.Persistence.Entities;
+using Moongate.Server.Services.Items;
+using Moongate.Ultima.Types;
+using Moongate.UO.Data.Items;
+
+namespace Moongate.Tests.Server.Items;
+
+/// <summary>
+/// Dropping a held item onto a paperdoll. The chain is POL's equip_item, minus the parts this shard has
+/// no concept for — strength requirements, dressing others, death. The one that matters for safety is
+/// the layer: it comes from the item, never from the request.
+/// </summary>
+public class WearItemTests
+{
+    private const int RobeItemId = 7939;
+
+    [Fact]
+    public void WearingSomethingNobodyIsHolding_IsRefused()
+    {
+        var actor = Actor();
+
+        Assert.False(DragDropService.EvaluateWear(actor, null, new(0x4000000A), actor.Id, Wearable()).Accepted);
+    }
+
+    // The held item is the authority. A packet naming anything else is a desynced or hostile client,
+    // and honouring it would let one wear what it never lifted.
+    [Fact]
+    public void WearingAnItemOtherThanTheHeldOne_IsRefused()
+    {
+        var actor = Actor();
+        var held = Robe(0x4000000A);
+
+        Assert.False(DragDropService.EvaluateWear(actor, held, new(0x4000000B), actor.Id, Wearable()).Accepted);
+    }
+
+    [Fact]
+    public void WearingSomethingWithNoLayer_IsRefused()
+    {
+        var actor = Actor();
+        var held = Robe(0x4000000A);
+
+        Assert.False(DragDropService.EvaluateWear(actor, held, held.Id, actor.Id, NotWearable()).Accepted);
+    }
+
+    [Fact]
+    public void WearingOntoAnOccupiedLayer_IsRefused()
+    {
+        var actor = Actor();
+
+        actor.EquippedItemIds[LayerType.OuterTorso] = new(0x4000000F);
+
+        var held = Robe(0x4000000A);
+
+        Assert.False(DragDropService.EvaluateWear(actor, held, held.Id, actor.Id, Wearable()).Accepted);
+    }
+
+    // POL gates dressing someone else behind can_clothe; there is no permission concept here yet, so
+    // the answer is no rather than a guess at one.
+    [Fact]
+    public void WearingOntoSomebodyElse_IsRefused()
+    {
+        var actor = Actor();
+        var held = Robe(0x4000000A);
+
+        Assert.False(DragDropService.EvaluateWear(actor, held, held.Id, new(0x00000009), Wearable()).Accepted);
+    }
+
+    [Fact]
+    public void WearingAFreeLayerOnYourself_IsAccepted()
+    {
+        var actor = Actor();
+        var held = Robe(0x4000000A);
+
+        Assert.True(DragDropService.EvaluateWear(actor, held, held.Id, actor.Id, Wearable()).Accepted);
+    }
+
+    // A template with no Equip block at all is the same answer as one whose layer is None: not wearable.
+    [Fact]
+    public void WearingATemplateWithNoEquipBlock_IsRefused()
+    {
+        var actor = Actor();
+        var held = Robe(0x4000000A);
+
+        Assert.False(DragDropService.EvaluateWear(actor, held, held.Id, actor.Id, null).Accepted);
+    }
+
+    private static MobileEntity Actor()
+        => new() { Id = new(0x00000001), MapId = 1, Position = new(100, 100, 0) };
+
+    private static ItemEntity Robe(uint serial)
+        => new() { Id = new(serial), TemplateId = "robe", ItemId = RobeItemId };
+
+    private static ItemTemplate Wearable()
+        => new() { Id = "robe", ItemId = RobeItemId, Equip = new() { Layer = LayerType.OuterTorso } };
+
+    private static ItemTemplate NotWearable()
+        => new() { Id = "robe", ItemId = RobeItemId, Equip = new() { Layer = LayerType.None } };
+}


### PR DESCRIPTION
Fixes #199.

Dragging a held item onto the paperdoll did nothing but log `No handler for packet 0x13 (DropWearItem) - not implemented yet`, leaving the item stuck to the cursor because nothing accepted it and nothing bounced it back.

## The layer comes from the item, never from the request

POL's `equip_item` validates the client's layer byte and then assigns `item->layer = item->tile_layer` over the top (`eqpitem.cpp:63`). The client says where it *thinks* the item goes; the server uses what the item *is*. Honouring the request would let a client wear a dagger as a pair of boots. `EvaluateWear` takes the layer from the template, which the tiledata resolver filled from the item's own graphic at load, and the handler never passes `packet.Layer` on at all.

## Two things found while implementing, both changing the plan

**`ItemService.Equip` already publishes `ItemEquippedEvent`.** The plan had `Wear` publish it too, which would have raised it twice. Removed.

**Nothing turns that event into a `WornItemPacket`.** Its only subscriber is the Lua script one, and `Equip` does not raise `ItemChangedEvent` either, so `ItemRefreshSubscriber.RefreshOnMobile` never fires for an equip. Worn items would have been invisible — to the wearer as much as to everyone around — so `Wear` broadcasts the packet itself.

That broadcast gap is **wider than this packet**: every path through `ItemService.Equip` has it, and only this one now compensates. Worth its own issue rather than a wider change smuggled in here.

## Deliberately out of scope

- **Strength requirements.** `EquipSpec.StrengthReq` is validated when a template loads (`ItemTemplateValidator:70`) and enforced nowhere. Enforcing it touches every equip path.
- **Dressing other players.** POL gates it behind `can_clothe`; no permission concept exists here. Any target that is not the actor is refused, and a test pins that.
- **Death checks.** No equivalent yet.

## Tests

`WearItemTests` covers the seven answers of the decision: nothing held, a packet naming an item other than the held one, an item that wears nowhere, a template with no equip block at all, an occupied layer, somebody else's paperdoll, and the one case that succeeds.

`DropWearItemPacketTests` covers the wire format, and `DeclaredSize_MatchesThePacketLengthsTable` checked the declared 10 bytes against the client's own packet-length table — the size is confirmed by the client files, not by memory.

**No test drives `Handle`.** Nothing in this repo constructs a `PacketContext`; the convention is a testable static plus thin glue, and building session-mocking infrastructure would be a larger change than the feature. Flagging it rather than implying the handler is covered.

Full suite green (2249), DocFX at 0 warnings, packet reference regenerated (62 packets), hardcoded count bumped 61 → 62.

**Not yet verified with a real client** — the server boots with the handler registered, but dragging an item onto a paperdoll is the check only a client can make.
