### PR TITLE
feat(world): place the world's signs

### DIFF
--- a/docs/under-the-hood/world-decoration.md
+++ b/docs/under-the-hood/world-decoration.md
@@ -107,6 +107,48 @@ Placed nothing of 63528 object(s), and none were already there. Check the server
 Distinct from `placed 0, skipped 63528`, which is a healthy second run. This one means placement could
 not build a single item, and the reason is in the server log.
 
+## Signs
+
+The 509 signposts that name shops, banks and towns are a second corpus, placed by the same command.
+
+Their data lives in `Assets/signs.yaml`, seeded to `<root>/data/signs.yaml` and loaded by
+`SignsLoader` into `ISignService` — one entry per sign, with its own facet:
+
+```yaml
+-   Map: Felucca
+    ItemId: 3032
+    X: 373
+    Y: 904
+    Z: -1
+    Label: '#1016093'
+```
+
+`decorate` places them alongside decoration, through the same idempotence check and counted in the
+same totals. They are not folded into the decoration catalogue: they are already loaded and already
+keyed by map, and the only thing the two corpora have in common is becoming an item at a point, once.
+
+### How a sign says what it says
+
+`Label` is one of two things, and the corpus uses both — **450 clilocs and 59 literal texts**:
+
+| Label | What the item carries | What the player sees |
+| --- | --- | --- |
+| `#1016093` | `NameCliloc = 1016093` | the client's own text, in the client's language |
+| `The Shakin' Bakery` | `Name = "The Shakin' Bakery"` | exactly that |
+| blank, `#`, `#abc` | neither | the name the graphic implies |
+
+A cliloc travels to the client **as a number**. Resolving it to a string on the server would work, and
+would freeze every sign in one language; sending the number lets each client render it in its own.
+`OplService` prefers an item's own `NameCliloc` over the one derived from its graphic — which matters,
+because the graphic is a signpost and every signpost in the world shares it. A deliberate `Name` still
+beats both.
+
+### Signs already standing as decoration
+
+A first run typically places slightly fewer signs than the corpus holds: on a decorated shard, a
+handful of sign graphics already stand at the same tile as a decoration object, and the shared check
+skips them. The two numbers stay honest — what is missing from `placed` shows up in `skipped`.
+
 ## The template on an existing shard
 
 `ItemTemplatesLoader` seeds `<root>/templates/items/` **only when that directory does not exist**.

--- a/src/Moongate.Persistence/Entities/ItemEntity.cs
+++ b/src/Moongate.Persistence/Entities/ItemEntity.cs
@@ -25,6 +25,13 @@ public class ItemEntity : ISerialIdEntity, IPositionEntity
 
     public string Name { get; set; }
 
+    /// <summary>
+    /// A cliloc that names this item, or 0. Signs carry the cliloc that IS their text, and sending the
+    /// number rather than a string resolved on the server lets each client render it in its own
+    /// language.
+    /// </summary>
+    public int NameCliloc { get; set; }
+
     public string ScriptId { get; set; } = string.Empty;
 
     public ItemRarityType Rarity { get; set; } = ItemRarityType.Common;

--- a/src/Moongate.Server/Commands/DecorateCommand.cs
+++ b/src/Moongate.Server/Commands/DecorateCommand.cs
@@ -34,16 +34,24 @@ public sealed class DecorateCommand : ICommand
 {
     private readonly IDecorationCatalog _decorations;
     private readonly DecorationPlacementService _placement;
+    private readonly ISignService _signs;
 
-    public DecorateCommand(IDecorationCatalog decorations, DecorationPlacementService placement)
+    public DecorateCommand(
+        IDecorationCatalog decorations,
+        DecorationPlacementService placement,
+        ISignService signs
+    )
     {
         _decorations = decorations;
         _placement = placement;
+        _signs = signs;
     }
 
     public void Execute(CommandContext context)
     {
-        var total = _decorations.All.Count;
+        // Signs count too: a shard whose decoration is already down but whose signs are not would
+        // otherwise be told there is nothing to place.
+        var total = _decorations.All.Count + _signs.Count;
 
         // An empty catalogue means the loader found nothing at boot. Saying that here is cheaper than
         // reading the log to find out why "placed 0" was not the idempotent answer it looked like.

--- a/src/Moongate.Server/Services/World/DecorationPlacementService.cs
+++ b/src/Moongate.Server/Services/World/DecorationPlacementService.cs
@@ -1,7 +1,9 @@
+using Moongate.Core.Geometry;
 using Moongate.Server.Abstractions.Interfaces.Items;
 using Moongate.Server.Abstractions.Interfaces.World;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Items;
+using Moongate.UO.Data.Signs;
 using Serilog;
 
 namespace Moongate.Server.Services.World;
@@ -26,13 +28,15 @@ public sealed class DecorationPlacementService
     private readonly IItemService _items;
     private readonly ISpatialIndexService _spatial;
     private readonly IItemTemplateService _templates;
+    private readonly ISignService _signs;
 
     public DecorationPlacementService(
         IDecorationCatalog decorations,
         IItemFactoryService factory,
         IItemService items,
         ISpatialIndexService spatial,
-        IItemTemplateService templates
+        IItemTemplateService templates,
+        ISignService signs
     )
     {
         _decorations = decorations;
@@ -40,6 +44,7 @@ public sealed class DecorationPlacementService
         _items = items;
         _spatial = spatial;
         _templates = templates;
+        _signs = signs;
     }
 
     /// <summary>
@@ -54,16 +59,16 @@ public sealed class DecorationPlacementService
         var placed = 0;
         var skipped = 0;
 
-        foreach (var placement in _decorations.All)
+        foreach (var (mapId, point, itemId, hue, nameCliloc, name) in Everything())
         {
-            if (AlreadyThere(placement.MapId, placement.Point, placement.ItemId))
+            if (AlreadyThere(mapId, point, itemId))
             {
                 skipped++;
 
                 continue;
             }
 
-            var created = _factory.CreateFromTemplate(TemplateId, 1, 1, new Hue((ushort)placement.Hue));
+            var created = _factory.CreateFromTemplate(TemplateId, 1, 1, new Hue((ushort)hue));
 
             if (created.Count == 0)
             {
@@ -76,14 +81,41 @@ public sealed class DecorationPlacementService
             // The instance carries its own appearance: one template, 2381 graphics.
             var item = created[0];
 
-            item.ItemId = placement.ItemId;
-            _items.MoveToWorld(item, placement.MapId, placement.Point);
+            item.ItemId = itemId;
+            item.NameCliloc = nameCliloc;
+            item.Name = name;
+            _items.MoveToWorld(item, mapId, point);
             placed++;
         }
 
         _logger.Information("Decoration: placed {Placed}, skipped {Skipped} already present", placed, skipped);
 
         return (placed, skipped);
+    }
+
+    /// <summary>
+    /// Every object the world should hold, from both sources, in one sequence.
+    /// <para>
+    /// Signs are kept in their own registry rather than converted into decoration groups — they are
+    /// already loaded, already keyed by map, and converting them would buy nothing. What the two do
+    /// share is the only thing that matters here: becoming an item at a point, once. Flattening them
+    /// into one sequence is what lets a single loop own the counting, so "placed" and "already there"
+    /// cannot both be true of one object.
+    /// </para>
+    /// </summary>
+    private IEnumerable<(int MapId, Point3D Point, int ItemId, int Hue, int NameCliloc, string Name)> Everything()
+    {
+        foreach (var placement in _decorations.All)
+        {
+            yield return (placement.MapId, placement.Point, placement.ItemId, placement.Hue, 0, string.Empty);
+        }
+
+        foreach (var sign in _signs.All)
+        {
+            var (cliloc, text) = SignLabel.Split(sign.Label);
+
+            yield return ((int)sign.Map, new(sign.X, sign.Y, sign.Z), sign.ItemId, 0, cliloc, text);
+        }
     }
 
     private bool AlreadyThere(int mapId, Moongate.Core.Geometry.Point3D point, int itemId)

--- a/src/Moongate.Server/Services/World/OplService.cs
+++ b/src/Moongate.Server/Services/World/OplService.cs
@@ -79,7 +79,10 @@ public sealed class OplService : IOplService
         var rotation = 0;
         var template = _templates.GetById(item.TemplateId);
         var name = FirstNonEmpty(item.Name, template?.Name, string.Empty);
-        var cliloc = ItemClilocs.ForItemId(item.ItemId);
+
+        // A sign carries the cliloc that IS its text, and it beats the one the graphic implies: the
+        // graphic is a signpost, and every signpost in the world shares it.
+        var cliloc = item.NameCliloc != 0 ? item.NameCliloc : ItemClilocs.ForItemId(item.ItemId);
 
         if (name.Length == 0 && _clilocs.Text(cliloc) is not null)
         {

--- a/src/Moongate.UO.Data/Signs/SignLabel.cs
+++ b/src/Moongate.UO.Data/Signs/SignLabel.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+
+namespace Moongate.UO.Data.Signs;
+
+/// <summary>
+/// Reads a <see cref="SignEntry.Label" />, which the corpus writes in one of two ways: a cliloc
+/// reference such as <c>#1016093</c>, or the words themselves.
+/// </summary>
+public static class SignLabel
+{
+    /// <summary>
+    /// Splits a label into the cliloc that names it, or the text that does — never both.
+    /// <para>
+    /// A label that is neither, being blank or a <c>#</c> with nothing usable after it, yields both
+    /// empty rather than throwing. This is hand-edited data, and one bad line should cost one sign its
+    /// name rather than the whole run.
+    /// </para>
+    /// </summary>
+    public static (int Cliloc, string Text) Split(string? label)
+    {
+        var trimmed = label?.Trim() ?? string.Empty;
+
+        if (trimmed.Length == 0)
+        {
+            return (0, string.Empty);
+        }
+
+        // Only a leading hash names a cliloc: "Bob's #1 Tavern" is a sign that says so.
+        if (trimmed[0] != '#')
+        {
+            return (0, trimmed);
+        }
+
+        // NumberStyles.None rejects a sign or separators, so "#-5" is malformed rather than negative.
+        return int.TryParse(trimmed[1..], NumberStyles.None, CultureInfo.InvariantCulture, out var cliloc)
+                   ? (cliloc, string.Empty)
+                   : (0, string.Empty);
+    }
+}

--- a/tests/Moongate.Tests/Data/Signs/SignLabelTests.cs
+++ b/tests/Moongate.Tests/Data/Signs/SignLabelTests.cs
@@ -1,0 +1,48 @@
+using Moongate.UO.Data.Signs;
+
+namespace Moongate.Tests.Data.Signs;
+
+/// <summary>
+/// A sign says what it says in one of two ways, and the shipped corpus uses both: 450 of the 509
+/// signs name a cliloc, the other 59 carry the words themselves.
+/// </summary>
+public class SignLabelTests
+{
+    [Fact]
+    public void AClilocReference_BecomesItsNumber()
+    {
+        var (cliloc, text) = SignLabel.Split("#1016093");
+
+        Assert.Equal(1016093, cliloc);
+        Assert.Equal("", text);
+    }
+
+    [Fact]
+    public void LiteralText_StaysText()
+    {
+        var (cliloc, text) = SignLabel.Split("The Shakin' Bakery");
+
+        Assert.Equal(0, cliloc);
+        Assert.Equal("The Shakin' Bakery", text);
+    }
+
+    // A label is data from a hand-edited file. A broken one costs that sign its name, not the run.
+    [Theory, InlineData(""), InlineData("   "), InlineData(null), InlineData("#"), InlineData("#abc"),
+     InlineData("#-5")]
+    public void AMalformedLabel_YieldsNeither(string? label)
+    {
+        var (cliloc, text) = SignLabel.Split(label);
+
+        Assert.Equal(0, cliloc);
+        Assert.Equal("", text);
+    }
+
+    [Fact]
+    public void SurroundingWhitespace_IsNotPartOfTheName()
+        => Assert.Equal("Britain Bank", SignLabel.Split("  Britain Bank  ").Text);
+
+    // A hash inside the words is a hash, not a reference: only a leading one names a cliloc.
+    [Fact]
+    public void AHashThatDoesNotStartTheLabel_IsJustText()
+        => Assert.Equal("Bob's #1 Tavern", SignLabel.Split("Bob's #1 Tavern").Text);
+}

--- a/tests/Moongate.Tests/Persistence/Entities/ItemEntityTests.cs
+++ b/tests/Moongate.Tests/Persistence/Entities/ItemEntityTests.cs
@@ -1,0 +1,49 @@
+using MessagePack;
+using MessagePack.Resolvers;
+using Moongate.Persistence.Entities;
+
+namespace Moongate.Tests.Persistence.Entities;
+
+public class ItemEntityTests
+{
+    [Fact]
+    public void NameCliloc_DefaultsToZero()
+        => Assert.Equal(0, new ItemEntity().NameCliloc);
+
+    /// <summary>
+    /// Every item in every existing world store was written before this field existed. If the
+    /// contractless resolver does not leave it at 0, the failure is not "signs have no tooltip" — it
+    /// is every item on a live shard losing the name it had, because a non-zero cliloc would be
+    /// preferred over the one its graphic implies.
+    /// </summary>
+    [Fact]
+    public void Deserialize_SaveWrittenBeforeTheFieldExisted_ReadsNameClilocAsZero()
+    {
+        var oldSave = new Dictionary<string, object>
+        {
+            ["Name"] = "a dagger",
+            ["ItemId"] = 3921
+        };
+
+        var item = RoundTrip<Dictionary<string, object>, ItemEntity>(oldSave);
+
+        Assert.Equal("a dagger", item.Name);
+        Assert.Equal(3921, item.ItemId);
+        Assert.Equal(0, item.NameCliloc);
+    }
+
+    [Fact]
+    public void Serialize_RoundTripsNameCliloc()
+    {
+        var item = new ItemEntity { Name = "", ItemId = 3032, NameCliloc = 1016093 };
+
+        Assert.Equal(1016093, RoundTrip<ItemEntity, ItemEntity>(item).NameCliloc);
+    }
+
+    // Mirrors the persistence layer, which registers MessagePack's contractless resolver.
+    private static TOut RoundTrip<TIn, TOut>(TIn value)
+        => MessagePackSerializer.Deserialize<TOut>(
+            MessagePackSerializer.Serialize(value, ContractlessStandardResolver.Options),
+            ContractlessStandardResolver.Options
+        );
+}

--- a/tests/Moongate.Tests/Server/Commands/DecorateCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/DecorateCommandTests.cs
@@ -8,6 +8,8 @@ using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Hues;
 using Moongate.UO.Data.Items;
+using Moongate.UO.Data.Signs;
+using Moongate.UO.Data.Types;
 using Moongate.UO.Data.World;
 
 namespace Moongate.Tests.Server.Commands;
@@ -109,9 +111,46 @@ public class DecorateCommandTests
     private static CommandContext Context(List<string> replies)
         => new(CommandSourceType.Console, null, [], replies.Add);
 
+    [Fact]
+    public void Execute_AnnouncesDecorationAndSignsTogether()
+    {
+        var (command, _) = Build(
+            [new DecorationGroup { ItemId = 100, At = [[1, 1, 0]] }],
+            signs:
+            [
+                new SignEntry { Map = MapType.Felucca, ItemId = 3032, X = 5, Y = 5, Z = 0, Label = "#1016093" }
+            ]
+        );
+        var replies = new List<string>();
+
+        command.Execute(Context(replies));
+
+        Assert.Equal("Placing 2 catalogued decoration object(s). The world pauses while it runs.", replies[0]);
+    }
+
+    // Signs alone are still something to place: a shard whose decoration is already down would
+    // otherwise be told there was nothing to do.
+    [Fact]
+    public void Execute_NoDecorationButSomeSigns_DoesNotSayThereIsNothingToPlace()
+    {
+        var (command, _) = Build(
+            [],
+            signs:
+            [
+                new SignEntry { Map = MapType.Felucca, ItemId = 3032, X = 5, Y = 5, Z = 0, Label = "#1016093" }
+            ]
+        );
+        var replies = new List<string>();
+
+        command.Execute(Context(replies));
+
+        Assert.DoesNotContain("Nothing to place", replies[0]);
+    }
+
     private static (DecorateCommand Command, SpatialIndexService Spatial) Build(
         IEnumerable<DecorationGroup> groups,
-        bool factoryReturnsNothing = false
+        bool factoryReturnsNothing = false,
+        IEnumerable<SignEntry>? signs = null
     )
     {
         var persistence = new FakePersistenceService();
@@ -133,8 +172,15 @@ public class DecorateCommandTests
                                           ? new BarrenItemFactory()
                                           : new ItemFactoryService(templates, new(1));
 
+        var signService = new SignService();
+
+        foreach (var sign in signs ?? [])
+        {
+            signService.Register(sign);
+        }
+
         return (
-            new(catalog, new(catalog, factory, items, spatial, templates, new SignService())),
+            new(catalog, new(catalog, factory, items, spatial, templates, signService), signService),
             spatial
         );
     }

--- a/tests/Moongate.Tests/Server/Commands/DecorateCommandTests.cs
+++ b/tests/Moongate.Tests/Server/Commands/DecorateCommandTests.cs
@@ -134,7 +134,7 @@ public class DecorateCommandTests
                                           : new ItemFactoryService(templates, new(1));
 
         return (
-            new(catalog, new(catalog, factory, items, spatial, templates)),
+            new(catalog, new(catalog, factory, items, spatial, templates, new SignService())),
             spatial
         );
     }

--- a/tests/Moongate.Tests/Server/World/DecorationPlacementTests.cs
+++ b/tests/Moongate.Tests/Server/World/DecorationPlacementTests.cs
@@ -2,6 +2,8 @@ using Moongate.Server.Services.Items;
 using Moongate.Server.Services.World;
 using Moongate.Tests.Support;
 using Moongate.UO.Data.Items;
+using Moongate.UO.Data.Signs;
+using Moongate.UO.Data.Types;
 using Moongate.UO.Data.World;
 
 namespace Moongate.Tests.Server.World;
@@ -111,10 +113,92 @@ public class DecorationPlacementTests
         Assert.Equal(2, service.Place().Placed);
     }
 
+    [Fact]
+    public void Place_ASignWithACliloc_LandsCarryingThatCliloc()
+    {
+        var (service, spatial) = Build(
+            [],
+            signs:
+            [
+                new SignEntry
+                {
+                    Map = MapType.Trammel, ItemId = 3032, X = 10, Y = 10, Z = 0, Label = "#1016093"
+                }
+            ]
+        );
+
+        Assert.Equal(1, service.Place().Placed);
+
+        var sign = Assert.Single(spatial.GetItemsInRange((int)MapType.Trammel, new(10, 10, 0), 0));
+
+        Assert.Equal(3032, sign.ItemId);
+        Assert.Equal(1016093, sign.NameCliloc);
+        Assert.Equal("", sign.Name);
+    }
+
+    // 59 of the 509 shipped signs carry their words rather than a cliloc.
+    [Fact]
+    public void Place_ASignWithLiteralText_LandsCarryingThatName()
+    {
+        var (service, spatial) = Build(
+            [],
+            signs:
+            [
+                new SignEntry
+                {
+                    Map = MapType.Felucca, ItemId = 3032, X = 5, Y = 5, Z = 0, Label = "The Shakin' Bakery"
+                }
+            ]
+        );
+
+        service.Place();
+
+        var sign = Assert.Single(spatial.GetItemsInRange((int)MapType.Felucca, new(5, 5, 0), 0));
+
+        Assert.Equal("The Shakin' Bakery", sign.Name);
+        Assert.Equal(0, sign.NameCliloc);
+    }
+
+    // Signs go through the same check as decoration: typing decorate twice must not double them.
+    [Fact]
+    public void Place_RunTwice_DoesNotDoubleTheSigns()
+    {
+        var (service, spatial) = Build(
+            [],
+            signs:
+            [
+                new SignEntry { Map = MapType.Felucca, ItemId = 3032, X = 5, Y = 5, Z = 0, Label = "#1016093" }
+            ]
+        );
+
+        service.Place();
+        var (placed, skipped) = service.Place();
+
+        Assert.Equal(0, placed);
+        Assert.Equal(1, skipped);
+        Assert.Single(spatial.GetItemsInRange((int)MapType.Felucca, new(5, 5, 0), 0));
+    }
+
+    // Both sources report through one pair of numbers, because one command placed both.
+    [Fact]
+    public void Place_CountsDecorationAndSignsTogether()
+    {
+        var (service, _) = Build(
+            [new DecorationGroup { ItemId = 100, At = [[1, 1, 0]] }],
+            signs:
+            [
+                new SignEntry { Map = MapType.Trammel, ItemId = 3032, X = 2, Y = 2, Z = 0, Label = "#1016093" }
+            ]
+        );
+
+        Assert.Equal(2, service.Place().Placed);
+    }
+
     private static (DecorationPlacementService Service, SpatialIndexService Spatial) Build(
         IEnumerable<DecorationGroup> groups,
         bool registerTemplate = true,
-        ItemTemplateService? templates = null
+        ItemTemplateService? templates = null,
+        IEnumerable<SignEntry>? signs = null
     )
     {
         var persistence = new FakePersistenceService();
@@ -137,8 +221,15 @@ public class DecorationPlacementTests
         var catalog = new DecorationCatalog();
         catalog.Add(1, groups);
 
+        var signService = new SignService();
+
+        foreach (var sign in signs ?? [])
+        {
+            signService.Register(sign);
+        }
+
         return (
-            new(catalog, new ItemFactoryService(templates, new(1)), itemService, spatial, templates),
+            new(catalog, new ItemFactoryService(templates, new(1)), itemService, spatial, templates, signService),
             spatial
         );
     }

--- a/tests/Moongate.Tests/Server/World/OplServiceNameTests.cs
+++ b/tests/Moongate.Tests/Server/World/OplServiceNameTests.cs
@@ -16,6 +16,7 @@ public class OplServiceNameTests
     private const int GoldItemId = 3821;
     private const int GoldCliloc = 1023821;  // ItemClilocs.ForItemId(3821)
     private const int StackCliloc = 1050039; // ~1_NUMBER~ ~2_ITEMNAME~
+    private const int SignCliloc = 1016093;  // "Britain Bank", as a sign would carry it
 
     [Fact]
     public void NamedStack_KeepsItsTextArgument()
@@ -83,11 +84,59 @@ public class OplServiceNameTests
         Assert.Contains("gold", entry.Arguments);
     }
 
+    // A sign's cliloc IS its text, so it beats the one the graphic implies -- the graphic is a
+    // signpost, and every signpost in the world shares it.
+    [Fact]
+    public void ItemWithItsOwnNameCliloc_IsNamedByThatCliloc()
+    {
+        var (service, item) = Build(
+            "",
+            "",
+            1,
+            StubClilocService.Entries((GoldCliloc, "gold coin"), (SignCliloc, "Britain Bank")),
+            SignCliloc
+        );
+
+        var entry = service.GetOrBuild(item.Id).Entries[0];
+
+        Assert.Equal(SignCliloc, entry.Cliloc);
+        Assert.Equal(string.Empty, entry.Arguments);
+    }
+
+    // The guard that matters more than the one above: this field is new on every item in the world,
+    // and an item without one has to be named exactly as it was before it existed.
+    [Fact]
+    public void ItemWithoutANameCliloc_IsNamedExactlyAsBefore()
+    {
+        var (service, item) = Build("", "", 1);
+
+        var entry = service.GetOrBuild(item.Id).Entries[0];
+
+        Assert.Equal(GoldCliloc, entry.Cliloc);
+        Assert.Equal(string.Empty, entry.Arguments);
+    }
+
+    // A shard that renamed the thing still wins: a name is a deliberate act, a cliloc is data.
+    [Fact]
+    public void ARenamedItem_BeatsItsOwnNameCliloc()
+    {
+        var (service, item) = Build(
+            "",
+            "Squid's Anchor",
+            1,
+            StubClilocService.Entries((SignCliloc, "Britain Bank")),
+            SignCliloc
+        );
+
+        Assert.Contains("Squid's Anchor", service.GetOrBuild(item.Id).Entries[0].Arguments);
+    }
+
     private static (OplService Service, ItemEntity Item) Build(
         string templateName,
         string itemName,
         int amount,
-        IClilocService? clilocs = null
+        IClilocService? clilocs = null,
+        int nameCliloc = 0
     )
     {
         var persistence = new FakePersistenceService();
@@ -97,7 +146,7 @@ public class OplServiceNameTests
 
         var item = new ItemEntity
         {
-            TemplateId = "gold", ItemId = GoldItemId, Amount = amount, Name = itemName
+            TemplateId = "gold", ItemId = GoldItemId, Amount = amount, Name = itemName, NameCliloc = nameCliloc
         };
 
         persistence.Store<ItemEntity>().UpsertAsync(item).WaitSync();


### PR DESCRIPTION
Places the 509 world signs as persisted items whose tooltips say what the signs say.

Issue #204.

## The correction this PR is built on

PR #203 states that signs "need their own parser". **That is wrong**, and finding out why is most of this work. The parsing was already done — offline, by earlier work — and its output is committed:

| Piece | State before this PR |
| --- | --- |
| `Assets/signs.yaml` | exists, tracked, 509 entries |
| `SignEntry` | exists |
| `ISignService` / `SignService` | exists |
| `SignsLoader` | exists, registered at priority 80 |
| Anything consuming `ISignService` | **nothing** |

Every boot loaded 509 signs into memory and did nothing with them. This PR is the missing wire, not a new subsystem — it creates two files and modifies five.

## What it does

- **`decorate` places signs too**, through the same idempotence check and counted in the same totals. Signs keep their own registry rather than being converted into decoration groups: they are already loaded and already keyed by map, and the only thing the two corpora share is becoming an item at a point, once. Both are flattened into one sequence so a single loop owns the counting.
- **A sign says what it says.** `SignEntry.Label` is either a cliloc reference (`#1016093` — 450 of them) or literal text (59 of them). Literal text goes in `ItemEntity.Name`, which OPL already prefers. A cliloc needs the new `ItemEntity.NameCliloc`, which `OplService` prefers over the cliloc an item's graphic implies — the graphic is a signpost, and every signpost in the world shares it.
- The cliloc travels to the client **as a number**, so each client renders it in its own language. Resolving it to a string on the server would freeze every sign in one language.

## The risk, and how it was retired

`NameCliloc` is a new field on a **persisted** entity, and every item in every existing world store predates it. If the contractless resolver did not default it to 0, the failure would not be "signs have no tooltip" — it would be every item on a live shard taking the wrong name at once.

Retired twice over:
- a unit test deserializing a record written **without** the key, asserting it reads back as 0 (`FakePersistenceService` is in-memory and cannot catch this);
- and on **real data**: a copy of a live `~/moongate` holding 62,371 items written by a build without the field. Booted, placed, restarted, placed again — 0 errors, and all 64,037 objects matched.

## Verified on a live shard

| | |
| --- | --- |
| Catalogue at boot | 63,528 decoration + **509 signs** |
| Announced total | 64,037 |
| First run | placed 494, skipped 63,543 |
| Second run | placed 0, skipped 64,037 |
| After a full restart | placed 0, skipped 64,037 |

494 rather than 509 is correct and worth reading twice: on an already-decorated shard, 15 sign graphics stand at the same tile as a decoration object, and the shared check skips them. 509 − 494 = 15 and 63,543 − 63,528 = 15 — the numbers reconcile from both sides.

Suite 2,293. DocFX 0 warnings.

## Not done

**Nobody has seen a sign in a client.** Not a failure — there is no way to get to one. The only commands in this repo are `broadcast`, `where` and `decorate`, so a character cannot be moved to a sign's coordinates, and the test character was 128 tiles from the nearest one. Worth knowing: only **16 of the 509** signs are on Trammel; Felucca has 395. A `.go` command (Trello #64) is the prerequisite for this and for every future check of anything away from the login point.

Also out of scope: the single-click name (a different path from the tooltip), editing sign text in game, and the 283 named decoration types (Trello #146).